### PR TITLE
Optimize API collections

### DIFF
--- a/app/models/manageiq/providers/azure/inventory/collector.rb
+++ b/app/models/manageiq/providers/azure/inventory/collector.rb
@@ -250,6 +250,13 @@ class ManageIQ::Providers::Azure::Inventory::Collector < ManagerRefresh::Invento
     end
   end
 
+  def safe_targeted_request
+    yield
+  rescue ::Azure::Armrest::Exception => err
+    _log.debug("Record not found Error Class=#{err.class.name}, Message=#{err.message}")
+    nil
+  end
+
   private
 
   def raw_stack_resources(deployment)
@@ -263,6 +270,9 @@ class ManageIQ::Providers::Azure::Inventory::Collector < ManagerRefresh::Invento
     end
 
     resources
+  rescue ::Azure::Armrest::Exception => err
+    _log.debug("Records not found Error Class=#{err.class.name}, Message=#{err.message}")
+    []
   end
 
   def raw_power_status(instance)

--- a/app/models/manageiq/providers/azure/inventory/collector.rb
+++ b/app/models/manageiq/providers/azure/inventory/collector.rb
@@ -31,8 +31,20 @@ class ManageIQ::Providers::Azure::Inventory::Collector < ManagerRefresh::Invento
     @template_refs     = {} # templates need to be retrieved from VMDB
     @template_directs  = {} # templates contents already got by API
 
-    @nis = network_interface_service(@config)
-    @ips = ip_address_service(@config)
+    @nis  = network_interface_service(@config)
+    @ips  = ip_address_service(@config)
+    @vmm  = virtual_machine_service(@config)
+    @asm  = availability_set_service(@config)
+    @tds  = template_deployment_service(@config)
+    @rgs  = resource_group_service(@config)
+    @sas  = storage_account_service(@config)
+    @sds  = storage_disk_service(@config)
+    @mis  = managed_image_service(@config)
+    @vmis = virtual_machine_image_service(@config, :location => @ems.provider_region)
+
+    @vns = virtual_network_service(@config)
+    @nsg = network_security_group_service(@config)
+    @lbs = load_balancer_service(@config)
   end
 
   ##############################################################
@@ -71,7 +83,7 @@ class ManageIQ::Providers::Azure::Inventory::Collector < ManagerRefresh::Invento
   def instance_network_ports(instance)
     @indexed_network_ports ||= network_ports.index_by(&:id)
 
-    instance.properties.network_profile.network_interfaces.map(&:id).map { |x| @indexed_network_ports[x] }.compact
+    instance.properties.network_profile.network_interfaces.map { |x| @indexed_network_ports[x.id] }.compact
   end
 
   def instance_floating_ip(public_ip_obj)

--- a/app/models/manageiq/providers/azure/inventory/collector.rb
+++ b/app/models/manageiq/providers/azure/inventory/collector.rb
@@ -152,6 +152,10 @@ class ManageIQ::Providers::Azure::Inventory::Collector < ManagerRefresh::Invento
     @thread_limit * multiplier
   end
 
+  def parallel_thread_limit
+    options.parallel_thread_limit.to_i || 0
+  end
+
   def stacks_advanced_caching(stacks)
     if stacks_not_changed_cache.blank?
       db_stacks_timestamps              = {}

--- a/app/models/manageiq/providers/azure/inventory/collector.rb
+++ b/app/models/manageiq/providers/azure/inventory/collector.rb
@@ -95,9 +95,21 @@ class ManageIQ::Providers::Azure::Inventory::Collector < ManagerRefresh::Invento
     @indexed_floating_ips[public_ip_obj.id]
   end
 
-  def account_keys(storage_acct)
-    # TODO(lsmola) preload anc cache
-    collect_inventory(:account_keys) { @sas.list_account_keys(storage_acct.name, storage_acct.resource_group) }
+  def instance_managed_disk(disk_location)
+    @indexed_managed_disks ||= managed_disks.index_by { |x| x.id.downcase }
+
+    @indexed_managed_disks[disk_location.downcase]
+  end
+
+  def instance_account_keys(storage_acct)
+    (@indexed_instance_account_keys ||= {})[[storage_acct.name, storage_acct.resource_group]] ||=
+      collect_inventory(:account_keys) { @sas.list_account_keys(storage_acct.name, storage_acct.resource_group) }
+  end
+
+  def instance_storage_accounts(storage_name)
+    @indexes_instance_storage_accounts ||= storage_accounts.index_by { |x| x.name.downcase }
+
+    @indexes_instance_storage_accounts[storage_name.downcase]
   end
 
   def stacks

--- a/app/models/manageiq/providers/azure/inventory/collector.rb
+++ b/app/models/manageiq/providers/azure/inventory/collector.rb
@@ -236,7 +236,7 @@ class ManageIQ::Providers::Azure::Inventory::Collector < ManagerRefresh::Invento
       end
     end
 
-    self.stacks_resources_api_cache.merge!(results.to_h)
+    stacks_resources_api_cache.merge!(results.to_h)
   end
 
   def instances_power_state_advanced_caching(instances)

--- a/app/models/manageiq/providers/azure/inventory/collector/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/inventory/collector/cloud_manager.rb
@@ -36,6 +36,10 @@ class ManageIQ::Providers::Azure::Inventory::Collector::CloudManager < ManageIQ:
 
   def stacks
     @stacks_cache ||= collect_inventory(:deployments) { gather_data_for_this_region(@tds, 'list') }
+
+    stacks_advanced_caching(@stacks_cache)
+
+    @stacks_cache
   end
 
   def instances

--- a/app/models/manageiq/providers/azure/inventory/collector/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/inventory/collector/cloud_manager.rb
@@ -97,7 +97,7 @@ class ManageIQ::Providers::Azure::Inventory::Collector::CloudManager < ManageIQ:
   def stacks_in_parallel(arm_service, method_name)
     region = @ems.provider_region
 
-    Parallel.map(resource_groups, :in_threads => parallel_thread_limit) do |resource_group|
+    Parallel.map(resource_groups, :in_threads => thread_limit) do |resource_group|
       arm_service.send(method_name, resource_group.name).select do |resource|
         location = resource.respond_to?(:location) ? resource.location : resource_group.location
         location.casecmp(region).zero?

--- a/app/models/manageiq/providers/azure/inventory/collector/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/inventory/collector/cloud_manager.rb
@@ -43,7 +43,11 @@ class ManageIQ::Providers::Azure::Inventory::Collector::CloudManager < ManageIQ:
   end
 
   def instances
-    collect_inventory(:instances) { gather_data_for_this_region(@vmm) }
+    instances = collect_inventory(:instances) { gather_data_for_this_region(@vmm) }
+
+    instances_power_state_advanced_caching(instances)
+
+    instances
   end
 
   # The underlying method that gathers these images is a bit brittle.

--- a/app/models/manageiq/providers/azure/inventory/collector/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/inventory/collector/cloud_manager.rb
@@ -15,7 +15,7 @@ class ManageIQ::Providers::Azure::Inventory::Collector::CloudManager < ManageIQ:
   end
 
   def resource_groups
-    collect_inventory(:resource_groups) { @resource_groups ||= @rgs.list(:all => true) }
+    @resource_groups ||= collect_inventory(:resource_groups) { @rgs.list(:all => true) }
   end
 
   def flavors
@@ -35,7 +35,7 @@ class ManageIQ::Providers::Azure::Inventory::Collector::CloudManager < ManageIQ:
   end
 
   def stacks
-    @stacks_cache ||= collect_inventory(:deployments) { gather_data_for_this_region(@tds, 'list') }
+    @stacks_cache ||= collect_inventory(:deployments) { stacks_in_parallel(@tds, 'list') }
 
     stacks_advanced_caching(@stacks_cache)
 
@@ -86,5 +86,18 @@ class ManageIQ::Providers::Azure::Inventory::Collector::CloudManager < ManageIQ:
     else
       gather_data_for_this_region(@vmis)
     end
+  end
+
+  private
+
+  def stacks_in_parallel(arm_service, method_name)
+    region = @ems.provider_region
+
+    Parallel.map(resource_groups, :in_threads => parallel_thread_limit) do |resource_group|
+      arm_service.send(method_name, resource_group.name).select do |resource|
+        location = resource.respond_to?(:location) ? resource.location : resource_group.location
+        location.casecmp(region).zero?
+      end
+    end.flatten
   end
 end

--- a/app/models/manageiq/providers/azure/inventory/collector/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/inventory/collector/cloud_manager.rb
@@ -1,19 +1,4 @@
 class ManageIQ::Providers::Azure::Inventory::Collector::CloudManager < ManageIQ::Providers::Azure::Inventory::Collector
-  def initialize(_manager, _target)
-    super
-
-    @nis  = network_interface_service(@config)
-    @ips  = ip_address_service(@config)
-    @vmm  = virtual_machine_service(@config)
-    @asm  = availability_set_service(@config)
-    @tds  = template_deployment_service(@config)
-    @rgs  = resource_group_service(@config)
-    @sas  = storage_account_service(@config)
-    @sds  = storage_disk_service(@config)
-    @mis  = managed_image_service(@config)
-    @vmis = virtual_machine_image_service(@config, :location => manager.provider_region)
-  end
-
   def resource_groups
     @resource_groups ||= collect_inventory(:resource_groups) { @rgs.list(:all => true) }
   end

--- a/app/models/manageiq/providers/azure/inventory/collector/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/inventory/collector/cloud_manager.rb
@@ -22,17 +22,19 @@ class ManageIQ::Providers::Azure::Inventory::Collector::CloudManager < ManageIQ:
   def stacks
     @stacks_cache ||= collect_inventory(:deployments) { stacks_in_parallel(@tds, 'list') }
 
-    stacks_advanced_caching(@stacks_cache)
+    stacks_advanced_caching(@stacks_cache) unless @stacks_advanced_caching_done
+    @stacks_advanced_caching_done = true
 
     @stacks_cache
   end
 
   def instances
-    instances = collect_inventory(:instances) { gather_data_for_this_region(@vmm) }
+    @instances_cache ||= collect_inventory(:instances) { gather_data_for_this_region(@vmm) }
 
-    instances_power_state_advanced_caching(instances)
+    instances_power_state_advanced_caching(@instances_cache) unless @instances_advanced_caching_done
+    @instances_advanced_caching_done = true
 
-    instances
+    @instances_cache
   end
 
   # The underlying method that gathers these images is a bit brittle.

--- a/app/models/manageiq/providers/azure/inventory/collector/network_manager.rb
+++ b/app/models/manageiq/providers/azure/inventory/collector/network_manager.rb
@@ -4,7 +4,6 @@ class ManageIQ::Providers::Azure::Inventory::Collector::NetworkManager < ManageI
 
     @rgs = resource_group_service(@config)
     @vns = virtual_network_service(@config)
-    @ips = ip_address_service(@config)
     @nis = network_interface_service(@config)
     @nsg = network_security_group_service(@config)
     @lbs = load_balancer_service(@config)
@@ -18,15 +17,7 @@ class ManageIQ::Providers::Azure::Inventory::Collector::NetworkManager < ManageI
     gather_data_for_this_region(@nsg)
   end
 
-  def network_ports
-    network_interfaces
-  end
-
   def load_balancers
     @load_balancers ||= gather_data_for_this_region(@lbs)
-  end
-
-  def floating_ips
-    @floating_ips ||= gather_data_for_this_region(@ips)
   end
 end

--- a/app/models/manageiq/providers/azure/inventory/collector/network_manager.rb
+++ b/app/models/manageiq/providers/azure/inventory/collector/network_manager.rb
@@ -1,14 +1,4 @@
 class ManageIQ::Providers::Azure::Inventory::Collector::NetworkManager < ManageIQ::Providers::Azure::Inventory::Collector
-  def initialize(_manager, _target)
-    super
-
-    @rgs = resource_group_service(@config)
-    @vns = virtual_network_service(@config)
-    @nis = network_interface_service(@config)
-    @nsg = network_security_group_service(@config)
-    @lbs = load_balancer_service(@config)
-  end
-
   def cloud_networks
     gather_data_for_this_region(@vns)
   end

--- a/app/models/manageiq/providers/azure/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/azure/inventory/collector/target_collection.rb
@@ -30,7 +30,7 @@ class ManageIQ::Providers::Azure::Inventory::Collector::TargetCollection < Manag
     else
       collect_inventory_targeted(:resource_groups) do
         Parallel.map(refs, :in_threads => thread_limit) do |ems_ref|
-          @rgs.get(File.basename(ems_ref))
+          safe_targeted_request { @rgs.get(File.basename(ems_ref)) }
         end
       end
     end
@@ -77,7 +77,7 @@ class ManageIQ::Providers::Azure::Inventory::Collector::TargetCollection < Manag
       if not_fetched_refs.present?
         current_stacks = collect_inventory_targeted(:deployments) do
           Parallel.map(not_fetched_refs, :in_threads => thread_limit) do |ems_ref|
-            @tds.get_by_id(ems_ref)
+            safe_targeted_request { @tds.get_by_id(ems_ref) }
           end
         end
 
@@ -126,7 +126,7 @@ class ManageIQ::Providers::Azure::Inventory::Collector::TargetCollection < Manag
                            collect_inventory_targeted(:instances) do
                              Parallel.map(refs, :in_threads => thread_limit) do |ems_ref|
                                _subscription_id, group, _provider, _service, name = ems_ref.tr("\\", '/').split('/')
-                               @vmm.get(name, group)
+                               safe_targeted_request { @vmm.get(name, group) }
                              end
                            end
                          end
@@ -161,7 +161,7 @@ class ManageIQ::Providers::Azure::Inventory::Collector::TargetCollection < Manag
     else
       collect_inventory_targeted(:managed_images) do
         Parallel.map(refs, :in_threads => thread_limit) do |ems_ref|
-          @mis.get_by_id(ems_ref)
+          safe_targeted_request { @mis.get_by_id(ems_ref) }
         end
       end
     end
@@ -215,7 +215,7 @@ class ManageIQ::Providers::Azure::Inventory::Collector::TargetCollection < Manag
     else
       collect_inventory_targeted(:cloud_networks) do
         Parallel.map(refs, :in_threads => thread_limit) do |ems_ref|
-          @vns.get_by_id(ems_ref)
+          safe_targeted_request { @vns.get_by_id(ems_ref) }
         end
       end
     end
@@ -236,7 +236,7 @@ class ManageIQ::Providers::Azure::Inventory::Collector::TargetCollection < Manag
     else
       collect_inventory_targeted(:security_groups) do
         Parallel.map(refs, :in_threads => thread_limit) do |ems_ref|
-          @nsg.get_by_id(ems_ref)
+          safe_targeted_request { @nsg.get_by_id(ems_ref) }
         end
       end
     end
@@ -258,7 +258,7 @@ class ManageIQ::Providers::Azure::Inventory::Collector::TargetCollection < Manag
                                refs = refs.select { |ems_ref| ems_ref =~ /networkinterfaces/i }
                                collect_inventory_targeted(:network_ports) do
                                  Parallel.map(refs, :in_threads => thread_limit) do |ems_ref|
-                                   @nis.get_by_id(ems_ref)
+                                   safe_targeted_request { @nis.get_by_id(ems_ref) }
                                  end
                                end
                              end
@@ -279,7 +279,7 @@ class ManageIQ::Providers::Azure::Inventory::Collector::TargetCollection < Manag
                               else
                                 collect_inventory_targeted(:load_balancers) do
                                   Parallel.map(refs, :in_threads => thread_limit) do |ems_ref|
-                                    @lbs.get_by_id(ems_ref)
+                                    safe_targeted_request { @lbs.get_by_id(ems_ref) }
                                   end
                                 end
                               end
@@ -300,7 +300,7 @@ class ManageIQ::Providers::Azure::Inventory::Collector::TargetCollection < Manag
                             else
                               collect_inventory_targeted(:floating_ips) do
                                 Parallel.map(refs, :in_threads => thread_limit) do |ems_ref|
-                                  @ips.get_by_id(ems_ref)
+                                  safe_targeted_request { @ips.get_by_id(ems_ref) }
                                 end
                               end
                             end

--- a/app/models/manageiq/providers/azure/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/azure/inventory/collector/target_collection.rb
@@ -88,7 +88,7 @@ class ManageIQ::Providers::Azure::Inventory::Collector::TargetCollection < Manag
         stacks_advanced_caching(current_stacks, not_fetched_refs)
       end
 
-      refs.map { |x| targeted_stacks_cache[x] }
+      refs.map { |x| targeted_stacks_cache[x] }.compact
     end
   rescue ::Azure::Armrest::Exception => err
     _log.error("Error Class=#{err.class.name}, Message=#{err.message}")

--- a/app/models/manageiq/providers/azure/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/azure/inventory/collector/target_collection.rb
@@ -10,7 +10,7 @@ class ManageIQ::Providers::Azure::Inventory::Collector::TargetCollection < Manag
     # Reset the target cache, so we can access new targets inside
     target.manager_refs_by_association_reset
 
-    # Do stacks advanced caching to avoid not needed N+1 API calls
+    # Do instances advanced caching
     instances_power_state_advanced_caching(instances)
   end
 

--- a/app/models/manageiq/providers/azure/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/azure/inventory/collector/target_collection.rb
@@ -22,6 +22,9 @@ class ManageIQ::Providers::Azure::Inventory::Collector::TargetCollection < Manag
 
     # Reset the target cache, so we can access new targets inside
     target.manager_refs_by_association_reset
+
+    # Do stacks advanced caching to avoid not needed N+1 API calls
+    stacks_advanced_caching(stacks)
   end
 
   ###########################################

--- a/app/models/manageiq/providers/azure/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/azure/inventory/collector/target_collection.rb
@@ -191,23 +191,23 @@ class ManageIQ::Providers::Azure::Inventory::Collector::TargetCollection < Manag
     # TODO(lsmola) add filtered API
     urns = options.market_image_urns
 
-    collect_inventory_targeted(:market_images) do
-      imgs = if urns
-               urns.collect do |urn|
-                 publisher, offer, sku, version = urn.split(':')
+    imgs = collect_inventory_targeted(:market_images) do
+      if urns
+        urns.collect do |urn|
+          publisher, offer, sku, version = urn.split(':')
 
-                 ::Azure::Armrest::VirtualMachineImage.new(
-                   :location  => manager.provider_region,
-                   :publisher => publisher,
-                   :offer     => offer,
-                   :sku       => sku,
-                   :version   => version,
-                   :id        => urn
-                 )
-               end
-             else
-               gather_data_for_this_region(@vmis)
-             end
+          ::Azure::Armrest::VirtualMachineImage.new(
+            :location  => manager.provider_region,
+            :publisher => publisher,
+            :offer     => offer,
+            :sku       => sku,
+            :version   => version,
+            :id        => urn
+          )
+        end
+      else
+        gather_data_for_this_region(@vmis)
+      end
     end
 
     imgs.select do |image|

--- a/app/models/manageiq/providers/azure/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/azure/inventory/collector/target_collection.rb
@@ -525,7 +525,7 @@ class ManageIQ::Providers::Azure::Inventory::Collector::TargetCollection < Manag
       disks = instance.properties.storage_profile.data_disks + [instance.properties.storage_profile.os_disk]
       disks.each do |disk|
         if instance.managed_disk?
-          add_simple_target!(:managed_disks, disk.managed_disk.id )
+          add_simple_target!(:managed_disks, disk.managed_disk.id)
         else
           disk_location = disk.try(:vhd).try(:uri)
           if disk_location

--- a/app/models/manageiq/providers/azure/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/azure/inventory/collector/target_collection.rb
@@ -2,21 +2,6 @@ class ManageIQ::Providers::Azure::Inventory::Collector::TargetCollection < Manag
   def initialize(_manager, _target)
     super
 
-    @nis  = network_interface_service(@config)
-    @ips  = ip_address_service(@config)
-    @vmm  = virtual_machine_service(@config)
-    @asm  = availability_set_service(@config)
-    @tds  = template_deployment_service(@config)
-    @rgs  = resource_group_service(@config)
-    @sas  = storage_account_service(@config)
-    @sds  = storage_disk_service(@config)
-    @mis  = managed_image_service(@config)
-    @vmis = virtual_machine_image_service(@config, :location => @ems.provider_region)
-
-    @vns = virtual_network_service(@config)
-    @nsg = network_security_group_service(@config)
-    @lbs = load_balancer_service(@config)
-
     @targeted_stacks_cache = {}
 
     parse_targets!

--- a/app/models/manageiq/providers/azure/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/azure/inventory/collector/target_collection.rb
@@ -25,6 +25,7 @@ class ManageIQ::Providers::Azure::Inventory::Collector::TargetCollection < Manag
 
     # Do stacks advanced caching to avoid not needed N+1 API calls
     stacks_advanced_caching(stacks)
+    instances_power_state_advanced_caching(instances)
   end
 
   ###########################################

--- a/app/models/manageiq/providers/azure/inventory/parser/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/inventory/parser/cloud_manager.rb
@@ -121,7 +121,7 @@ class ManageIQ::Providers::Azure::Inventory::Parser::CloudManager < ManageIQ::Pr
         public_ip_obj = ipconfig.properties.try(:public_ip_address)
         next unless public_ip_obj
 
-        ip_profile = collector.ip_addresses.find { |ip| ip.id == public_ip_obj.id }
+        ip_profile = collector.instance_floating_ip(public_ip_obj)
         next unless ip_profile
 
         public_ip_addr = ip_profile.properties.try(:ip_address)

--- a/app/models/manageiq/providers/azure/inventory/parser/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/inventory/parser/cloud_manager.rb
@@ -176,9 +176,9 @@ class ManageIQ::Providers::Azure::Inventory::Parser::CloudManager < ManageIQ::Pr
         blob_name = uri.basename
 
         storage_acct = collector.instance_storage_accounts(storage_name)
-        mode = storage_acct.sku.name
+        mode = storage_acct.try(:sku).try(:name)
 
-        if collector.options.get_unmanaged_disk_space && disk_size.nil?
+        if collector.options.get_unmanaged_disk_space && disk_size.nil? && storage_acct.present?
           storage_keys = collector.instance_account_keys(storage_acct)
           storage_key  = storage_keys['key1'] || storage_keys['key2']
           blob_props   = storage_acct.blob_properties(container_name, blob_name, storage_key)

--- a/app/models/manageiq/providers/azure/inventory/parser/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/inventory/parser/cloud_manager.rb
@@ -154,7 +154,7 @@ class ManageIQ::Providers::Azure::Inventory::Parser::CloudManager < ManageIQ::Pr
     if instance.managed_disk?
       disk_type     = 'managed'
       disk_location = disk.managed_disk.id
-      managed_disk  = collector.managed_disks.find { |d| d.id.casecmp(disk_location).zero? }
+      managed_disk  = collector.instance_managed_disk(disk_location)
 
       if managed_disk
         disk_size = managed_disk.properties.disk_size_gb.gigabytes
@@ -175,11 +175,11 @@ class ManageIQ::Providers::Azure::Inventory::Parser::CloudManager < ManageIQ::Pr
         container_name = File.dirname(uri.path)
         blob_name = uri.basename
 
-        storage_acct = collector.storage_accounts.find { |s| s.name.casecmp(storage_name).zero? }
+        storage_acct = collector.instance_storage_accounts(storage_name)
         mode = storage_acct.sku.name
 
         if collector.options.get_unmanaged_disk_space && disk_size.nil?
-          storage_keys = collector.account_keys(storage_acct)
+          storage_keys = collector.instance_account_keys(storage_acct)
           storage_key  = storage_keys['key1'] || storage_keys['key2']
           blob_props   = storage_acct.blob_properties(container_name, blob_name, storage_key)
           disk_size    = blob_props.content_length.to_i

--- a/app/models/manageiq/providers/azure/inventory/parser/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/inventory/parser/cloud_manager.rb
@@ -110,7 +110,7 @@ class ManageIQ::Providers::Azure::Inventory::Parser::CloudManager < ManageIQ::Pr
   end
 
   def hardware_networks(persister_hardware, instance)
-    collector.get_vm_nics(instance).each do |nic_profile|
+    collector.instance_network_ports(instance).each do |nic_profile|
       nic_profile.properties.ip_configurations.each do |ipconfig|
         hostname        = ipconfig.name
         private_ip_addr = ipconfig.properties.try(:private_ip_address)

--- a/app/models/manageiq/providers/azure/inventory/parser/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/inventory/parser/cloud_manager.rb
@@ -13,7 +13,7 @@ class ManageIQ::Providers::Azure::Inventory::Parser::CloudManager < ManageIQ::Pr
     stack_templates
     instances
     managed_images
-    images
+    images if collector.options.get_private_images
     market_images if collector.options.get_market_images
 
     _log.info("#{log_header}...Complete")

--- a/app/models/manageiq/providers/azure/inventory_collection_default/cloud_manager.rb
+++ b/app/models/manageiq/providers/azure/inventory_collection_default/cloud_manager.rb
@@ -62,7 +62,8 @@ class ManageIQ::Providers::Azure::InventoryCollectionDefault::CloudManager < Man
 
     def orchestration_stacks(extra_attributes = {})
       attributes = {
-        :model_class => ::ManageIQ::Providers::Azure::CloudManager::OrchestrationStack,
+        :model_class    => ::ManageIQ::Providers::Azure::CloudManager::OrchestrationStack,
+        :saver_strategy => :default # TODO(lsmola) can't batch unless we do smart batching
       }
 
       super(attributes.merge!(extra_attributes))

--- a/app/models/manageiq/providers/azure/refresh_helper_methods.rb
+++ b/app/models/manageiq/providers/azure/refresh_helper_methods.rb
@@ -26,7 +26,7 @@ module ManageIQ::Providers::Azure::RefreshHelperMethods
     _log.debug("Retrieving Targeted #{collection_name}...Complete - Count [#{inv_count}]")
     _log.debug("Memory usage: #{'%.02f' % collector_memory_usage} MiB")
 
-    inventory
+    inventory.try(:compact)
   end
 
   def collector_memory_usage

--- a/app/models/manageiq/providers/azure/refresh_helper_methods.rb
+++ b/app/models/manageiq/providers/azure/refresh_helper_methods.rb
@@ -15,6 +15,20 @@ module ManageIQ::Providers::Azure::RefreshHelperMethods
     inventory
   end
 
+  def collect_inventory_targeted(inv_type)
+    collection_name = inv_type.to_s.titleize
+
+    _log.debug("Retrieving Targeted #{collection_name}...")
+
+    inventory = yield
+    inv_count = inventory.blank? ? 0 : inventory.length
+
+    _log.debug("Retrieving Targeted #{collection_name}...Complete - Count [#{inv_count}]")
+    _log.debug("Memory usage: #{'%.02f' % collector_memory_usage} MiB")
+
+    inventory
+  end
+
   def collector_memory_usage
     require 'miq-process'
     MiqProcess.processInfo[:proportional_set_size].to_f / 1.megabyte

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -36,13 +36,33 @@
     # If get_market_images is enabled with no filters, all public images will be added
     # This will cause performance issues during refresh and at places in the UI where images are listed
     :get_market_images: false
+    # Optionally collecting private images [Graph refresh only]
+    :get_private_images: true
     :market_image_urns:
       - MicrosoftWindowsServer:WindowsServer-HUB:2016-Datacenter-HUB:2016.127.20170630
       - OpenLogic:CentOS:7.3:7.3.20170517
       - RedHat:RHEL:7.3:7.3.2017051117
     # Collecting disk information on unmanaged VM's slows down the refresh.
     :get_unmanaged_disk_space: true
+    # Limit of threads we spawn to speed up API queries [Graph refresh only]
     :parallel_thread_limit: 25
+    # Switches refresh to graph refresh on [Graph refresh only]
+    :inventory_object_refresh: false
+    # Switches graph targeted refresh on [massive refresh performance optimization [Graph refresh only]]
+    :allow_targeted_refresh: true
+    # A threshold for fetching all entities from the API, instead of query for 1 entity [Graph refresh only]
+    :targeted_api_collection_threshold: 500
+    # Not fetching resources and templates of deployments unless deployment changed [Graph refresh only]
+    :enabled_deployments_caching: true
+    :inventory_collections:
+      # Strategy for saving, another allowed is :batch, doing batch SQL queries [Graph refresh only]
+      :saver_strategy: :default
+  :azure_network:
+    # Same options as in :azure, applied for a network manager
+    :inventory_object_refresh: false
+    :allow_targeted_refresh: true
+    :inventory_collections:
+      :saver_strategy: :default
 :http_proxy:
   :azure:
     :host:

--- a/spec/models/manageiq/providers/azure/cloud_manager/azure_refresher_spec_common.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/azure_refresher_spec_common.rb
@@ -35,6 +35,15 @@ module AzureRefresherSpecCommon
     }
   ].freeze
 
+
+  GRAPH_REFRESH_ADDITIONAL_SETTINGS = [
+    {
+      :targeted_api_collection_threshold => 0,
+    }, {
+      :targeted_api_collection_threshold => 500,
+    }
+  ].freeze
+
   ALL_REFRESH_SETTINGS = (AzureRefresherSpecCommon::ALL_GRAPH_REFRESH_SETTINGS + AzureRefresherSpecCommon::ALL_OLD_REFRESH_SETTINGS).freeze
 
   MODELS = %i(
@@ -772,6 +781,74 @@ module AzureRefresherSpecCommon
     )
 
     expect(@network_port.device.id).to eql(@floating_ip.vm.id)
+  end
+
+  def assert_lbs_with_vms
+    assert_specific_load_balancers
+    assert_specific_load_balancer_networking
+    assert_specific_load_balancer_listeners
+    assert_specific_load_balancer_health_checks
+
+    assert_counts(
+      :availability_zone                 => 1,
+      :cloud_network                     => 1,
+      :cloud_subnet                      => 1,
+      :disk                              => 2,
+      :ext_management_system             => 2,
+      :flavor                            => 2,
+      :floating_ip                       => 4,
+      :hardware                          => 2,
+      :load_balancer                     => 2,
+      :load_balancer_health_check        => 2,
+      :load_balancer_health_check_member => 2,
+      :load_balancer_listener            => 1,
+      :load_balancer_listener_pool       => 1,
+      :load_balancer_pool                => 1,
+      :load_balancer_pool_member         => 2,
+      :load_balancer_pool_member_pool    => 2,
+      :network                           => 4,
+      :network_port                      => 4,
+      :operating_system                  => 2,
+      :resource_group                    => 1,
+      :security_group                    => 2,
+      :vm                                => 2,
+      :vm_or_template                    => 2
+    )
+  end
+
+  def assert_stack_and_vm_targeted_refresh
+    assert_specific_orchestration_template
+    assert_specific_orchestration_stack
+
+    assert_counts(
+      :availability_zone                 => 1,
+      :cloud_network                     => 1,
+      :cloud_subnet                      => 1,
+      :disk                              => 2,
+      :ext_management_system             => 2,
+      :flavor                            => 1,
+      :floating_ip                       => 1,
+      :hardware                          => 2,
+      :load_balancer                     => 1,
+      :load_balancer_health_check        => 1,
+      :load_balancer_health_check_member => 2,
+      :load_balancer_listener            => 1,
+      :load_balancer_listener_pool       => 1,
+      :load_balancer_pool                => 1,
+      :load_balancer_pool_member         => 2,
+      :load_balancer_pool_member_pool    => 2,
+      :network                           => 2,
+      :network_port                      => 3,
+      :operating_system                  => 2,
+      :orchestration_stack               => 2,
+      :orchestration_stack_output        => 1,
+      :orchestration_stack_parameter     => 29,
+      :orchestration_stack_resource      => 10,
+      :orchestration_template            => 2,
+      :resource_group                    => 1,
+      :vm                                => 2,
+      :vm_or_template                    => 2
+    )
   end
 
   def lb_non_stack_target

--- a/spec/models/manageiq/providers/azure/cloud_manager/azure_refresher_spec_common.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/azure_refresher_spec_common.rb
@@ -85,7 +85,7 @@ module AzureRefresherSpecCommon
   end
 
   def serialize_inventory
-    skip_atributes = %w(updated_on last_refresh_date updated_at last_updated)
+    skip_atributes = %w(updated_on last_refresh_date updated_at last_updated finish_time)
     inventory = {}
     AzureRefresherSpecCommon::MODELS.each do |rel|
       inventory[rel] = rel.to_s.classify.constantize.all.collect do |e|

--- a/spec/models/manageiq/providers/azure/cloud_manager/azure_refresher_spec_common.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/azure_refresher_spec_common.rb
@@ -13,19 +13,8 @@ module AzureRefresherSpecCommon
       :inventory_object_refresh => true,
       :inventory_collections    => {
         :saver_strategy => :batch,
-        :use_ar_object  => true,
-      },
-    }, {
-      :get_private_images       => true,
-      :inventory_object_refresh => true,
-      :inventory_collections    => {
-        :saver_strategy => :batch,
         :use_ar_object  => false,
       },
-    }, {
-      :get_private_images               => true,
-      :inventory_object_saving_strategy => :recursive,
-      :inventory_object_refresh         => true
     }
   ].freeze
 

--- a/spec/models/manageiq/providers/azure/cloud_manager/azure_refresher_spec_common.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/azure_refresher_spec_common.rb
@@ -850,6 +850,76 @@ module AzureRefresherSpecCommon
     )
   end
 
+  def network_port_target
+    network_port_id = "/subscriptions/#{@ems.subscription}/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944"
+    ManagerRefresh::Target.new(:manager     => @ems,
+                               :association => :network_ports,
+                               :manager_ref => {:ems_ref => network_port_id})
+  end
+
+  def non_existent_network_port_target
+    network_port_id = "/subscriptions/#{@ems.subscription}/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/non_existent"
+    ManagerRefresh::Target.new(:manager     => @ems,
+                               :association => :network_ports,
+                               :manager_ref => {:ems_ref => network_port_id})
+  end
+
+  def cloud_network_target
+    cloud_network_id = "/subscriptions/#{@ems.subscription}/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2"
+    ManagerRefresh::Target.new(:manager     => @ems,
+                               :association => :cloud_networks,
+                               :manager_ref => {:ems_ref => cloud_network_id})
+  end
+
+  def non_existent_cloud_network_target
+    cloud_network_id = "/subscriptions/#{@ems.subscription}/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/non_existent"
+    ManagerRefresh::Target.new(:manager     => @ems,
+                               :association => :cloud_networks,
+                               :manager_ref => {:ems_ref => cloud_network_id})
+  end
+
+  def security_group_target
+    security_group_id = "/subscriptions/#{@ems.subscription}/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg"
+    ManagerRefresh::Target.new(:manager     => @ems,
+                               :association => :security_groups,
+                               :manager_ref => {:ems_ref => security_group_id})
+  end
+
+  def non_existent_security_group_target
+    security_group_id = "/subscriptions/#{@ems.subscription}/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/non_existent"
+    ManagerRefresh::Target.new(:manager     => @ems,
+                               :association => :security_groups,
+                               :manager_ref => {:ems_ref => security_group_id})
+  end
+
+  def floating_ip_target
+    floating_ip_id = "/subscriptions/#{@ems.subscription}/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip"
+    ManagerRefresh::Target.new(:manager     => @ems,
+                               :association => :floating_ips,
+                               :manager_ref => {:ems_ref => floating_ip_id})
+  end
+
+  def non_existent_floating_ip_target
+    floating_ip_id = "/subscriptions/#{@ems.subscription}/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/non_existent"
+    ManagerRefresh::Target.new(:manager     => @ems,
+                               :association => :floating_ips,
+                               :manager_ref => {:ems_ref => floating_ip_id})
+  end
+
+  def resource_group_target
+    resource_group_id = "/subscriptions//#{@ems.subscription}/resourcegroups/miq-azure-test4"
+    ManagerRefresh::Target.new(:manager     => @ems,
+                               :association => :resource_groups,
+                               :manager_ref => {:ems_ref => resource_group_id})
+  end
+
+  def non_existent_resource_group_target
+    resource_group_id = "/subscriptions//#{@ems.subscription}/resourcegroups/miq-azure-test4"
+    ManagerRefresh::Target.new(:manager     => @ems,
+                               :association => :resource_groups,
+                               :manager_ref => {:ems_ref => resource_group_id})
+  end
+
   def lb_non_stack_target
     lb_resource_id = "/subscriptions/#{@ems.subscription}/"\
                             "resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1"
@@ -907,8 +977,24 @@ module AzureRefresherSpecCommon
                                :manager_ref => {:ems_ref => vm_resource_id})
   end
 
+  def non_existent_vm_target
+    vm_resource_id = "#{@ems.subscription}\\#{@resource_group_managed_vm}\\microsoft.compute/virtualmachines\\non_existent_vm_that_does_not_exist"
+
+    ManagerRefresh::Target.new(:manager     => @ems,
+                               :association => :vms,
+                               :manager_ref => {:ems_ref => vm_resource_id})
+  end
+
   def parent_orchestration_stack_target
     stack_resource_id = "/subscriptions/#{@ems.subscription}/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-deployment-dont-delete"
+
+    ManagerRefresh::Target.new(:manager     => @ems,
+                               :association => :orchestration_stacks,
+                               :manager_ref => {:ems_ref => stack_resource_id})
+  end
+
+  def non_existent_orchestration_stack_target
+    stack_resource_id = "/subscriptions/#{@ems.subscription}/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/non_existent"
 
     ManagerRefresh::Target.new(:manager     => @ems,
                                :association => :orchestration_stacks,
@@ -936,6 +1022,13 @@ module AzureRefresherSpecCommon
                                :manager_ref => {:ems_ref => lb_resource_id})
   end
 
+  def non_existent_lb_target
+    lb_resource_id = "/subscriptions/#{@ems.subscription}/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/non_existent_lb"
+    ManagerRefresh::Target.new(:manager     => @ems,
+                               :association => :load_balancers,
+                               :manager_ref => {:ems_ref => lb_resource_id})
+  end
+
   def template_target
     template_resource_id = "https://miqazuretest14047.blob.core.windows.net/system/"\
                                  "Microsoft.Compute/Images/miq-test-container/"\
@@ -944,5 +1037,29 @@ module AzureRefresherSpecCommon
     ManagerRefresh::Target.new(:manager     => @ems,
                                :association => :miq_templates,
                                :manager_ref => {:ems_ref => template_resource_id})
+  end
+
+  def non_existent_template_target
+    template_resource_id = "https://miqazuretest14047.blob.core.windows.net/system/"\
+                                 "Microsoft.Compute/Images/miq-test-container/"\
+                                 "non_existent_template.vhd"
+
+    ManagerRefresh::Target.new(:manager     => @ems,
+                               :association => :miq_templates,
+                               :manager_ref => {:ems_ref => template_resource_id})
+  end
+
+  def flavor_target
+    flavor_resource_name = "basic_a0"
+    ManagerRefresh::Target.new(:manager     => @ems,
+                               :association => :flavors,
+                               :manager_ref => {:name => flavor_resource_name})
+  end
+
+  def non_existent_flavor_target
+    flavor_resource_name = "non_existent"
+    ManagerRefresh::Target.new(:manager     => @ems,
+                               :association => :flavors,
+                               :manager_ref => {:name => flavor_resource_name})
   end
 end

--- a/spec/models/manageiq/providers/azure/cloud_manager/azure_refresher_spec_common.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/azure_refresher_spec_common.rb
@@ -3,23 +3,27 @@ module AzureRefresherSpecCommon
 
   ALL_GRAPH_REFRESH_SETTINGS = [
     {
+      :get_private_images       => true,
       :inventory_object_refresh => true,
       :inventory_collections    => {
         :saver_strategy => :default,
       },
     }, {
+      :get_private_images       => true,
       :inventory_object_refresh => true,
       :inventory_collections    => {
         :saver_strategy => :batch,
         :use_ar_object  => true,
       },
     }, {
+      :get_private_images       => true,
       :inventory_object_refresh => true,
       :inventory_collections    => {
         :saver_strategy => :batch,
         :use_ar_object  => false,
       },
     }, {
+      :get_private_images               => true,
       :inventory_object_saving_strategy => :recursive,
       :inventory_object_refresh         => true
     }

--- a/spec/models/manageiq/providers/azure/cloud_manager/azure_refresher_spec_common.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/azure_refresher_spec_common.rb
@@ -35,7 +35,6 @@ module AzureRefresherSpecCommon
     }
   ].freeze
 
-
   GRAPH_REFRESH_ADDITIONAL_SETTINGS = [
     {
       :targeted_api_collection_threshold => 0,

--- a/spec/models/manageiq/providers/azure/cloud_manager/deployments_caching_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/deployments_caching_spec.rb
@@ -58,7 +58,8 @@ describe ManageIQ::Providers::Azure::CloudManager::Refresher do
         2.times do # Run twice to verify that a second run with existing data does not change anything
           refresh_with_cassette(
             [parent_orchestration_stack_target],
-            "_targeted/targeted_api_collection_threshold_500/orchestration_stack_refresh")
+            "_targeted/targeted_api_collection_threshold_500/orchestration_stack_refresh"
+          )
 
           assert_stack_and_vm_targeted_refresh
         end

--- a/spec/models/manageiq/providers/azure/cloud_manager/deployments_caching_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/deployments_caching_spec.rb
@@ -1,0 +1,96 @@
+require 'azure-armrest'
+require_relative "azure_refresher_spec_common"
+
+describe ManageIQ::Providers::Azure::CloudManager::Refresher do
+  include AzureRefresherSpecCommon
+
+  [
+    {
+      :enabled_deployments_caching => true,
+      :get_private_images          => true,
+      :inventory_object_refresh    => true,
+      :inventory_collections       => {
+        :saver_strategy => :default,
+      },
+    }, {
+      :enabled_deployments_caching => false,
+      :get_private_images          => true,
+      :inventory_object_refresh    => true,
+      :inventory_collections       => {
+        :saver_strategy => :default,
+      },
+    }
+  ].each do |refresh_settings|
+    context "with settings #{refresh_settings}" do
+      before do
+        _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
+
+        @ems = FactoryGirl.create(:ems_azure_with_vcr_authentication, :zone => zone, :provider_region => 'eastus')
+
+        @resource_group    = 'miq-azure-test1'
+        @managed_vm        = 'miqazure-linux-managed'
+        @device_name       = 'miq-test-rhel1' # Make sure this is running if generating a new cassette.
+        @vm_powered_off    = 'miqazure-centos1' # Make sure this is powered off if generating a new cassette.
+        @ip_address        = '52.224.165.15' # This will change if you had to restart the @device_name.
+        @mismatch_ip       = '52.168.33.118' # This will change if you had to restart the 'miqmismatch1' VM.
+        @managed_os_disk   = "miqazure-linux-managed_OsDisk_1_7b2bdf790a7d4379ace2846d307730cd"
+        @managed_data_disk = "miqazure-linux-managed-data-disk"
+        @template          = nil
+        @avail_zone        = nil
+
+        @resource_group_managed_vm = "miq-azure-test4"
+      end
+
+      after do
+        ::Azure::Armrest::Configuration.clear_caches
+      end
+
+      it "will refresh orchestration stack" do
+        @refresh_settings = refresh_settings.merge(:allow_targeted_refresh => true)
+
+        stub_settings_merge(
+          :ems_refresh => {
+            :azure         => @refresh_settings,
+            :azure_network => @refresh_settings,
+          }
+        )
+
+        2.times do # Run twice to verify that a second run with existing data does not change anything
+          refresh_with_cassette(
+            [parent_orchestration_stack_target],
+            "_targeted/targeted_api_collection_threshold_500/orchestration_stack_refresh")
+
+          assert_stack_and_vm_targeted_refresh
+        end
+      end
+
+      it "will perform a full refresh" do
+        @refresh_settings = refresh_settings
+        2.times do # Run twice to verify that a second run with existing data does not change anything
+          setup_ems_and_cassette(refresh_settings)
+
+          assert_table_counts
+          assert_ems
+          assert_specific_az
+          assert_specific_cloud_network
+          assert_specific_flavor
+          assert_specific_disk
+          assert_specific_security_group
+          assert_specific_vm_powered_on
+          assert_specific_vm_powered_off
+          assert_specific_template
+          assert_specific_orchestration_template
+          assert_specific_orchestration_stack
+          assert_specific_nic_and_ip
+          assert_specific_load_balancers
+          assert_specific_load_balancer_networking
+          assert_specific_load_balancer_listeners
+          assert_specific_load_balancer_health_checks
+          assert_specific_vm_with_managed_disks
+          assert_specific_managed_disk
+          assert_specific_resource_group
+        end
+      end
+    end
+  end
+end

--- a/spec/models/manageiq/providers/azure/cloud_manager/targeted_refresher_scope_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/targeted_refresher_scope_spec.rb
@@ -71,6 +71,30 @@ describe ManageIQ::Providers::Azure::CloudManager::Refresher do
           refresh_with_cassette([vm_with_managed_disk_target], "_targeted_scope/vm_with_managed_disk_refresh")
         end
 
+        it "will refresh multiple objects at once" do
+          targets = [
+            vm_with_managed_disk_target,
+            vm_powered_on_target,
+            vm_powered_off_target,
+            non_existent_vm_target,
+            lb_target,
+            non_existent_lb_target,
+            network_port_target,
+            non_existent_network_port_target,
+            cloud_network_target,
+            non_existent_cloud_network_target,
+            security_group_target,
+            non_existent_security_group_target,
+            resource_group_target,
+            non_existent_resource_group_target,
+            non_existent_orchestration_stack_target,
+            flavor_target,
+            non_existent_flavor_target
+          ]
+
+          refresh_with_cassette(targets, "_targeted_scope/multiple_targets_refresh")
+        end
+
         it "will refresh orchestration stack" do
           refresh_with_cassette([parent_orchestration_stack_target], "_targeted_scope/orchestration_stack_refresh")
         end

--- a/spec/models/manageiq/providers/azure/cloud_manager/targeted_refresher_scope_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/targeted_refresher_scope_spec.rb
@@ -95,6 +95,22 @@ describe ManageIQ::Providers::Azure::CloudManager::Refresher do
           refresh_with_cassette(targets, "_targeted_scope/multiple_targets_refresh")
         end
 
+        it "will refresh cloud network" do
+          refresh_with_cassette([cloud_network_target], "_targeted_scope/cloud_network_refresh")
+        end
+
+        it "will refresh resource group target" do
+          refresh_with_cassette([resource_group_target], "_targeted_scope/resource_group_refresh")
+        end
+
+        it "will refresh security group target" do
+          refresh_with_cassette([security_group_target], "_targeted_scope/security_group_refresh")
+        end
+
+        it "will refresh network_port target" do
+          refresh_with_cassette([network_port_target], "_targeted_scope/network_port_refresh")
+        end
+
         it "will refresh orchestration stack" do
           refresh_with_cassette([parent_orchestration_stack_target], "_targeted_scope/orchestration_stack_refresh")
         end

--- a/spec/models/manageiq/providers/azure/cloud_manager/targeted_refresher_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/targeted_refresher_spec.rb
@@ -202,6 +202,51 @@ describe ManageIQ::Providers::Azure::CloudManager::Refresher do
             end
           end
 
+          it "will refresh cloud network" do
+            2.times do # Run twice to verify that a second run with existing data does not change anything
+              refresh_with_cassette([cloud_network_target], vcr_suffix("cloud_network_refresh"))
+              assert_counts(
+                :cloud_network         => 1,
+                :cloud_subnet          => 1,
+                :ext_management_system => 2
+              )
+            end
+          end
+
+          it "will refresh resource group target" do
+            2.times do # Run twice to verify that a second run with existing data does not change anything
+              refresh_with_cassette([resource_group_target], vcr_suffix("resource_group_refresh"))
+              assert_counts(
+                :resource_group        => 1,
+                :ext_management_system => 2
+              )
+            end
+          end
+
+          it "will refresh security group target" do
+            2.times do # Run twice to verify that a second run with existing data does not change anything
+              refresh_with_cassette([security_group_target], vcr_suffix("security_group_refresh"))
+              assert_counts(
+                :security_group        => 1,
+                :ext_management_system => 2
+              )
+            end
+          end
+
+          it "will refresh network_port target" do
+            2.times do # Run twice to verify that a second run with existing data does not change anything
+              refresh_with_cassette([network_port_target], vcr_suffix("network_port_refresh"))
+              assert_counts(
+                :cloud_network         => 1,
+                :cloud_subnet          => 1,
+                :ext_management_system => 2,
+                :floating_ip           => 1,
+                :network_port          => 1,
+                :security_group        => 1,
+              )
+            end
+          end
+
           it "will refresh orchestration stack" do
             2.times do # Run twice to verify that a second run with existing data does not change anything
               refresh_with_cassette([parent_orchestration_stack_target], vcr_suffix("orchestration_stack_refresh"))

--- a/spec/models/manageiq/providers/azure/cloud_manager/targeted_refresher_spec.rb
+++ b/spec/models/manageiq/providers/azure/cloud_manager/targeted_refresher_spec.rb
@@ -6,327 +6,270 @@ describe ManageIQ::Providers::Azure::CloudManager::Refresher do
 
   AzureRefresherSpecCommon::ALL_GRAPH_REFRESH_SETTINGS.each do |refresh_settings|
     context "with settings #{refresh_settings}" do
-      before(:each) do
-        @refresh_settings = refresh_settings.merge(:allow_targeted_refresh => true)
+      AzureRefresherSpecCommon::GRAPH_REFRESH_ADDITIONAL_SETTINGS.each do |additional_settings|
+        context "with additional settings #{additional_settings}" do
+          before(:each) do
+            @refresh_settings = refresh_settings.merge(:allow_targeted_refresh => true)
+            @refresh_settings.merge(additional_settings)
 
-        stub_settings_merge(
-          :ems_refresh => {
-            :azure         => @refresh_settings,
-            :azure_network => @refresh_settings,
-          }
-        )
-      end
+            @sub_path = "targeted_api_collection_threshold_#{additional_settings[:targeted_api_collection_threshold]}/"
 
-      before do
-        _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
+            stub_settings_merge(
+              :ems_refresh => {
+                :azure         => @refresh_settings,
+                :azure_network => @refresh_settings,
+              }
+            )
+          end
 
-        @ems = FactoryGirl.create(:ems_azure_with_vcr_authentication, :zone => zone, :provider_region => 'eastus')
+          before do
+            _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
 
-        @resource_group    = 'miq-azure-test1'
-        @managed_vm        = 'miqazure-linux-managed'
-        @device_name       = 'miq-test-rhel1' # Make sure this is running if generating a new cassette.
-        @vm_powered_off    = 'miqazure-centos1' # Make sure this is powered off if generating a new cassette.
-        @ip_address        = '52.224.165.15'  # This will change if you had to restart the @device_name.
-        @mismatch_ip       = '52.168.33.118'  # This will change if you had to restart the 'miqmismatch1' VM.
-        @managed_os_disk   = "miqazure-linux-managed_OsDisk_1_7b2bdf790a7d4379ace2846d307730cd"
-        @managed_data_disk = "miqazure-linux-managed-data-disk"
-        @template          = nil
-        @avail_zone        = nil
+            @ems = FactoryGirl.create(:ems_azure_with_vcr_authentication, :zone => zone, :provider_region => 'eastus')
 
-        @resource_group_managed_vm = "miq-azure-test4"
-      end
+            @resource_group    = 'miq-azure-test1'
+            @managed_vm        = 'miqazure-linux-managed'
+            @device_name       = 'miq-test-rhel1' # Make sure this is running if generating a new cassette.
+            @vm_powered_off    = 'miqazure-centos1' # Make sure this is powered off if generating a new cassette.
+            @ip_address        = '52.224.165.15'  # This will change if you had to restart the @device_name.
+            @mismatch_ip       = '52.168.33.118'  # This will change if you had to restart the 'miqmismatch1' VM.
+            @managed_os_disk   = "miqazure-linux-managed_OsDisk_1_7b2bdf790a7d4379ace2846d307730cd"
+            @managed_data_disk = "miqazure-linux-managed-data-disk"
+            @template          = nil
+            @avail_zone        = nil
 
-      after do
-        ::Azure::Armrest::Configuration.clear_caches
-      end
+            @resource_group_managed_vm = "miq-azure-test4"
+          end
 
-      it ".ems_type" do
-        expect(described_class.ems_type).to eq(:azure)
-      end
+          after do
+            ::Azure::Armrest::Configuration.clear_caches
+          end
 
-      it "will refresh powered on VM" do
-        2.times do # Run twice to verify that a second run with existing data does not change anything
-          refresh_with_cassette([vm_powered_on_target], "_targeted/powered_on_vm_refresh")
+          it ".ems_type" do
+            expect(described_class.ems_type).to eq(:azure)
+          end
 
-          assert_specific_az
-          assert_specific_cloud_network
-          assert_specific_flavor
-          assert_specific_disk
-          assert_specific_security_group
-          assert_specific_vm_powered_on
+          it "will refresh powered on VM" do
+            2.times do # Run twice to verify that a second run with existing data does not change anything
+              refresh_with_cassette([vm_powered_on_target], vcr_suffix("powered_on_vm_refresh"))
 
-          assert_counts(
-            :availability_zone     => 1,
-            :cloud_network         => 1,
-            :cloud_subnet          => 1,
-            :disk                  => 1,
-            :ext_management_system => 2,
-            :flavor                => 1,
-            :floating_ip           => 1,
-            :hardware              => 1,
-            :network               => 2,
-            :network_port          => 1,
-            :operating_system      => 1,
-            :resource_group        => 1,
-            :security_group        => 1,
-            :vm                    => 1,
-            :vm_or_template        => 1
-          )
+              assert_specific_az
+              assert_specific_cloud_network
+              assert_specific_flavor
+              assert_specific_disk
+              assert_specific_security_group
+              assert_specific_vm_powered_on
+
+              assert_counts(
+                :availability_zone     => 1,
+                :cloud_network         => 1,
+                :cloud_subnet          => 1,
+                :disk                  => 1,
+                :ext_management_system => 2,
+                :flavor                => 1,
+                :floating_ip           => 1,
+                :hardware              => 1,
+                :network               => 2,
+                :network_port          => 1,
+                :operating_system      => 1,
+                :resource_group        => 1,
+                :security_group        => 1,
+                :vm                    => 1,
+                :vm_or_template        => 1
+              )
+            end
+          end
+
+          it "will refresh powered off VM" do
+            2.times do # Run twice to verify that a second run with existing data does not change anything
+              refresh_with_cassette([vm_powered_off_target], vcr_suffix("powered_off_vm_refresh"))
+
+              assert_specific_az
+              assert_specific_flavor
+              assert_specific_vm_powered_off
+
+              assert_counts(
+                :availability_zone     => 1,
+                :cloud_network         => 1,
+                :cloud_subnet          => 1,
+                :disk                  => 1,
+                :ext_management_system => 2,
+                :flavor                => 1,
+                :floating_ip           => 1,
+                :hardware              => 1,
+                :network               => 2,
+                :network_port          => 1,
+                :operating_system      => 1,
+                :resource_group        => 1,
+                :security_group        => 1,
+                :vm                    => 1,
+                :vm_or_template        => 1
+              )
+            end
+          end
+
+          it "will refresh VM with managed disk" do
+            2.times do # Run twice to verify that a second run with existing data does not change anything
+              refresh_with_cassette([vm_with_managed_disk_target], vcr_suffix("vm_with_managed_disk_refresh"))
+
+              assert_specific_az
+              assert_specific_flavor
+              assert_specific_vm_with_managed_disks
+              assert_specific_managed_disk
+
+              assert_counts(
+                :availability_zone     => 1,
+                :cloud_network         => 1,
+                :cloud_subnet          => 1,
+                :disk                  => 2,
+                :ext_management_system => 2,
+                :flavor                => 1,
+                :floating_ip           => 1,
+                :hardware              => 1,
+                :network               => 2,
+                :network_port          => 1,
+                :operating_system      => 1,
+                :resource_group        => 1,
+                :security_group        => 1,
+                :vm                    => 1,
+                :vm_or_template        => 1
+              )
+            end
+          end
+
+          it "will refresh orchestration stack" do
+            2.times do # Run twice to verify that a second run with existing data does not change anything
+              refresh_with_cassette([parent_orchestration_stack_target], vcr_suffix("orchestration_stack_refresh"))
+
+              assert_stack_and_vm_targeted_refresh
+            end
+          end
+
+          it "will refresh orchestration stack followed by Vm refresh" do
+            2.times do # Run twice to verify that a second run with existing data does not change anything
+              refresh_with_cassette([parent_orchestration_stack_target], vcr_suffix("orchestration_stack_refresh"))
+
+              assert_stack_and_vm_targeted_refresh
+
+              refresh_with_cassette([child_orchestration_stack_vm_target], vcr_suffix("orchestration_stack_vm_refresh"))
+              assert_stack_and_vm_targeted_refresh
+            end
+          end
+
+          it "will refresh orchestration stack with vms" do
+            2.times do # Run twice to verify that a second run with existing data does not change anything
+              refresh_with_cassette([parent_orchestration_stack_target,
+                                     child_orchestration_stack_vm_target,
+                                     child_orchestration_stack_vm_target2], vcr_suffix("orchestration_stack_refresh"))
+
+              assert_stack_and_vm_targeted_refresh
+            end
+          end
+
+          it "will refresh orchestration stack followed by LoadBalancer refresh" do
+            2.times do # Run twice to verify that a second run with existing data does not change anything
+              refresh_with_cassette([parent_orchestration_stack_target], vcr_suffix("orchestration_stack_refresh"))
+
+              assert_stack_and_vm_targeted_refresh
+
+              refresh_with_cassette([lb_target], vcr_suffix("orchestration_stack_lb_refresh"))
+              assert_stack_and_vm_targeted_refresh
+            end
+          end
+
+          it "will refresh LoadBalancer created by stack" do
+            2.times do # Run twice to verify that a second run with existing data does not change anything
+              refresh_with_cassette([lb_target], vcr_suffix("lb_created_by_stack_refresh"))
+
+              assert_counts(
+                :ext_management_system             => 2,
+                :floating_ip                       => 1,
+                :load_balancer                     => 1,
+                :load_balancer_health_check        => 1,
+                :load_balancer_health_check_member => 2,
+                :load_balancer_listener            => 1,
+                :load_balancer_listener_pool       => 1,
+                :load_balancer_pool                => 1,
+                :load_balancer_pool_member         => 2,
+                :load_balancer_pool_member_pool    => 2,
+                :network_port                      => 1,
+              )
+            end
+          end
+
+          it "will refresh LoadBalancer" do
+            2.times do # Run twice to verify that a second run with existing data does not change anything
+              refresh_with_cassette([lb_non_stack_target], vcr_suffix("lb_refresh"))
+
+              assert_counts(
+                :ext_management_system             => 2,
+                :floating_ip                       => 1,
+                :load_balancer                     => 1,
+                :load_balancer_health_check        => 1,
+                :load_balancer_health_check_member => 2,
+                :load_balancer_listener            => 1,
+                :load_balancer_listener_pool       => 1,
+                :load_balancer_pool                => 1,
+                :load_balancer_pool_member         => 2,
+                :load_balancer_pool_member_pool    => 2,
+                :network_port                      => 1
+              )
+            end
+          end
+
+          it "will refresh LoadBalancer with Vms refreshed before" do
+            # Refresh Vms first
+            2.times do # Run twice to verify that a second run with existing data does not change anything
+              # Refresh Vms
+              refresh_with_cassette(lbs_vms_targets, vcr_suffix("lb_vms_refresh"))
+
+              assert_counts(
+                :availability_zone     => 1,
+                :cloud_network         => 1,
+                :cloud_subnet          => 1,
+                :disk                  => 2,
+                :ext_management_system => 2,
+                :flavor                => 2,
+                :floating_ip           => 2,
+                :hardware              => 2,
+                :network               => 4,
+                :network_port          => 2,
+                :operating_system      => 2,
+                :resource_group        => 1,
+                :security_group        => 2,
+                :vm                    => 2,
+                :vm_or_template        => 2
+              )
+            end
+
+            # Refresh LBs, those have to connect to the Vms
+            2.times do # Run twice to verify that a second run with existing data does not change anything
+              refresh_with_cassette(lbs_targets, vcr_suffix("lbs_refresh"))
+
+              assert_lbs_with_vms
+            end
+          end
+
+          it "will refresh LoadBalancer with Vms" do
+            2.times do # Run twice to verify that a second run with existing data does not change anything
+              refresh_with_cassette(lbs_targets + lbs_vms_targets, vcr_suffix("lb_with_vms_refresh"))
+
+              assert_lbs_with_vms
+            end
+          end
+
+          it "will refresh Template" do
+            2.times do # Run twice to verify that a second run with existing data does not change anything
+              refresh_with_cassette([template_target], vcr_suffix("template_refresh"))
+
+              assert_specific_template
+            end
+          end
+
+          def vcr_suffix(suffix)
+            "_targeted/#{@sub_path}#{suffix}"
+          end
         end
-      end
-
-      it "will refresh powered off VM" do
-        2.times do # Run twice to verify that a second run with existing data does not change anything
-          refresh_with_cassette([vm_powered_off_target], "_targeted/powered_off_vm_refresh")
-
-          assert_specific_az
-          assert_specific_flavor
-          assert_specific_vm_powered_off
-
-          assert_counts(
-            :availability_zone     => 1,
-            :cloud_network         => 1,
-            :cloud_subnet          => 1,
-            :disk                  => 1,
-            :ext_management_system => 2,
-            :flavor                => 1,
-            :floating_ip           => 1,
-            :hardware              => 1,
-            :network               => 2,
-            :network_port          => 1,
-            :operating_system      => 1,
-            :resource_group        => 1,
-            :security_group        => 1,
-            :vm                    => 1,
-            :vm_or_template        => 1
-          )
-        end
-      end
-
-      it "will refresh VM with managed disk" do
-        2.times do # Run twice to verify that a second run with existing data does not change anything
-          refresh_with_cassette([vm_with_managed_disk_target], "_targeted/vm_with_managed_disk_refresh")
-
-          assert_specific_az
-          assert_specific_flavor
-          assert_specific_vm_with_managed_disks
-          assert_specific_managed_disk
-
-          assert_counts(
-            :availability_zone     => 1,
-            :cloud_network         => 1,
-            :cloud_subnet          => 1,
-            :disk                  => 2,
-            :ext_management_system => 2,
-            :flavor                => 1,
-            :floating_ip           => 1,
-            :hardware              => 1,
-            :network               => 2,
-            :network_port          => 1,
-            :operating_system      => 1,
-            :resource_group        => 1,
-            :security_group        => 1,
-            :vm                    => 1,
-            :vm_or_template        => 1
-          )
-        end
-      end
-
-      it "will refresh orchestration stack" do
-        2.times do # Run twice to verify that a second run with existing data does not change anything
-          refresh_with_cassette([parent_orchestration_stack_target], "_targeted/orchestration_stack_refresh")
-
-          assert_stack_and_vm_targeted_refresh
-        end
-      end
-
-      it "will refresh orchestration stack followed by Vm refresh" do
-        2.times do # Run twice to verify that a second run with existing data does not change anything
-          refresh_with_cassette([parent_orchestration_stack_target], "_targeted/orchestration_stack_refresh")
-
-          assert_stack_and_vm_targeted_refresh
-
-          refresh_with_cassette([child_orchestration_stack_vm_target], "_targeted/orchestration_stack_vm_refresh")
-          assert_stack_and_vm_targeted_refresh
-        end
-      end
-
-      it "will refresh orchestration stack with vms" do
-        2.times do # Run twice to verify that a second run with existing data does not change anything
-          refresh_with_cassette([parent_orchestration_stack_target,
-                                 child_orchestration_stack_vm_target,
-                                 child_orchestration_stack_vm_target2], "_targeted/orchestration_stack_refresh")
-
-          assert_stack_and_vm_targeted_refresh
-        end
-      end
-
-      it "will refresh orchestration stack followed by LoadBalancer refresh" do
-        2.times do # Run twice to verify that a second run with existing data does not change anything
-          refresh_with_cassette([parent_orchestration_stack_target], "_targeted/orchestration_stack_refresh")
-
-          assert_stack_and_vm_targeted_refresh
-
-          refresh_with_cassette([lb_target], "_targeted/orchestration_stack_lb_refresh")
-          assert_stack_and_vm_targeted_refresh
-        end
-      end
-
-      it "will refresh LoadBalancer created by stack" do
-        2.times do # Run twice to verify that a second run with existing data does not change anything
-          refresh_with_cassette([lb_target], "_targeted/lb_created_by_stack_refresh")
-
-          assert_counts(
-            :ext_management_system             => 2,
-            :floating_ip                       => 1,
-            :load_balancer                     => 1,
-            :load_balancer_health_check        => 1,
-            :load_balancer_health_check_member => 2,
-            :load_balancer_listener            => 1,
-            :load_balancer_listener_pool       => 1,
-            :load_balancer_pool                => 1,
-            :load_balancer_pool_member         => 2,
-            :load_balancer_pool_member_pool    => 2,
-            :network_port                      => 1,
-          )
-        end
-      end
-
-      it "will refresh LoadBalancer" do
-        2.times do # Run twice to verify that a second run with existing data does not change anything
-          refresh_with_cassette([lb_non_stack_target], "_targeted/lb_refresh")
-
-          assert_counts(
-            :ext_management_system             => 2,
-            :floating_ip                       => 1,
-            :load_balancer                     => 1,
-            :load_balancer_health_check        => 1,
-            :load_balancer_health_check_member => 2,
-            :load_balancer_listener            => 1,
-            :load_balancer_listener_pool       => 1,
-            :load_balancer_pool                => 1,
-            :load_balancer_pool_member         => 2,
-            :load_balancer_pool_member_pool    => 2,
-            :network_port                      => 1
-          )
-        end
-      end
-
-      it "will refresh LoadBalancer with Vms refreshed before" do
-        # Refresh Vms first
-        2.times do # Run twice to verify that a second run with existing data does not change anything
-          # Refresh Vms
-          refresh_with_cassette(lbs_vms_targets, "_targeted/lb_vms_refresh")
-
-          assert_counts(
-            :availability_zone     => 1,
-            :cloud_network         => 1,
-            :cloud_subnet          => 1,
-            :disk                  => 2,
-            :ext_management_system => 2,
-            :flavor                => 2,
-            :floating_ip           => 2,
-            :hardware              => 2,
-            :network               => 4,
-            :network_port          => 2,
-            :operating_system      => 2,
-            :resource_group        => 1,
-            :security_group        => 2,
-            :vm                    => 2,
-            :vm_or_template        => 2
-          )
-        end
-
-        # Refresh LBs, those have to connect to the Vms
-        2.times do # Run twice to verify that a second run with existing data does not change anything
-          refresh_with_cassette(lbs_targets, "_targeted/lbs_refresh")
-
-          assert_lbs_with_vms
-        end
-      end
-
-      it "will refresh LoadBalancer with Vms" do
-        2.times do # Run twice to verify that a second run with existing data does not change anything
-          refresh_with_cassette(lbs_targets + lbs_vms_targets, "_targeted/lb_with_vms_refresh")
-
-          assert_lbs_with_vms
-        end
-      end
-
-      it "will refresh Template" do
-        2.times do # Run twice to verify that a second run with existing data does not change anything
-          refresh_with_cassette([template_target], "_targeted/template_refresh")
-
-          assert_specific_template
-        end
-      end
-
-      def assert_lbs_with_vms
-        assert_specific_load_balancers
-        assert_specific_load_balancer_networking
-        assert_specific_load_balancer_listeners
-        assert_specific_load_balancer_health_checks
-
-        assert_counts(
-          :availability_zone                 => 1,
-          :cloud_network                     => 1,
-          :cloud_subnet                      => 1,
-          :disk                              => 2,
-          :ext_management_system             => 2,
-          :flavor                            => 2,
-          :floating_ip                       => 4,
-          :hardware                          => 2,
-          :load_balancer                     => 2,
-          :load_balancer_health_check        => 2,
-          :load_balancer_health_check_member => 2,
-          :load_balancer_listener            => 1,
-          :load_balancer_listener_pool       => 1,
-          :load_balancer_pool                => 1,
-          :load_balancer_pool_member         => 2,
-          :load_balancer_pool_member_pool    => 2,
-          :network                           => 4,
-          :network_port                      => 4,
-          :operating_system                  => 2,
-          :resource_group                    => 1,
-          :security_group                    => 2,
-          :vm                                => 2,
-          :vm_or_template                    => 2
-        )
-      end
-
-      def assert_stack_and_vm_targeted_refresh
-        assert_specific_orchestration_template
-        assert_specific_orchestration_stack
-
-        assert_counts(
-          :availability_zone                 => 1,
-          :cloud_network                     => 1,
-          :cloud_subnet                      => 1,
-          :disk                              => 2,
-          :ext_management_system             => 2,
-          :flavor                            => 1,
-          :floating_ip                       => 1,
-          :hardware                          => 2,
-          :load_balancer                     => 1,
-          :load_balancer_health_check        => 1,
-          :load_balancer_health_check_member => 2,
-          :load_balancer_listener            => 1,
-          :load_balancer_listener_pool       => 1,
-          :load_balancer_pool                => 1,
-          :load_balancer_pool_member         => 2,
-          :load_balancer_pool_member_pool    => 2,
-          :network                           => 2,
-          :network_port                      => 3,
-          :operating_system                  => 2,
-          :orchestration_stack               => 2,
-          :orchestration_stack_output        => 1,
-          :orchestration_stack_parameter     => 29,
-          :orchestration_stack_resource      => 10,
-          :orchestration_template            => 2,
-          :resource_group                    => 1,
-          :vm                                => 2,
-          :vm_or_template                    => 2
-        )
       end
     end
   end

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_0/cloud_network_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_0/cloud_network_refresh.yml
@@ -37,25 +37,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 7d108843-a6de-4cc5-92b1-0868af680000
+      - ebd2e972-482d-4bce-9a85-162a84613000
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzaSHqGwHOauf4voYLrGKKV_qqkqjaznT_tZ1QtZbn20sdC8Y_T3CD-0IV2fjcuDcGJtadDc1bq8-qtFWwcy4SYChbgBcbkuvMtkXSHH8vuWi4AIxVLM1OwZYPRvAX3J_kuXZYBF3vm-kQp8iRsPoP00xe7d0eBt4uIsNeod-nB2MgAA;
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzGjywk_6ytdKk7J9zG5xr2lQhPkeImCBcvwVivls0Iq63Fr1ZoYa0XsuytlqsHOT2qtj_yK3yNFsJtBsjybHYTExBndxFQs6h1199LOqaBQbVkOQtSwuaIbgM4nwNkv9i7_VGzPJHg8P-IoMjKtTJhO8HUrsdij35vV5UbhkpFjggAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=005; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=003; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Wed, 07 Mar 2018 20:15:26 GMT
+      - Tue, 13 Mar 2018 09:04:00 GMT
       Content-Length:
       - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1520457326","not_before":"1520453426","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MjYsIm5iZiI6MTUyMDQ1MzQyNiwiZXhwIjoxNTIwNDU3MzI2LCJhaW8iOiJZMk5nWUZnM1ZTb25RVDZncW42dU9kZUdvNHVMQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUTRnUWZkNm14VXlTc1Fob3IyZ0FBQSIsInZlciI6IjEuMCJ9.cXVtvbA20Qqk3Vd6I9V2JeVoczYtuGbyZd0QQIEeoHWdsLCXzLWkNGZauHk2ioWJIoZSDC5LVT0siDS6dwcWKpl-9Y59-KyCVGwgOJ4pXH2xya_Kg6jysSxzOiX6CzNaz4VXrkM5KfK5Q5ZhcKIzJ-CtEJGH5uVM3EC3wnfEZFrxu_t-nANtMwkiF2TB0fNU1PHyEI186OhQCF7xOxnKxi3OaqZahN1Uy6xScgZpPU-25USMia4LAI3JJBZf3Dpm2N-5pepjOIdkrA6b7D4hb3f6llcga7cPhBjmSMiQFwa5N-9xKUjuOQohIieMAQmszZSsLWSBJcJfl36-eObc7w"}'
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1520935440","not_before":"1520931540","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA5MzE1NDAsIm5iZiI6MTUyMDkzMTU0MCwiZXhwIjoxNTIwOTM1NDQwLCJhaW8iOiJZMk5nWUdBTzluZzJLY25wRWNmV20xS1NCOXJmQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiY3VuUzZ5MUl6a3VhaFJZcWhHRXdBQSIsInZlciI6IjEuMCJ9.el95m2jWhpRPmDtJRsUg0KuMR7KUDQVmOL1b1YeSVwiAl9IH3F0EC-t3HDtBiRbzNx10Tmyc6rzkYsPcun_THOHn3_lqUA0XJXsUiW9DL0qny2dgLDwQFsDf9cdG5NuEKl9byrsCg15ZQ8SxWzvgRKbvv2jfKeptYFux4k0U6IU1gLM5uAbII_cpJqeaVWfWQ48JPDNWyybjGttjtASfAZRML2YgJTKUbmhmgopd1NFYqoy_MSja9C1Z5IJCwVOO8tmbdqhdA29jQVcCznZdADyaorLpwu00zXJmqLEpqWgDEMmpBQ2Cin9LgoYIMuglQ1gexvx7rdMC31e3GCI8dQ"}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:26 GMT
+  recorded_at: Tue, 13 Mar 2018 09:04:00 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -72,7 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MjYsIm5iZiI6MTUyMDQ1MzQyNiwiZXhwIjoxNTIwNDU3MzI2LCJhaW8iOiJZMk5nWUZnM1ZTb25RVDZncW42dU9kZUdvNHVMQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUTRnUWZkNm14VXlTc1Fob3IyZ0FBQSIsInZlciI6IjEuMCJ9.cXVtvbA20Qqk3Vd6I9V2JeVoczYtuGbyZd0QQIEeoHWdsLCXzLWkNGZauHk2ioWJIoZSDC5LVT0siDS6dwcWKpl-9Y59-KyCVGwgOJ4pXH2xya_Kg6jysSxzOiX6CzNaz4VXrkM5KfK5Q5ZhcKIzJ-CtEJGH5uVM3EC3wnfEZFrxu_t-nANtMwkiF2TB0fNU1PHyEI186OhQCF7xOxnKxi3OaqZahN1Uy6xScgZpPU-25USMia4LAI3JJBZf3Dpm2N-5pepjOIdkrA6b7D4hb3f6llcga7cPhBjmSMiQFwa5N-9xKUjuOQohIieMAQmszZSsLWSBJcJfl36-eObc7w
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA5MzE1NDAsIm5iZiI6MTUyMDkzMTU0MCwiZXhwIjoxNTIwOTM1NDQwLCJhaW8iOiJZMk5nWUdBTzluZzJLY25wRWNmV20xS1NCOXJmQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiY3VuUzZ5MUl6a3VhaFJZcWhHRXdBQSIsInZlciI6IjEuMCJ9.el95m2jWhpRPmDtJRsUg0KuMR7KUDQVmOL1b1YeSVwiAl9IH3F0EC-t3HDtBiRbzNx10Tmyc6rzkYsPcun_THOHn3_lqUA0XJXsUiW9DL0qny2dgLDwQFsDf9cdG5NuEKl9byrsCg15ZQ8SxWzvgRKbvv2jfKeptYFux4k0U6IU1gLM5uAbII_cpJqeaVWfWQ48JPDNWyybjGttjtASfAZRML2YgJTKUbmhmgopd1NFYqoy_MSja9C1Z5IJCwVOO8tmbdqhdA29jQVcCznZdADyaorLpwu00zXJmqLEpqWgDEMmpBQ2Cin9LgoYIMuglQ1gexvx7rdMC31e3GCI8dQ
   response:
     status:
       code: 200
@@ -91,26 +91,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14996'
+      - '14999'
       X-Ms-Request-Id:
-      - cb58078a-8307-42c9-bf29-8fa72db099f3
+      - 4472754c-effd-4bb0-b061-a60591ceafa3
       X-Ms-Correlation-Request-Id:
-      - cb58078a-8307-42c9-bf29-8fa72db099f3
+      - 4472754c-effd-4bb0-b061-a60591ceafa3
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201526Z:cb58078a-8307-42c9-bf29-8fa72db099f3
+      - WESTEUROPE:20180313T090400Z:4472754c-effd-4bb0-b061-a60591ceafa3
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:15:25 GMT
+      - Tue, 13 Mar 2018 09:03:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID","subscriptionId":"AZURE_SUBSCRIPTION_ID","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:27 GMT
+  recorded_at: Tue, 13 Mar 2018 09:04:00 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers?api-version=2015-01-01
@@ -127,7 +127,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MjYsIm5iZiI6MTUyMDQ1MzQyNiwiZXhwIjoxNTIwNDU3MzI2LCJhaW8iOiJZMk5nWUZnM1ZTb25RVDZncW42dU9kZUdvNHVMQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUTRnUWZkNm14VXlTc1Fob3IyZ0FBQSIsInZlciI6IjEuMCJ9.cXVtvbA20Qqk3Vd6I9V2JeVoczYtuGbyZd0QQIEeoHWdsLCXzLWkNGZauHk2ioWJIoZSDC5LVT0siDS6dwcWKpl-9Y59-KyCVGwgOJ4pXH2xya_Kg6jysSxzOiX6CzNaz4VXrkM5KfK5Q5ZhcKIzJ-CtEJGH5uVM3EC3wnfEZFrxu_t-nANtMwkiF2TB0fNU1PHyEI186OhQCF7xOxnKxi3OaqZahN1Uy6xScgZpPU-25USMia4LAI3JJBZf3Dpm2N-5pepjOIdkrA6b7D4hb3f6llcga7cPhBjmSMiQFwa5N-9xKUjuOQohIieMAQmszZSsLWSBJcJfl36-eObc7w
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA5MzE1NDAsIm5iZiI6MTUyMDkzMTU0MCwiZXhwIjoxNTIwOTM1NDQwLCJhaW8iOiJZMk5nWUdBTzluZzJLY25wRWNmV20xS1NCOXJmQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiY3VuUzZ5MUl6a3VhaFJZcWhHRXdBQSIsInZlciI6IjEuMCJ9.el95m2jWhpRPmDtJRsUg0KuMR7KUDQVmOL1b1YeSVwiAl9IH3F0EC-t3HDtBiRbzNx10Tmyc6rzkYsPcun_THOHn3_lqUA0XJXsUiW9DL0qny2dgLDwQFsDf9cdG5NuEKl9byrsCg15ZQ8SxWzvgRKbvv2jfKeptYFux4k0U6IU1gLM5uAbII_cpJqeaVWfWQ48JPDNWyybjGttjtASfAZRML2YgJTKUbmhmgopd1NFYqoy_MSja9C1Z5IJCwVOO8tmbdqhdA29jQVcCznZdADyaorLpwu00zXJmqLEpqWgDEMmpBQ2Cin9LgoYIMuglQ1gexvx7rdMC31e3GCI8dQ
   response:
     status:
       code: 200
@@ -144,39 +144,37 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14979'
+      - '14911'
       X-Ms-Request-Id:
-      - 1d0f345f-fe6b-4a66-8fcb-f93e39dab59b
+      - 06776bb7-8fee-4ba9-a745-c92d8af92728
       X-Ms-Correlation-Request-Id:
-      - 1d0f345f-fe6b-4a66-8fcb-f93e39dab59b
+      - 06776bb7-8fee-4ba9-a745-c92d8af92728
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201528Z:1d0f345f-fe6b-4a66-8fcb-f93e39dab59b
+      - WESTEUROPE:20180313T090402Z:06776bb7-8fee-4ba9-a745-c92d8af92728
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:15:27 GMT
+      - Tue, 13 Mar 2018 09:04:02 GMT
       Content-Length:
-      - '310505'
+      - '322992'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"},{"applicationId":"d87dcbc6-a371-462e-88e3-28ad15ec4e64","roleDefinitionId":"861776c5-e0df-4f95-be4f-ac1eec193323"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
+      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"},{"applicationId":"d87dcbc6-a371-462e-88e3-28ad15ec4e64","roleDefinitionId":"861776c5-e0df-4f95-be4f-ac1eec193323"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["East
+        Asia","Southeast Asia","Australia East","Australia Southeast","Japan East","Japan
+        West","Central India","South India","West India","West Europe","North Europe","Canada
+        Central","Canada East","Brazil South","West US","Central US","East US","South
+        Central US","East US 2","West Central US","North Central US","West US 2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
         US","Central US","East US","South Central US","West Europe","North Europe","East
         Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
         Central US","North Central US","Japan East","Japan West","Brazil South","Central
         India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"operations","locations":["West
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["East
+        Asia","Southeast Asia","Australia East","Australia Southeast","Japan East","Japan
+        West","Central India","South India","West India","West Europe","North Europe","Canada
+        Central","Canada East","Brazil South","West US","Central US","East US","South
+        Central US","East US 2","West Central US","North Central US","West US 2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"operations","locations":["West
         US","Central US","East US","South Central US","West Europe","North Europe","East
         Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
         Central US","North Central US","Japan East","Japan West","Brazil South","Central
@@ -232,177 +230,177 @@ http_interactions:
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/internalLoadBalancers","locations":[],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"domainNames/slots/roles/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"domainNames/slots/roles/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"domainNames/capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"domainNames/serviceCertificates","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
         US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
         Central","Canada East","UK South","UK West","West US","Central US","South
         Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
-        East","Australia Southeast","West US 2","West Central US","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        East","Australia Southeast","West US 2","West Central US","France Central","South
+        India","Central India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
         US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
         Central","Canada East","UK South","UK West","West US","Central US","South
         Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
-        East","Australia Southeast","West US 2","West Central US","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metrics","locations":["North
+        East","Australia Southeast","West US 2","West Central US","France Central","South
+        India","Central India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metrics","locations":["North
         Central US","South Central US","East US","East US 2","Canada Central","Canada
         East","West US","West US 2","West Central US","Central US","East Asia","Southeast
         Asia","North Europe","West Europe","UK South","UK West","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"resourceTypes","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"moveSubscriptionResources","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"validateSubscriptionMoveAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operationStatuses","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operatingSystems","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"operatingSystemFamilies","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicNetwork","namespace":"Microsoft.ClassicNetwork","resourceTypes":[{"resourceType":"virtualNetworks","locations":["East
+        India","West India","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"resourceTypes","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"moveSubscriptionResources","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"validateSubscriptionMoveAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operationStatuses","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operatingSystems","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"operatingSystemFamilies","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicNetwork","namespace":"Microsoft.ClassicNetwork","resourceTypes":[{"resourceType":"virtualNetworks","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"virtualNetworks/remoteVirtualNetworkPeeringProxies","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01"]},{"resourceType":"virtualNetworks/remoteVirtualNetworkPeeringProxies","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"reservedIps","locations":["East
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01"]},{"resourceType":"reservedIps","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"gatewaySupportedDevices","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"networkSecurityGroups","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"gatewaySupportedDevices","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"networkSecurityGroups","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicStorage","namespace":"Microsoft.ClassicStorage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"expressRouteCrossConnections","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"expressRouteCrossConnections/peerings","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicStorage","namespace":"Microsoft.ClassicStorage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkStorageAccountAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"storageAccounts/services","locations":["West
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkStorageAccountAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"storageAccounts/services","locations":["West
         US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
         Asia","Australia East","Australia Southeast","South India","Central India","West
         India","West US 2","West Central US","East US","East US 2","North Central
         US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
-        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/diagnosticSettings","locations":["West
+        South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/diagnosticSettings","locations":["West
         US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
         Asia","Australia East","Australia Southeast","South India","Central India","West
         India","West US 2","West Central US","East US","East US 2","North Central
         US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
-        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"disks","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"images","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"vmImages","locations":[],"apiVersions":["2016-11-01"]},{"resourceType":"publicImages","locations":[],"apiVersions":["2016-11-01","2016-04-01"]},{"resourceType":"osImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"osPlatformImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute","namespace":"Microsoft.Compute","authorizations":[{"applicationId":"60e6cd67-9c8c-4951-9b3c-23c25a2169af","roleDefinitionId":"e4770acb-272e-4dc8-87f3-12f44a612224"},{"applicationId":"a303894e-f1d8-4a37-bf10-67aa654a0596","roleDefinitionId":"903ac751-8ad5-4e5a-bfc2-5e49f450a241"},{"applicationId":"a8b6bf88-1d1a-4626-b040-9a729ea93c65","roleDefinitionId":"45c8267c-80ba-4b96-9a43-115b8f49fccd"}],"resourceTypes":[{"resourceType":"availabilitySets","locations":["East
+        South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"disks","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"images","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"vmImages","locations":[],"apiVersions":["2016-11-01"]},{"resourceType":"storageAccounts/vmImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"publicImages","locations":[],"apiVersions":["2016-11-01","2016-04-01"]},{"resourceType":"osImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"osPlatformImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute","namespace":"Microsoft.Compute","authorizations":[{"applicationId":"60e6cd67-9c8c-4951-9b3c-23c25a2169af","roleDefinitionId":"e4770acb-272e-4dc8-87f3-12f44a612224"},{"applicationId":"a303894e-f1d8-4a37-bf10-67aa654a0596","roleDefinitionId":"903ac751-8ad5-4e5a-bfc2-5e49f450a241"},{"applicationId":"a8b6bf88-1d1a-4626-b040-9a729ea93c65","roleDefinitionId":"45c8267c-80ba-4b96-9a43-115b8f49fccd"}],"resourceTypes":[{"resourceType":"availabilitySets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations/usages","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations/usages","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"sharedVMImages","locations":["West
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"sharedVMImages","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"sharedVMImages/versions","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"locations/capsoperations","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"disks","locations":["Southeast
@@ -410,27 +408,27 @@ http_interactions:
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"snapshots","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"snapshots","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"locations/diskoperations","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"locations/diskoperations","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"images","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"images","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"]},{"resourceType":"locations/logAnalytics","locations":["East
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"]},{"resourceType":"locations/logAnalytics","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
         US","East US","South Central US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
@@ -500,7 +498,10 @@ http_interactions:
         Central US","West Europe","North Europe","East US","UK West","UK South","West
         Central US","West US 2","South India","Central India","West India","Canada
         East","Canada Central","Korea South","Korea Central"],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"managedClusters","locations":["East
-        US","West Europe","Central US","Canada Central","Canada East"],"apiVersions":["2017-08-31"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
+        US","West Europe","Central US","Canada Central","Canada East"],"apiVersions":["2017-08-31"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operationresults","locations":["East
+        US","West Europe","Central US","UK West","UK South","West Central US","West
+        US 2","South India","Central India","West India","Canada East","Canada Central","Korea
+        South","Korea Central"],"apiVersions":["2017-08-31","2016-03-30"]},{"resourceType":"locations/operations","locations":["Japan
         East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
@@ -547,7 +548,12 @@ http_interactions:
         US","East Asia","East US","East US 2","Japan East","Japan West","North Central
         US","North Europe","South Central US","South India","Southeast Asia","West
         Central US","West Europe","West India","West US","West US 2","UK West","UK
-        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"},{"applicationId":"f5c26e74-f226-4ae8-85f0-b4af0080ac9e","roleDefinitionId":"529d7ae6-e892-4d43-809d-8547aeb90643"}],"resourceTypes":[{"resourceType":"components","locations":["East
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/consumergroups","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/disasterrecoveryconfigs","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"},{"applicationId":"f5c26e74-f226-4ae8-85f0-b4af0080ac9e","roleDefinitionId":"529d7ae6-e892-4d43-809d-8547aeb90643"}],"resourceTypes":[{"resourceType":"components","locations":["East
         US","South Central US","North Europe","West Europe","Southeast Asia","West
         US 2"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
         US","South Central US","North Europe","West Europe","Southeast Asia","West
@@ -563,7 +569,7 @@ http_interactions:
         US","South Central US","North Europe","West Europe","Southeast Asia","West
         US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"listMigrationdate","locations":["East
         US","South Central US","North Europe","West Europe","Southeast Asia","West
-        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2018-03-01","2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
@@ -614,32 +620,32 @@ http_interactions:
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/accessPolicies","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"vaults/accessPolicies","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-10-01","2015-06-01","2014-12-19-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"deletedVaults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01","2014-12-19-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"deletedVaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-10-01"]},{"resourceType":"locations/deletedVaults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations/deletedVaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
         Central US","West Europe","Southeast Asia","Japan East","West Central US"],"apiVersions":["2016-04-01"]},{"resourceType":"webServices","locations":["South
         Central US","West Europe","Southeast Asia","Japan East","East US 2","West
         Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"operations","locations":["South
@@ -665,97 +671,102 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"networkWatchers/lenses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"networkWatchers/lenses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2018-02-01","2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"ddosProtectionPlans","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","West
         US 2","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
@@ -846,7 +857,7 @@ http_interactions:
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
         West","Korea Central","Korea South"],"apiVersions":["2017-07-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ResourceHealth","namespace":"Microsoft.ResourceHealth","authorizations":[{"applicationId":"8bdebf23-c0fe-4187-a378-717ad86f6a53","roleDefinitionId":"cc026344-c8b1-4561-83ba-59eba84b27cc"}],"resourceTypes":[{"resourceType":"availabilityStatuses","locations":[],"apiVersions":["2017-07-01","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"notifications","locations":["Australia
-        Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Security","namespace":"Microsoft.Security","authorization":{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
+        Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Security","namespace":"Microsoft.Security","authorizations":[{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},{"applicationId":"fc780465-2017-40d4-a0c5-307022471b92"}],"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatuses","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/virtualMachines","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/endpoints","locations":["Central
@@ -898,620 +909,650 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Central India","South
         India"],"apiVersions":["2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Sql","namespace":"Microsoft.Sql","authorizations":[{"applicationId":"e4ab13ed-33cb-41b4-9140-6e264582cf85","roleDefinitionId":"ec3ddc95-44dc-47a2-9926-5e9f5ffd44ec"},{"applicationId":"0130cc9f-7ac5-4026-bd5f-80a08a54e6d9","roleDefinitionId":"45e8abf8-0ec4-44f3-9c37-cff4f7779302"},{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},{"applicationId":"76c7f279-7959-468f-8943-3954880e0d8c","roleDefinitionId":"7f7513a8-73f9-4c5f-97a2-c41f0ea783ef"}],"resourceTypes":[{"resourceType":"operations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/capabilities","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/databaseAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/databaseOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverKeyOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/keys","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/encryptionProtector","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/usages","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01","2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/communicationLinks","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administrators","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administratorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/restorableDroppedDatabases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recoverableDatabases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/geoBackupPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/importExportOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/operationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/backupLongTermRetentionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/automaticTuning","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/automaticTuning","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/databases/transparentDataEncryption","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recommendedElasticPools","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/auditingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/connectionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/connectionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies/rules","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/securityAlertPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/securityAlertPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/auditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/extendedAuditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/elasticpools","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-09-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/jobAgentOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/jobAgentAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/disasterRecoveryConfiguration","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/dnsAliases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/failoverGroups","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/virtualNetworkRules","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/virtualNetworkRulesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/virtualNetworkRulesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/databaseRestoreAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metricDefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/aggregatedDatabaseMetrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metricdefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries/queryText","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPools/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/extensions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPoolEstimates","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditRecords","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentScans","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/vulnerabilityAssessments","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessment","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/syncGroups","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups/syncMembers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/syncAgents","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"managedInstances/administrators","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/databases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metricDefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/administratorAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/administratorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncMemberOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncAgentOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncDatabaseIds","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorizations":[{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},{"applicationId":"e406a681-f3d4-42a8-90b6-c2b029497af1"}],"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/capabilities","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/databaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"locations/databaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverKeyOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/keys","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/encryptionProtector","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01","2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/communicationLinks","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/restorableDroppedDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recoverableDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/geoBackupPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/importExportOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/operationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/backupLongTermRetentionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/databases/transparentDataEncryption","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recommendedElasticPools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies/rules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/extendedAuditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/elasticPoolAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/elasticPoolOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/elasticpools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-09-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/jobAgentOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/jobAgentAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/disasterRecoveryConfiguration","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/dnsAliases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/failoverGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/virtualNetworkRules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/virtualNetworkRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/virtualNetworkRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/databaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/aggregatedDatabaseMetrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metricdefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries/queryText","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPools/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/extensions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPoolEstimates","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditRecords","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentScans","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/vulnerabilityAssessments","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessment","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/syncGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups/syncMembers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/syncAgents","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"managedInstances/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/administratorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncMemberOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncAgentOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncDatabaseIds","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/longTermRetentionPolicyOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionPolicyAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionBackupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionBackupAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorizations":[{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},{"applicationId":"e406a681-f3d4-42a8-90b6-c2b029497af1"}],"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/asyncoperations","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/asyncoperations","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/listAccountSas","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/listAccountSas","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/listServiceSas","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/listServiceSas","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/blobServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/blobServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/tableServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/tableServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/queueServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/queueServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/fileServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/fileServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01","2016-01-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01","2016-01-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
         US","West US","West Europe","North Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":["East
         US","West US","West Europe","North Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.visualstudio","namespace":"microsoft.visualstudio","authorization":{"applicationId":"499b84ac-1321-427f-aa17-267ca6975798","roleDefinitionId":"6a18f445-86f0-4e2e-b8a9-6b9b5677e3d8"},"resourceTypes":[{"resourceType":"account","locations":["North
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.visualstudio","namespace":"microsoft.visualstudio","authorization":{"applicationId":"499b84ac-1321-427f-aa17-267ca6975798","roleDefinitionId":"6a18f445-86f0-4e2e-b8a9-6b9b5677e3d8"},"resourceTypes":[{"resourceType":"account","locations":["North
         Central US","South Central US","East US","West US","Central US","North Europe","West
         Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
         East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/project","locations":["North
@@ -1795,12 +1836,12 @@ http_interactions:
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","Canada Central","Canada East","UK South","UK West","West US 2","West
-        Central US","South India","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","South India","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","South India","Canada Central","Canada East","UK South","UK West","West
-        US 2","West Central US","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Capacity","namespace":"Microsoft.Capacity","authorization":{"applicationId":"4d0ad6c7-f6c3-46d8-ab0d-1406d5e6c86b","roleDefinitionId":"FD9C0A9A-4DB9-4F41-8A61-98385DEB6E2D"},"resourceTypes":[{"resourceType":"resources","locations":["South
+        US 2","West Central US","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Capacity","namespace":"Microsoft.Capacity","authorization":{"applicationId":"4d0ad6c7-f6c3-46d8-ab0d-1406d5e6c86b","roleDefinitionId":"FD9C0A9A-4DB9-4F41-8A61-98385DEB6E2D"},"resourceTypes":[{"resourceType":"resources","locations":["South
         Central US"],"apiVersions":["2017-11-01"]},{"resourceType":"reservationOrders","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/reservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/reservations/revisions","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"catalogs","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"appliedReservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"checkOffers","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"checkScopes","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"calculatePrice","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/calculateRefund","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/return","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/split","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/merge","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"validateReservationOrder","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/availableScopes","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Cdn","namespace":"Microsoft.Cdn","resourceTypes":[{"resourceType":"profiles","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
@@ -1876,9 +1917,9 @@ http_interactions:
         2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/updateAccountsCreationSettings","locations":["West
         US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/accountsCreationSettings","locations":["West
         US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2016-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Commerce","namespace":"Microsoft.Commerce","resourceTypes":[{"resourceType":"UsageAggregates","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]},{"resourceType":"RateCard","locations":[],"apiVersions":["2016-08-31-preview","2015-06-01-preview","2015-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Consumption","namespace":"Microsoft.Consumption","resourceTypes":[{"resourceType":"ReservationSummaries","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationTransactions","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Balances","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Marketplaces","locations":[],"apiVersions":["2018-01-31"]},{"resourceType":"Pricesheets","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationDetails","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Budgets","locations":[],"apiVersions":["2018-01-31","2017-12-30-preview"]},{"resourceType":"Terms","locations":[],"apiVersions":["2018-01-31","2017-12-30-preview"]},{"resourceType":"UsageDetails","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview","2017-04-24-preview"]},{"resourceType":"Operations","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview","2017-04-24-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerInstance","namespace":"Microsoft.ContainerInstance","resourceTypes":[{"resourceType":"containerGroups","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/usages","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/operations","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/operations","locations":["West
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
         US"],"apiVersions":["2016-04-08"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.CustomerInsights","namespace":"Microsoft.CustomerInsights","authorization":{"applicationId":"38c77d00-5fcb-4cce-9d93-af4738258e3c","roleDefinitionId":"E006F9C7-F333-477C-8AD6-1F3A9FE87F55"},"resourceTypes":[{"resourceType":"hubs","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/profiles","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/interactions","locations":["East
@@ -1895,7 +1936,9 @@ http_interactions:
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"operations","locations":["East
         US 2"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Databricks","namespace":"Microsoft.Databricks","authorizations":[{"applicationId":"d9327919-6775-4843-9037-3fb0fb0473cb","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},{"applicationId":"2ff814a6-3304-4ab8-85cb-cd0e6f879c1d","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"}],"resourceTypes":[{"resourceType":"workspaces","locations":["West
         US","East US 2","West Europe","East US","North Europe","Southeast Asia","East
-        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]},{"resourceType":"locations","locations":["West
+        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2017-09-01-preview"]},{"resourceType":"workspaces/virtualNetworkPeerings","locations":["West
+        US","East US 2","West Europe","North Europe","East US","Southeast Asia","East
+        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01"]},{"resourceType":"locations","locations":["West
         US","East US 2","West Europe","North Europe","East US","Southeast Asia"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
         US","East US 2","West Europe","East US","North Europe","Southeast Asia","East
         Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataCatalog","namespace":"Microsoft.DataCatalog","resourceTypes":[{"resourceType":"catalogs","locations":["East
@@ -1919,23 +1962,26 @@ http_interactions:
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers/listSasTokens","locations":["East
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataLakeStore","namespace":"Microsoft.DataLakeStore","authorization":{"applicationId":"e9f49c6b-5ce5-44c8-925d-015017e9f7ad","roleDefinitionId":"17eb9cca-f08a-4499-b2d3-852d175f614f"},"resourceTypes":[{"resourceType":"accounts","locations":["East
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/firewallRules","locations":["East
-        US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataMigration","namespace":"Microsoft.DataMigration","authorization":{"applicationId":"a4bad4aa-bf02-4631-9f78-a64ffdba8150","roleDefinitionId":"b831a21d-db98-4760-89cb-bef871952df1","managedByRoleDefinitionId":"6256fb55-9e59-4018-a9e1-76b11c0a4c89"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services/projects","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationStatuses","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
+        US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataMigration","namespace":"Microsoft.DataMigration","authorization":{"applicationId":"a4bad4aa-bf02-4631-9f78-a64ffdba8150","roleDefinitionId":"b831a21d-db98-4760-89cb-bef871952df1","managedByRoleDefinitionId":"6256fb55-9e59-4018-a9e1-76b11c0a4c89"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services/projects","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationStatuses","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
-        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/recoverableServers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
@@ -1959,7 +2005,10 @@ http_interactions:
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
-        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/recoverableServers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
@@ -2015,12 +2064,7 @@ http_interactions:
         US 2","East US","West US","Central US","East US 2","West Central US","West
         Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
         US 2","East US","West US","Central US","East US 2","West Central US","West
-        Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","West
-        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
-        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
-        India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/consumergroups","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/disasterrecoveryconfigs","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
         US 2","South Central US","Central US","Australia Southeast","Central India","West
         Central US","West US 2","Canada East","Canada Central","Brazil South","UK
         South","UK West","East Asia","Australia East","Japan East","Japan West","North
@@ -2131,7 +2175,7 @@ http_interactions:
         West","Japan East","East Asia","Southeast Asia","West Europe","North Europe","East
         US","West US","Australia East","Australia Southeast","Central US","Brazil
         South","Central India","West India","South India","South Central US","Canada
-        Central","Canada East","West Central US","West US 2"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
+        Central","Canada East","West Central US","West US 2"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-05","2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
         Central US","East US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"operations","locations":["West
         Central US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
         Central US","East US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.PolicyInsights","namespace":"Microsoft.PolicyInsights","authorization":{"applicationId":"1d78a85d-813d-46f0-b496-dd72f50a3ec0","roleDefinitionId":"63d2b225-4c34-4641-8768-21a1f7c68ce8"},"resourceTypes":[{"resourceType":"policyEvents","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"policyStates","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
@@ -2163,12 +2207,12 @@ http_interactions:
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
         Central US","South Central US","North Europe","West Europe","East Asia","Southeast
         Asia","West US","East US","Japan West","Japan East","Brazil South","Central
         US","East US 2","Australia East","Australia Southeast","South India","Central
@@ -2193,7 +2237,8 @@ http_interactions:
         US","West US 2","East US","East US 2","North Europe","West Europe","Southeast
         Asia","East Asia","North Central US","South Central US","Japan West","Australia
         East","Brazil South","Central India","West Central US","Canada Central","UK
-        South"],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ServiceBus","namespace":"Microsoft.ServiceBus","authorization":{"applicationId":"80a10ef9-8168-493d-abf9-3297c4ef6e3c","roleDefinitionId":"2b7763f7-bbe2-4e19-befe-28c79f1cf7f7"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        South"],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.SecurityGraph","namespace":"Microsoft.SecurityGraph","resourceTypes":[{"resourceType":"operations","locations":["West
+        US"],"apiVersions":["2017-04-01-preview"]},{"resourceType":"diagnosticSettings","locations":[],"apiVersions":["2017-04-01-preview"]},{"resourceType":"diagnosticSettingsCategories","locations":[],"apiVersions":["2017-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ServiceBus","namespace":"Microsoft.ServiceBus","authorization":{"applicationId":"80a10ef9-8168-493d-abf9-3297c4ef6e3c","roleDefinitionId":"2b7763f7-bbe2-4e19-befe-28c79f1cf7f7"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US 2","West
         US","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
@@ -2208,52 +2253,62 @@ http_interactions:
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/clusterVersions","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"clusters/applications","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operations","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/clusterVersions","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/environments","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operations","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
         Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applianceDefinitions","locations":["West
         Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applications","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
-        Central US"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
+        Central US"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
-        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
-        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups","locations":["West
-        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
-        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups/cloudEndpoints","locations":["West
-        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
-        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups/serverEndpoints","locations":["West
-        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
-        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/registeredServers","locations":["West
-        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
-        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/workflows","locations":["West
-        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
-        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
+        US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
+        US","Canada Central","Canada East","Central US","East US 2","UK South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups","locations":["West
+        US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
+        US","Canada Central","Canada East","Central US","East US 2","UK South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups/cloudEndpoints","locations":["West
+        US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
+        US","Canada Central","Canada East","Central US","East US 2","UK South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups/serverEndpoints","locations":["West
+        US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
+        US","Canada Central","Canada East","Central US","East US 2","UK South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/registeredServers","locations":["West
+        US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
+        US","Canada Central","Canada East","Central US","East US 2","UK South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/workflows","locations":["West
+        US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
+        US","Canada Central","Canada East","Central US","East US 2","UK South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","West Central US","Japan East","Japan West","Australia East","Australia
         Southeast"],"apiVersions":["2017-06-01","2017-05-15","2017-01-01","2016-10-01","2016-06-01","2015-03-15","2014-09-01"]},{"resourceType":"operations","locations":["West
@@ -2332,10 +2387,10 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:28 GMT
+  recorded_at: Tue, 13 Mar 2018 09:04:02 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2?api-version=2018-03-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2349,7 +2404,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MjYsIm5iZiI6MTUyMDQ1MzQyNiwiZXhwIjoxNTIwNDU3MzI2LCJhaW8iOiJZMk5nWUZnM1ZTb25RVDZncW42dU9kZUdvNHVMQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUTRnUWZkNm14VXlTc1Fob3IyZ0FBQSIsInZlciI6IjEuMCJ9.cXVtvbA20Qqk3Vd6I9V2JeVoczYtuGbyZd0QQIEeoHWdsLCXzLWkNGZauHk2ioWJIoZSDC5LVT0siDS6dwcWKpl-9Y59-KyCVGwgOJ4pXH2xya_Kg6jysSxzOiX6CzNaz4VXrkM5KfK5Q5ZhcKIzJ-CtEJGH5uVM3EC3wnfEZFrxu_t-nANtMwkiF2TB0fNU1PHyEI186OhQCF7xOxnKxi3OaqZahN1Uy6xScgZpPU-25USMia4LAI3JJBZf3Dpm2N-5pepjOIdkrA6b7D4hb3f6llcga7cPhBjmSMiQFwa5N-9xKUjuOQohIieMAQmszZSsLWSBJcJfl36-eObc7w
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA5MzE1NDAsIm5iZiI6MTUyMDkzMTU0MCwiZXhwIjoxNTIwOTM1NDQwLCJhaW8iOiJZMk5nWUdBTzluZzJLY25wRWNmV20xS1NCOXJmQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiY3VuUzZ5MUl6a3VhaFJZcWhHRXdBQSIsInZlciI6IjEuMCJ9.el95m2jWhpRPmDtJRsUg0KuMR7KUDQVmOL1b1YeSVwiAl9IH3F0EC-t3HDtBiRbzNx10Tmyc6rzkYsPcun_THOHn3_lqUA0XJXsUiW9DL0qny2dgLDwQFsDf9cdG5NuEKl9byrsCg15ZQ8SxWzvgRKbvv2jfKeptYFux4k0U6IU1gLM5uAbII_cpJqeaVWfWQ48JPDNWyybjGttjtASfAZRML2YgJTKUbmhmgopd1NFYqoy_MSja9C1Z5IJCwVOO8tmbdqhdA29jQVcCznZdADyaorLpwu00zXJmqLEpqWgDEMmpBQ2Cin9LgoYIMuglQ1gexvx7rdMC31e3GCI8dQ
   response:
     status:
       code: 200
@@ -2366,398 +2421,42 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"92982330-0f29-406e-bba9-ad19198579a5"
+      - W/"f5bbd20f-7ae4-4b6d-89c8-eb3481fcbe05"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 8c39c078-507a-44a5-ba10-4ce833966874
+      - 66a4eae3-34a7-4867-af41-c1298614a8d5
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14978'
+      - '14916'
       X-Ms-Correlation-Request-Id:
-      - 99c483fe-b7c0-4ec0-988f-9d9957440cbb
+      - 3748fd17-a197-4050-874b-a0db7fbc3ec7
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201531Z:99c483fe-b7c0-4ec0-988f-9d9957440cbb
+      - WESTEUROPE:20180313T090403Z:3748fd17-a197-4050-874b-a0db7fbc3ec7
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:15:30 GMT
+      - Tue, 13 Mar 2018 09:04:03 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"spec0deply1lb\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb\",\r\n
-        \ \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"8cd72f7c-03bd-4584-abc6-d9ce77ae6202\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
+      string: "{\r\n  \"name\": \"miq-azure-test2\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2\",\r\n
+        \ \"etag\": \"W/\\\"f5bbd20f-7ae4-4b6d-89c8-eb3481fcbe05\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
+        \"f950a3cf-749a-49d5-a7fb-33a400b0e93c\",\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\":
+        [\r\n        \"172.25.0.0/16\"\r\n      ]\r\n    },\r\n    \"subnets\": [\r\n
+        \     {\r\n        \"name\": \"default\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2/subnets/default\",\r\n
+        \       \"etag\": \"W/\\\"f5bbd20f-7ae4-4b6d-89c8-eb3481fcbe05\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip\"\r\n
-        \         },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
-        \           }\r\n          ],\r\n          \"inboundNatRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"BackendPool1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"backendIPConfigurations\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1\"\r\n
-        \           }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\":
-        [\r\n      {\r\n        \"name\": \"LBRule\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\":
-        80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        5,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\"\r\n
-        \         },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/probes/tcpProbe\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n
-        \       \"name\": \"tcpProbe\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/probes/tcpProbe\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Tcp\",\r\n          \"port\": 80,\r\n          \"intervalInSeconds\":
-        5,\r\n          \"numberOfProbes\": 2,\r\n          \"loadBalancingRules\":
-        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\":
-        [\r\n      {\r\n        \"name\": \"RDP-VM0\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 50001,\r\n          \"backendPort\":
-        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1\"\r\n
-        \         }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"RDP-VM1\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 50002,\r\n          \"backendPort\":
-        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
+        \         \"addressPrefix\": \"172.25.0.0/24\",\r\n          \"ipConfigurations\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944/ipConfigurations/ipconfig1\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"virtualNetworkPeerings\":
+        [],\r\n    \"enableDdosProtection\": false,\r\n    \"enableVmProtection\":
+        false\r\n  }\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:31 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MjYsIm5iZiI6MTUyMDQ1MzQyNiwiZXhwIjoxNTIwNDU3MzI2LCJhaW8iOiJZMk5nWUZnM1ZTb25RVDZncW42dU9kZUdvNHVMQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUTRnUWZkNm14VXlTc1Fob3IyZ0FBQSIsInZlciI6IjEuMCJ9.cXVtvbA20Qqk3Vd6I9V2JeVoczYtuGbyZd0QQIEeoHWdsLCXzLWkNGZauHk2ioWJIoZSDC5LVT0siDS6dwcWKpl-9Y59-KyCVGwgOJ4pXH2xya_Kg6jysSxzOiX6CzNaz4VXrkM5KfK5Q5ZhcKIzJ-CtEJGH5uVM3EC3wnfEZFrxu_t-nANtMwkiF2TB0fNU1PHyEI186OhQCF7xOxnKxi3OaqZahN1Uy6xScgZpPU-25USMia4LAI3JJBZf3Dpm2N-5pepjOIdkrA6b7D4hb3f6llcga7cPhBjmSMiQFwa5N-9xKUjuOQohIieMAQmszZSsLWSBJcJfl36-eObc7w
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"92982330-0f29-406e-bba9-ad19198579a5"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - fa3a812f-b413-4d90-97a4-7b4ffe096357
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14978'
-      X-Ms-Correlation-Request-Id:
-      - 7db16e12-6f97-4d1b-bde4-e0da42be9d97
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201534Z:7db16e12-6f97-4d1b-bde4-e0da42be9d97
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:15:33 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"spec0deply1lb\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb\",\r\n
-        \ \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"8cd72f7c-03bd-4584-abc6-d9ce77ae6202\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip\"\r\n
-        \         },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
-        \           }\r\n          ],\r\n          \"inboundNatRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"BackendPool1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"backendIPConfigurations\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1\"\r\n
-        \           }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\":
-        [\r\n      {\r\n        \"name\": \"LBRule\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\":
-        80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        5,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\"\r\n
-        \         },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/probes/tcpProbe\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n
-        \       \"name\": \"tcpProbe\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/probes/tcpProbe\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Tcp\",\r\n          \"port\": 80,\r\n          \"intervalInSeconds\":
-        5,\r\n          \"numberOfProbes\": 2,\r\n          \"loadBalancingRules\":
-        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\":
-        [\r\n      {\r\n        \"name\": \"RDP-VM0\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 50001,\r\n          \"backendPort\":
-        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1\"\r\n
-        \         }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"RDP-VM1\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 50002,\r\n          \"backendPort\":
-        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:34 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MjYsIm5iZiI6MTUyMDQ1MzQyNiwiZXhwIjoxNTIwNDU3MzI2LCJhaW8iOiJZMk5nWUZnM1ZTb25RVDZncW42dU9kZUdvNHVMQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUTRnUWZkNm14VXlTc1Fob3IyZ0FBQSIsInZlciI6IjEuMCJ9.cXVtvbA20Qqk3Vd6I9V2JeVoczYtuGbyZd0QQIEeoHWdsLCXzLWkNGZauHk2ioWJIoZSDC5LVT0siDS6dwcWKpl-9Y59-KyCVGwgOJ4pXH2xya_Kg6jysSxzOiX6CzNaz4VXrkM5KfK5Q5ZhcKIzJ-CtEJGH5uVM3EC3wnfEZFrxu_t-nANtMwkiF2TB0fNU1PHyEI186OhQCF7xOxnKxi3OaqZahN1Uy6xScgZpPU-25USMia4LAI3JJBZf3Dpm2N-5pepjOIdkrA6b7D4hb3f6llcga7cPhBjmSMiQFwa5N-9xKUjuOQohIieMAQmszZSsLWSBJcJfl36-eObc7w
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"92982330-0f29-406e-bba9-ad19198579a5"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 7ee9f13b-4845-49e1-bfb3-bd6524a12625
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14987'
-      X-Ms-Correlation-Request-Id:
-      - e7c00888-de63-45e5-8acf-fd63ecbd23f1
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201535Z:e7c00888-de63-45e5-8acf-fd63ecbd23f1
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:15:34 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"spec0deply1lb\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb\",\r\n
-        \ \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"8cd72f7c-03bd-4584-abc6-d9ce77ae6202\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip\"\r\n
-        \         },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
-        \           }\r\n          ],\r\n          \"inboundNatRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"BackendPool1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"backendIPConfigurations\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1\"\r\n
-        \           }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\":
-        [\r\n      {\r\n        \"name\": \"LBRule\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\":
-        80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        5,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\"\r\n
-        \         },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/probes/tcpProbe\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n
-        \       \"name\": \"tcpProbe\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/probes/tcpProbe\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Tcp\",\r\n          \"port\": 80,\r\n          \"intervalInSeconds\":
-        5,\r\n          \"numberOfProbes\": 2,\r\n          \"loadBalancingRules\":
-        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\":
-        [\r\n      {\r\n        \"name\": \"RDP-VM0\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 50001,\r\n          \"backendPort\":
-        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1\"\r\n
-        \         }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"RDP-VM1\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 50002,\r\n          \"backendPort\":
-        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:35 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MjYsIm5iZiI6MTUyMDQ1MzQyNiwiZXhwIjoxNTIwNDU3MzI2LCJhaW8iOiJZMk5nWUZnM1ZTb25RVDZncW42dU9kZUdvNHVMQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUTRnUWZkNm14VXlTc1Fob3IyZ0FBQSIsInZlciI6IjEuMCJ9.cXVtvbA20Qqk3Vd6I9V2JeVoczYtuGbyZd0QQIEeoHWdsLCXzLWkNGZauHk2ioWJIoZSDC5LVT0siDS6dwcWKpl-9Y59-KyCVGwgOJ4pXH2xya_Kg6jysSxzOiX6CzNaz4VXrkM5KfK5Q5ZhcKIzJ-CtEJGH5uVM3EC3wnfEZFrxu_t-nANtMwkiF2TB0fNU1PHyEI186OhQCF7xOxnKxi3OaqZahN1Uy6xScgZpPU-25USMia4LAI3JJBZf3Dpm2N-5pepjOIdkrA6b7D4hb3f6llcga7cPhBjmSMiQFwa5N-9xKUjuOQohIieMAQmszZSsLWSBJcJfl36-eObc7w
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"2080997a-38a6-420d-ba86-e9582e1331c7"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 97443fd3-a440-45ed-bab2-2136049b57e0
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14977'
-      X-Ms-Correlation-Request-Id:
-      - 988820e6-f3e1-475f-a579-2a63fc1088f1
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201535Z:988820e6-f3e1-475f-a579-2a63fc1088f1
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:15:35 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"spec0deply1ip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip\",\r\n
-        \ \"etag\": \"W/\\\"2080997a-38a6-420d-ba86-e9582e1331c7\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"a08b891e-e45a-4970-aefc-f6c996989490\",\r\n    \"publicIPAddressVersion\":
-        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
-        4,\r\n    \"dnsSettings\": {\r\n      \"domainNameLabel\": \"spec0deply1dns\",\r\n
-        \     \"fqdn\": \"spec0deply1dns.eastus.cloudapp.azure.com\"\r\n    },\r\n
-        \   \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
-        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:35 GMT
+  recorded_at: Tue, 13 Mar 2018 09:04:03 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_0/lb_created_by_stack_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_0/lb_created_by_stack_refresh.yml
@@ -1,6 +1,62 @@
 ---
 http_interactions:
 - request:
+    method: post
+    uri: https://login.microsoftonline.com/AZURE_TENANT_ID/oauth2/token
+    body:
+      encoding: UTF-8
+      string: grant_type=client_credentials&client_id=AZURE_CLIENT_ID&client_secret=AZURE_CLIENT_SECRET&resource=https%3A%2F%2Fmanagement.azure.com%2F
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Server:
+      - Microsoft-IIS/10.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Request-Id:
+      - b8742e01-4d18-4f5d-8a5c-69d1a7f32300
+      P3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Set-Cookie:
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzLAZFSLsja6Is8XkcRY43D07OLuNY5IrZlCRYpFL6-mMnK5a7Ao7bdIp2Jw-GZf5nF9IgNMIDFcRvJ46ZvPRVeQeF-841lzZBJU7wv0E5uBEWhLReb8RI4cvxBQPXonsXCh3MZ9-AVe0gt8J48a-vPyyI4_2tolWAMpl_XU8k2L8gAA;
+        domain=.login.microsoftonline.com; path=/; secure; HttpOnly
+      - stsservicecookie=ests; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=006; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 12 Mar 2018 09:35:04 GMT
+      Content-Length:
+      - '1505'
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1520850904","not_before":"1520847004","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcwMDQsIm5iZiI6MTUyMDg0NzAwNCwiZXhwIjoxNTIwODUwOTA0LCJhaW8iOiJZMk5nWURCbm0vSkw2OTgrb1NBRzBWVmZleTUwQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQVM1MHVCaE5YVS1LWEduUnBfTWpBQSIsInZlciI6IjEuMCJ9.HeDjjsRC3BJD-1JG4BwI00zAOhlQXsgKF0cawnVlhx6TIT2EoU_K4C0iQdTI0-_BxfjoupVUBDFq1Bw4rZgO1YNT802CyHkNqWDhyxakJdjwfRo1ar55NxHbA2NLHmd_lIbHgC6zk1tgr1_uqAYhk2WDLO1azOkXMFISZ1qi1RroJeoPsyToOLjS8NkRHSIhqk0IEp2DcBjc8FCW6KORvTeOR9jkQdu3AieJ-ofhZj2uK_hmES5DfnsKipN9pPLm8-tcfGmtgmoDhf7KwoA7G1rR4MFl6Reu7i8XthQjvhGQxOJofMwypN1F4aL5_2twBpbrnGRp8UPzMohFsD6coA"}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:35:09 GMT
+- request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
     body:
@@ -16,7 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcwMDQsIm5iZiI6MTUyMDg0NzAwNCwiZXhwIjoxNTIwODUwOTA0LCJhaW8iOiJZMk5nWURCbm0vSkw2OTgrb1NBRzBWVmZleTUwQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQVM1MHVCaE5YVS1LWEduUnBfTWpBQSIsInZlciI6IjEuMCJ9.HeDjjsRC3BJD-1JG4BwI00zAOhlQXsgKF0cawnVlhx6TIT2EoU_K4C0iQdTI0-_BxfjoupVUBDFq1Bw4rZgO1YNT802CyHkNqWDhyxakJdjwfRo1ar55NxHbA2NLHmd_lIbHgC6zk1tgr1_uqAYhk2WDLO1azOkXMFISZ1qi1RroJeoPsyToOLjS8NkRHSIhqk0IEp2DcBjc8FCW6KORvTeOR9jkQdu3AieJ-ofhZj2uK_hmES5DfnsKipN9pPLm8-tcfGmtgmoDhf7KwoA7G1rR4MFl6Reu7i8XthQjvhGQxOJofMwypN1F4aL5_2twBpbrnGRp8UPzMohFsD6coA
   response:
     status:
       code: 200
@@ -35,26 +91,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14997'
+      - '14999'
       X-Ms-Request-Id:
-      - cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - 7f881b7a-542b-4323-89b8-2df29f5694f9
       X-Ms-Correlation-Request-Id:
-      - cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - 7f881b7a-542b-4323-89b8-2df29f5694f9
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102417Z:cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - WESTEUROPE:20180312T093505Z:7f881b7a-542b-4323-89b8-2df29f5694f9
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:17 GMT
+      - Mon, 12 Mar 2018 09:35:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID","subscriptionId":"AZURE_SUBSCRIPTION_ID","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:22 GMT
+  recorded_at: Mon, 12 Mar 2018 09:35:10 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers?api-version=2015-01-01
@@ -71,7 +127,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcwMDQsIm5iZiI6MTUyMDg0NzAwNCwiZXhwIjoxNTIwODUwOTA0LCJhaW8iOiJZMk5nWURCbm0vSkw2OTgrb1NBRzBWVmZleTUwQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQVM1MHVCaE5YVS1LWEduUnBfTWpBQSIsInZlciI6IjEuMCJ9.HeDjjsRC3BJD-1JG4BwI00zAOhlQXsgKF0cawnVlhx6TIT2EoU_K4C0iQdTI0-_BxfjoupVUBDFq1Bw4rZgO1YNT802CyHkNqWDhyxakJdjwfRo1ar55NxHbA2NLHmd_lIbHgC6zk1tgr1_uqAYhk2WDLO1azOkXMFISZ1qi1RroJeoPsyToOLjS8NkRHSIhqk0IEp2DcBjc8FCW6KORvTeOR9jkQdu3AieJ-ofhZj2uK_hmES5DfnsKipN9pPLm8-tcfGmtgmoDhf7KwoA7G1rR4MFl6Reu7i8XthQjvhGQxOJofMwypN1F4aL5_2twBpbrnGRp8UPzMohFsD6coA
   response:
     status:
       code: 200
@@ -88,19 +144,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - '14994'
       X-Ms-Request-Id:
-      - fe3532ca-59a2-474e-9094-8a3697b82bef
+      - d1cd95d5-f14e-4623-9c2f-e3c6f7c374e1
       X-Ms-Correlation-Request-Id:
-      - fe3532ca-59a2-474e-9094-8a3697b82bef
+      - d1cd95d5-f14e-4623-9c2f-e3c6f7c374e1
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102419Z:fe3532ca-59a2-474e-9094-8a3697b82bef
+      - WESTEUROPE:20180312T093506Z:d1cd95d5-f14e-4623-9c2f-e3c6f7c374e1
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:18 GMT
+      - Mon, 12 Mar 2018 09:35:06 GMT
       Content-Length:
       - '320853'
     body:
@@ -2322,10 +2378,10 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:23 GMT
+  recorded_at: Mon, 12 Mar 2018 09:35:11 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb?api-version=2018-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2339,7 +2395,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcwMDQsIm5iZiI6MTUyMDg0NzAwNCwiZXhwIjoxNTIwODUwOTA0LCJhaW8iOiJZMk5nWURCbm0vSkw2OTgrb1NBRzBWVmZleTUwQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQVM1MHVCaE5YVS1LWEduUnBfTWpBQSIsInZlciI6IjEuMCJ9.HeDjjsRC3BJD-1JG4BwI00zAOhlQXsgKF0cawnVlhx6TIT2EoU_K4C0iQdTI0-_BxfjoupVUBDFq1Bw4rZgO1YNT802CyHkNqWDhyxakJdjwfRo1ar55NxHbA2NLHmd_lIbHgC6zk1tgr1_uqAYhk2WDLO1azOkXMFISZ1qi1RroJeoPsyToOLjS8NkRHSIhqk0IEp2DcBjc8FCW6KORvTeOR9jkQdu3AieJ-ofhZj2uK_hmES5DfnsKipN9pPLm8-tcfGmtgmoDhf7KwoA7G1rR4MFl6Reu7i8XthQjvhGQxOJofMwypN1F4aL5_2twBpbrnGRp8UPzMohFsD6coA
   response:
     status:
       code: 200
@@ -2356,87 +2412,96 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67"
+      - W/"92982330-0f29-406e-bba9-ad19198579a5"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - '080de667-081e-4d58-9e94-9e7243d4200e'
+      - 73c6405d-f89c-4e73-9760-c5b53915eb21
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
+      - '14994'
       X-Ms-Correlation-Request-Id:
-      - '093d49ac-c85f-440e-956b-955b6698dd19'
+      - 4072160b-238b-4f8c-bde7-855ec1e9ccc1
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102419Z:093d49ac-c85f-440e-956b-955b6698dd19
+      - WESTEUROPE:20180312T093507Z:4072160b-238b-4f8c-bde7-855ec1e9ccc1
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:19 GMT
+      - Mon, 12 Mar 2018 09:35:07 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1\",\r\n
-        \ \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n  \"type\":
+      string: "{\r\n  \"name\": \"spec0deply1lb\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb\",\r\n
+        \ \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n  \"type\":
         \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"7ab88756-810f-4083-95db-8b05d50e38f2\",\r\n
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"8cd72f7c-03bd-4584-abc6-d9ce77ae6202\",\r\n
         \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
+        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\"\r\n
+        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip\"\r\n
         \         },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
         \           }\r\n          ],\r\n          \"inboundNatRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\"\r\n
+        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1\"\r\n
         \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
+        [\r\n      {\r\n        \"name\": \"BackendPool1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\",\r\n
+        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"backendIPConfigurations\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\"\r\n
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1\"\r\n
         \           }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
+        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
         \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-rule\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
+        [\r\n      {\r\n        \"name\": \"LBRule\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\",\r\n
+        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
+        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
         \         },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\":
         80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
+        5,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
         false,\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\"\r\n
-        \         },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\"\r\n
+        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\"\r\n
+        \         },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/probes/tcpProbe\"\r\n
         \         }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n
-        \       \"name\": \"rspec-lb-probe\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
+        \       \"name\": \"tcpProbe\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/probes/tcpProbe\",\r\n
+        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
+        \         \"protocol\": \"Tcp\",\r\n          \"port\": 80,\r\n          \"intervalInSeconds\":
+        5,\r\n          \"numberOfProbes\": 2,\r\n          \"loadBalancingRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
         \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-NAT\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
+        [\r\n      {\r\n        \"name\": \"RDP-VM0\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0\",\r\n
+        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 3441,\r\n          \"backendPort\":
+        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
+        \         },\r\n          \"frontendPort\": 50001,\r\n          \"backendPort\":
         3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
         4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
+        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1\"\r\n
+        \         }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"RDP-VM1\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1\",\r\n
+        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
+        \         },\r\n          \"frontendPort\": 50002,\r\n          \"backendPort\":
+        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
+        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
+        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1\"\r\n
         \         }\r\n        }\r\n      }\r\n    ],\r\n    \"outboundNatRules\":
         [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
         \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:24 GMT
+  recorded_at: Mon, 12 Mar 2018 09:35:12 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip?api-version=2018-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2450,7 +2515,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcwMDQsIm5iZiI6MTUyMDg0NzAwNCwiZXhwIjoxNTIwODUwOTA0LCJhaW8iOiJZMk5nWURCbm0vSkw2OTgrb1NBRzBWVmZleTUwQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQVM1MHVCaE5YVS1LWEduUnBfTWpBQSIsInZlciI6IjEuMCJ9.HeDjjsRC3BJD-1JG4BwI00zAOhlQXsgKF0cawnVlhx6TIT2EoU_K4C0iQdTI0-_BxfjoupVUBDFq1Bw4rZgO1YNT802CyHkNqWDhyxakJdjwfRo1ar55NxHbA2NLHmd_lIbHgC6zk1tgr1_uqAYhk2WDLO1azOkXMFISZ1qi1RroJeoPsyToOLjS8NkRHSIhqk0IEp2DcBjc8FCW6KORvTeOR9jkQdu3AieJ-ofhZj2uK_hmES5DfnsKipN9pPLm8-tcfGmtgmoDhf7KwoA7G1rR4MFl6Reu7i8XthQjvhGQxOJofMwypN1F4aL5_2twBpbrnGRp8UPzMohFsD6coA
   response:
     status:
       code: 200
@@ -2467,183 +2532,38 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"7a8e5fe7-f777-4435-992b-a54f28c2f28c"
+      - W/"2080997a-38a6-420d-ba86-e9582e1331c7"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - bd22ca22-a01f-4ecf-9230-a4558fb66931
+      - 12afbb44-5581-42c8-b20e-6d33753626a5
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
+      - '14994'
       X-Ms-Correlation-Request-Id:
-      - 19c674a8-c8da-4b5e-8265-5ebc21926459
+      - 2f96b7fa-7846-4d02-aa37-f8dd338bb456
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102420Z:19c674a8-c8da-4b5e-8265-5ebc21926459
+      - WESTEUROPE:20180312T093511Z:2f96b7fa-7846-4d02-aa37-f8dd338bb456
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:19 GMT
+      - Mon, 12 Mar 2018 09:35:11 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb2\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2\",\r\n
-        \ \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"e2e30a77-f81b-43fc-9693-08303e43deed\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/backendAddressPools/rspec-lb2-pool\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\r\n
-        \       }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\": [],\r\n    \"probes\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-probe\",\r\n        \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/probes/rspec-lb2-probe\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\": [],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:25 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"a38434c8-7b23-4092-b7c6-402238eac0dc"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 0fd15240-6a1c-4b39-a4f6-aa53fd8591c2
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Correlation-Request-Id:
-      - 5cc03163-922e-41a1-9601-dba2d7cf2a81
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102421Z:5cc03163-922e-41a1-9601-dba2d7cf2a81
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Mon, 12 Mar 2018 10:24:20 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb1-LoadBalancerFrontEnd\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\",\r\n
-        \ \"etag\": \"W/\\\"a38434c8-7b23-4092-b7c6-402238eac0dc\\\"\",\r\n  \"location\":
+      string: "{\r\n  \"name\": \"spec0deply1ip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip\",\r\n
+        \ \"etag\": \"W/\\\"2080997a-38a6-420d-ba86-e9582e1331c7\\\"\",\r\n  \"location\":
         \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"f28e0f25-b372-4edf-97d9-13a9e3b4ba2d\",\r\n    \"ipAddress\":
-        \"40.71.82.83\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\":
-        \"Static\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipTags\": [],\r\n
-        \   \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
-        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:25 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"cddd97d1-6111-4477-8a00-3dc885237a1d"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 1403e5b6-8fa0-4cd3-89b1-76b6c4fd805b
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
-      X-Ms-Correlation-Request-Id:
-      - e4a5f369-a742-466f-bd8f-42e17eaaf9c9
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102421Z:e4a5f369-a742-466f-bd8f-42e17eaaf9c9
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Mon, 12 Mar 2018 10:24:21 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb2-publicip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\",\r\n
-        \ \"etag\": \"W/\\\"cddd97d1-6111-4477-8a00-3dc885237a1d\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"83e7257d-ab94-4229-8eb5-4798f37ef28d\",\r\n    \"publicIPAddressVersion\":
+        \   \"resourceGuid\": \"a08b891e-e45a-4970-aefc-f6c996989490\",\r\n    \"publicIPAddressVersion\":
         \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
-        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
+        4,\r\n    \"dnsSettings\": {\r\n      \"domainNameLabel\": \"spec0deply1dns\",\r\n
+        \     \"fqdn\": \"spec0deply1dns.eastus.cloudapp.azure.com\"\r\n    },\r\n
+        \   \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
         \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
         \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:26 GMT
+  recorded_at: Mon, 12 Mar 2018 09:35:15 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_0/lb_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_0/lb_refresh.yml
@@ -1,6 +1,62 @@
 ---
 http_interactions:
 - request:
+    method: post
+    uri: https://login.microsoftonline.com/AZURE_TENANT_ID/oauth2/token
+    body:
+      encoding: UTF-8
+      string: grant_type=client_credentials&client_id=AZURE_CLIENT_ID&client_secret=AZURE_CLIENT_SECRET&resource=https%3A%2F%2Fmanagement.azure.com%2F
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Server:
+      - Microsoft-IIS/10.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Request-Id:
+      - 3648a0fa-3247-438f-9a53-c51308c82200
+      P3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Set-Cookie:
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzacYWZL4vEQa5Z6qUZivvzX__hJ5bPcjA4AXr89rv5l63_wMzXPmDCbjd_25HANRRJHtNFHdKvEc5WoyPwGOQvVL-0fgSIbN6asQmoADQmZFIOdF4186cJw2bdWtXXedIXAAUHH-FYQn80xpSIQr3oah7qfsWO4ZcIkOIkNR49fkgAA;
+        domain=.login.microsoftonline.com; path=/; secure; HttpOnly
+      - stsservicecookie=ests; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=002; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 12 Mar 2018 09:38:25 GMT
+      Content-Length:
+      - '1505'
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"Bearer","expires_in":"3600","ext_expires_in":"0","expires_on":"1520851106","not_before":"1520847206","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcyMDYsIm5iZiI6MTUyMDg0NzIwNiwiZXhwIjoxNTIwODUxMTA2LCJhaW8iOiJZMk5nWU5oWGJ0Ri9TNGw1R2V2NUJxTnpqVVp2QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiLXFCSU5rY3lqME9hVThVVENNZ2lBQSIsInZlciI6IjEuMCJ9.AZb-Z48yHSS8csSXe9CbzDfvjBO62RXUzpP0jjUh8hgQxq-cAxKibqchYIwJ93So9AMKCnvjeIFyD6HG8xEW8Wh0JDf1SAj_Oh82bL0UbKaqCx51dCNYI_cHyCknpeJpEMYl0An59icu31KU8o48dRfferJIPR7pxyJWZEZgr6arzkVl8AMClMQFRMGiK-gqDMuqmxt_gKfUnUJaMQ0KuKG3Lab0fXw644-3FifZzKvRQRfCdACDyBU_AYJkuBkVr7manbF--9SaHYhYPSON83_YJ3rYuoi6uYnhZJawFz4ttnKID9y8u_cr0ydl7p6HEzXl5HDftQzCzdUluIvVIQ"}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:38:30 GMT
+- request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
     body:
@@ -16,7 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcyMDYsIm5iZiI6MTUyMDg0NzIwNiwiZXhwIjoxNTIwODUxMTA2LCJhaW8iOiJZMk5nWU5oWGJ0Ri9TNGw1R2V2NUJxTnpqVVp2QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiLXFCSU5rY3lqME9hVThVVENNZ2lBQSIsInZlciI6IjEuMCJ9.AZb-Z48yHSS8csSXe9CbzDfvjBO62RXUzpP0jjUh8hgQxq-cAxKibqchYIwJ93So9AMKCnvjeIFyD6HG8xEW8Wh0JDf1SAj_Oh82bL0UbKaqCx51dCNYI_cHyCknpeJpEMYl0An59icu31KU8o48dRfferJIPR7pxyJWZEZgr6arzkVl8AMClMQFRMGiK-gqDMuqmxt_gKfUnUJaMQ0KuKG3Lab0fXw644-3FifZzKvRQRfCdACDyBU_AYJkuBkVr7manbF--9SaHYhYPSON83_YJ3rYuoi6uYnhZJawFz4ttnKID9y8u_cr0ydl7p6HEzXl5HDftQzCzdUluIvVIQ
   response:
     status:
       code: 200
@@ -37,24 +93,24 @@ http_interactions:
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
       - '14997'
       X-Ms-Request-Id:
-      - cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - cf87accc-1bf0-4519-8ebf-9c7d6489abc5
       X-Ms-Correlation-Request-Id:
-      - cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - cf87accc-1bf0-4519-8ebf-9c7d6489abc5
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102417Z:cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - WESTEUROPE:20180312T093826Z:cf87accc-1bf0-4519-8ebf-9c7d6489abc5
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:17 GMT
+      - Mon, 12 Mar 2018 09:38:25 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID","subscriptionId":"AZURE_SUBSCRIPTION_ID","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:22 GMT
+  recorded_at: Mon, 12 Mar 2018 09:38:31 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers?api-version=2015-01-01
@@ -71,7 +127,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcyMDYsIm5iZiI6MTUyMDg0NzIwNiwiZXhwIjoxNTIwODUxMTA2LCJhaW8iOiJZMk5nWU5oWGJ0Ri9TNGw1R2V2NUJxTnpqVVp2QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiLXFCSU5rY3lqME9hVThVVENNZ2lBQSIsInZlciI6IjEuMCJ9.AZb-Z48yHSS8csSXe9CbzDfvjBO62RXUzpP0jjUh8hgQxq-cAxKibqchYIwJ93So9AMKCnvjeIFyD6HG8xEW8Wh0JDf1SAj_Oh82bL0UbKaqCx51dCNYI_cHyCknpeJpEMYl0An59icu31KU8o48dRfferJIPR7pxyJWZEZgr6arzkVl8AMClMQFRMGiK-gqDMuqmxt_gKfUnUJaMQ0KuKG3Lab0fXw644-3FifZzKvRQRfCdACDyBU_AYJkuBkVr7manbF--9SaHYhYPSON83_YJ3rYuoi6uYnhZJawFz4ttnKID9y8u_cr0ydl7p6HEzXl5HDftQzCzdUluIvVIQ
   response:
     status:
       code: 200
@@ -90,17 +146,17 @@ http_interactions:
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
       - '14988'
       X-Ms-Request-Id:
-      - fe3532ca-59a2-474e-9094-8a3697b82bef
+      - 329fe02d-68b8-4b4d-8958-da52f7a9e4f0
       X-Ms-Correlation-Request-Id:
-      - fe3532ca-59a2-474e-9094-8a3697b82bef
+      - 329fe02d-68b8-4b4d-8958-da52f7a9e4f0
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102419Z:fe3532ca-59a2-474e-9094-8a3697b82bef
+      - WESTEUROPE:20180312T093827Z:329fe02d-68b8-4b4d-8958-da52f7a9e4f0
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:18 GMT
+      - Mon, 12 Mar 2018 09:38:27 GMT
       Content-Length:
       - '320853'
     body:
@@ -2322,7 +2378,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:23 GMT
+  recorded_at: Mon, 12 Mar 2018 09:38:32 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1?api-version=2018-01-01
@@ -2339,7 +2395,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcyMDYsIm5iZiI6MTUyMDg0NzIwNiwiZXhwIjoxNTIwODUxMTA2LCJhaW8iOiJZMk5nWU5oWGJ0Ri9TNGw1R2V2NUJxTnpqVVp2QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiLXFCSU5rY3lqME9hVThVVENNZ2lBQSIsInZlciI6IjEuMCJ9.AZb-Z48yHSS8csSXe9CbzDfvjBO62RXUzpP0jjUh8hgQxq-cAxKibqchYIwJ93So9AMKCnvjeIFyD6HG8xEW8Wh0JDf1SAj_Oh82bL0UbKaqCx51dCNYI_cHyCknpeJpEMYl0An59icu31KU8o48dRfferJIPR7pxyJWZEZgr6arzkVl8AMClMQFRMGiK-gqDMuqmxt_gKfUnUJaMQ0KuKG3Lab0fXw644-3FifZzKvRQRfCdACDyBU_AYJkuBkVr7manbF--9SaHYhYPSON83_YJ3rYuoi6uYnhZJawFz4ttnKID9y8u_cr0ydl7p6HEzXl5HDftQzCzdUluIvVIQ
   response:
     status:
       code: 200
@@ -2360,22 +2416,22 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - '080de667-081e-4d58-9e94-9e7243d4200e'
+      - e1ef3e64-c7de-4d7c-9c1e-7fb965b46584
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
+      - '14990'
       X-Ms-Correlation-Request-Id:
-      - '093d49ac-c85f-440e-956b-955b6698dd19'
+      - 9f5435ed-a4c6-4857-af2b-a9532040771c
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102419Z:093d49ac-c85f-440e-956b-955b6698dd19
+      - WESTEUROPE:20180312T093828Z:9f5435ed-a4c6-4857-af2b-a9532040771c
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:19 GMT
+      - Mon, 12 Mar 2018 09:38:27 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"rspec-lb1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1\",\r\n
@@ -2433,88 +2489,7 @@ http_interactions:
         [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
         \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:24 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"7a8e5fe7-f777-4435-992b-a54f28c2f28c"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - bd22ca22-a01f-4ecf-9230-a4558fb66931
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Correlation-Request-Id:
-      - 19c674a8-c8da-4b5e-8265-5ebc21926459
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102420Z:19c674a8-c8da-4b5e-8265-5ebc21926459
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Mon, 12 Mar 2018 10:24:19 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb2\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2\",\r\n
-        \ \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"e2e30a77-f81b-43fc-9693-08303e43deed\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/backendAddressPools/rspec-lb2-pool\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\r\n
-        \       }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\": [],\r\n    \"probes\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-probe\",\r\n        \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/probes/rspec-lb2-probe\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\": [],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:25 GMT
+  recorded_at: Mon, 12 Mar 2018 09:38:33 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd?api-version=2018-01-01
@@ -2531,7 +2506,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcyMDYsIm5iZiI6MTUyMDg0NzIwNiwiZXhwIjoxNTIwODUxMTA2LCJhaW8iOiJZMk5nWU5oWGJ0Ri9TNGw1R2V2NUJxTnpqVVp2QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiLXFCSU5rY3lqME9hVThVVENNZ2lBQSIsInZlciI6IjEuMCJ9.AZb-Z48yHSS8csSXe9CbzDfvjBO62RXUzpP0jjUh8hgQxq-cAxKibqchYIwJ93So9AMKCnvjeIFyD6HG8xEW8Wh0JDf1SAj_Oh82bL0UbKaqCx51dCNYI_cHyCknpeJpEMYl0An59icu31KU8o48dRfferJIPR7pxyJWZEZgr6arzkVl8AMClMQFRMGiK-gqDMuqmxt_gKfUnUJaMQ0KuKG3Lab0fXw644-3FifZzKvRQRfCdACDyBU_AYJkuBkVr7manbF--9SaHYhYPSON83_YJ3rYuoi6uYnhZJawFz4ttnKID9y8u_cr0ydl7p6HEzXl5HDftQzCzdUluIvVIQ
   response:
     status:
       code: 200
@@ -2552,22 +2527,22 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 0fd15240-6a1c-4b39-a4f6-aa53fd8591c2
+      - 5f12de1a-054a-4bf0-9ff4-edac63e8af0b
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
+      - '14990'
       X-Ms-Correlation-Request-Id:
-      - 5cc03163-922e-41a1-9601-dba2d7cf2a81
+      - bcc6d2da-1d30-4a60-a8ab-6ce73dccca85
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102421Z:5cc03163-922e-41a1-9601-dba2d7cf2a81
+      - WESTEUROPE:20180312T093829Z:bcc6d2da-1d30-4a60-a8ab-6ce73dccca85
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:20 GMT
+      - Mon, 12 Mar 2018 09:38:28 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"rspec-lb1-LoadBalancerFrontEnd\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\",\r\n
@@ -2580,70 +2555,5 @@ http_interactions:
         \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
         \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:25 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"cddd97d1-6111-4477-8a00-3dc885237a1d"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 1403e5b6-8fa0-4cd3-89b1-76b6c4fd805b
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
-      X-Ms-Correlation-Request-Id:
-      - e4a5f369-a742-466f-bd8f-42e17eaaf9c9
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102421Z:e4a5f369-a742-466f-bd8f-42e17eaaf9c9
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Mon, 12 Mar 2018 10:24:21 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb2-publicip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\",\r\n
-        \ \"etag\": \"W/\\\"cddd97d1-6111-4477-8a00-3dc885237a1d\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"83e7257d-ab94-4229-8eb5-4798f37ef28d\",\r\n    \"publicIPAddressVersion\":
-        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
-        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
-        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:26 GMT
+  recorded_at: Mon, 12 Mar 2018 09:38:33 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_0/lb_vms_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_0/lb_vms_refresh.yml
@@ -37,25 +37,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - f47bff27-fbb6-4423-bdb9-c5ebc0580000
+      - 2c5f402a-e407-4fff-acc8-7d21e90a2300
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHz2dfDmsarYlAWh3-noHTckfe9-N-m8urJilVchIAg-0CqM34Stj1apa0awQqJ7h0rmf6lV2t9_sfFfWp24k9anE2W01ZKzUco74PSf9QfcfJKZBKzpxZDCg2-beN90P2YjMbwPMu9QQtwAmdWjzJBKowqEUjfQZwjgetaCyo7e1wgAA;
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzQkjxqVgLaPgDKr7ketoahrPE_w9-mJlroAp85OzFeqxLPH7b1M6q6h-EP_RXH4e98FyYyLh80snn_vp-08VEpXQ411LegddanW9M3kDSPFY5NL9Iij2NHDw-gkvrSkKpr44jFiORqGolgX-R56ZCuj5P-QWX2btyl55QSLE5c5AgAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=005; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=006; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Wed, 07 Mar 2018 20:19:45 GMT
+      - Mon, 12 Mar 2018 09:38:30 GMT
       Content-Length:
       - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1520457585","not_before":"1520453685","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2ODUsIm5iZiI6MTUyMDQ1MzY4NSwiZXhwIjoxNTIwNDU3NTg1LCJhaW8iOiJZMk5nWUpDZDhXSnQweXhCbDUvc0Y1YjhPKytVQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSl85NzlMYjdJMFM5dWNYcndGZ0FBQSIsInZlciI6IjEuMCJ9.QDvUV9U7FuTHX-bOtNPkoVA6h_IGpmcmiIsI-bLi0UeBhTl50wRFXx8NOuTvbuv_Omd9GMWXx2exZ-aTUHjZ8O0yo-znrTJjPIg82aLk868BFBOYRf7jy6hBCaAVMCpMR15AA73qVOBhAns5XN47-ja7T1KzKHox-4PGuFrA-4sxZR7PAvz4UH-68uCVNNPhGs09ugQOTQXDFZne0Gr2uE3SDirqEic4o1twqGG6vRsgGHoFiidl_lRyGAKK3gQnrost55jujfhI2MUp4PPykbIFSAVUz35KdC-RfNC70XOGa7r2-1GCPpSFPyq1f98B6_eoPmkJS9KQAO-d_OtJog"}'
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1520851110","not_before":"1520847210","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcyMTAsIm5iZiI6MTUyMDg0NzIxMCwiZXhwIjoxNTIwODUxMTEwLCJhaW8iOiJZMk5nWUpodFB0a2k2MFo1cHgyTHlWdHU5NzI3QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiS2tCZkxBZmtfMC1zeUgwaDZRb2pBQSIsInZlciI6IjEuMCJ9.Vfp8xCOV2qO_lW6yNVyfhqgGpT2ZG_Z3Nj79KQIrcAD9IDe8IaKlPoG_nmf3qLcXuKGG2QgEZe28-uL17_Yumns3TDPYvaCyONJ7HR4WOz6Sj-_DrXX3lUyHFe6HcaWli0q0eu4QpLcTUTRe6LkQ-u7jfsgw-ovI2FqwrL_lXv7TNhE7ZX-QvZJni2QYDvFGGZW6i2Y4TCOMQmqmWVu-VTfxHXZ_JJMGfiNXaV3Io_zjY8XkGKvXMHjdcpqM4b4fluhxYp-LJ2LkV1VNf7yIi8KrGtLWZzC1a0KC3gqNWxCYV08j1UAZxEVEZycyUQeJsaEHR9WDgll6xt8KR85KgQ"}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:19:46 GMT
+  recorded_at: Mon, 12 Mar 2018 09:38:35 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -72,7 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2ODUsIm5iZiI6MTUyMDQ1MzY4NSwiZXhwIjoxNTIwNDU3NTg1LCJhaW8iOiJZMk5nWUpDZDhXSnQweXhCbDUvc0Y1YjhPKytVQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSl85NzlMYjdJMFM5dWNYcndGZ0FBQSIsInZlciI6IjEuMCJ9.QDvUV9U7FuTHX-bOtNPkoVA6h_IGpmcmiIsI-bLi0UeBhTl50wRFXx8NOuTvbuv_Omd9GMWXx2exZ-aTUHjZ8O0yo-znrTJjPIg82aLk868BFBOYRf7jy6hBCaAVMCpMR15AA73qVOBhAns5XN47-ja7T1KzKHox-4PGuFrA-4sxZR7PAvz4UH-68uCVNNPhGs09ugQOTQXDFZne0Gr2uE3SDirqEic4o1twqGG6vRsgGHoFiidl_lRyGAKK3gQnrost55jujfhI2MUp4PPykbIFSAVUz35KdC-RfNC70XOGa7r2-1GCPpSFPyq1f98B6_eoPmkJS9KQAO-d_OtJog
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcyMTAsIm5iZiI6MTUyMDg0NzIxMCwiZXhwIjoxNTIwODUxMTEwLCJhaW8iOiJZMk5nWUpodFB0a2k2MFo1cHgyTHlWdHU5NzI3QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiS2tCZkxBZmtfMC1zeUgwaDZRb2pBQSIsInZlciI6IjEuMCJ9.Vfp8xCOV2qO_lW6yNVyfhqgGpT2ZG_Z3Nj79KQIrcAD9IDe8IaKlPoG_nmf3qLcXuKGG2QgEZe28-uL17_Yumns3TDPYvaCyONJ7HR4WOz6Sj-_DrXX3lUyHFe6HcaWli0q0eu4QpLcTUTRe6LkQ-u7jfsgw-ovI2FqwrL_lXv7TNhE7ZX-QvZJni2QYDvFGGZW6i2Y4TCOMQmqmWVu-VTfxHXZ_JJMGfiNXaV3Io_zjY8XkGKvXMHjdcpqM4b4fluhxYp-LJ2LkV1VNf7yIi8KrGtLWZzC1a0KC3gqNWxCYV08j1UAZxEVEZycyUQeJsaEHR9WDgll6xt8KR85KgQ
   response:
     status:
       code: 200
@@ -91,26 +91,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14999'
+      - '14998'
       X-Ms-Request-Id:
-      - 5a106844-faaf-4c32-83a9-fd2f1f859cd8
+      - 82fb7bea-d211-4577-96b6-7103e6412d87
       X-Ms-Correlation-Request-Id:
-      - 5a106844-faaf-4c32-83a9-fd2f1f859cd8
+      - 82fb7bea-d211-4577-96b6-7103e6412d87
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201946Z:5a106844-faaf-4c32-83a9-fd2f1f859cd8
+      - WESTEUROPE:20180312T093831Z:82fb7bea-d211-4577-96b6-7103e6412d87
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:19:45 GMT
+      - Mon, 12 Mar 2018 09:38:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID","subscriptionId":"AZURE_SUBSCRIPTION_ID","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:19:46 GMT
+  recorded_at: Mon, 12 Mar 2018 09:38:35 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers?api-version=2015-01-01
@@ -127,7 +127,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2ODUsIm5iZiI6MTUyMDQ1MzY4NSwiZXhwIjoxNTIwNDU3NTg1LCJhaW8iOiJZMk5nWUpDZDhXSnQweXhCbDUvc0Y1YjhPKytVQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSl85NzlMYjdJMFM5dWNYcndGZ0FBQSIsInZlciI6IjEuMCJ9.QDvUV9U7FuTHX-bOtNPkoVA6h_IGpmcmiIsI-bLi0UeBhTl50wRFXx8NOuTvbuv_Omd9GMWXx2exZ-aTUHjZ8O0yo-znrTJjPIg82aLk868BFBOYRf7jy6hBCaAVMCpMR15AA73qVOBhAns5XN47-ja7T1KzKHox-4PGuFrA-4sxZR7PAvz4UH-68uCVNNPhGs09ugQOTQXDFZne0Gr2uE3SDirqEic4o1twqGG6vRsgGHoFiidl_lRyGAKK3gQnrost55jujfhI2MUp4PPykbIFSAVUz35KdC-RfNC70XOGa7r2-1GCPpSFPyq1f98B6_eoPmkJS9KQAO-d_OtJog
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcyMTAsIm5iZiI6MTUyMDg0NzIxMCwiZXhwIjoxNTIwODUxMTEwLCJhaW8iOiJZMk5nWUpodFB0a2k2MFo1cHgyTHlWdHU5NzI3QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiS2tCZkxBZmtfMC1zeUgwaDZRb2pBQSIsInZlciI6IjEuMCJ9.Vfp8xCOV2qO_lW6yNVyfhqgGpT2ZG_Z3Nj79KQIrcAD9IDe8IaKlPoG_nmf3qLcXuKGG2QgEZe28-uL17_Yumns3TDPYvaCyONJ7HR4WOz6Sj-_DrXX3lUyHFe6HcaWli0q0eu4QpLcTUTRe6LkQ-u7jfsgw-ovI2FqwrL_lXv7TNhE7ZX-QvZJni2QYDvFGGZW6i2Y4TCOMQmqmWVu-VTfxHXZ_JJMGfiNXaV3Io_zjY8XkGKvXMHjdcpqM4b4fluhxYp-LJ2LkV1VNf7yIi8KrGtLWZzC1a0KC3gqNWxCYV08j1UAZxEVEZycyUQeJsaEHR9WDgll6xt8KR85KgQ
   response:
     status:
       code: 200
@@ -144,39 +144,37 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14975'
+      - '14985'
       X-Ms-Request-Id:
-      - d59c4a38-0413-4454-bf34-d5c63d522c6f
+      - f03e82d3-dbc9-400e-a64f-b04fcf8f315f
       X-Ms-Correlation-Request-Id:
-      - d59c4a38-0413-4454-bf34-d5c63d522c6f
+      - f03e82d3-dbc9-400e-a64f-b04fcf8f315f
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201947Z:d59c4a38-0413-4454-bf34-d5c63d522c6f
+      - WESTEUROPE:20180312T093836Z:f03e82d3-dbc9-400e-a64f-b04fcf8f315f
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:19:47 GMT
+      - Mon, 12 Mar 2018 09:38:35 GMT
       Content-Length:
-      - '310901'
+      - '320853'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"},{"applicationId":"d87dcbc6-a371-462e-88e3-28ad15ec4e64","roleDefinitionId":"861776c5-e0df-4f95-be4f-ac1eec193323"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
+      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"},{"applicationId":"d87dcbc6-a371-462e-88e3-28ad15ec4e64","roleDefinitionId":"861776c5-e0df-4f95-be4f-ac1eec193323"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["East
+        Asia","Southeast Asia","Australia East","Australia Southeast","Japan East","Japan
+        West","Central India","South India","West India","West Europe","North Europe","Canada
+        Central","Canada East","Brazil South","West US","Central US","East US","South
+        Central US","East US 2","West Central US","North Central US","West US 2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
         US","Central US","East US","South Central US","West Europe","North Europe","East
         Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
         Central US","North Central US","Japan East","Japan West","Brazil South","Central
         India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"operations","locations":["West
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["East
+        Asia","Southeast Asia","Australia East","Australia Southeast","Japan East","Japan
+        West","Central India","South India","West India","West Europe","North Europe","Canada
+        Central","Canada East","Brazil South","West US","Central US","East US","South
+        Central US","East US 2","West Central US","North Central US","West US 2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"operations","locations":["West
         US","Central US","East US","South Central US","West Europe","North Europe","East
         Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
         Central US","North Central US","Japan East","Japan West","Brazil South","Central
@@ -232,177 +230,177 @@ http_interactions:
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/internalLoadBalancers","locations":[],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"domainNames/slots/roles/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"domainNames/slots/roles/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"domainNames/capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"domainNames/serviceCertificates","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
         US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
         Central","Canada East","UK South","UK West","West US","Central US","South
         Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
-        East","Australia Southeast","West US 2","West Central US","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        East","Australia Southeast","West US 2","West Central US","France Central","South
+        India","Central India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
         US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
         Central","Canada East","UK South","UK West","West US","Central US","South
         Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
-        East","Australia Southeast","West US 2","West Central US","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metrics","locations":["North
+        East","Australia Southeast","West US 2","West Central US","France Central","South
+        India","Central India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metrics","locations":["North
         Central US","South Central US","East US","East US 2","Canada Central","Canada
         East","West US","West US 2","West Central US","Central US","East Asia","Southeast
         Asia","North Europe","West Europe","UK South","UK West","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"resourceTypes","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"moveSubscriptionResources","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"validateSubscriptionMoveAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operationStatuses","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operatingSystems","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"operatingSystemFamilies","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicNetwork","namespace":"Microsoft.ClassicNetwork","resourceTypes":[{"resourceType":"virtualNetworks","locations":["East
+        India","West India","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"resourceTypes","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"moveSubscriptionResources","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"validateSubscriptionMoveAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operationStatuses","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operatingSystems","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"operatingSystemFamilies","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicNetwork","namespace":"Microsoft.ClassicNetwork","resourceTypes":[{"resourceType":"virtualNetworks","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"virtualNetworks/remoteVirtualNetworkPeeringProxies","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01"]},{"resourceType":"virtualNetworks/remoteVirtualNetworkPeeringProxies","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"reservedIps","locations":["East
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01"]},{"resourceType":"reservedIps","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"gatewaySupportedDevices","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"networkSecurityGroups","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"gatewaySupportedDevices","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"networkSecurityGroups","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicStorage","namespace":"Microsoft.ClassicStorage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"expressRouteCrossConnections","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"expressRouteCrossConnections/peerings","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicStorage","namespace":"Microsoft.ClassicStorage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkStorageAccountAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"storageAccounts/services","locations":["West
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkStorageAccountAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"storageAccounts/services","locations":["West
         US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
         Asia","Australia East","Australia Southeast","South India","Central India","West
         India","West US 2","West Central US","East US","East US 2","North Central
         US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
-        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/diagnosticSettings","locations":["West
+        South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/diagnosticSettings","locations":["West
         US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
         Asia","Australia East","Australia Southeast","South India","Central India","West
         India","West US 2","West Central US","East US","East US 2","North Central
         US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
-        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"disks","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"images","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"vmImages","locations":[],"apiVersions":["2016-11-01"]},{"resourceType":"publicImages","locations":[],"apiVersions":["2016-11-01","2016-04-01"]},{"resourceType":"osImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"osPlatformImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute","namespace":"Microsoft.Compute","authorizations":[{"applicationId":"60e6cd67-9c8c-4951-9b3c-23c25a2169af","roleDefinitionId":"e4770acb-272e-4dc8-87f3-12f44a612224"},{"applicationId":"a303894e-f1d8-4a37-bf10-67aa654a0596","roleDefinitionId":"903ac751-8ad5-4e5a-bfc2-5e49f450a241"},{"applicationId":"a8b6bf88-1d1a-4626-b040-9a729ea93c65","roleDefinitionId":"45c8267c-80ba-4b96-9a43-115b8f49fccd"}],"resourceTypes":[{"resourceType":"availabilitySets","locations":["East
+        South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"disks","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"images","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"vmImages","locations":[],"apiVersions":["2016-11-01"]},{"resourceType":"storageAccounts/vmImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"publicImages","locations":[],"apiVersions":["2016-11-01","2016-04-01"]},{"resourceType":"osImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"osPlatformImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute","namespace":"Microsoft.Compute","authorizations":[{"applicationId":"60e6cd67-9c8c-4951-9b3c-23c25a2169af","roleDefinitionId":"e4770acb-272e-4dc8-87f3-12f44a612224"},{"applicationId":"a303894e-f1d8-4a37-bf10-67aa654a0596","roleDefinitionId":"903ac751-8ad5-4e5a-bfc2-5e49f450a241"},{"applicationId":"a8b6bf88-1d1a-4626-b040-9a729ea93c65","roleDefinitionId":"45c8267c-80ba-4b96-9a43-115b8f49fccd"}],"resourceTypes":[{"resourceType":"availabilitySets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations/usages","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations/usages","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"sharedVMImages","locations":["West
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"sharedVMImages","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"sharedVMImages/versions","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"locations/capsoperations","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"disks","locations":["Southeast
@@ -410,27 +408,27 @@ http_interactions:
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"snapshots","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"snapshots","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"locations/diskoperations","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"locations/diskoperations","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"images","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"images","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"]},{"resourceType":"locations/logAnalytics","locations":["East
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"]},{"resourceType":"locations/logAnalytics","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
         US","East US","South Central US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
@@ -547,7 +545,12 @@ http_interactions:
         US","East Asia","East US","East US 2","Japan East","Japan West","North Central
         US","North Europe","South Central US","South India","Southeast Asia","West
         Central US","West Europe","West India","West US","West US 2","UK West","UK
-        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"},{"applicationId":"f5c26e74-f226-4ae8-85f0-b4af0080ac9e","roleDefinitionId":"529d7ae6-e892-4d43-809d-8547aeb90643"}],"resourceTypes":[{"resourceType":"components","locations":["East
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/consumergroups","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/disasterrecoveryconfigs","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"},{"applicationId":"f5c26e74-f226-4ae8-85f0-b4af0080ac9e","roleDefinitionId":"529d7ae6-e892-4d43-809d-8547aeb90643"}],"resourceTypes":[{"resourceType":"components","locations":["East
         US","South Central US","North Europe","West Europe","Southeast Asia","West
         US 2"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
         US","South Central US","North Europe","West Europe","Southeast Asia","West
@@ -614,32 +617,32 @@ http_interactions:
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/accessPolicies","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"vaults/accessPolicies","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-10-01","2015-06-01","2014-12-19-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"deletedVaults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01","2014-12-19-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"deletedVaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-10-01"]},{"resourceType":"locations/deletedVaults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations/deletedVaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
         Central US","West Europe","Southeast Asia","Japan East","West Central US"],"apiVersions":["2016-04-01"]},{"resourceType":"webServices","locations":["South
         Central US","West Europe","Southeast Asia","Japan East","East US 2","West
         Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"operations","locations":["South
@@ -665,97 +668,97 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"networkWatchers/lenses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"networkWatchers/lenses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","West
         US 2","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
@@ -846,7 +849,7 @@ http_interactions:
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
         West","Korea Central","Korea South"],"apiVersions":["2017-07-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ResourceHealth","namespace":"Microsoft.ResourceHealth","authorizations":[{"applicationId":"8bdebf23-c0fe-4187-a378-717ad86f6a53","roleDefinitionId":"cc026344-c8b1-4561-83ba-59eba84b27cc"}],"resourceTypes":[{"resourceType":"availabilityStatuses","locations":[],"apiVersions":["2017-07-01","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"notifications","locations":["Australia
-        Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Security","namespace":"Microsoft.Security","authorization":{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
+        Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Security","namespace":"Microsoft.Security","authorizations":[{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},{"applicationId":"fc780465-2017-40d4-a0c5-307022471b92"}],"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatuses","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/virtualMachines","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/endpoints","locations":["Central
@@ -898,565 +901,595 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Central India","South
         India"],"apiVersions":["2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Sql","namespace":"Microsoft.Sql","authorizations":[{"applicationId":"e4ab13ed-33cb-41b4-9140-6e264582cf85","roleDefinitionId":"ec3ddc95-44dc-47a2-9926-5e9f5ffd44ec"},{"applicationId":"0130cc9f-7ac5-4026-bd5f-80a08a54e6d9","roleDefinitionId":"45e8abf8-0ec4-44f3-9c37-cff4f7779302"},{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},{"applicationId":"76c7f279-7959-468f-8943-3954880e0d8c","roleDefinitionId":"7f7513a8-73f9-4c5f-97a2-c41f0ea783ef"}],"resourceTypes":[{"resourceType":"operations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/capabilities","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/databaseAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/databaseOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverKeyOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/keys","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/encryptionProtector","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/usages","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01","2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/communicationLinks","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administrators","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administratorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/restorableDroppedDatabases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recoverableDatabases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/geoBackupPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/importExportOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/operationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/backupLongTermRetentionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/automaticTuning","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/automaticTuning","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/databases/transparentDataEncryption","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recommendedElasticPools","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/auditingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/connectionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/connectionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies/rules","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/securityAlertPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/securityAlertPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/auditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/extendedAuditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/elasticpools","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-09-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/jobAgentOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/jobAgentAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/disasterRecoveryConfiguration","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/dnsAliases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/failoverGroups","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/virtualNetworkRules","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/virtualNetworkRulesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/virtualNetworkRulesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/databaseRestoreAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metricDefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/aggregatedDatabaseMetrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metricdefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries/queryText","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPools/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/extensions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPoolEstimates","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditRecords","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentScans","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/vulnerabilityAssessments","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessment","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/syncGroups","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups/syncMembers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/syncAgents","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"managedInstances/administrators","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/databases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metricDefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/administratorAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/administratorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncMemberOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncAgentOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncDatabaseIds","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorizations":[{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},{"applicationId":"e406a681-f3d4-42a8-90b6-c2b029497af1"}],"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/capabilities","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/databaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"locations/databaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverKeyOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/keys","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/encryptionProtector","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01","2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/communicationLinks","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/restorableDroppedDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recoverableDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/geoBackupPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/importExportOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/operationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/backupLongTermRetentionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/databases/transparentDataEncryption","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recommendedElasticPools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies/rules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/extendedAuditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/elasticPoolAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/elasticPoolOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/elasticpools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-09-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/jobAgentOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/jobAgentAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/disasterRecoveryConfiguration","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/dnsAliases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/failoverGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/virtualNetworkRules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/virtualNetworkRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/virtualNetworkRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/databaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/aggregatedDatabaseMetrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metricdefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries/queryText","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPools/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/extensions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPoolEstimates","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditRecords","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentScans","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/vulnerabilityAssessments","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessment","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/syncGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups/syncMembers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/syncAgents","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"managedInstances/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/administratorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncMemberOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncAgentOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncDatabaseIds","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/longTermRetentionPolicyOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionPolicyAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionBackupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionBackupAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorizations":[{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},{"applicationId":"e406a681-f3d4-42a8-90b6-c2b029497af1"}],"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
@@ -1795,12 +1828,12 @@ http_interactions:
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","Canada Central","Canada East","UK South","UK West","West US 2","West
-        Central US","South India","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","South India","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","South India","Canada Central","Canada East","UK South","UK West","West
-        US 2","West Central US","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Capacity","namespace":"Microsoft.Capacity","authorization":{"applicationId":"4d0ad6c7-f6c3-46d8-ab0d-1406d5e6c86b","roleDefinitionId":"FD9C0A9A-4DB9-4F41-8A61-98385DEB6E2D"},"resourceTypes":[{"resourceType":"resources","locations":["South
+        US 2","West Central US","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Capacity","namespace":"Microsoft.Capacity","authorization":{"applicationId":"4d0ad6c7-f6c3-46d8-ab0d-1406d5e6c86b","roleDefinitionId":"FD9C0A9A-4DB9-4F41-8A61-98385DEB6E2D"},"resourceTypes":[{"resourceType":"resources","locations":["South
         Central US"],"apiVersions":["2017-11-01"]},{"resourceType":"reservationOrders","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/reservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/reservations/revisions","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"catalogs","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"appliedReservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"checkOffers","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"checkScopes","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"calculatePrice","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/calculateRefund","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/return","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/split","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/merge","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"validateReservationOrder","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/availableScopes","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Cdn","namespace":"Microsoft.Cdn","resourceTypes":[{"resourceType":"profiles","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
@@ -1876,9 +1909,9 @@ http_interactions:
         2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/updateAccountsCreationSettings","locations":["West
         US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/accountsCreationSettings","locations":["West
         US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2016-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Commerce","namespace":"Microsoft.Commerce","resourceTypes":[{"resourceType":"UsageAggregates","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]},{"resourceType":"RateCard","locations":[],"apiVersions":["2016-08-31-preview","2015-06-01-preview","2015-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Consumption","namespace":"Microsoft.Consumption","resourceTypes":[{"resourceType":"ReservationSummaries","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationTransactions","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Balances","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Marketplaces","locations":[],"apiVersions":["2018-01-31"]},{"resourceType":"Pricesheets","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationDetails","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Budgets","locations":[],"apiVersions":["2018-01-31","2017-12-30-preview"]},{"resourceType":"Terms","locations":[],"apiVersions":["2018-01-31","2017-12-30-preview"]},{"resourceType":"UsageDetails","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview","2017-04-24-preview"]},{"resourceType":"Operations","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview","2017-04-24-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerInstance","namespace":"Microsoft.ContainerInstance","resourceTypes":[{"resourceType":"containerGroups","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/usages","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/operations","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/operations","locations":["West
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
         US"],"apiVersions":["2016-04-08"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.CustomerInsights","namespace":"Microsoft.CustomerInsights","authorization":{"applicationId":"38c77d00-5fcb-4cce-9d93-af4738258e3c","roleDefinitionId":"E006F9C7-F333-477C-8AD6-1F3A9FE87F55"},"resourceTypes":[{"resourceType":"hubs","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/profiles","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/interactions","locations":["East
@@ -1895,7 +1928,9 @@ http_interactions:
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"operations","locations":["East
         US 2"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Databricks","namespace":"Microsoft.Databricks","authorizations":[{"applicationId":"d9327919-6775-4843-9037-3fb0fb0473cb","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},{"applicationId":"2ff814a6-3304-4ab8-85cb-cd0e6f879c1d","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"}],"resourceTypes":[{"resourceType":"workspaces","locations":["West
         US","East US 2","West Europe","East US","North Europe","Southeast Asia","East
-        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]},{"resourceType":"locations","locations":["West
+        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2017-09-01-preview"]},{"resourceType":"workspaces/virtualNetworkPeerings","locations":["West
+        US","East US 2","West Europe","North Europe","East US","Southeast Asia","East
+        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01"]},{"resourceType":"locations","locations":["West
         US","East US 2","West Europe","North Europe","East US","Southeast Asia"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
         US","East US 2","West Europe","East US","North Europe","Southeast Asia","East
         Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataCatalog","namespace":"Microsoft.DataCatalog","resourceTypes":[{"resourceType":"catalogs","locations":["East
@@ -1919,23 +1954,26 @@ http_interactions:
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers/listSasTokens","locations":["East
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataLakeStore","namespace":"Microsoft.DataLakeStore","authorization":{"applicationId":"e9f49c6b-5ce5-44c8-925d-015017e9f7ad","roleDefinitionId":"17eb9cca-f08a-4499-b2d3-852d175f614f"},"resourceTypes":[{"resourceType":"accounts","locations":["East
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/firewallRules","locations":["East
-        US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataMigration","namespace":"Microsoft.DataMigration","authorization":{"applicationId":"a4bad4aa-bf02-4631-9f78-a64ffdba8150","roleDefinitionId":"b831a21d-db98-4760-89cb-bef871952df1","managedByRoleDefinitionId":"6256fb55-9e59-4018-a9e1-76b11c0a4c89"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services/projects","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationStatuses","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
+        US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataMigration","namespace":"Microsoft.DataMigration","authorization":{"applicationId":"a4bad4aa-bf02-4631-9f78-a64ffdba8150","roleDefinitionId":"b831a21d-db98-4760-89cb-bef871952df1","managedByRoleDefinitionId":"6256fb55-9e59-4018-a9e1-76b11c0a4c89"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services/projects","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationStatuses","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
-        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/recoverableServers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
@@ -1959,7 +1997,10 @@ http_interactions:
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
-        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/recoverableServers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
@@ -2015,12 +2056,7 @@ http_interactions:
         US 2","East US","West US","Central US","East US 2","West Central US","West
         Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
         US 2","East US","West US","Central US","East US 2","West Central US","West
-        Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","West
-        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
-        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
-        India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/consumergroups","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/disasterrecoveryconfigs","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
         US 2","South Central US","Central US","Australia Southeast","Central India","West
         Central US","West US 2","Canada East","Canada Central","Brazil South","UK
         South","UK West","East Asia","Australia East","Japan East","Japan West","North
@@ -2131,7 +2167,7 @@ http_interactions:
         West","Japan East","East Asia","Southeast Asia","West Europe","North Europe","East
         US","West US","Australia East","Australia Southeast","Central US","Brazil
         South","Central India","West India","South India","South Central US","Canada
-        Central","Canada East","West Central US","West US 2"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
+        Central","Canada East","West Central US","West US 2"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-05","2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
         Central US","East US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"operations","locations":["West
         Central US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
         Central US","East US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.PolicyInsights","namespace":"Microsoft.PolicyInsights","authorization":{"applicationId":"1d78a85d-813d-46f0-b496-dd72f50a3ec0","roleDefinitionId":"63d2b225-4c34-4641-8768-21a1f7c68ce8"},"resourceTypes":[{"resourceType":"policyEvents","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"policyStates","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
@@ -2163,12 +2199,12 @@ http_interactions:
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
         Central US","South Central US","North Europe","West Europe","East Asia","Southeast
         Asia","West US","East US","Japan West","Japan East","Brazil South","Central
         US","East US 2","Australia East","Australia Southeast","South India","Central
@@ -2208,40 +2244,50 @@ http_interactions:
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/clusterVersions","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"clusters/applications","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operations","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/clusterVersions","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/environments","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operations","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
         Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applianceDefinitions","locations":["West
         Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applications","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
-        Central US"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
+        Central US"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
         US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
         US","Canada Central","Canada East","Central US","East US 2","UK South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups","locations":["West
         US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
@@ -2332,199 +2378,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:19:48 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2ODUsIm5iZiI6MTUyMDQ1MzY4NSwiZXhwIjoxNTIwNDU3NTg1LCJhaW8iOiJZMk5nWUpDZDhXSnQweXhCbDUvc0Y1YjhPKytVQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSl85NzlMYjdJMFM5dWNYcndGZ0FBQSIsInZlciI6IjEuMCJ9.QDvUV9U7FuTHX-bOtNPkoVA6h_IGpmcmiIsI-bLi0UeBhTl50wRFXx8NOuTvbuv_Omd9GMWXx2exZ-aTUHjZ8O0yo-znrTJjPIg82aLk868BFBOYRf7jy6hBCaAVMCpMR15AA73qVOBhAns5XN47-ja7T1KzKHox-4PGuFrA-4sxZR7PAvz4UH-68uCVNNPhGs09ugQOTQXDFZne0Gr2uE3SDirqEic4o1twqGG6vRsgGHoFiidl_lRyGAKK3gQnrost55jujfhI2MUp4PPykbIFSAVUz35KdC-RfNC70XOGa7r2-1GCPpSFPyq1f98B6_eoPmkJS9KQAO-d_OtJog
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - ce4369f6-82cc-4da2-8028-57dabd2f455c
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14975'
-      X-Ms-Correlation-Request-Id:
-      - 57396f2f-e2ad-417e-a95f-71cd0966ab2f
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201948Z:57396f2f-e2ad-417e-a95f-71cd0966ab2f
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:19:48 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1\",\r\n
-        \ \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"7ab88756-810f-4083-95db-8b05d50e38f2\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ],\r\n          \"inboundNatRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"backendIPConfigurations\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\"\r\n
-        \           }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-rule\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\":
-        80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\"\r\n
-        \         },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n
-        \       \"name\": \"rspec-lb-probe\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-NAT\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 3441,\r\n          \"backendPort\":
-        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:19:48 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2ODUsIm5iZiI6MTUyMDQ1MzY4NSwiZXhwIjoxNTIwNDU3NTg1LCJhaW8iOiJZMk5nWUpDZDhXSnQweXhCbDUvc0Y1YjhPKytVQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSl85NzlMYjdJMFM5dWNYcndGZ0FBQSIsInZlciI6IjEuMCJ9.QDvUV9U7FuTHX-bOtNPkoVA6h_IGpmcmiIsI-bLi0UeBhTl50wRFXx8NOuTvbuv_Omd9GMWXx2exZ-aTUHjZ8O0yo-znrTJjPIg82aLk868BFBOYRf7jy6hBCaAVMCpMR15AA73qVOBhAns5XN47-ja7T1KzKHox-4PGuFrA-4sxZR7PAvz4UH-68uCVNNPhGs09ugQOTQXDFZne0Gr2uE3SDirqEic4o1twqGG6vRsgGHoFiidl_lRyGAKK3gQnrost55jujfhI2MUp4PPykbIFSAVUz35KdC-RfNC70XOGa7r2-1GCPpSFPyq1f98B6_eoPmkJS9KQAO-d_OtJog
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"7a8e5fe7-f777-4435-992b-a54f28c2f28c"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - fa1a6d06-95d1-4a07-bf0b-5fb66a2c8510
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14980'
-      X-Ms-Correlation-Request-Id:
-      - 553c07f6-e76a-435e-84bc-a07fd7522a41
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201948Z:553c07f6-e76a-435e-84bc-a07fd7522a41
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:19:48 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb2\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2\",\r\n
-        \ \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"e2e30a77-f81b-43fc-9693-08303e43deed\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/backendAddressPools/rspec-lb2-pool\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\r\n
-        \       }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\": [],\r\n    \"probes\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-probe\",\r\n        \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/probes/rspec-lb2-probe\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\": [],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:19:49 GMT
+  recorded_at: Mon, 12 Mar 2018 09:38:40 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a?api-version=2017-12-01
@@ -2541,7 +2395,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2ODUsIm5iZiI6MTUyMDQ1MzY4NSwiZXhwIjoxNTIwNDU3NTg1LCJhaW8iOiJZMk5nWUpDZDhXSnQweXhCbDUvc0Y1YjhPKytVQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSl85NzlMYjdJMFM5dWNYcndGZ0FBQSIsInZlciI6IjEuMCJ9.QDvUV9U7FuTHX-bOtNPkoVA6h_IGpmcmiIsI-bLi0UeBhTl50wRFXx8NOuTvbuv_Omd9GMWXx2exZ-aTUHjZ8O0yo-znrTJjPIg82aLk868BFBOYRf7jy6hBCaAVMCpMR15AA73qVOBhAns5XN47-ja7T1KzKHox-4PGuFrA-4sxZR7PAvz4UH-68uCVNNPhGs09ugQOTQXDFZne0Gr2uE3SDirqEic4o1twqGG6vRsgGHoFiidl_lRyGAKK3gQnrost55jujfhI2MUp4PPykbIFSAVUz35KdC-RfNC70XOGa7r2-1GCPpSFPyq1f98B6_eoPmkJS9KQAO-d_OtJog
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcyMTAsIm5iZiI6MTUyMDg0NzIxMCwiZXhwIjoxNTIwODUxMTEwLCJhaW8iOiJZMk5nWUpodFB0a2k2MFo1cHgyTHlWdHU5NzI3QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiS2tCZkxBZmtfMC1zeUgwaDZRb2pBQSIsInZlciI6IjEuMCJ9.Vfp8xCOV2qO_lW6yNVyfhqgGpT2ZG_Z3Nj79KQIrcAD9IDe8IaKlPoG_nmf3qLcXuKGG2QgEZe28-uL17_Yumns3TDPYvaCyONJ7HR4WOz6Sj-_DrXX3lUyHFe6HcaWli0q0eu4QpLcTUTRe6LkQ-u7jfsgw-ovI2FqwrL_lXv7TNhE7ZX-QvZJni2QYDvFGGZW6i2Y4TCOMQmqmWVu-VTfxHXZ_JJMGfiNXaV3Io_zjY8XkGKvXMHjdcpqM4b4fluhxYp-LJ2LkV1VNf7yIi8KrGtLWZzC1a0KC3gqNWxCYV08j1UAZxEVEZycyUQeJsaEHR9WDgll6xt8KR85KgQ
   response:
     status:
       code: 200
@@ -2560,26 +2414,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/LowCostGet3Min;4727,Microsoft.Compute/LowCostGet30Min;37832
+      - Microsoft.Compute/LowCostGet3Min;4745,Microsoft.Compute/LowCostGet30Min;37863
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
       - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
       X-Ms-Request-Id:
-      - 938a8d64-e0de-4e7d-8f55-606a1b988ba8
+      - 5719717f-b5a4-4542-9e02-e32752c79234
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14981'
+      - '14987'
       X-Ms-Correlation-Request-Id:
-      - 1a62d94c-54c2-4634-a910-c32502417805
+      - 657c2e54-51e0-4350-ae5c-51b0c084fa07
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201949Z:1a62d94c-54c2-4634-a910-c32502417805
+      - WESTEUROPE:20180312T093836Z:657c2e54-51e0-4350-ae5c-51b0c084fa07
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:19:48 GMT
+      - Mon, 12 Mar 2018 09:38:36 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"23b0beab-16d2-4135-a01f-2fe713217fd0\",\r\n
@@ -2610,7 +2464,7 @@ http_interactions:
         \"eastus\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a\",\r\n
         \ \"name\": \"rspec-lb-a\"\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:19:49 GMT
+  recorded_at: Mon, 12 Mar 2018 09:38:41 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b?api-version=2017-12-01
@@ -2627,7 +2481,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2ODUsIm5iZiI6MTUyMDQ1MzY4NSwiZXhwIjoxNTIwNDU3NTg1LCJhaW8iOiJZMk5nWUpDZDhXSnQweXhCbDUvc0Y1YjhPKytVQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSl85NzlMYjdJMFM5dWNYcndGZ0FBQSIsInZlciI6IjEuMCJ9.QDvUV9U7FuTHX-bOtNPkoVA6h_IGpmcmiIsI-bLi0UeBhTl50wRFXx8NOuTvbuv_Omd9GMWXx2exZ-aTUHjZ8O0yo-znrTJjPIg82aLk868BFBOYRf7jy6hBCaAVMCpMR15AA73qVOBhAns5XN47-ja7T1KzKHox-4PGuFrA-4sxZR7PAvz4UH-68uCVNNPhGs09ugQOTQXDFZne0Gr2uE3SDirqEic4o1twqGG6vRsgGHoFiidl_lRyGAKK3gQnrost55jujfhI2MUp4PPykbIFSAVUz35KdC-RfNC70XOGa7r2-1GCPpSFPyq1f98B6_eoPmkJS9KQAO-d_OtJog
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcyMTAsIm5iZiI6MTUyMDg0NzIxMCwiZXhwIjoxNTIwODUxMTEwLCJhaW8iOiJZMk5nWUpodFB0a2k2MFo1cHgyTHlWdHU5NzI3QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiS2tCZkxBZmtfMC1zeUgwaDZRb2pBQSIsInZlciI6IjEuMCJ9.Vfp8xCOV2qO_lW6yNVyfhqgGpT2ZG_Z3Nj79KQIrcAD9IDe8IaKlPoG_nmf3qLcXuKGG2QgEZe28-uL17_Yumns3TDPYvaCyONJ7HR4WOz6Sj-_DrXX3lUyHFe6HcaWli0q0eu4QpLcTUTRe6LkQ-u7jfsgw-ovI2FqwrL_lXv7TNhE7ZX-QvZJni2QYDvFGGZW6i2Y4TCOMQmqmWVu-VTfxHXZ_JJMGfiNXaV3Io_zjY8XkGKvXMHjdcpqM4b4fluhxYp-LJ2LkV1VNf7yIi8KrGtLWZzC1a0KC3gqNWxCYV08j1UAZxEVEZycyUQeJsaEHR9WDgll6xt8KR85KgQ
   response:
     status:
       code: 200
@@ -2646,26 +2500,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/LowCostGet3Min;4726,Microsoft.Compute/LowCostGet30Min;37831
+      - Microsoft.Compute/LowCostGet3Min;4744,Microsoft.Compute/LowCostGet30Min;37862
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
       - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
       X-Ms-Request-Id:
-      - e68466bf-463c-414a-aaaa-1a9de435ac52
+      - c5aebc29-9ee4-47c8-8645-2222a2f2a2f8
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14975'
+      - '14988'
       X-Ms-Correlation-Request-Id:
-      - 5fdb171d-9e86-479f-97f3-d04c6ee96c99
+      - d7f54792-e8d0-4e1d-b980-c5d5ef79134b
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201950Z:5fdb171d-9e86-479f-97f3-d04c6ee96c99
+      - WESTEUROPE:20180312T093837Z:d7f54792-e8d0-4e1d-b980-c5d5ef79134b
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:19:49 GMT
+      - Mon, 12 Mar 2018 09:38:36 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"834a70b5-868d-4466-9dda-14e0f6b2caaf\",\r\n
@@ -2696,7 +2550,7 @@ http_interactions:
         \"eastus\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b\",\r\n
         \ \"name\": \"rspec-lb-b\"\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:19:50 GMT
+  recorded_at: Mon, 12 Mar 2018 09:38:42 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670?api-version=2018-01-01
@@ -2713,7 +2567,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2ODUsIm5iZiI6MTUyMDQ1MzY4NSwiZXhwIjoxNTIwNDU3NTg1LCJhaW8iOiJZMk5nWUpDZDhXSnQweXhCbDUvc0Y1YjhPKytVQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSl85NzlMYjdJMFM5dWNYcndGZ0FBQSIsInZlciI6IjEuMCJ9.QDvUV9U7FuTHX-bOtNPkoVA6h_IGpmcmiIsI-bLi0UeBhTl50wRFXx8NOuTvbuv_Omd9GMWXx2exZ-aTUHjZ8O0yo-znrTJjPIg82aLk868BFBOYRf7jy6hBCaAVMCpMR15AA73qVOBhAns5XN47-ja7T1KzKHox-4PGuFrA-4sxZR7PAvz4UH-68uCVNNPhGs09ugQOTQXDFZne0Gr2uE3SDirqEic4o1twqGG6vRsgGHoFiidl_lRyGAKK3gQnrost55jujfhI2MUp4PPykbIFSAVUz35KdC-RfNC70XOGa7r2-1GCPpSFPyq1f98B6_eoPmkJS9KQAO-d_OtJog
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcyMTAsIm5iZiI6MTUyMDg0NzIxMCwiZXhwIjoxNTIwODUxMTEwLCJhaW8iOiJZMk5nWUpodFB0a2k2MFo1cHgyTHlWdHU5NzI3QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiS2tCZkxBZmtfMC1zeUgwaDZRb2pBQSIsInZlciI6IjEuMCJ9.Vfp8xCOV2qO_lW6yNVyfhqgGpT2ZG_Z3Nj79KQIrcAD9IDe8IaKlPoG_nmf3qLcXuKGG2QgEZe28-uL17_Yumns3TDPYvaCyONJ7HR4WOz6Sj-_DrXX3lUyHFe6HcaWli0q0eu4QpLcTUTRe6LkQ-u7jfsgw-ovI2FqwrL_lXv7TNhE7ZX-QvZJni2QYDvFGGZW6i2Y4TCOMQmqmWVu-VTfxHXZ_JJMGfiNXaV3Io_zjY8XkGKvXMHjdcpqM4b4fluhxYp-LJ2LkV1VNf7yIi8KrGtLWZzC1a0KC3gqNWxCYV08j1UAZxEVEZycyUQeJsaEHR9WDgll6xt8KR85KgQ
   response:
     status:
       code: 200
@@ -2734,22 +2588,22 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 6c067313-385a-4cc2-bf89-1cb612b1f2e8
+      - 2d7c76c0-51da-4984-8543-00b2347fec9e
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14981'
+      - '14988'
       X-Ms-Correlation-Request-Id:
-      - a926ce43-8f85-4ea8-9b76-1d987371c6db
+      - c9783a10-43c8-4afd-9c05-9a122a7608c8
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201950Z:a926ce43-8f85-4ea8-9b76-1d987371c6db
+      - WESTEUROPE:20180312T093839Z:c9783a10-43c8-4afd-9c05-9a122a7608c8
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:19:49 GMT
+      - Mon, 12 Mar 2018 09:38:38 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"rspec-lb-a670\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670\",\r\n
@@ -2777,7 +2631,7 @@ http_interactions:
         \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
         \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:19:50 GMT
+  recorded_at: Mon, 12 Mar 2018 09:38:43 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843?api-version=2018-01-01
@@ -2794,7 +2648,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2ODUsIm5iZiI6MTUyMDQ1MzY4NSwiZXhwIjoxNTIwNDU3NTg1LCJhaW8iOiJZMk5nWUpDZDhXSnQweXhCbDUvc0Y1YjhPKytVQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSl85NzlMYjdJMFM5dWNYcndGZ0FBQSIsInZlciI6IjEuMCJ9.QDvUV9U7FuTHX-bOtNPkoVA6h_IGpmcmiIsI-bLi0UeBhTl50wRFXx8NOuTvbuv_Omd9GMWXx2exZ-aTUHjZ8O0yo-znrTJjPIg82aLk868BFBOYRf7jy6hBCaAVMCpMR15AA73qVOBhAns5XN47-ja7T1KzKHox-4PGuFrA-4sxZR7PAvz4UH-68uCVNNPhGs09ugQOTQXDFZne0Gr2uE3SDirqEic4o1twqGG6vRsgGHoFiidl_lRyGAKK3gQnrost55jujfhI2MUp4PPykbIFSAVUz35KdC-RfNC70XOGa7r2-1GCPpSFPyq1f98B6_eoPmkJS9KQAO-d_OtJog
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcyMTAsIm5iZiI6MTUyMDg0NzIxMCwiZXhwIjoxNTIwODUxMTEwLCJhaW8iOiJZMk5nWUpodFB0a2k2MFo1cHgyTHlWdHU5NzI3QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiS2tCZkxBZmtfMC1zeUgwaDZRb2pBQSIsInZlciI6IjEuMCJ9.Vfp8xCOV2qO_lW6yNVyfhqgGpT2ZG_Z3Nj79KQIrcAD9IDe8IaKlPoG_nmf3qLcXuKGG2QgEZe28-uL17_Yumns3TDPYvaCyONJ7HR4WOz6Sj-_DrXX3lUyHFe6HcaWli0q0eu4QpLcTUTRe6LkQ-u7jfsgw-ovI2FqwrL_lXv7TNhE7ZX-QvZJni2QYDvFGGZW6i2Y4TCOMQmqmWVu-VTfxHXZ_JJMGfiNXaV3Io_zjY8XkGKvXMHjdcpqM4b4fluhxYp-LJ2LkV1VNf7yIi8KrGtLWZzC1a0KC3gqNWxCYV08j1UAZxEVEZycyUQeJsaEHR9WDgll6xt8KR85KgQ
   response:
     status:
       code: 200
@@ -2815,22 +2669,22 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - dd9cf385-d24d-4580-b0d8-ff0f0e944094
+      - 775af42b-1aaf-45ab-8103-42a733af6814
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - '14989'
       X-Ms-Correlation-Request-Id:
-      - d37254f5-a4b2-4875-9946-774350482eb8
+      - e09d743c-a8fa-4ceb-97df-84726b341dc7
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201951Z:d37254f5-a4b2-4875-9946-774350482eb8
+      - WESTEUROPE:20180312T093839Z:e09d743c-a8fa-4ceb-97df-84726b341dc7
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:19:50 GMT
+      - Mon, 12 Mar 2018 09:38:38 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"rspec-lb-b843\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843\",\r\n
@@ -2855,10 +2709,10 @@ http_interactions:
         \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
         \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:19:51 GMT
+  recorded_at: Mon, 12 Mar 2018 09:38:44 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups/miq-azure-test1?api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a/instanceView?api-version=2017-12-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2872,60 +2726,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2ODUsIm5iZiI6MTUyMDQ1MzY4NSwiZXhwIjoxNTIwNDU3NTg1LCJhaW8iOiJZMk5nWUpDZDhXSnQweXhCbDUvc0Y1YjhPKytVQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSl85NzlMYjdJMFM5dWNYcndGZ0FBQSIsInZlciI6IjEuMCJ9.QDvUV9U7FuTHX-bOtNPkoVA6h_IGpmcmiIsI-bLi0UeBhTl50wRFXx8NOuTvbuv_Omd9GMWXx2exZ-aTUHjZ8O0yo-znrTJjPIg82aLk868BFBOYRf7jy6hBCaAVMCpMR15AA73qVOBhAns5XN47-ja7T1KzKHox-4PGuFrA-4sxZR7PAvz4UH-68uCVNNPhGs09ugQOTQXDFZne0Gr2uE3SDirqEic4o1twqGG6vRsgGHoFiidl_lRyGAKK3gQnrost55jujfhI2MUp4PPykbIFSAVUz35KdC-RfNC70XOGa7r2-1GCPpSFPyq1f98B6_eoPmkJS9KQAO-d_OtJog
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14976'
-      X-Ms-Request-Id:
-      - 16c44c6f-af58-4274-9f11-552f8ac6603d
-      X-Ms-Correlation-Request-Id:
-      - 16c44c6f-af58-4274-9f11-552f8ac6603d
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201951Z:16c44c6f-af58-4274-9f11-552f8ac6603d
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:19:51 GMT
-      Content-Length:
-      - '183'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1","name":"miq-azure-test1","location":"eastus","properties":{"provisioningState":"Succeeded"}}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:19:51 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute/locations/eastus/vmSizes?api-version=2017-12-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2ODUsIm5iZiI6MTUyMDQ1MzY4NSwiZXhwIjoxNTIwNDU3NTg1LCJhaW8iOiJZMk5nWUpDZDhXSnQweXhCbDUvc0Y1YjhPKytVQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSl85NzlMYjdJMFM5dWNYcndGZ0FBQSIsInZlciI6IjEuMCJ9.QDvUV9U7FuTHX-bOtNPkoVA6h_IGpmcmiIsI-bLi0UeBhTl50wRFXx8NOuTvbuv_Omd9GMWXx2exZ-aTUHjZ8O0yo-znrTJjPIg82aLk868BFBOYRf7jy6hBCaAVMCpMR15AA73qVOBhAns5XN47-ja7T1KzKHox-4PGuFrA-4sxZR7PAvz4UH-68uCVNNPhGs09ugQOTQXDFZne0Gr2uE3SDirqEic4o1twqGG6vRsgGHoFiidl_lRyGAKK3gQnrost55jujfhI2MUp4PPykbIFSAVUz35KdC-RfNC70XOGa7r2-1GCPpSFPyq1f98B6_eoPmkJS9KQAO-d_OtJog
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcyMTAsIm5iZiI6MTUyMDg0NzIxMCwiZXhwIjoxNTIwODUxMTEwLCJhaW8iOiJZMk5nWUpodFB0a2k2MFo1cHgyTHlWdHU5NzI3QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiS2tCZkxBZmtfMC1zeUgwaDZRb2pBQSIsInZlciI6IjEuMCJ9.Vfp8xCOV2qO_lW6yNVyfhqgGpT2ZG_Z3Nj79KQIrcAD9IDe8IaKlPoG_nmf3qLcXuKGG2QgEZe28-uL17_Yumns3TDPYvaCyONJ7HR4WOz6Sj-_DrXX3lUyHFe6HcaWli0q0eu4QpLcTUTRe6LkQ-u7jfsgw-ovI2FqwrL_lXv7TNhE7ZX-QvZJni2QYDvFGGZW6i2Y4TCOMQmqmWVu-VTfxHXZ_JJMGfiNXaV3Io_zjY8XkGKvXMHjdcpqM4b4fluhxYp-LJ2LkV1VNf7yIi8KrGtLWZzC1a0KC3gqNWxCYV08j1UAZxEVEZycyUQeJsaEHR9WDgll6xt8KR85KgQ
   response:
     status:
       code: 200
@@ -2944,26 +2745,233 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/LowCostGet3Min;4725,Microsoft.Compute/LowCostGet30Min;37830
+      - Microsoft.Compute/GetInstanceView3Min;4793,Microsoft.Compute/GetInstanceView30Min;23908
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
       - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
       X-Ms-Request-Id:
-      - 99be1292-5598-41a7-a57a-ee6bdc2ecfd9
+      - f0af1e25-21fc-45ba-a06d-047e6970d5e6
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14975'
+      - '14993'
       X-Ms-Correlation-Request-Id:
-      - b5679738-7ace-4034-beb2-fff9a31e64f6
+      - d7863fce-1bf4-43e3-af3d-a1e57eb78edf
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201953Z:b5679738-7ace-4034-beb2-fff9a31e64f6
+      - WESTEUROPE:20180312T093849Z:d7863fce-1bf4-43e3-af3d-a1e57eb78edf
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:19:52 GMT
+      - Mon, 12 Mar 2018 09:38:49 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"platformUpdateDomain\": 0,\r\n  \"platformFaultDomain\": 0,\r\n
+        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
+        [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
+        \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
+        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2018-03-12T09:38:40+00:00\"\r\n
+        \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"rspec-lb-a\",\r\n
+        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
+        succeeded\",\r\n          \"time\": \"2016-09-03T14:04:26.7359609+00:00\"\r\n
+        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
+        \"https://miqazuretest16487.blob.core.windows.net/bootdiagnostics-rspeclba-23b0beab-16d2-4135-a01f-2fe713217fd0/rspec-lb-a.23b0beab-16d2-4135-a01f-2fe713217fd0.screenshot.bmp\",\r\n
+        \   \"serialConsoleLogBlobUri\": \"https://miqazuretest16487.blob.core.windows.net/bootdiagnostics-rspeclba-23b0beab-16d2-4135-a01f-2fe713217fd0/rspec-lb-a.23b0beab-16d2-4135-a01f-2fe713217fd0.serialconsole.log\"\r\n
+        \ },\r\n  \"extensions\": [\r\n    {\r\n      \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n
+        \   }\r\n  ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n
+        \     \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n
+        \     \"time\": \"2016-09-03T14:04:26.7828345+00:00\"\r\n    },\r\n    {\r\n
+        \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
+        \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:38:53 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b/instanceView?api-version=2017-12-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcyMTAsIm5iZiI6MTUyMDg0NzIxMCwiZXhwIjoxNTIwODUxMTEwLCJhaW8iOiJZMk5nWUpodFB0a2k2MFo1cHgyTHlWdHU5NzI3QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiS2tCZkxBZmtfMC1zeUgwaDZRb2pBQSIsInZlciI6IjEuMCJ9.Vfp8xCOV2qO_lW6yNVyfhqgGpT2ZG_Z3Nj79KQIrcAD9IDe8IaKlPoG_nmf3qLcXuKGG2QgEZe28-uL17_Yumns3TDPYvaCyONJ7HR4WOz6Sj-_DrXX3lUyHFe6HcaWli0q0eu4QpLcTUTRe6LkQ-u7jfsgw-ovI2FqwrL_lXv7TNhE7ZX-QvZJni2QYDvFGGZW6i2Y4TCOMQmqmWVu-VTfxHXZ_JJMGfiNXaV3Io_zjY8XkGKvXMHjdcpqM4b4fluhxYp-LJ2LkV1VNf7yIi8KrGtLWZzC1a0KC3gqNWxCYV08j1UAZxEVEZycyUQeJsaEHR9WDgll6xt8KR85KgQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/GetInstanceView3Min;4792,Microsoft.Compute/GetInstanceView30Min;23907
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      X-Ms-Request-Id:
+      - 1b45ca18-a525-4d33-9f4e-f5635319982f
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14987'
+      X-Ms-Correlation-Request-Id:
+      - 4f99a317-7f69-4a50-ada0-0eac2183075d
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T093849Z:4f99a317-7f69-4a50-ada0-0eac2183075d
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:38:49 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"platformUpdateDomain\": 1,\r\n  \"platformFaultDomain\": 1,\r\n
+        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
+        [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
+        \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
+        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2018-03-12T09:38:49+00:00\"\r\n
+        \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"rspec-lb-b\",\r\n
+        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
+        succeeded\",\r\n          \"time\": \"2016-09-03T14:07:52.9377685+00:00\"\r\n
+        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
+        \"https://amissteastorage.blob.core.windows.net/bootdiagnostics-rspeclbb-834a70b5-868d-4466-9dda-14e0f6b2caaf/rspec-lb-b.834a70b5-868d-4466-9dda-14e0f6b2caaf.screenshot.bmp\",\r\n
+        \   \"serialConsoleLogBlobUri\": \"https://amissteastorage.blob.core.windows.net/bootdiagnostics-rspeclbb-834a70b5-868d-4466-9dda-14e0f6b2caaf/rspec-lb-b.834a70b5-868d-4466-9dda-14e0f6b2caaf.serialconsole.log\"\r\n
+        \ },\r\n  \"extensions\": [\r\n    {\r\n      \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n
+        \   }\r\n  ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n
+        \     \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n
+        \     \"time\": \"2016-09-03T14:07:52.9846158+00:00\"\r\n    },\r\n    {\r\n
+        \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
+        \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:38:54 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups/miq-azure-test1?api-version=2017-08-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcyMTAsIm5iZiI6MTUyMDg0NzIxMCwiZXhwIjoxNTIwODUxMTEwLCJhaW8iOiJZMk5nWUpodFB0a2k2MFo1cHgyTHlWdHU5NzI3QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiS2tCZkxBZmtfMC1zeUgwaDZRb2pBQSIsInZlciI6IjEuMCJ9.Vfp8xCOV2qO_lW6yNVyfhqgGpT2ZG_Z3Nj79KQIrcAD9IDe8IaKlPoG_nmf3qLcXuKGG2QgEZe28-uL17_Yumns3TDPYvaCyONJ7HR4WOz6Sj-_DrXX3lUyHFe6HcaWli0q0eu4QpLcTUTRe6LkQ-u7jfsgw-ovI2FqwrL_lXv7TNhE7ZX-QvZJni2QYDvFGGZW6i2Y4TCOMQmqmWVu-VTfxHXZ_JJMGfiNXaV3Io_zjY8XkGKvXMHjdcpqM4b4fluhxYp-LJ2LkV1VNf7yIi8KrGtLWZzC1a0KC3gqNWxCYV08j1UAZxEVEZycyUQeJsaEHR9WDgll6xt8KR85KgQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14987'
+      X-Ms-Request-Id:
+      - '038911b4-6c0b-42ef-9286-86af2e0281d8'
+      X-Ms-Correlation-Request-Id:
+      - '038911b4-6c0b-42ef-9286-86af2e0281d8'
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T093850Z:038911b4-6c0b-42ef-9286-86af2e0281d8
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:38:49 GMT
+      Content-Length:
+      - '183'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1","name":"miq-azure-test1","location":"eastus","properties":{"provisioningState":"Succeeded"}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:38:54 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute/locations/eastus/vmSizes?api-version=2017-12-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcyMTAsIm5iZiI6MTUyMDg0NzIxMCwiZXhwIjoxNTIwODUxMTEwLCJhaW8iOiJZMk5nWUpodFB0a2k2MFo1cHgyTHlWdHU5NzI3QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiS2tCZkxBZmtfMC1zeUgwaDZRb2pBQSIsInZlciI6IjEuMCJ9.Vfp8xCOV2qO_lW6yNVyfhqgGpT2ZG_Z3Nj79KQIrcAD9IDe8IaKlPoG_nmf3qLcXuKGG2QgEZe28-uL17_Yumns3TDPYvaCyONJ7HR4WOz6Sj-_DrXX3lUyHFe6HcaWli0q0eu4QpLcTUTRe6LkQ-u7jfsgw-ovI2FqwrL_lXv7TNhE7ZX-QvZJni2QYDvFGGZW6i2Y4TCOMQmqmWVu-VTfxHXZ_JJMGfiNXaV3Io_zjY8XkGKvXMHjdcpqM4b4fluhxYp-LJ2LkV1VNf7yIi8KrGtLWZzC1a0KC3gqNWxCYV08j1UAZxEVEZycyUQeJsaEHR9WDgll6xt8KR85KgQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/LowCostGet3Min;4738,Microsoft.Compute/LowCostGet30Min;37856
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      X-Ms-Request-Id:
+      - 40ac5083-3f87-4430-bd69-ea116c884eef
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14985'
+      X-Ms-Correlation-Request-Id:
+      - 7185d5d4-6aec-499e-8ef8-3c988548b56b
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T093850Z:7185d5d4-6aec-499e-8ef8-3c988548b56b
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:38:50 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"Standard_B1ms\",\r\n
@@ -3440,6 +3448,12 @@ http_interactions:
         \   },\r\n    {\r\n      \"name\": \"Standard_F72s_v2\",\r\n      \"numberOfCores\":
         72,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
         589824,\r\n      \"memoryInMB\": 147456,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_L8s_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1811981,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_L16s_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        3623962,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
         \   },\r\n    {\r\n      \"name\": \"Standard_ND6s\",\r\n      \"numberOfCores\":
         6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
         344064,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 12\r\n
@@ -3466,10 +3480,10 @@ http_interactions:
         391168,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
         \   }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:19:53 GMT
+  recorded_at: Mon, 12 Mar 2018 09:38:55 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-a-ip?api-version=2018-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3483,7 +3497,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2ODUsIm5iZiI6MTUyMDQ1MzY4NSwiZXhwIjoxNTIwNDU3NTg1LCJhaW8iOiJZMk5nWUpDZDhXSnQweXhCbDUvc0Y1YjhPKytVQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSl85NzlMYjdJMFM5dWNYcndGZ0FBQSIsInZlciI6IjEuMCJ9.QDvUV9U7FuTHX-bOtNPkoVA6h_IGpmcmiIsI-bLi0UeBhTl50wRFXx8NOuTvbuv_Omd9GMWXx2exZ-aTUHjZ8O0yo-znrTJjPIg82aLk868BFBOYRf7jy6hBCaAVMCpMR15AA73qVOBhAns5XN47-ja7T1KzKHox-4PGuFrA-4sxZR7PAvz4UH-68uCVNNPhGs09ugQOTQXDFZne0Gr2uE3SDirqEic4o1twqGG6vRsgGHoFiidl_lRyGAKK3gQnrost55jujfhI2MUp4PPykbIFSAVUz35KdC-RfNC70XOGa7r2-1GCPpSFPyq1f98B6_eoPmkJS9KQAO-d_OtJog
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcyMTAsIm5iZiI6MTUyMDg0NzIxMCwiZXhwIjoxNTIwODUxMTEwLCJhaW8iOiJZMk5nWUpodFB0a2k2MFo1cHgyTHlWdHU5NzI3QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiS2tCZkxBZmtfMC1zeUgwaDZRb2pBQSIsInZlciI6IjEuMCJ9.Vfp8xCOV2qO_lW6yNVyfhqgGpT2ZG_Z3Nj79KQIrcAD9IDe8IaKlPoG_nmf3qLcXuKGG2QgEZe28-uL17_Yumns3TDPYvaCyONJ7HR4WOz6Sj-_DrXX3lUyHFe6HcaWli0q0eu4QpLcTUTRe6LkQ-u7jfsgw-ovI2FqwrL_lXv7TNhE7ZX-QvZJni2QYDvFGGZW6i2Y4TCOMQmqmWVu-VTfxHXZ_JJMGfiNXaV3Io_zjY8XkGKvXMHjdcpqM4b4fluhxYp-LJ2LkV1VNf7yIi8KrGtLWZzC1a0KC3gqNWxCYV08j1UAZxEVEZycyUQeJsaEHR9WDgll6xt8KR85KgQ
   response:
     status:
       code: 200
@@ -3499,63 +3513,42 @@ http_interactions:
       - application/json; charset=utf-8
       Expires:
       - "-1"
+      Etag:
+      - W/"3ba30997-7d2f-470c-96f6-301158e93b7c"
       Vary:
       - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/LowCostGet3Min;4723,Microsoft.Compute/LowCostGet30Min;37828
+      X-Ms-Request-Id:
+      - b50cbad2-afbf-417d-816b-d77b3faf021a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
-      X-Ms-Request-Id:
-      - c136f5f0-9a04-464d-9ecd-e8126aeafbec
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14975'
+      - '14989'
       X-Ms-Correlation-Request-Id:
-      - 1fbc0e9a-fa59-4331-9515-a78e60515299
+      - c48393fe-8b42-48e9-8118-abe7a83eab8b
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202001Z:1fbc0e9a-fa59-4331-9515-a78e60515299
+      - WESTEUROPE:20180312T093851Z:c48393fe-8b42-48e9-8118-abe7a83eab8b
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:20:00 GMT
+      - Mon, 12 Mar 2018 09:38:50 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"23b0beab-16d2-4135-a01f-2fe713217fd0\",\r\n
-        \   \"availabilitySet\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/RSPEC-LB\"\r\n
-        \   },\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_F1s\"\r\n
-        \   },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
-        \"RedHat\",\r\n        \"offer\": \"RHEL\",\r\n        \"sku\": \"6.7\",\r\n
-        \       \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
-        \"Linux\",\r\n        \"name\": \"rspec-lb-a\",\r\n        \"createOption\":
-        \"FromImage\",\r\n        \"vhd\": {\r\n          \"uri\": \"https://rspeclb.blob.core.windows.net/vhds/rspec-lb-a201682122839.vhd\"\r\n
-        \       },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n      \"dataDisks\":
-        []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"rspec-lb-a\",\r\n
-        \     \"adminUsername\": \"bronaghs\",\r\n      \"linuxConfiguration\": {\r\n
-        \       \"disablePasswordAuthentication\": false\r\n      },\r\n      \"secrets\":
-        []\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670\"}]},\r\n
-        \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
-        true,\r\n        \"storageUri\": \"https://miqazuretest16487.blob.core.windows.net/\"\r\n
-        \     }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n
-        \ \"resources\": [\r\n    {\r\n      \"properties\": {\r\n        \"publisher\":
-        \"Microsoft.OSTCExtensions\",\r\n        \"type\": \"LinuxDiagnostic\",\r\n
-        \       \"typeHandlerVersion\": \"2.3\",\r\n        \"autoUpgradeMinorVersion\":
-        true,\r\n        \"settings\": {\"xmlCfg\":\"PFdhZENmZz48RGlhZ25vc3RpY01vbml0b3JDb25maWd1cmF0aW9uIG92ZXJhbGxRdW90YUluTUI9IjQwOTYiPjxEaWFnbm9zdGljSW5mcmFzdHJ1Y3R1cmVMb2dzIHNjaGVkdWxlZFRyYW5zZmVyUGVyaW9kPSJQVDFNIiBzY2hlZHVsZWRUcmFuc2ZlckxvZ0xldmVsRmlsdGVyPSJXYXJuaW5nIi8+PFBlcmZvcm1hbmNlQ291bnRlcnMgc2NoZWR1bGVkVHJhbnNmZXJQZXJpb2Q9IlBUMU0iPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlTWVtb3J5IiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQnl0ZXMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcUGVyY2VudEF2YWlsYWJsZU1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iTWVtb3J5IHVzZWQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50VXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgcGVyY2VudGFnZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkQnlDYWNoZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHVzZWQgYnkgY2FjaGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1BlclNlYyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50UGVyU2Vjb25kIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFnZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1JlYWRQZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2UgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1dyaXR0ZW5QZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2Ugd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iU3dhcCBhdmFpbGFibGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50QXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZFN3YXAiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlN3YXAgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRJZGxlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgaWRsZSB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFVzZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iUGVyY2VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkNQVSB1c2VyIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50TmljZVRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIG5pY2UgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRQcml2aWxlZ2VkVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgcHJpdmlsZWdlZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudEludGVycnVwdFRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIGludGVycnVwdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudERQQ1RpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIERQQyB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFByb2Nlc3NvclRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIHBlcmNlbnRhZ2UgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50SU9XYWl0VGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgSU8gd2FpdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xSZWFkQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCBndWVzdCBPUyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXFdyaXRlQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGUgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xUcmFuc2ZlcnNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXJzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcUmVhZHNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xXcml0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVJlYWRUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVdyaXRlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlNlY29uZHMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJEaXNrIHdyaXRlIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xBdmVyYWdlVHJhbnNmZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXIgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXEF2ZXJhZ2VEaXNrUXVldWVMZW5ndGgiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcXVldWUgbGVuZ3RoIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVHJhbnNtaXR0ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgb3V0IGd1ZXN0IE9TIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzUmVjZWl2ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgaW4gZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1RyYW5zbWl0dGVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHNlbnQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1JlY2VpdmVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHJlY2VpdmVkIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVG90YWwiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxSeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyByZWNlaXZlZCBlcnJvcnMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxUeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyBzZW50IGVycm9ycyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTmV0d29ya0ludGVyZmFjZVxUb3RhbENvbGxpc2lvbnMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgY29sbGlzaW9ucyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48L1BlcmZvcm1hbmNlQ291bnRlcnM+PE1ldHJpY3MgcmVzb3VyY2VJZD0iL3N1YnNjcmlwdGlvbnMvMjU4NmM2NGItMzhiNC00NTI3LWExNDAtMDEyZDQ5ZGZjMDJjL3Jlc291cmNlR3JvdXBzL21pcS1henVyZS10ZXN0MS9wcm92aWRlcnMvTWljcm9zb2Z0LkNvbXB1dGUvdmlydHVhbE1hY2hpbmVzL3JzcGVjLWxiLWEiPjxNZXRyaWNBZ2dyZWdhdGlvbiBzY2hlZHVsZWRUcmFuc2ZlclBlcmlvZD0iUFQxSCIvPjxNZXRyaWNBZ2dyZWdhdGlvbiBzY2hlZHVsZWRUcmFuc2ZlclBlcmlvZD0iUFQxTSIvPjwvTWV0cmljcz48L0RpYWdub3N0aWNNb25pdG9yQ29uZmlndXJhdGlvbj48L1dhZENmZz4=\",\"StorageAccount\":\"miqazuretest16487\"},\r\n
-        \       \"provisioningState\": \"Succeeded\"\r\n      },\r\n      \"type\":
-        \"Microsoft.Compute/virtualMachines/extensions\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a/extensions/Microsoft.Insights.VMDiagnosticsSettings\",\r\n
-        \     \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n    }\r\n
-        \ ],\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\":
-        \"eastus\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a\",\r\n
-        \ \"name\": \"rspec-lb-a\"\r\n}"
+      string: "{\r\n  \"name\": \"rspec-lb-a-ip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-a-ip\",\r\n
+        \ \"etag\": \"W/\\\"3ba30997-7d2f-470c-96f6-301158e93b7c\\\"\",\r\n  \"location\":
+        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"3c605f75-23c0-46ab-ba2b-6fd4430140fd\",\r\n    \"publicIPAddressVersion\":
+        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
+        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
+        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
+        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:20:01 GMT
+  recorded_at: Mon, 12 Mar 2018 09:38:55 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-b-ip?api-version=2018-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3569,7 +3562,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2ODUsIm5iZiI6MTUyMDQ1MzY4NSwiZXhwIjoxNTIwNDU3NTg1LCJhaW8iOiJZMk5nWUpDZDhXSnQweXhCbDUvc0Y1YjhPKytVQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSl85NzlMYjdJMFM5dWNYcndGZ0FBQSIsInZlciI6IjEuMCJ9.QDvUV9U7FuTHX-bOtNPkoVA6h_IGpmcmiIsI-bLi0UeBhTl50wRFXx8NOuTvbuv_Omd9GMWXx2exZ-aTUHjZ8O0yo-znrTJjPIg82aLk868BFBOYRf7jy6hBCaAVMCpMR15AA73qVOBhAns5XN47-ja7T1KzKHox-4PGuFrA-4sxZR7PAvz4UH-68uCVNNPhGs09ugQOTQXDFZne0Gr2uE3SDirqEic4o1twqGG6vRsgGHoFiidl_lRyGAKK3gQnrost55jujfhI2MUp4PPykbIFSAVUz35KdC-RfNC70XOGa7r2-1GCPpSFPyq1f98B6_eoPmkJS9KQAO-d_OtJog
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcyMTAsIm5iZiI6MTUyMDg0NzIxMCwiZXhwIjoxNTIwODUxMTEwLCJhaW8iOiJZMk5nWUpodFB0a2k2MFo1cHgyTHlWdHU5NzI3QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiS2tCZkxBZmtfMC1zeUgwaDZRb2pBQSIsInZlciI6IjEuMCJ9.Vfp8xCOV2qO_lW6yNVyfhqgGpT2ZG_Z3Nj79KQIrcAD9IDe8IaKlPoG_nmf3qLcXuKGG2QgEZe28-uL17_Yumns3TDPYvaCyONJ7HR4WOz6Sj-_DrXX3lUyHFe6HcaWli0q0eu4QpLcTUTRe6LkQ-u7jfsgw-ovI2FqwrL_lXv7TNhE7ZX-QvZJni2QYDvFGGZW6i2Y4TCOMQmqmWVu-VTfxHXZ_JJMGfiNXaV3Io_zjY8XkGKvXMHjdcpqM4b4fluhxYp-LJ2LkV1VNf7yIi8KrGtLWZzC1a0KC3gqNWxCYV08j1UAZxEVEZycyUQeJsaEHR9WDgll6xt8KR85KgQ
   response:
     status:
       code: 200
@@ -3585,63 +3578,42 @@ http_interactions:
       - application/json; charset=utf-8
       Expires:
       - "-1"
+      Etag:
+      - W/"cf6012c7-3d47-438f-84d7-332ad1ef4500"
       Vary:
       - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/LowCostGet3Min;4729,Microsoft.Compute/LowCostGet30Min;37904
+      X-Ms-Request-Id:
+      - 2ddfcbbf-ca33-4369-9567-6dcafea91b8a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
-      X-Ms-Request-Id:
-      - e62b1436-67c8-469b-b90d-6f236adc1238
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14980'
+      - '14989'
       X-Ms-Correlation-Request-Id:
-      - 9fce2c56-f59d-4549-9a9d-f5841941516e
+      - ebefd0f2-19e3-4f02-96a0-e7ad234cafd5
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202002Z:9fce2c56-f59d-4549-9a9d-f5841941516e
+      - WESTEUROPE:20180312T093851Z:ebefd0f2-19e3-4f02-96a0-e7ad234cafd5
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:20:01 GMT
+      - Mon, 12 Mar 2018 09:38:51 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"834a70b5-868d-4466-9dda-14e0f6b2caaf\",\r\n
-        \   \"availabilitySet\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/RSPEC-LB\"\r\n
-        \   },\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n
-        \   },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
-        \"RedHat\",\r\n        \"offer\": \"RHEL\",\r\n        \"sku\": \"6.7\",\r\n
-        \       \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
-        \"Linux\",\r\n        \"name\": \"rspec-lb-b\",\r\n        \"createOption\":
-        \"FromImage\",\r\n        \"vhd\": {\r\n          \"uri\": \"https://rspeclb.blob.core.windows.net/vhds/rspec-lb-b201682123650.vhd\"\r\n
-        \       },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n      \"dataDisks\":
-        []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"rspec-lb-b\",\r\n
-        \     \"adminUsername\": \"bronaghs\",\r\n      \"linuxConfiguration\": {\r\n
-        \       \"disablePasswordAuthentication\": false\r\n      },\r\n      \"secrets\":
-        []\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843\"}]},\r\n
-        \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
-        true,\r\n        \"storageUri\": \"https://amissteastorage.blob.core.windows.net/\"\r\n
-        \     }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n
-        \ \"resources\": [\r\n    {\r\n      \"properties\": {\r\n        \"publisher\":
-        \"Microsoft.OSTCExtensions\",\r\n        \"type\": \"LinuxDiagnostic\",\r\n
-        \       \"typeHandlerVersion\": \"2.3\",\r\n        \"autoUpgradeMinorVersion\":
-        true,\r\n        \"settings\": {\"xmlCfg\":\"PFdhZENmZz48RGlhZ25vc3RpY01vbml0b3JDb25maWd1cmF0aW9uIG92ZXJhbGxRdW90YUluTUI9IjQwOTYiPjxEaWFnbm9zdGljSW5mcmFzdHJ1Y3R1cmVMb2dzIHNjaGVkdWxlZFRyYW5zZmVyUGVyaW9kPSJQVDFNIiBzY2hlZHVsZWRUcmFuc2ZlckxvZ0xldmVsRmlsdGVyPSJXYXJuaW5nIi8+PFBlcmZvcm1hbmNlQ291bnRlcnMgc2NoZWR1bGVkVHJhbnNmZXJQZXJpb2Q9IlBUMU0iPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlTWVtb3J5IiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQnl0ZXMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcUGVyY2VudEF2YWlsYWJsZU1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iTWVtb3J5IHVzZWQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50VXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgcGVyY2VudGFnZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkQnlDYWNoZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHVzZWQgYnkgY2FjaGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1BlclNlYyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50UGVyU2Vjb25kIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFnZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1JlYWRQZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2UgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1dyaXR0ZW5QZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2Ugd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iU3dhcCBhdmFpbGFibGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50QXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZFN3YXAiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlN3YXAgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRJZGxlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgaWRsZSB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFVzZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iUGVyY2VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkNQVSB1c2VyIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50TmljZVRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIG5pY2UgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRQcml2aWxlZ2VkVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgcHJpdmlsZWdlZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudEludGVycnVwdFRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIGludGVycnVwdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudERQQ1RpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIERQQyB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFByb2Nlc3NvclRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIHBlcmNlbnRhZ2UgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50SU9XYWl0VGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgSU8gd2FpdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xSZWFkQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCBndWVzdCBPUyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXFdyaXRlQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGUgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xUcmFuc2ZlcnNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXJzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcUmVhZHNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xXcml0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVJlYWRUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVdyaXRlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlNlY29uZHMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJEaXNrIHdyaXRlIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xBdmVyYWdlVHJhbnNmZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXIgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXEF2ZXJhZ2VEaXNrUXVldWVMZW5ndGgiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcXVldWUgbGVuZ3RoIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVHJhbnNtaXR0ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgb3V0IGd1ZXN0IE9TIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzUmVjZWl2ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgaW4gZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1RyYW5zbWl0dGVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHNlbnQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1JlY2VpdmVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHJlY2VpdmVkIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVG90YWwiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxSeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyByZWNlaXZlZCBlcnJvcnMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxUeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyBzZW50IGVycm9ycyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTmV0d29ya0ludGVyZmFjZVxUb3RhbENvbGxpc2lvbnMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgY29sbGlzaW9ucyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48L1BlcmZvcm1hbmNlQ291bnRlcnM+PE1ldHJpY3MgcmVzb3VyY2VJZD0iL3N1YnNjcmlwdGlvbnMvMjU4NmM2NGItMzhiNC00NTI3LWExNDAtMDEyZDQ5ZGZjMDJjL3Jlc291cmNlR3JvdXBzL21pcS1henVyZS10ZXN0MS9wcm92aWRlcnMvTWljcm9zb2Z0LkNvbXB1dGUvdmlydHVhbE1hY2hpbmVzL3JzcGVjLWxiLWIiPjxNZXRyaWNBZ2dyZWdhdGlvbiBzY2hlZHVsZWRUcmFuc2ZlclBlcmlvZD0iUFQxSCIvPjxNZXRyaWNBZ2dyZWdhdGlvbiBzY2hlZHVsZWRUcmFuc2ZlclBlcmlvZD0iUFQxTSIvPjwvTWV0cmljcz48L0RpYWdub3N0aWNNb25pdG9yQ29uZmlndXJhdGlvbj48L1dhZENmZz4=\",\"StorageAccount\":\"amissteastorage\"},\r\n
-        \       \"provisioningState\": \"Succeeded\"\r\n      },\r\n      \"type\":
-        \"Microsoft.Compute/virtualMachines/extensions\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b/extensions/Microsoft.Insights.VMDiagnosticsSettings\",\r\n
-        \     \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n    }\r\n
-        \ ],\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\":
-        \"eastus\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b\",\r\n
-        \ \"name\": \"rspec-lb-b\"\r\n}"
+      string: "{\r\n  \"name\": \"rspec-lb-b-ip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-b-ip\",\r\n
+        \ \"etag\": \"W/\\\"cf6012c7-3d47-438f-84d7-332ad1ef4500\\\"\",\r\n  \"location\":
+        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"5d1a2425-a351-4c0f-bc87-37e6500bff22\",\r\n    \"publicIPAddressVersion\":
+        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
+        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\"\r\n
+        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
+        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:20:02 GMT
+  recorded_at: Mon, 12 Mar 2018 09:38:56 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a/instanceView?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb?api-version=2017-10-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3655,7 +3627,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2ODUsIm5iZiI6MTUyMDQ1MzY4NSwiZXhwIjoxNTIwNDU3NTg1LCJhaW8iOiJZMk5nWUpDZDhXSnQweXhCbDUvc0Y1YjhPKytVQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSl85NzlMYjdJMFM5dWNYcndGZ0FBQSIsInZlciI6IjEuMCJ9.QDvUV9U7FuTHX-bOtNPkoVA6h_IGpmcmiIsI-bLi0UeBhTl50wRFXx8NOuTvbuv_Omd9GMWXx2exZ-aTUHjZ8O0yo-znrTJjPIg82aLk868BFBOYRf7jy6hBCaAVMCpMR15AA73qVOBhAns5XN47-ja7T1KzKHox-4PGuFrA-4sxZR7PAvz4UH-68uCVNNPhGs09ugQOTQXDFZne0Gr2uE3SDirqEic4o1twqGG6vRsgGHoFiidl_lRyGAKK3gQnrost55jujfhI2MUp4PPykbIFSAVUz35KdC-RfNC70XOGa7r2-1GCPpSFPyq1f98B6_eoPmkJS9KQAO-d_OtJog
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcyMTAsIm5iZiI6MTUyMDg0NzIxMCwiZXhwIjoxNTIwODUxMTEwLCJhaW8iOiJZMk5nWUpodFB0a2k2MFo1cHgyTHlWdHU5NzI3QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiS2tCZkxBZmtfMC1zeUgwaDZRb2pBQSIsInZlciI6IjEuMCJ9.Vfp8xCOV2qO_lW6yNVyfhqgGpT2ZG_Z3Nj79KQIrcAD9IDe8IaKlPoG_nmf3qLcXuKGG2QgEZe28-uL17_Yumns3TDPYvaCyONJ7HR4WOz6Sj-_DrXX3lUyHFe6HcaWli0q0eu4QpLcTUTRe6LkQ-u7jfsgw-ovI2FqwrL_lXv7TNhE7ZX-QvZJni2QYDvFGGZW6i2Y4TCOMQmqmWVu-VTfxHXZ_JJMGfiNXaV3Io_zjY8XkGKvXMHjdcpqM4b4fluhxYp-LJ2LkV1VNf7yIi8KrGtLWZzC1a0KC3gqNWxCYV08j1UAZxEVEZycyUQeJsaEHR9WDgll6xt8KR85KgQ
   response:
     status:
       code: 200
@@ -3668,207 +3640,32 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Content-Type:
-      - application/json; charset=utf-8
+      - application/json
       Expires:
       - "-1"
       Vary:
       - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/GetInstanceView3Min;4792,Microsoft.Compute/GetInstanceView30Min;23916
+      X-Ms-Request-Id:
+      - ccfedd65-ad3e-42ce-a5ed-655c9c1a0536
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
-      X-Ms-Request-Id:
-      - 8ae8c09c-919b-477f-9654-33fb7ad1225a
       Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
       - '14987'
       X-Ms-Correlation-Request-Id:
-      - ad0965d4-34fc-4a7d-a398-5b3cc9a331f1
+      - 2f8ea89b-1037-4ed8-bf41-d9f99afb303b
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202013Z:ad0965d4-34fc-4a7d-a398-5b3cc9a331f1
+      - WESTEUROPE:20180312T093852Z:2f8ea89b-1037-4ed8-bf41-d9f99afb303b
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:20:13 GMT
+      - Mon, 12 Mar 2018 09:38:51 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"platformUpdateDomain\": 0,\r\n  \"platformFaultDomain\": 0,\r\n
-        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
-        [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
-        \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
-        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2018-03-07T20:20:02+00:00\"\r\n
-        \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"rspec-lb-a\",\r\n
-        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
-        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"time\": \"2016-09-03T14:04:26.7359609+00:00\"\r\n
-        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
-        \"https://miqazuretest16487.blob.core.windows.net/bootdiagnostics-rspeclba-23b0beab-16d2-4135-a01f-2fe713217fd0/rspec-lb-a.23b0beab-16d2-4135-a01f-2fe713217fd0.screenshot.bmp\",\r\n
-        \   \"serialConsoleLogBlobUri\": \"https://miqazuretest16487.blob.core.windows.net/bootdiagnostics-rspeclba-23b0beab-16d2-4135-a01f-2fe713217fd0/rspec-lb-a.23b0beab-16d2-4135-a01f-2fe713217fd0.serialconsole.log\"\r\n
-        \ },\r\n  \"extensions\": [\r\n    {\r\n      \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n
-        \   }\r\n  ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n
-        \     \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n
-        \     \"time\": \"2016-09-03T14:04:26.7828345+00:00\"\r\n    },\r\n    {\r\n
-        \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
-        \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
+      string: '{"sku":{"name":"Premium_LRS","tier":"Premium"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb","name":"rspeclb","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-09-02T16:29:11.6823797Z","primaryEndpoints":{"blob":"https://rspeclb.blob.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:20:13 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Network/networkInterfaces?api-version=2017-11-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2ODUsIm5iZiI6MTUyMDQ1MzY4NSwiZXhwIjoxNTIwNDU3NTg1LCJhaW8iOiJZMk5nWUpDZDhXSnQweXhCbDUvc0Y1YjhPKytVQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSl85NzlMYjdJMFM5dWNYcndGZ0FBQSIsInZlciI6IjEuMCJ9.QDvUV9U7FuTHX-bOtNPkoVA6h_IGpmcmiIsI-bLi0UeBhTl50wRFXx8NOuTvbuv_Omd9GMWXx2exZ-aTUHjZ8O0yo-znrTJjPIg82aLk868BFBOYRf7jy6hBCaAVMCpMR15AA73qVOBhAns5XN47-ja7T1KzKHox-4PGuFrA-4sxZR7PAvz4UH-68uCVNNPhGs09ugQOTQXDFZne0Gr2uE3SDirqEic4o1twqGG6vRsgGHoFiidl_lRyGAKK3gQnrost55jujfhI2MUp4PPykbIFSAVUz35KdC-RfNC70XOGa7r2-1GCPpSFPyq1f98B6_eoPmkJS9KQAO-d_OtJog
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - bc32ae64-edc7-4c1c-9d20-c2001b33f9b2
-      X-Ms-Correlation-Request-Id:
-      - bc32ae64-edc7-4c1c-9d20-c2001b33f9b2
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202015Z:bc32ae64-edc7-4c1c-9d20-c2001b33f9b2
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:20:14 GMT
-      Content-Length:
-      - '31614'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[{"name":"miqazure-coreos1235","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235","etag":"W/\"4a6546ab-a4c0-4d27-bccd-f6ebf3c405a2\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"fb0a5e60-a6c2-4bb8-a2f5-0c16216a49b0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235/ipConfigurations/ipconfig1","etag":"W/\"4a6546ab-a4c0-4d27-bccd-f6ebf3c405a2\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.20.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/publicIPAddresses/miqazure-coreos1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/virtualNetworks/miq-azure-test3/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"rliadcyr3l1elbnsw4rabxqg1f.dx.internal.cloudapp.net"},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkSecurityGroups/miqazure-coreos1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Compute/virtualMachines/miqazure-coreos1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"dbergerprov1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/dbergerprov1","etag":"W/\"074dd836-918c-4e40-a118-94f0d366e175\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"ecdcd2f0-91bb-4c40-91cd-a3d76fc5e455","ipConfigurations":[{"name":"dbergerprov1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/dbergerprov1/ipConfigurations/dbergerprov1","etag":"W/\"074dd836-918c-4e40-a118-94f0d366e175\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.9","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/dbergerprov1-publicIp"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/virtualMachines/dbergerprov1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-rhel1390","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390","etag":"W/\"f006e6f9-0292-42cd-99fc-f72f194553c1\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"98853f48-2806-4065-be57-cf9159550440","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1","etag":"W/\"f006e6f9-0292-42cd-99fc-f72f194553c1\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"macAddress":"00-0D-3A-10-EB-AB","enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-ubuntu1989","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989","etag":"W/\"64e07488-15a2-4cec-b84a-6fd5ef04323c\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"134a6669-ac4a-4d08-a0db-387bc4c49537","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989/ipConfigurations/ipconfig1","etag":"W/\"64e07488-15a2-4cec-b84a-6fd5ef04323c\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.17.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-ubuntu1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest18687/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-win12610","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610","etag":"W/\"dd925ef5-33d1-402c-a0f4-18c78c2641f4\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"5c2eef2c-0b36-4277-a940-957ed4d13be0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610/ipConfigurations/ipconfig1","etag":"W/\"dd925ef5-33d1-402c-a0f4-18c78c2641f4\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.18.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-win12"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest19881/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-winimg241","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241","etag":"W/\"4a17a745-16a9-42d9-88c9-17a518959525\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"8ed2f3b0-4a4b-49ae-9f1d-ff7890dbd396","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241/ipConfigurations/ipconfig1","etag":"W/\"4a17a745-16a9-42d9-88c9-17a518959525\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.7","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqtestwinimg6202"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-centos1611","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611","etag":"W/\"26031ef6-bb55-4019-8185-2dd1edcb207c\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"f1760e49-9853-4fdc-acfc-4ea232b9ed76","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1","etag":"W/\"26031ef6-bb55-4019-8185-2dd1edcb207c\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.5","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqmismatch1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1","etag":"W/\"3a72d0c3-bfda-4da5-a61b-e8c33e43de79\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"23d804a8-b623-49e7-9c8d-1d64245bef1e","ipConfigurations":[{"name":"miqmismatch1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1/ipConfigurations/miqmismatch1","etag":"W/\"3a72d0c3-bfda-4da5-a61b-e8c33e43de79\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.8","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqmismatch1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqmismatch1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"rspec-lb-a670","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670","etag":"W/\"cf3a0b0d-d596-4f33-bc31-749f92ba4f00\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"46cb8216-786e-408e-9d86-c0855b357349","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1","etag":"W/\"cf3a0b0d-d596-4f33-bc31-749f92ba4f00\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.6","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-a-ip"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"rspec-lb-b843","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843","etag":"W/\"76aabe0c-8678-43f0-81a5-2f15784a4b99\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"3ef6fa01-ac34-43a1-8fd7-67c706b4d8ef","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1","etag":"W/\"76aabe0c-8678-43f0-81a5-2f15784a4b99\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.11","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-b-ip"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"spec0deply1nic0","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","etag":"W/\"b817491c-aab8-4aab-b41d-b07bfffa5639\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"80ad9866-071d-4e3f-91d0-d47954eccee0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1","etag":"W/\"b817491c-aab8-4aab-b41d-b07bfffa5639\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.4","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"spec0deply1nic1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","etag":"W/\"2ec58a0b-4c03-4d0a-b788-9daffd54e7b2\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"57bbf7aa-d6c4-4f56-8f6a-089d15334221","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1","etag":"W/\"2ec58a0b-4c03-4d0a-b788-9daffd54e7b2\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.5","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqmismatch2656","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqmismatch2656","etag":"W/\"fef6a836-2802-4897-90c3-b3d71f133384\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"969dde6c-73c0-4340-877d-2b5fe2060026","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqmismatch2656/ipConfigurations/ipconfig1","etag":"W/\"fef6a836-2802-4897-90c3-b3d71f133384\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"172.23.0.4","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/virtualNetworks/miqazuretest33606/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkSecurityGroups/miqmismatch2-nsg"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Compute/virtualMachines/miqmismatch2"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-linux-manag944","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944","etag":"W/\"b6339880-8ead-4c9e-b5c0-f38c4f8612d5\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"c5e8b90e-5a78-49b0-b224-b70ed3fb45e5","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944/ipConfigurations/ipconfig1","etag":"W/\"b6339880-8ead-4c9e-b5c0-f38c4f8612d5\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"172.25.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqazure-linux-managed-ip"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"jf-metrics-2751","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751","etag":"W/\"c5f6f02a-b17c-4f34-882b-11c7adef0b44\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"207a58d3-f18d-4dab-8168-919877297a52","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751/ipConfigurations/ipconfig1","etag":"W/\"c5f6f02a-b17c-4f34-882b-11c7adef0b44\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.7","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-2"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-2"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/jf-metrics-2"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"jf-metrics-3421","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421","etag":"W/\"0b6f160b-ad10-48f8-9d0c-657193bb823f\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"b8b345e8-a353-4700-992e-be48a717b4e2","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421/ipConfigurations/ipconfig1","etag":"W/\"0b6f160b-ad10-48f8-9d0c-657193bb823f\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.8","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-3"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-3"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/jf-metrics-3"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-oraclelinux310","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310","etag":"W/\"54cd4fe1-3ed5-4a8c-bc8d-527679c7a631\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"6a3fc1d7-4532-4ca0-b5c2-546cc8f7f313","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310/ipConfigurations/ipconfig1","etag":"W/\"54cd4fe1-3ed5-4a8c-bc8d-527679c7a631\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.5","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-oraclelinux993","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993","etag":"W/\"a9432274-7b40-4eb3-a64f-a04267a423ff\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"75d8ed14-e0ae-4d84-99f6-e3f43d073e76","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993/ipConfigurations/ipconfig1","etag":"W/\"a9432274-7b40-4eb3-a64f-a04267a423ff\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.6","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux2"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux2"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"}]}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:20:15 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Network/publicIPAddresses?api-version=2017-11-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2ODUsIm5iZiI6MTUyMDQ1MzY4NSwiZXhwIjoxNTIwNDU3NTg1LCJhaW8iOiJZMk5nWUpDZDhXSnQweXhCbDUvc0Y1YjhPKytVQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSl85NzlMYjdJMFM5dWNYcndGZ0FBQSIsInZlciI6IjEuMCJ9.QDvUV9U7FuTHX-bOtNPkoVA6h_IGpmcmiIsI-bLi0UeBhTl50wRFXx8NOuTvbuv_Omd9GMWXx2exZ-aTUHjZ8O0yo-znrTJjPIg82aLk868BFBOYRf7jy6hBCaAVMCpMR15AA73qVOBhAns5XN47-ja7T1KzKHox-4PGuFrA-4sxZR7PAvz4UH-68uCVNNPhGs09ugQOTQXDFZne0Gr2uE3SDirqEic4o1twqGG6vRsgGHoFiidl_lRyGAKK3gQnrost55jujfhI2MUp4PPykbIFSAVUz35KdC-RfNC70XOGa7r2-1GCPpSFPyq1f98B6_eoPmkJS9KQAO-d_OtJog
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - b0b00e0c-4624-49be-9cdf-d4124643a0fe
-      X-Ms-Correlation-Request-Id:
-      - b0b00e0c-4624-49be-9cdf-d4124643a0fe
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202017Z:b0b00e0c-4624-49be-9cdf-d4124643a0fe
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:20:17 GMT
-      Content-Length:
-      - '13978'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[{"name":"miqazure-coreos1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/publicIPAddresses/miqazure-coreos1","etag":"W/\"da64b64b-a755-4389-a2f3-5cba32f18c06\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"28617ed1-0270-4b39-873a-c3b48b3deef1","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"dbergerprov1-publicIp","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/dbergerprov1-publicIp","etag":"W/\"3d984c69-3f35-41ce-bdfc-8d207053a6a9\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"eb0e8804-e169-44ac-bb47-0929370977d2","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/dbergerprov1/ipConfigurations/dbergerprov1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"ladas_test","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/ladas_test","etag":"W/\"32e21623-9a1b-4c40-80f4-6a350aa237a7\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"3daa5f66-5a01-4242-b95b-c4e0ee8f0c36","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[]},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miq-test-rhel1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1","etag":"W/\"054052bb-11ff-4f6e-ac1a-3427c2fd17aa\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"f6cfc635-411e-48ce-a627-39a2fc0d3168","ipAddress":"52.224.165.15","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miq-test-ubuntu1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-ubuntu1","etag":"W/\"bcae50c5-146f-4fcb-a461-7c1030ba7b74\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"e272bd74-f661-484f-b223-88dd128a4049","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miq-test-win12","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-win12","etag":"W/\"56ce00f4-50d7-4682-9ee8-6836bf5c0ea6\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"b9200977-8147-40a5-83c2-d5892d5ddedc","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miqazure-centos1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1","etag":"W/\"734a3944-a880-444c-8c92-cace6e28e303\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"475a66f0-9e89-4226-a9f0-9baaaf31d619","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miqtestwinimg6202","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqtestwinimg6202","etag":"W/\"b656279a-26ff-4021-94bb-263420cf494e\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"fb942169-855b-44f8-b12f-fd63e961b140","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"rspec-lb-a-ip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-a-ip","etag":"W/\"3ba30997-7d2f-470c-96f6-301158e93b7c\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"3c605f75-23c0-46ab-ba2b-6fd4430140fd","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"rspec-lb-b-ip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-b-ip","etag":"W/\"cf6012c7-3d47-438f-84d7-332ad1ef4500\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"5d1a2425-a351-4c0f-bc87-37e6500bff22","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"rspec-lb1-LoadBalancerFrontEnd","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd","etag":"W/\"a38434c8-7b23-4092-b7c6-402238eac0dc\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"f28e0f25-b372-4edf-97d9-13a9e3b4ba2d","ipAddress":"40.71.82.83","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"rspec-lb2-publicip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip","etag":"W/\"cddd97d1-6111-4477-8a00-3dc885237a1d\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"83e7257d-ab94-4229-8eb5-4798f37ef28d","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"spec0deply1ip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip","etag":"W/\"2080997a-38a6-420d-ba86-e9582e1331c7\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"a08b891e-e45a-4970-aefc-f6c996989490","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"spec0deply1dns","fqdn":"spec0deply1dns.eastus.cloudapp.azure.com"},"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miqazure-linux-managed-ip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqazure-linux-managed-ip","etag":"W/\"0efc9684-fb7d-4fb7-b9b9-f33dbac04a28\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"6a2a9142-26e8-45cd-93bf-7318192f3528","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miqmismatch1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqmismatch1","etag":"W/\"9b8b1729-21c4-4c53-94f2-15715315ad73\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"a97c71d0-6b78-4ffe-8e5c-0be1ee653f8c","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"miqmismatch1","fqdn":"miqmismatch1.eastus.cloudapp.azure.com"},"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1/ipConfigurations/miqmismatch1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"jf-metrics-2","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-2","etag":"W/\"b43ebe01-574c-4454-87eb-3401fbcf36f2\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"e446f3e4-9410-4d7f-bb04-2652096359de","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"jf-metrics-3","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-3","etag":"W/\"a6ee7100-6202-4ae2-a2db-f828abec8af9\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"de5995a4-15c1-40ba-ad78-67e70a92654b","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miqazure-oraclelinux1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux1","etag":"W/\"98bee7b4-2fcc-471d-b5ce-92850e6c3d6b\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"f2ac7c18-520b-4b42-94e7-da264a842f41","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miqazure-oraclelinux2","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux2","etag":"W/\"0865cebc-95b9-49d2-9f10-21dbafb23cac\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"2f4e1091-46f0-474c-a697-8dbcea6ba2a6","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}}]}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:20:18 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Storage/storageAccounts?api-version=2017-10-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2ODUsIm5iZiI6MTUyMDQ1MzY4NSwiZXhwIjoxNTIwNDU3NTg1LCJhaW8iOiJZMk5nWUpDZDhXSnQweXhCbDUvc0Y1YjhPKytVQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSl85NzlMYjdJMFM5dWNYcndGZ0FBQSIsInZlciI6IjEuMCJ9.QDvUV9U7FuTHX-bOtNPkoVA6h_IGpmcmiIsI-bLi0UeBhTl50wRFXx8NOuTvbuv_Omd9GMWXx2exZ-aTUHjZ8O0yo-znrTJjPIg82aLk868BFBOYRf7jy6hBCaAVMCpMR15AA73qVOBhAns5XN47-ja7T1KzKHox-4PGuFrA-4sxZR7PAvz4UH-68uCVNNPhGs09ugQOTQXDFZne0Gr2uE3SDirqEic4o1twqGG6vRsgGHoFiidl_lRyGAKK3gQnrost55jujfhI2MUp4PPykbIFSAVUz35KdC-RfNC70XOGa7r2-1GCPpSFPyq1f98B6_eoPmkJS9KQAO-d_OtJog
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - b9925af9-1838-4b00-9b1a-5cf90ddc05d4
-      X-Ms-Correlation-Request-Id:
-      - b9925af9-1838-4b00-9b1a-5cf90ddc05d4
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202018Z:b9925af9-1838-4b00-9b1a-5cf90ddc05d4
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:20:18 GMT
-      Content-Length:
-      - '8649'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","name":"miqazuretest18686","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T17:22:54.7808677Z","primaryEndpoints":{"blob":"https://miqazuretest18686.blob.core.windows.net/","queue":"https://miqazuretest18686.queue.core.windows.net/","table":"https://miqazuretest18686.table.core.windows.net/","file":"https://miqazuretest18686.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","name":"miqazuretest14047","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T17:30:25.7028008Z","primaryEndpoints":{"blob":"https://miqazuretest14047.blob.core.windows.net/","queue":"https://miqazuretest14047.queue.core.windows.net/","table":"https://miqazuretest14047.table.core.windows.net/","file":"https://miqazuretest14047.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Premium_LRS","tier":"Premium"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb","name":"rspeclb","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-09-02T16:29:11.6823797Z","primaryEndpoints":{"blob":"https://rspeclb.blob.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","name":"spec0deply1stor","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-04-04T23:05:07.8274794Z","primaryEndpoints":{"blob":"https://spec0deply1stor.blob.core.windows.net/","queue":"https://spec0deply1stor.queue.core.windows.net/","table":"https://spec0deply1stor.table.core.windows.net/","file":"https://spec0deply1stor.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Storage/storageAccounts/miqazuretest26611","name":"miqazuretest26611","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2211656Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2211656Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-05-02T18:01:29.2743021Z","primaryEndpoints":{"blob":"https://miqazuretest26611.blob.core.windows.net/","queue":"https://miqazuretest26611.queue.core.windows.net/","table":"https://miqazuretest26611.table.core.windows.net/","file":"https://miqazuretest26611.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","name":"miqazuretest16487","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T17:26:55.3231669Z","primaryEndpoints":{"blob":"https://miqazuretest16487.blob.core.windows.net/","queue":"https://miqazuretest16487.queue.core.windows.net/","table":"https://miqazuretest16487.table.core.windows.net/","file":"https://miqazuretest16487.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Storage/storageAccounts/miqazuretest32946","name":"miqazuretest32946","type":"Microsoft.Storage/storageAccounts","location":"westus","tags":{"delete":"false"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.0404359Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.0404359Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T21:18:37.0793411Z","primaryEndpoints":{"blob":"https://miqazuretest32946.blob.core.windows.net/","queue":"https://miqazuretest32946.queue.core.windows.net/","table":"https://miqazuretest32946.table.core.windows.net/","file":"https://miqazuretest32946.file.core.windows.net/"},"primaryLocation":"westus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Storage/storageAccounts/miqazureshared1","name":"miqazureshared1","type":"Microsoft.Storage/storageAccounts","location":"centralus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.1935084Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.1935084Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T20:42:52.498085Z","primaryEndpoints":{"blob":"https://miqazureshared1.blob.core.windows.net/","queue":"https://miqazureshared1.queue.core.windows.net/","table":"https://miqazureshared1.table.core.windows.net/","file":"https://miqazureshared1.file.core.windows.net/"},"primaryLocation":"centralus","statusOfPrimary":"available","secondaryLocation":"eastus2","statusOfSecondary":"available","secondaryEndpoints":{"blob":"https://miqazureshared1-secondary.blob.core.windows.net/","queue":"https://miqazureshared1-secondary.queue.core.windows.net/","table":"https://miqazureshared1-secondary.table.core.windows.net/"}}}]}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:20:19 GMT
+  recorded_at: Mon, 12 Mar 2018 09:38:56 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb/listKeys?api-version=2017-10-01
@@ -3885,7 +3682,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2ODUsIm5iZiI6MTUyMDQ1MzY4NSwiZXhwIjoxNTIwNDU3NTg1LCJhaW8iOiJZMk5nWUpDZDhXSnQweXhCbDUvc0Y1YjhPKytVQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSl85NzlMYjdJMFM5dWNYcndGZ0FBQSIsInZlciI6IjEuMCJ9.QDvUV9U7FuTHX-bOtNPkoVA6h_IGpmcmiIsI-bLi0UeBhTl50wRFXx8NOuTvbuv_Omd9GMWXx2exZ-aTUHjZ8O0yo-znrTJjPIg82aLk868BFBOYRf7jy6hBCaAVMCpMR15AA73qVOBhAns5XN47-ja7T1KzKHox-4PGuFrA-4sxZR7PAvz4UH-68uCVNNPhGs09ugQOTQXDFZne0Gr2uE3SDirqEic4o1twqGG6vRsgGHoFiidl_lRyGAKK3gQnrost55jujfhI2MUp4PPykbIFSAVUz35KdC-RfNC70XOGa7r2-1GCPpSFPyq1f98B6_eoPmkJS9KQAO-d_OtJog
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcyMTAsIm5iZiI6MTUyMDg0NzIxMCwiZXhwIjoxNTIwODUxMTEwLCJhaW8iOiJZMk5nWUpodFB0a2k2MFo1cHgyTHlWdHU5NzI3QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiS2tCZkxBZmtfMC1zeUgwaDZRb2pBQSIsInZlciI6IjEuMCJ9.Vfp8xCOV2qO_lW6yNVyfhqgGpT2ZG_Z3Nj79KQIrcAD9IDe8IaKlPoG_nmf3qLcXuKGG2QgEZe28-uL17_Yumns3TDPYvaCyONJ7HR4WOz6Sj-_DrXX3lUyHFe6HcaWli0q0eu4QpLcTUTRe6LkQ-u7jfsgw-ovI2FqwrL_lXv7TNhE7ZX-QvZJni2QYDvFGGZW6i2Y4TCOMQmqmWVu-VTfxHXZ_JJMGfiNXaV3Io_zjY8XkGKvXMHjdcpqM4b4fluhxYp-LJ2LkV1VNf7yIi8KrGtLWZzC1a0KC3gqNWxCYV08j1UAZxEVEZycyUQeJsaEHR9WDgll6xt8KR85KgQ
       Content-Length:
       - '0'
   response:
@@ -3906,26 +3703,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 2b428c7c-6d35-422f-9199-091cd28e6857
+      - 936ab09f-310a-4a16-a948-ffc3ca970ebd
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1198'
+      - '1197'
       X-Ms-Correlation-Request-Id:
-      - d9f11db0-6f94-4b3f-8632-c4ef80e93c1f
+      - 7fd9c5a2-afc6-4b9f-b6d2-8e1ac00dad79
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202019Z:d9f11db0-6f94-4b3f-8632-c4ef80e93c1f
+      - WESTEUROPE:20180312T093852Z:7fd9c5a2-afc6-4b9f-b6d2-8e1ac00dad79
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:20:19 GMT
+      - Mon, 12 Mar 2018 09:38:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keys":[{"keyName":"key1","value":"xMvZwiumnKCZnYVJjdtGLqaO1c2v6ERPx4XPDZO7TM1l7/jM1TxAAgtfCMkRn72aRPhqLqwWAn8n5a1iSGRHtA==","permissions":"Full"},{"keyName":"key2","value":"3nDvKhjGAIAvgnH2reuv7tzyeb/0dddgVeUT13VODYD5xO/jeAvQ7tkF3JqP2BAuFrmQqMB4GLkB4/cW4veYeA==","permissions":"Full"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:20:19 GMT
+  recorded_at: Mon, 12 Mar 2018 09:38:57 GMT
 - request:
     method: head
     uri: https://rspeclb.blob.core.windows.net/vhds/rspec-lb-a201682122839.vhd
@@ -3942,7 +3739,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:20:19 GMT
+      - Mon, 12 Mar 2018 09:38:57 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -3950,7 +3747,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey rspeclb:CBN0hh7/XPhc9LpTNqFe8lImTKLb+NYTloqMMUjo5i0=
+      - SharedKey rspeclb:4F/Y5mZbyznRkk1JDp7JDUeHmrVxmIuWChEyRpuc3pk=
   response:
     status:
       code: 200
@@ -4005,150 +3802,16 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       X-Ms-Request-Id:
-      - 9126b840-601c-0002-4c51-b6673d000000
+      - 0cb4351d-301c-0033-57e5-b93cea000000
       X-Ms-Version:
       - '2016-05-31'
       Date:
-      - Wed, 07 Mar 2018 20:20:19 GMT
+      - Mon, 12 Mar 2018 09:38:52 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:20:20 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b/instanceView?api-version=2017-12-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2ODUsIm5iZiI6MTUyMDQ1MzY4NSwiZXhwIjoxNTIwNDU3NTg1LCJhaW8iOiJZMk5nWUpDZDhXSnQweXhCbDUvc0Y1YjhPKytVQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSl85NzlMYjdJMFM5dWNYcndGZ0FBQSIsInZlciI6IjEuMCJ9.QDvUV9U7FuTHX-bOtNPkoVA6h_IGpmcmiIsI-bLi0UeBhTl50wRFXx8NOuTvbuv_Omd9GMWXx2exZ-aTUHjZ8O0yo-znrTJjPIg82aLk868BFBOYRf7jy6hBCaAVMCpMR15AA73qVOBhAns5XN47-ja7T1KzKHox-4PGuFrA-4sxZR7PAvz4UH-68uCVNNPhGs09ugQOTQXDFZne0Gr2uE3SDirqEic4o1twqGG6vRsgGHoFiidl_lRyGAKK3gQnrost55jujfhI2MUp4PPykbIFSAVUz35KdC-RfNC70XOGa7r2-1GCPpSFPyq1f98B6_eoPmkJS9KQAO-d_OtJog
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/GetInstanceView3Min;4791,Microsoft.Compute/GetInstanceView30Min;23915
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
-      X-Ms-Request-Id:
-      - 92b6235d-3ff0-438f-82d4-5f132bcfc12c
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14977'
-      X-Ms-Correlation-Request-Id:
-      - 6b551d8f-74de-4e0d-b969-91e3d2f475af
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202026Z:6b551d8f-74de-4e0d-b969-91e3d2f475af
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:20:25 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"platformUpdateDomain\": 1,\r\n  \"platformFaultDomain\": 1,\r\n
-        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
-        [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
-        \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
-        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2018-03-07T20:20:20+00:00\"\r\n
-        \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"rspec-lb-b\",\r\n
-        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
-        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"time\": \"2016-09-03T14:07:52.9377685+00:00\"\r\n
-        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
-        \"https://amissteastorage.blob.core.windows.net/bootdiagnostics-rspeclbb-834a70b5-868d-4466-9dda-14e0f6b2caaf/rspec-lb-b.834a70b5-868d-4466-9dda-14e0f6b2caaf.screenshot.bmp\",\r\n
-        \   \"serialConsoleLogBlobUri\": \"https://amissteastorage.blob.core.windows.net/bootdiagnostics-rspeclbb-834a70b5-868d-4466-9dda-14e0f6b2caaf/rspec-lb-b.834a70b5-868d-4466-9dda-14e0f6b2caaf.serialconsole.log\"\r\n
-        \ },\r\n  \"extensions\": [\r\n    {\r\n      \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n
-        \   }\r\n  ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n
-        \     \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n
-        \     \"time\": \"2016-09-03T14:07:52.9846158+00:00\"\r\n    },\r\n    {\r\n
-        \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
-        \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:20:26 GMT
-- request:
-    method: post
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb/listKeys?api-version=2017-10-01
-    body:
-      encoding: ASCII-8BIT
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2ODUsIm5iZiI6MTUyMDQ1MzY4NSwiZXhwIjoxNTIwNDU3NTg1LCJhaW8iOiJZMk5nWUpDZDhXSnQweXhCbDUvc0Y1YjhPKytVQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSl85NzlMYjdJMFM5dWNYcndGZ0FBQSIsInZlciI6IjEuMCJ9.QDvUV9U7FuTHX-bOtNPkoVA6h_IGpmcmiIsI-bLi0UeBhTl50wRFXx8NOuTvbuv_Omd9GMWXx2exZ-aTUHjZ8O0yo-znrTJjPIg82aLk868BFBOYRf7jy6hBCaAVMCpMR15AA73qVOBhAns5XN47-ja7T1KzKHox-4PGuFrA-4sxZR7PAvz4UH-68uCVNNPhGs09ugQOTQXDFZne0Gr2uE3SDirqEic4o1twqGG6vRsgGHoFiidl_lRyGAKK3gQnrost55jujfhI2MUp4PPykbIFSAVUz35KdC-RfNC70XOGa7r2-1GCPpSFPyq1f98B6_eoPmkJS9KQAO-d_OtJog
-      Content-Length:
-      - '0'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 8c8c82ed-33d4-4a5b-b289-6735d630cf62
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1198'
-      X-Ms-Correlation-Request-Id:
-      - 3c2fedf3-c448-4a12-992b-987ff35cb20a
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202026Z:3c2fedf3-c448-4a12-992b-987ff35cb20a
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:20:25 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"keys":[{"keyName":"key1","value":"xMvZwiumnKCZnYVJjdtGLqaO1c2v6ERPx4XPDZO7TM1l7/jM1TxAAgtfCMkRn72aRPhqLqwWAn8n5a1iSGRHtA==","permissions":"Full"},{"keyName":"key2","value":"3nDvKhjGAIAvgnH2reuv7tzyeb/0dddgVeUT13VODYD5xO/jeAvQ7tkF3JqP2BAuFrmQqMB4GLkB4/cW4veYeA==","permissions":"Full"}]}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:20:26 GMT
+  recorded_at: Mon, 12 Mar 2018 09:38:57 GMT
 - request:
     method: head
     uri: https://rspeclb.blob.core.windows.net/vhds/rspec-lb-b201682123650.vhd
@@ -4165,7 +3828,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:20:26 GMT
+      - Mon, 12 Mar 2018 09:38:57 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -4173,7 +3836,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey rspeclb:K/g2AUTR/Hp8jgvb7jmbxRbhZylIQK6QaDZ7r9EHbGs=
+      - SharedKey rspeclb:EFxO/5vsEuzuiKCYAmheamu1H6JqAnDzFKx6Lr14kVY=
   response:
     status:
       code: 200
@@ -4228,16 +3891,16 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       X-Ms-Request-Id:
-      - d74a2457-501c-0045-7151-b6b856000000
+      - c2fe09cf-d01c-001b-2be5-b94b55000000
       X-Ms-Version:
       - '2016-05-31'
       Date:
-      - Wed, 07 Mar 2018 20:20:26 GMT
+      - Mon, 12 Mar 2018 09:38:53 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:20:27 GMT
+  recorded_at: Mon, 12 Mar 2018 09:38:58 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg?api-version=2018-01-01
@@ -4254,7 +3917,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2ODUsIm5iZiI6MTUyMDQ1MzY4NSwiZXhwIjoxNTIwNDU3NTg1LCJhaW8iOiJZMk5nWUpDZDhXSnQweXhCbDUvc0Y1YjhPKytVQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSl85NzlMYjdJMFM5dWNYcndGZ0FBQSIsInZlciI6IjEuMCJ9.QDvUV9U7FuTHX-bOtNPkoVA6h_IGpmcmiIsI-bLi0UeBhTl50wRFXx8NOuTvbuv_Omd9GMWXx2exZ-aTUHjZ8O0yo-znrTJjPIg82aLk868BFBOYRf7jy6hBCaAVMCpMR15AA73qVOBhAns5XN47-ja7T1KzKHox-4PGuFrA-4sxZR7PAvz4UH-68uCVNNPhGs09ugQOTQXDFZne0Gr2uE3SDirqEic4o1twqGG6vRsgGHoFiidl_lRyGAKK3gQnrost55jujfhI2MUp4PPykbIFSAVUz35KdC-RfNC70XOGa7r2-1GCPpSFPyq1f98B6_eoPmkJS9KQAO-d_OtJog
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcyMTAsIm5iZiI6MTUyMDg0NzIxMCwiZXhwIjoxNTIwODUxMTEwLCJhaW8iOiJZMk5nWUpodFB0a2k2MFo1cHgyTHlWdHU5NzI3QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiS2tCZkxBZmtfMC1zeUgwaDZRb2pBQSIsInZlciI6IjEuMCJ9.Vfp8xCOV2qO_lW6yNVyfhqgGpT2ZG_Z3Nj79KQIrcAD9IDe8IaKlPoG_nmf3qLcXuKGG2QgEZe28-uL17_Yumns3TDPYvaCyONJ7HR4WOz6Sj-_DrXX3lUyHFe6HcaWli0q0eu4QpLcTUTRe6LkQ-u7jfsgw-ovI2FqwrL_lXv7TNhE7ZX-QvZJni2QYDvFGGZW6i2Y4TCOMQmqmWVu-VTfxHXZ_JJMGfiNXaV3Io_zjY8XkGKvXMHjdcpqM4b4fluhxYp-LJ2LkV1VNf7yIi8KrGtLWZzC1a0KC3gqNWxCYV08j1UAZxEVEZycyUQeJsaEHR9WDgll6xt8KR85KgQ
   response:
     status:
       code: 200
@@ -4275,22 +3938,22 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - f7b59e23-ad79-4292-b3ef-5e5eb14d8059
+      - 11e066b5-00d6-4ae0-a499-6db80047de26
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14972'
+      - '14987'
       X-Ms-Correlation-Request-Id:
-      - 174a66e7-f164-42f8-8df4-20e106a99e00
+      - 444b7820-99f6-459d-908e-edd365490de9
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202027Z:174a66e7-f164-42f8-8df4-20e106a99e00
+      - WESTEUROPE:20180312T093855Z:444b7820-99f6-459d-908e-edd365490de9
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:20:27 GMT
+      - Mon, 12 Mar 2018 09:38:55 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"rspec-lb-a-nsg\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg\",\r\n
@@ -4375,7 +4038,7 @@ http_interactions:
         \   ],\r\n    \"networkInterfaces\": [\r\n      {\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670\"\r\n
         \     }\r\n    ]\r\n  }\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:20:27 GMT
+  recorded_at: Mon, 12 Mar 2018 09:39:00 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg?api-version=2018-01-01
@@ -4392,7 +4055,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2ODUsIm5iZiI6MTUyMDQ1MzY4NSwiZXhwIjoxNTIwNDU3NTg1LCJhaW8iOiJZMk5nWUpDZDhXSnQweXhCbDUvc0Y1YjhPKytVQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSl85NzlMYjdJMFM5dWNYcndGZ0FBQSIsInZlciI6IjEuMCJ9.QDvUV9U7FuTHX-bOtNPkoVA6h_IGpmcmiIsI-bLi0UeBhTl50wRFXx8NOuTvbuv_Omd9GMWXx2exZ-aTUHjZ8O0yo-znrTJjPIg82aLk868BFBOYRf7jy6hBCaAVMCpMR15AA73qVOBhAns5XN47-ja7T1KzKHox-4PGuFrA-4sxZR7PAvz4UH-68uCVNNPhGs09ugQOTQXDFZne0Gr2uE3SDirqEic4o1twqGG6vRsgGHoFiidl_lRyGAKK3gQnrost55jujfhI2MUp4PPykbIFSAVUz35KdC-RfNC70XOGa7r2-1GCPpSFPyq1f98B6_eoPmkJS9KQAO-d_OtJog
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcyMTAsIm5iZiI6MTUyMDg0NzIxMCwiZXhwIjoxNTIwODUxMTEwLCJhaW8iOiJZMk5nWUpodFB0a2k2MFo1cHgyTHlWdHU5NzI3QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiS2tCZkxBZmtfMC1zeUgwaDZRb2pBQSIsInZlciI6IjEuMCJ9.Vfp8xCOV2qO_lW6yNVyfhqgGpT2ZG_Z3Nj79KQIrcAD9IDe8IaKlPoG_nmf3qLcXuKGG2QgEZe28-uL17_Yumns3TDPYvaCyONJ7HR4WOz6Sj-_DrXX3lUyHFe6HcaWli0q0eu4QpLcTUTRe6LkQ-u7jfsgw-ovI2FqwrL_lXv7TNhE7ZX-QvZJni2QYDvFGGZW6i2Y4TCOMQmqmWVu-VTfxHXZ_JJMGfiNXaV3Io_zjY8XkGKvXMHjdcpqM4b4fluhxYp-LJ2LkV1VNf7yIi8KrGtLWZzC1a0KC3gqNWxCYV08j1UAZxEVEZycyUQeJsaEHR9WDgll6xt8KR85KgQ
   response:
     status:
       code: 200
@@ -4413,22 +4076,22 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 29328cb8-fa05-43c9-bd3d-25602bc2b53f
+      - 3627eb6b-c6c3-4086-be33-c9e4eccaa1ea
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14973'
+      - '14987'
       X-Ms-Correlation-Request-Id:
-      - ab3a2b39-4d20-4692-9dda-fb551fafbf6e
+      - '079071fe-af3f-4318-a8d3-3a7007208c00'
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202027Z:ab3a2b39-4d20-4692-9dda-fb551fafbf6e
+      - WESTEUROPE:20180312T093856Z:079071fe-af3f-4318-a8d3-3a7007208c00
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:20:27 GMT
+      - Mon, 12 Mar 2018 09:38:56 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"rspec-lb-b-nsg\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg\",\r\n
@@ -4513,7 +4176,7 @@ http_interactions:
         \   ],\r\n    \"networkInterfaces\": [\r\n      {\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843\"\r\n
         \     }\r\n    ]\r\n  }\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:20:28 GMT
+  recorded_at: Mon, 12 Mar 2018 09:39:00 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1?api-version=2018-01-01
@@ -4530,7 +4193,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2ODUsIm5iZiI6MTUyMDQ1MzY4NSwiZXhwIjoxNTIwNDU3NTg1LCJhaW8iOiJZMk5nWUpDZDhXSnQweXhCbDUvc0Y1YjhPKytVQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSl85NzlMYjdJMFM5dWNYcndGZ0FBQSIsInZlciI6IjEuMCJ9.QDvUV9U7FuTHX-bOtNPkoVA6h_IGpmcmiIsI-bLi0UeBhTl50wRFXx8NOuTvbuv_Omd9GMWXx2exZ-aTUHjZ8O0yo-znrTJjPIg82aLk868BFBOYRf7jy6hBCaAVMCpMR15AA73qVOBhAns5XN47-ja7T1KzKHox-4PGuFrA-4sxZR7PAvz4UH-68uCVNNPhGs09ugQOTQXDFZne0Gr2uE3SDirqEic4o1twqGG6vRsgGHoFiidl_lRyGAKK3gQnrost55jujfhI2MUp4PPykbIFSAVUz35KdC-RfNC70XOGa7r2-1GCPpSFPyq1f98B6_eoPmkJS9KQAO-d_OtJog
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcyMTAsIm5iZiI6MTUyMDg0NzIxMCwiZXhwIjoxNTIwODUxMTEwLCJhaW8iOiJZMk5nWUpodFB0a2k2MFo1cHgyTHlWdHU5NzI3QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiS2tCZkxBZmtfMC1zeUgwaDZRb2pBQSIsInZlciI6IjEuMCJ9.Vfp8xCOV2qO_lW6yNVyfhqgGpT2ZG_Z3Nj79KQIrcAD9IDe8IaKlPoG_nmf3qLcXuKGG2QgEZe28-uL17_Yumns3TDPYvaCyONJ7HR4WOz6Sj-_DrXX3lUyHFe6HcaWli0q0eu4QpLcTUTRe6LkQ-u7jfsgw-ovI2FqwrL_lXv7TNhE7ZX-QvZJni2QYDvFGGZW6i2Y4TCOMQmqmWVu-VTfxHXZ_JJMGfiNXaV3Io_zjY8XkGKvXMHjdcpqM4b4fluhxYp-LJ2LkV1VNf7yIi8KrGtLWZzC1a0KC3gqNWxCYV08j1UAZxEVEZycyUQeJsaEHR9WDgll6xt8KR85KgQ
   response:
     status:
       code: 200
@@ -4547,36 +4210,36 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"fceae1ac-4620-482a-bc6d-79c867179ae5"
+      - W/"a8b09238-30fc-4b36-a58d-e3cc69e267c5"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - c5a0dac0-ce1f-493d-a568-12c284e12be0
+      - 331826c6-06e4-478a-b0b6-3955f2905b71
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14975'
+      - '14988'
       X-Ms-Correlation-Request-Id:
-      - 7b793fcd-312e-4dbd-808c-037b946d82f8
+      - a3fa5e08-dbf5-41b0-a688-edc36d4c37da
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202029Z:7b793fcd-312e-4dbd-808c-037b946d82f8
+      - WESTEUROPE:20180312T093856Z:a3fa5e08-dbf5-41b0-a688-edc36d4c37da
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:20:29 GMT
+      - Mon, 12 Mar 2018 09:38:56 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"miq-azure-test1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1\",\r\n
-        \ \"etag\": \"W/\\\"fceae1ac-4620-482a-bc6d-79c867179ae5\\\"\",\r\n  \"type\":
+        \ \"etag\": \"W/\\\"a8b09238-30fc-4b36-a58d-e3cc69e267c5\\\"\",\r\n  \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
         \"d74c1e5f-50e4-4c8a-a7fe-78eaddc6b915\",\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\":
         [\r\n        \"10.16.0.0/16\"\r\n      ]\r\n    },\r\n    \"subnets\": [\r\n
         \     {\r\n        \"name\": \"default\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\",\r\n
-        \       \"etag\": \"W/\\\"fceae1ac-4620-482a-bc6d-79c867179ae5\\\"\",\r\n
+        \       \"etag\": \"W/\\\"a8b09238-30fc-4b36-a58d-e3cc69e267c5\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"addressPrefix\": \"10.16.0.0/24\",\r\n          \"ipConfigurations\":
         [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1\"\r\n
@@ -4586,813 +4249,10 @@ http_interactions:
         \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/dbergerprov1/ipConfigurations/dbergerprov1\"\r\n
         \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
         \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/ladas_test_1/ipConfigurations/ladas_test_1\"\r\n
         \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"virtualNetworkPeerings\":
         [],\r\n    \"enableDdosProtection\": false,\r\n    \"enableVmProtection\":
         false\r\n  }\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:20:29 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2ODUsIm5iZiI6MTUyMDQ1MzY4NSwiZXhwIjoxNTIwNDU3NTg1LCJhaW8iOiJZMk5nWUpDZDhXSnQweXhCbDUvc0Y1YjhPKytVQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSl85NzlMYjdJMFM5dWNYcndGZ0FBQSIsInZlciI6IjEuMCJ9.QDvUV9U7FuTHX-bOtNPkoVA6h_IGpmcmiIsI-bLi0UeBhTl50wRFXx8NOuTvbuv_Omd9GMWXx2exZ-aTUHjZ8O0yo-znrTJjPIg82aLk868BFBOYRf7jy6hBCaAVMCpMR15AA73qVOBhAns5XN47-ja7T1KzKHox-4PGuFrA-4sxZR7PAvz4UH-68uCVNNPhGs09ugQOTQXDFZne0Gr2uE3SDirqEic4o1twqGG6vRsgGHoFiidl_lRyGAKK3gQnrost55jujfhI2MUp4PPykbIFSAVUz35KdC-RfNC70XOGa7r2-1GCPpSFPyq1f98B6_eoPmkJS9KQAO-d_OtJog
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"cf3a0b0d-d596-4f33-bc31-749f92ba4f00"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 54715bd0-da47-4001-8dd9-1e93d007d878
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14977'
-      X-Ms-Correlation-Request-Id:
-      - 23c88bca-1754-4340-979b-3ffe0b1529d6
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202029Z:23c88bca-1754-4340-979b-3ffe0b1529d6
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:20:28 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb-a670\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670\",\r\n
-        \ \"etag\": \"W/\\\"cf3a0b0d-d596-4f33-bc31-749f92ba4f00\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"46cb8216-786e-408e-9d86-c0855b357349\",\r\n    \"ipConfigurations\":
-        [\r\n      {\r\n        \"name\": \"ipconfig1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\",\r\n
-        \       \"etag\": \"W/\\\"cf3a0b0d-d596-4f33-bc31-749f92ba4f00\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAddress\": \"10.16.0.6\",\r\n          \"privateIPAllocationMethod\":
-        \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-a-ip\"\r\n
-        \         },\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\"\r\n
-        \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
-        \"IPv4\",\r\n          \"loadBalancerBackendAddressPools\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\"\r\n
-        \           }\r\n          ],\r\n          \"loadBalancerInboundNatRules\":
-        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\":
-        {\r\n      \"dnsServers\": [],\r\n      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\":
-        \"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net\"\r\n    },\r\n    \"enableAcceleratedNetworking\":
-        false,\r\n    \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\":
-        {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg\"\r\n
-        \   },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a\"\r\n
-        \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
-        \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:20:29 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2ODUsIm5iZiI6MTUyMDQ1MzY4NSwiZXhwIjoxNTIwNDU3NTg1LCJhaW8iOiJZMk5nWUpDZDhXSnQweXhCbDUvc0Y1YjhPKytVQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSl85NzlMYjdJMFM5dWNYcndGZ0FBQSIsInZlciI6IjEuMCJ9.QDvUV9U7FuTHX-bOtNPkoVA6h_IGpmcmiIsI-bLi0UeBhTl50wRFXx8NOuTvbuv_Omd9GMWXx2exZ-aTUHjZ8O0yo-znrTJjPIg82aLk868BFBOYRf7jy6hBCaAVMCpMR15AA73qVOBhAns5XN47-ja7T1KzKHox-4PGuFrA-4sxZR7PAvz4UH-68uCVNNPhGs09ugQOTQXDFZne0Gr2uE3SDirqEic4o1twqGG6vRsgGHoFiidl_lRyGAKK3gQnrost55jujfhI2MUp4PPykbIFSAVUz35KdC-RfNC70XOGa7r2-1GCPpSFPyq1f98B6_eoPmkJS9KQAO-d_OtJog
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"76aabe0c-8678-43f0-81a5-2f15784a4b99"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 85267b77-a335-4034-8616-5eb9e4617888
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14973'
-      X-Ms-Correlation-Request-Id:
-      - cd745ebc-69d5-469a-9b50-fbc7b1f74d9c
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202029Z:cd745ebc-69d5-469a-9b50-fbc7b1f74d9c
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:20:29 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb-b843\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843\",\r\n
-        \ \"etag\": \"W/\\\"76aabe0c-8678-43f0-81a5-2f15784a4b99\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"3ef6fa01-ac34-43a1-8fd7-67c706b4d8ef\",\r\n    \"ipConfigurations\":
-        [\r\n      {\r\n        \"name\": \"ipconfig1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\",\r\n
-        \       \"etag\": \"W/\\\"76aabe0c-8678-43f0-81a5-2f15784a4b99\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAddress\": \"10.16.0.11\",\r\n          \"privateIPAllocationMethod\":
-        \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-b-ip\"\r\n
-        \         },\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\"\r\n
-        \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
-        \"IPv4\",\r\n          \"loadBalancerBackendAddressPools\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\":
-        {\r\n      \"dnsServers\": [],\r\n      \"appliedDnsServers\": []\r\n    },\r\n
-        \   \"enableAcceleratedNetworking\": false,\r\n    \"enableIPForwarding\":
-        false,\r\n    \"networkSecurityGroup\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg\"\r\n
-        \   },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b\"\r\n
-        \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
-        \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:20:30 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2ODUsIm5iZiI6MTUyMDQ1MzY4NSwiZXhwIjoxNTIwNDU3NTg1LCJhaW8iOiJZMk5nWUpDZDhXSnQweXhCbDUvc0Y1YjhPKytVQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSl85NzlMYjdJMFM5dWNYcndGZ0FBQSIsInZlciI6IjEuMCJ9.QDvUV9U7FuTHX-bOtNPkoVA6h_IGpmcmiIsI-bLi0UeBhTl50wRFXx8NOuTvbuv_Omd9GMWXx2exZ-aTUHjZ8O0yo-znrTJjPIg82aLk868BFBOYRf7jy6hBCaAVMCpMR15AA73qVOBhAns5XN47-ja7T1KzKHox-4PGuFrA-4sxZR7PAvz4UH-68uCVNNPhGs09ugQOTQXDFZne0Gr2uE3SDirqEic4o1twqGG6vRsgGHoFiidl_lRyGAKK3gQnrost55jujfhI2MUp4PPykbIFSAVUz35KdC-RfNC70XOGa7r2-1GCPpSFPyq1f98B6_eoPmkJS9KQAO-d_OtJog
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - ed39095a-1543-4dc1-ba4b-704445eb2d61
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14974'
-      X-Ms-Correlation-Request-Id:
-      - e9f1f058-5c90-4536-a910-31a4b1541d18
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202035Z:e9f1f058-5c90-4536-a910-31a4b1541d18
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:20:34 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1\",\r\n
-        \ \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"7ab88756-810f-4083-95db-8b05d50e38f2\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ],\r\n          \"inboundNatRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"backendIPConfigurations\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\"\r\n
-        \           }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-rule\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\":
-        80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\"\r\n
-        \         },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n
-        \       \"name\": \"rspec-lb-probe\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-NAT\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 3441,\r\n          \"backendPort\":
-        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:20:35 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2ODUsIm5iZiI6MTUyMDQ1MzY4NSwiZXhwIjoxNTIwNDU3NTg1LCJhaW8iOiJZMk5nWUpDZDhXSnQweXhCbDUvc0Y1YjhPKytVQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSl85NzlMYjdJMFM5dWNYcndGZ0FBQSIsInZlciI6IjEuMCJ9.QDvUV9U7FuTHX-bOtNPkoVA6h_IGpmcmiIsI-bLi0UeBhTl50wRFXx8NOuTvbuv_Omd9GMWXx2exZ-aTUHjZ8O0yo-znrTJjPIg82aLk868BFBOYRf7jy6hBCaAVMCpMR15AA73qVOBhAns5XN47-ja7T1KzKHox-4PGuFrA-4sxZR7PAvz4UH-68uCVNNPhGs09ugQOTQXDFZne0Gr2uE3SDirqEic4o1twqGG6vRsgGHoFiidl_lRyGAKK3gQnrost55jujfhI2MUp4PPykbIFSAVUz35KdC-RfNC70XOGa7r2-1GCPpSFPyq1f98B6_eoPmkJS9KQAO-d_OtJog
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"7a8e5fe7-f777-4435-992b-a54f28c2f28c"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - d79726cb-7063-44ea-8ed9-28c034a2f5c0
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14973'
-      X-Ms-Correlation-Request-Id:
-      - d3c05d80-0e26-49d2-808c-2751e0d7399f
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202038Z:d3c05d80-0e26-49d2-808c-2751e0d7399f
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:20:38 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb2\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2\",\r\n
-        \ \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"e2e30a77-f81b-43fc-9693-08303e43deed\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/backendAddressPools/rspec-lb2-pool\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\r\n
-        \       }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\": [],\r\n    \"probes\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-probe\",\r\n        \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/probes/rspec-lb2-probe\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\": [],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:20:39 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2ODUsIm5iZiI6MTUyMDQ1MzY4NSwiZXhwIjoxNTIwNDU3NTg1LCJhaW8iOiJZMk5nWUpDZDhXSnQweXhCbDUvc0Y1YjhPKytVQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSl85NzlMYjdJMFM5dWNYcndGZ0FBQSIsInZlciI6IjEuMCJ9.QDvUV9U7FuTHX-bOtNPkoVA6h_IGpmcmiIsI-bLi0UeBhTl50wRFXx8NOuTvbuv_Omd9GMWXx2exZ-aTUHjZ8O0yo-znrTJjPIg82aLk868BFBOYRf7jy6hBCaAVMCpMR15AA73qVOBhAns5XN47-ja7T1KzKHox-4PGuFrA-4sxZR7PAvz4UH-68uCVNNPhGs09ugQOTQXDFZne0Gr2uE3SDirqEic4o1twqGG6vRsgGHoFiidl_lRyGAKK3gQnrost55jujfhI2MUp4PPykbIFSAVUz35KdC-RfNC70XOGa7r2-1GCPpSFPyq1f98B6_eoPmkJS9KQAO-d_OtJog
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 5dc5d9ec-f1cf-4186-bbc1-8aa06080c67d
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14971'
-      X-Ms-Correlation-Request-Id:
-      - f41d494a-600b-4926-b8d2-06d35463c951
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202039Z:f41d494a-600b-4926-b8d2-06d35463c951
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:20:39 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1\",\r\n
-        \ \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"7ab88756-810f-4083-95db-8b05d50e38f2\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ],\r\n          \"inboundNatRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"backendIPConfigurations\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\"\r\n
-        \           }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-rule\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\":
-        80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\"\r\n
-        \         },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n
-        \       \"name\": \"rspec-lb-probe\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-NAT\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 3441,\r\n          \"backendPort\":
-        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:20:39 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2ODUsIm5iZiI6MTUyMDQ1MzY4NSwiZXhwIjoxNTIwNDU3NTg1LCJhaW8iOiJZMk5nWUpDZDhXSnQweXhCbDUvc0Y1YjhPKytVQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSl85NzlMYjdJMFM5dWNYcndGZ0FBQSIsInZlciI6IjEuMCJ9.QDvUV9U7FuTHX-bOtNPkoVA6h_IGpmcmiIsI-bLi0UeBhTl50wRFXx8NOuTvbuv_Omd9GMWXx2exZ-aTUHjZ8O0yo-znrTJjPIg82aLk868BFBOYRf7jy6hBCaAVMCpMR15AA73qVOBhAns5XN47-ja7T1KzKHox-4PGuFrA-4sxZR7PAvz4UH-68uCVNNPhGs09ugQOTQXDFZne0Gr2uE3SDirqEic4o1twqGG6vRsgGHoFiidl_lRyGAKK3gQnrost55jujfhI2MUp4PPykbIFSAVUz35KdC-RfNC70XOGa7r2-1GCPpSFPyq1f98B6_eoPmkJS9KQAO-d_OtJog
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"7a8e5fe7-f777-4435-992b-a54f28c2f28c"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 83690c48-45dd-4dfd-85a4-4465e366ff1f
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14972'
-      X-Ms-Correlation-Request-Id:
-      - fa516b7e-bd9f-4078-9177-5f5e1ae52b28
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202039Z:fa516b7e-bd9f-4078-9177-5f5e1ae52b28
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:20:39 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb2\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2\",\r\n
-        \ \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"e2e30a77-f81b-43fc-9693-08303e43deed\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/backendAddressPools/rspec-lb2-pool\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\r\n
-        \       }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\": [],\r\n    \"probes\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-probe\",\r\n        \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/probes/rspec-lb2-probe\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\": [],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:20:39 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2ODUsIm5iZiI6MTUyMDQ1MzY4NSwiZXhwIjoxNTIwNDU3NTg1LCJhaW8iOiJZMk5nWUpDZDhXSnQweXhCbDUvc0Y1YjhPKytVQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSl85NzlMYjdJMFM5dWNYcndGZ0FBQSIsInZlciI6IjEuMCJ9.QDvUV9U7FuTHX-bOtNPkoVA6h_IGpmcmiIsI-bLi0UeBhTl50wRFXx8NOuTvbuv_Omd9GMWXx2exZ-aTUHjZ8O0yo-znrTJjPIg82aLk868BFBOYRf7jy6hBCaAVMCpMR15AA73qVOBhAns5XN47-ja7T1KzKHox-4PGuFrA-4sxZR7PAvz4UH-68uCVNNPhGs09ugQOTQXDFZne0Gr2uE3SDirqEic4o1twqGG6vRsgGHoFiidl_lRyGAKK3gQnrost55jujfhI2MUp4PPykbIFSAVUz35KdC-RfNC70XOGa7r2-1GCPpSFPyq1f98B6_eoPmkJS9KQAO-d_OtJog
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"a38434c8-7b23-4092-b7c6-402238eac0dc"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 54a184b1-2aaf-4e1f-8b5f-633d65031203
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14974'
-      X-Ms-Correlation-Request-Id:
-      - dc05a507-cab8-4fd4-9422-855b94b7a5ee
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202040Z:dc05a507-cab8-4fd4-9422-855b94b7a5ee
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:20:40 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb1-LoadBalancerFrontEnd\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\",\r\n
-        \ \"etag\": \"W/\\\"a38434c8-7b23-4092-b7c6-402238eac0dc\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"f28e0f25-b372-4edf-97d9-13a9e3b4ba2d\",\r\n    \"ipAddress\":
-        \"40.71.82.83\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\":
-        \"Static\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipTags\": [],\r\n
-        \   \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
-        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:20:40 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2ODUsIm5iZiI6MTUyMDQ1MzY4NSwiZXhwIjoxNTIwNDU3NTg1LCJhaW8iOiJZMk5nWUpDZDhXSnQweXhCbDUvc0Y1YjhPKytVQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSl85NzlMYjdJMFM5dWNYcndGZ0FBQSIsInZlciI6IjEuMCJ9.QDvUV9U7FuTHX-bOtNPkoVA6h_IGpmcmiIsI-bLi0UeBhTl50wRFXx8NOuTvbuv_Omd9GMWXx2exZ-aTUHjZ8O0yo-znrTJjPIg82aLk868BFBOYRf7jy6hBCaAVMCpMR15AA73qVOBhAns5XN47-ja7T1KzKHox-4PGuFrA-4sxZR7PAvz4UH-68uCVNNPhGs09ugQOTQXDFZne0Gr2uE3SDirqEic4o1twqGG6vRsgGHoFiidl_lRyGAKK3gQnrost55jujfhI2MUp4PPykbIFSAVUz35KdC-RfNC70XOGa7r2-1GCPpSFPyq1f98B6_eoPmkJS9KQAO-d_OtJog
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"cddd97d1-6111-4477-8a00-3dc885237a1d"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - d41eb614-457f-4358-8151-c34c0270e311
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14973'
-      X-Ms-Correlation-Request-Id:
-      - c48ce3a6-a4d5-4b91-8aa7-0af16677ad20
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202040Z:c48ce3a6-a4d5-4b91-8aa7-0af16677ad20
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:20:40 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb2-publicip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\",\r\n
-        \ \"etag\": \"W/\\\"cddd97d1-6111-4477-8a00-3dc885237a1d\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"83e7257d-ab94-4229-8eb5-4798f37ef28d\",\r\n    \"publicIPAddressVersion\":
-        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
-        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
-        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:20:40 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-a-ip?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2ODUsIm5iZiI6MTUyMDQ1MzY4NSwiZXhwIjoxNTIwNDU3NTg1LCJhaW8iOiJZMk5nWUpDZDhXSnQweXhCbDUvc0Y1YjhPKytVQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSl85NzlMYjdJMFM5dWNYcndGZ0FBQSIsInZlciI6IjEuMCJ9.QDvUV9U7FuTHX-bOtNPkoVA6h_IGpmcmiIsI-bLi0UeBhTl50wRFXx8NOuTvbuv_Omd9GMWXx2exZ-aTUHjZ8O0yo-znrTJjPIg82aLk868BFBOYRf7jy6hBCaAVMCpMR15AA73qVOBhAns5XN47-ja7T1KzKHox-4PGuFrA-4sxZR7PAvz4UH-68uCVNNPhGs09ugQOTQXDFZne0Gr2uE3SDirqEic4o1twqGG6vRsgGHoFiidl_lRyGAKK3gQnrost55jujfhI2MUp4PPykbIFSAVUz35KdC-RfNC70XOGa7r2-1GCPpSFPyq1f98B6_eoPmkJS9KQAO-d_OtJog
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"3ba30997-7d2f-470c-96f6-301158e93b7c"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - f4c36323-a56b-4d08-ba29-e5f01e51669d
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14976'
-      X-Ms-Correlation-Request-Id:
-      - dccaa8da-dd3b-4afc-9a8d-0d0efbc9eddd
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202041Z:dccaa8da-dd3b-4afc-9a8d-0d0efbc9eddd
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:20:40 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb-a-ip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-a-ip\",\r\n
-        \ \"etag\": \"W/\\\"3ba30997-7d2f-470c-96f6-301158e93b7c\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"3c605f75-23c0-46ab-ba2b-6fd4430140fd\",\r\n    \"publicIPAddressVersion\":
-        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
-        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
-        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:20:41 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-b-ip?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2ODUsIm5iZiI6MTUyMDQ1MzY4NSwiZXhwIjoxNTIwNDU3NTg1LCJhaW8iOiJZMk5nWUpDZDhXSnQweXhCbDUvc0Y1YjhPKytVQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSl85NzlMYjdJMFM5dWNYcndGZ0FBQSIsInZlciI6IjEuMCJ9.QDvUV9U7FuTHX-bOtNPkoVA6h_IGpmcmiIsI-bLi0UeBhTl50wRFXx8NOuTvbuv_Omd9GMWXx2exZ-aTUHjZ8O0yo-znrTJjPIg82aLk868BFBOYRf7jy6hBCaAVMCpMR15AA73qVOBhAns5XN47-ja7T1KzKHox-4PGuFrA-4sxZR7PAvz4UH-68uCVNNPhGs09ugQOTQXDFZne0Gr2uE3SDirqEic4o1twqGG6vRsgGHoFiidl_lRyGAKK3gQnrost55jujfhI2MUp4PPykbIFSAVUz35KdC-RfNC70XOGa7r2-1GCPpSFPyq1f98B6_eoPmkJS9KQAO-d_OtJog
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"cf6012c7-3d47-438f-84d7-332ad1ef4500"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - c1bf317d-8e31-43f2-8695-86358d53b0d4
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14976'
-      X-Ms-Correlation-Request-Id:
-      - e44926b4-f0f4-47a5-8757-c8b96c30227a
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202041Z:e44926b4-f0f4-47a5-8757-c8b96c30227a
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:20:40 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb-b-ip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-b-ip\",\r\n
-        \ \"etag\": \"W/\\\"cf6012c7-3d47-438f-84d7-332ad1ef4500\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"5d1a2425-a351-4c0f-bc87-37e6500bff22\",\r\n    \"publicIPAddressVersion\":
-        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
-        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\"\r\n
-        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
-        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:20:41 GMT
+  recorded_at: Mon, 12 Mar 2018 09:39:01 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_0/lb_with_vms_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_0/lb_with_vms_refresh.yml
@@ -37,25 +37,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - eb7d0e5e-da94-4036-9e89-7067e3770000
+      - 89387979-88a2-4583-9539-68ceb3e82400
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzOhIN7ug6KB6hga7WTm4_Euzx3BMeoPclc0d8N9Q4pA--vobZwqS4NccG6W3HwH-R_Emt2YO1x9CK8YWOPS8C1ukugWnHJPZegBOgRDUyGW4B7Thnn5kzxwfvzoJac0M1a5TMLHhAYGl28fmYwPJblT5HjjMo0x4uDDtWUSw17rkgAA;
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzHjqdRjHi5dsqORazrTe8rWkJw6C-ZCsm0ujdM_XGN5bxeesd8ntqHdAE8asm5_T5iEf2nJJmby296bxLoWrgl3uRBYOZ6V_zlWorvOdLFivZPgy6jwNrhneZVG5OLmiXbrFPbBHciNGsNttlamtPCMuFnob6mKhymm2ahood9GYgAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=002; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=006; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Wed, 07 Mar 2018 20:20:44 GMT
+      - Mon, 12 Mar 2018 09:37:50 GMT
       Content-Length:
       - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1520457644","not_before":"1520453744","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3NDQsIm5iZiI6MTUyMDQ1Mzc0NCwiZXhwIjoxNTIwNDU3NjQ0LCJhaW8iOiJZMk5nWURnd3hlVlFnaXVicisrQy8zbEdURW9XQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWGc1OTY1VGFOa0NlaVhCbjQzY0FBQSIsInZlciI6IjEuMCJ9.Hb3eiQ0l3ptAb6f8__A2kTEQEBrM6qo6k1lLTXs-51ZLWyA9iXIFHgLkrVFLNLPxOhIpZJnjSNyW479kaM1VOHGuqb-LzY__qn16PwOlAaliVdsXR2553kGtoEa5AtKAes8UwtUqzWcH9X13ZjYw_7-4q91g8Nj-sYkB2KuqaDV8wRgSZEOgLTvZwoh_nEELqYgzqqanqMMuLbEM6RNzoV5_aCJ6dQd_c7N-atFVskTda9NUfx2jChUly9XTyjvlpwkULlh4HbHupTH_T2XmuLKDYJIrtWpYWOEap5Z52rc53vTevmWA3ZrikvaAoEp2Dy6_rWwc671TC8wD3FteNg"}'
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1520851070","not_before":"1520847170","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcxNzAsIm5iZiI6MTUyMDg0NzE3MCwiZXhwIjoxNTIwODUxMDcwLCJhaW8iOiJZMk5nWU9nMERWVFlkajBwTzZXYksrRFBlVWtSQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZVhrNGlhS0lnMFdWT1dqT3MtZ2tBQSIsInZlciI6IjEuMCJ9.emFcGC-VWC-Lld27ItZWJLk9UwzAHU9pH6Djmv3czLr2nlcn4oRAnzyobCBT-CZBihKM6sg9Z5-HBDsc3BlVPdvzRwWPglwFapKh6H4h9FT2EcLLCUZU3dftOHg8m8pAGJFiyocZ3EzY9cJFJ3t1-E172fYltCe95Mme21ockcumg4hE-0vT-94C-MZEw--4hB3_QxYb02Lcp1gYfcS0RBrvnjLnRXvixay8_jP99cI1zNviF2DOpqIdkNpRMinuWGZaoVr-kcWH7o_dWMTk10hpOaTYn923feYi0VkLqS96I-2eh-RmNVVOAWRaHRSHMF8XXYBYF1cdXLSGWEKhHw"}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:20:44 GMT
+  recorded_at: Mon, 12 Mar 2018 09:37:55 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -72,7 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3NDQsIm5iZiI6MTUyMDQ1Mzc0NCwiZXhwIjoxNTIwNDU3NjQ0LCJhaW8iOiJZMk5nWURnd3hlVlFnaXVicisrQy8zbEdURW9XQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWGc1OTY1VGFOa0NlaVhCbjQzY0FBQSIsInZlciI6IjEuMCJ9.Hb3eiQ0l3ptAb6f8__A2kTEQEBrM6qo6k1lLTXs-51ZLWyA9iXIFHgLkrVFLNLPxOhIpZJnjSNyW479kaM1VOHGuqb-LzY__qn16PwOlAaliVdsXR2553kGtoEa5AtKAes8UwtUqzWcH9X13ZjYw_7-4q91g8Nj-sYkB2KuqaDV8wRgSZEOgLTvZwoh_nEELqYgzqqanqMMuLbEM6RNzoV5_aCJ6dQd_c7N-atFVskTda9NUfx2jChUly9XTyjvlpwkULlh4HbHupTH_T2XmuLKDYJIrtWpYWOEap5Z52rc53vTevmWA3ZrikvaAoEp2Dy6_rWwc671TC8wD3FteNg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcxNzAsIm5iZiI6MTUyMDg0NzE3MCwiZXhwIjoxNTIwODUxMDcwLCJhaW8iOiJZMk5nWU9nMERWVFlkajBwTzZXYksrRFBlVWtSQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZVhrNGlhS0lnMFdWT1dqT3MtZ2tBQSIsInZlciI6IjEuMCJ9.emFcGC-VWC-Lld27ItZWJLk9UwzAHU9pH6Djmv3czLr2nlcn4oRAnzyobCBT-CZBihKM6sg9Z5-HBDsc3BlVPdvzRwWPglwFapKh6H4h9FT2EcLLCUZU3dftOHg8m8pAGJFiyocZ3EzY9cJFJ3t1-E172fYltCe95Mme21ockcumg4hE-0vT-94C-MZEw--4hB3_QxYb02Lcp1gYfcS0RBrvnjLnRXvixay8_jP99cI1zNviF2DOpqIdkNpRMinuWGZaoVr-kcWH7o_dWMTk10hpOaTYn923feYi0VkLqS96I-2eh-RmNVVOAWRaHRSHMF8XXYBYF1cdXLSGWEKhHw
   response:
     status:
       code: 200
@@ -91,26 +91,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14996'
+      - '14998'
       X-Ms-Request-Id:
-      - e608c519-b7ce-4cb0-9168-b85bd3031853
+      - 3a93cb68-2f97-47e9-8d84-60e02fae3570
       X-Ms-Correlation-Request-Id:
-      - e608c519-b7ce-4cb0-9168-b85bd3031853
+      - 3a93cb68-2f97-47e9-8d84-60e02fae3570
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202045Z:e608c519-b7ce-4cb0-9168-b85bd3031853
+      - WESTEUROPE:20180312T093754Z:3a93cb68-2f97-47e9-8d84-60e02fae3570
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:20:44 GMT
+      - Mon, 12 Mar 2018 09:37:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID","subscriptionId":"AZURE_SUBSCRIPTION_ID","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:20:45 GMT
+  recorded_at: Mon, 12 Mar 2018 09:37:58 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers?api-version=2015-01-01
@@ -127,7 +127,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3NDQsIm5iZiI6MTUyMDQ1Mzc0NCwiZXhwIjoxNTIwNDU3NjQ0LCJhaW8iOiJZMk5nWURnd3hlVlFnaXVicisrQy8zbEdURW9XQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWGc1OTY1VGFOa0NlaVhCbjQzY0FBQSIsInZlciI6IjEuMCJ9.Hb3eiQ0l3ptAb6f8__A2kTEQEBrM6qo6k1lLTXs-51ZLWyA9iXIFHgLkrVFLNLPxOhIpZJnjSNyW479kaM1VOHGuqb-LzY__qn16PwOlAaliVdsXR2553kGtoEa5AtKAes8UwtUqzWcH9X13ZjYw_7-4q91g8Nj-sYkB2KuqaDV8wRgSZEOgLTvZwoh_nEELqYgzqqanqMMuLbEM6RNzoV5_aCJ6dQd_c7N-atFVskTda9NUfx2jChUly9XTyjvlpwkULlh4HbHupTH_T2XmuLKDYJIrtWpYWOEap5Z52rc53vTevmWA3ZrikvaAoEp2Dy6_rWwc671TC8wD3FteNg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcxNzAsIm5iZiI6MTUyMDg0NzE3MCwiZXhwIjoxNTIwODUxMDcwLCJhaW8iOiJZMk5nWU9nMERWVFlkajBwTzZXYksrRFBlVWtSQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZVhrNGlhS0lnMFdWT1dqT3MtZ2tBQSIsInZlciI6IjEuMCJ9.emFcGC-VWC-Lld27ItZWJLk9UwzAHU9pH6Djmv3czLr2nlcn4oRAnzyobCBT-CZBihKM6sg9Z5-HBDsc3BlVPdvzRwWPglwFapKh6H4h9FT2EcLLCUZU3dftOHg8m8pAGJFiyocZ3EzY9cJFJ3t1-E172fYltCe95Mme21ockcumg4hE-0vT-94C-MZEw--4hB3_QxYb02Lcp1gYfcS0RBrvnjLnRXvixay8_jP99cI1zNviF2DOpqIdkNpRMinuWGZaoVr-kcWH7o_dWMTk10hpOaTYn923feYi0VkLqS96I-2eh-RmNVVOAWRaHRSHMF8XXYBYF1cdXLSGWEKhHw
   response:
     status:
       code: 200
@@ -144,39 +144,37 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14973'
+      - '14992'
       X-Ms-Request-Id:
-      - 444ede02-7f2b-4bb5-984c-176989fdaba4
+      - 33e54892-71f3-4fc1-a42a-ed88b954a188
       X-Ms-Correlation-Request-Id:
-      - 444ede02-7f2b-4bb5-984c-176989fdaba4
+      - 33e54892-71f3-4fc1-a42a-ed88b954a188
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202046Z:444ede02-7f2b-4bb5-984c-176989fdaba4
+      - WESTEUROPE:20180312T093756Z:33e54892-71f3-4fc1-a42a-ed88b954a188
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:20:45 GMT
+      - Mon, 12 Mar 2018 09:37:55 GMT
       Content-Length:
-      - '310901'
+      - '320853'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"},{"applicationId":"d87dcbc6-a371-462e-88e3-28ad15ec4e64","roleDefinitionId":"861776c5-e0df-4f95-be4f-ac1eec193323"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
+      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"},{"applicationId":"d87dcbc6-a371-462e-88e3-28ad15ec4e64","roleDefinitionId":"861776c5-e0df-4f95-be4f-ac1eec193323"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["East
+        Asia","Southeast Asia","Australia East","Australia Southeast","Japan East","Japan
+        West","Central India","South India","West India","West Europe","North Europe","Canada
+        Central","Canada East","Brazil South","West US","Central US","East US","South
+        Central US","East US 2","West Central US","North Central US","West US 2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
         US","Central US","East US","South Central US","West Europe","North Europe","East
         Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
         Central US","North Central US","Japan East","Japan West","Brazil South","Central
         India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"operations","locations":["West
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["East
+        Asia","Southeast Asia","Australia East","Australia Southeast","Japan East","Japan
+        West","Central India","South India","West India","West Europe","North Europe","Canada
+        Central","Canada East","Brazil South","West US","Central US","East US","South
+        Central US","East US 2","West Central US","North Central US","West US 2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"operations","locations":["West
         US","Central US","East US","South Central US","West Europe","North Europe","East
         Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
         Central US","North Central US","Japan East","Japan West","Brazil South","Central
@@ -232,177 +230,177 @@ http_interactions:
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/internalLoadBalancers","locations":[],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"domainNames/slots/roles/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"domainNames/slots/roles/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"domainNames/capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"domainNames/serviceCertificates","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
         US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
         Central","Canada East","UK South","UK West","West US","Central US","South
         Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
-        East","Australia Southeast","West US 2","West Central US","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        East","Australia Southeast","West US 2","West Central US","France Central","South
+        India","Central India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
         US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
         Central","Canada East","UK South","UK West","West US","Central US","South
         Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
-        East","Australia Southeast","West US 2","West Central US","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metrics","locations":["North
+        East","Australia Southeast","West US 2","West Central US","France Central","South
+        India","Central India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metrics","locations":["North
         Central US","South Central US","East US","East US 2","Canada Central","Canada
         East","West US","West US 2","West Central US","Central US","East Asia","Southeast
         Asia","North Europe","West Europe","UK South","UK West","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"resourceTypes","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"moveSubscriptionResources","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"validateSubscriptionMoveAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operationStatuses","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operatingSystems","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"operatingSystemFamilies","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicNetwork","namespace":"Microsoft.ClassicNetwork","resourceTypes":[{"resourceType":"virtualNetworks","locations":["East
+        India","West India","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"resourceTypes","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"moveSubscriptionResources","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"validateSubscriptionMoveAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operationStatuses","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operatingSystems","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"operatingSystemFamilies","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicNetwork","namespace":"Microsoft.ClassicNetwork","resourceTypes":[{"resourceType":"virtualNetworks","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"virtualNetworks/remoteVirtualNetworkPeeringProxies","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01"]},{"resourceType":"virtualNetworks/remoteVirtualNetworkPeeringProxies","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"reservedIps","locations":["East
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01"]},{"resourceType":"reservedIps","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"gatewaySupportedDevices","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"networkSecurityGroups","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"gatewaySupportedDevices","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"networkSecurityGroups","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicStorage","namespace":"Microsoft.ClassicStorage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"expressRouteCrossConnections","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"expressRouteCrossConnections/peerings","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicStorage","namespace":"Microsoft.ClassicStorage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkStorageAccountAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"storageAccounts/services","locations":["West
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkStorageAccountAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"storageAccounts/services","locations":["West
         US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
         Asia","Australia East","Australia Southeast","South India","Central India","West
         India","West US 2","West Central US","East US","East US 2","North Central
         US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
-        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/diagnosticSettings","locations":["West
+        South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/diagnosticSettings","locations":["West
         US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
         Asia","Australia East","Australia Southeast","South India","Central India","West
         India","West US 2","West Central US","East US","East US 2","North Central
         US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
-        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"disks","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"images","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"vmImages","locations":[],"apiVersions":["2016-11-01"]},{"resourceType":"publicImages","locations":[],"apiVersions":["2016-11-01","2016-04-01"]},{"resourceType":"osImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"osPlatformImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute","namespace":"Microsoft.Compute","authorizations":[{"applicationId":"60e6cd67-9c8c-4951-9b3c-23c25a2169af","roleDefinitionId":"e4770acb-272e-4dc8-87f3-12f44a612224"},{"applicationId":"a303894e-f1d8-4a37-bf10-67aa654a0596","roleDefinitionId":"903ac751-8ad5-4e5a-bfc2-5e49f450a241"},{"applicationId":"a8b6bf88-1d1a-4626-b040-9a729ea93c65","roleDefinitionId":"45c8267c-80ba-4b96-9a43-115b8f49fccd"}],"resourceTypes":[{"resourceType":"availabilitySets","locations":["East
+        South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"disks","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"images","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"vmImages","locations":[],"apiVersions":["2016-11-01"]},{"resourceType":"storageAccounts/vmImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"publicImages","locations":[],"apiVersions":["2016-11-01","2016-04-01"]},{"resourceType":"osImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"osPlatformImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute","namespace":"Microsoft.Compute","authorizations":[{"applicationId":"60e6cd67-9c8c-4951-9b3c-23c25a2169af","roleDefinitionId":"e4770acb-272e-4dc8-87f3-12f44a612224"},{"applicationId":"a303894e-f1d8-4a37-bf10-67aa654a0596","roleDefinitionId":"903ac751-8ad5-4e5a-bfc2-5e49f450a241"},{"applicationId":"a8b6bf88-1d1a-4626-b040-9a729ea93c65","roleDefinitionId":"45c8267c-80ba-4b96-9a43-115b8f49fccd"}],"resourceTypes":[{"resourceType":"availabilitySets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations/usages","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations/usages","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"sharedVMImages","locations":["West
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"sharedVMImages","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"sharedVMImages/versions","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"locations/capsoperations","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"disks","locations":["Southeast
@@ -410,27 +408,27 @@ http_interactions:
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"snapshots","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"snapshots","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"locations/diskoperations","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"locations/diskoperations","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"images","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"images","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"]},{"resourceType":"locations/logAnalytics","locations":["East
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"]},{"resourceType":"locations/logAnalytics","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
         US","East US","South Central US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
@@ -547,7 +545,12 @@ http_interactions:
         US","East Asia","East US","East US 2","Japan East","Japan West","North Central
         US","North Europe","South Central US","South India","Southeast Asia","West
         Central US","West Europe","West India","West US","West US 2","UK West","UK
-        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"},{"applicationId":"f5c26e74-f226-4ae8-85f0-b4af0080ac9e","roleDefinitionId":"529d7ae6-e892-4d43-809d-8547aeb90643"}],"resourceTypes":[{"resourceType":"components","locations":["East
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/consumergroups","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/disasterrecoveryconfigs","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"},{"applicationId":"f5c26e74-f226-4ae8-85f0-b4af0080ac9e","roleDefinitionId":"529d7ae6-e892-4d43-809d-8547aeb90643"}],"resourceTypes":[{"resourceType":"components","locations":["East
         US","South Central US","North Europe","West Europe","Southeast Asia","West
         US 2"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
         US","South Central US","North Europe","West Europe","Southeast Asia","West
@@ -614,32 +617,32 @@ http_interactions:
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/accessPolicies","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"vaults/accessPolicies","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-10-01","2015-06-01","2014-12-19-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"deletedVaults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01","2014-12-19-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"deletedVaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-10-01"]},{"resourceType":"locations/deletedVaults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations/deletedVaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
         Central US","West Europe","Southeast Asia","Japan East","West Central US"],"apiVersions":["2016-04-01"]},{"resourceType":"webServices","locations":["South
         Central US","West Europe","Southeast Asia","Japan East","East US 2","West
         Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"operations","locations":["South
@@ -665,97 +668,97 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"networkWatchers/lenses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"networkWatchers/lenses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","West
         US 2","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
@@ -846,7 +849,7 @@ http_interactions:
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
         West","Korea Central","Korea South"],"apiVersions":["2017-07-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ResourceHealth","namespace":"Microsoft.ResourceHealth","authorizations":[{"applicationId":"8bdebf23-c0fe-4187-a378-717ad86f6a53","roleDefinitionId":"cc026344-c8b1-4561-83ba-59eba84b27cc"}],"resourceTypes":[{"resourceType":"availabilityStatuses","locations":[],"apiVersions":["2017-07-01","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"notifications","locations":["Australia
-        Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Security","namespace":"Microsoft.Security","authorization":{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
+        Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Security","namespace":"Microsoft.Security","authorizations":[{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},{"applicationId":"fc780465-2017-40d4-a0c5-307022471b92"}],"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatuses","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/virtualMachines","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/endpoints","locations":["Central
@@ -898,565 +901,595 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Central India","South
         India"],"apiVersions":["2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Sql","namespace":"Microsoft.Sql","authorizations":[{"applicationId":"e4ab13ed-33cb-41b4-9140-6e264582cf85","roleDefinitionId":"ec3ddc95-44dc-47a2-9926-5e9f5ffd44ec"},{"applicationId":"0130cc9f-7ac5-4026-bd5f-80a08a54e6d9","roleDefinitionId":"45e8abf8-0ec4-44f3-9c37-cff4f7779302"},{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},{"applicationId":"76c7f279-7959-468f-8943-3954880e0d8c","roleDefinitionId":"7f7513a8-73f9-4c5f-97a2-c41f0ea783ef"}],"resourceTypes":[{"resourceType":"operations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/capabilities","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/databaseAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/databaseOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverKeyOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/keys","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/encryptionProtector","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/usages","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01","2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/communicationLinks","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administrators","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administratorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/restorableDroppedDatabases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recoverableDatabases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/geoBackupPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/importExportOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/operationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/backupLongTermRetentionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/automaticTuning","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/automaticTuning","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/databases/transparentDataEncryption","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recommendedElasticPools","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/auditingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/connectionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/connectionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies/rules","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/securityAlertPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/securityAlertPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/auditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/extendedAuditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/elasticpools","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-09-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/jobAgentOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/jobAgentAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/disasterRecoveryConfiguration","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/dnsAliases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/failoverGroups","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/virtualNetworkRules","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/virtualNetworkRulesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/virtualNetworkRulesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/databaseRestoreAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metricDefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/aggregatedDatabaseMetrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metricdefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries/queryText","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPools/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/extensions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPoolEstimates","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditRecords","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentScans","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/vulnerabilityAssessments","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessment","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/syncGroups","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups/syncMembers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/syncAgents","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"managedInstances/administrators","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/databases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metricDefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/administratorAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/administratorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncMemberOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncAgentOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncDatabaseIds","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorizations":[{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},{"applicationId":"e406a681-f3d4-42a8-90b6-c2b029497af1"}],"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/capabilities","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/databaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"locations/databaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverKeyOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/keys","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/encryptionProtector","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01","2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/communicationLinks","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/restorableDroppedDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recoverableDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/geoBackupPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/importExportOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/operationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/backupLongTermRetentionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/databases/transparentDataEncryption","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recommendedElasticPools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies/rules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/extendedAuditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/elasticPoolAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/elasticPoolOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/elasticpools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-09-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/jobAgentOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/jobAgentAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/disasterRecoveryConfiguration","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/dnsAliases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/failoverGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/virtualNetworkRules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/virtualNetworkRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/virtualNetworkRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/databaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/aggregatedDatabaseMetrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metricdefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries/queryText","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPools/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/extensions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPoolEstimates","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditRecords","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentScans","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/vulnerabilityAssessments","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessment","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/syncGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups/syncMembers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/syncAgents","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"managedInstances/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/administratorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncMemberOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncAgentOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncDatabaseIds","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/longTermRetentionPolicyOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionPolicyAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionBackupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionBackupAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorizations":[{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},{"applicationId":"e406a681-f3d4-42a8-90b6-c2b029497af1"}],"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
@@ -1795,12 +1828,12 @@ http_interactions:
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","Canada Central","Canada East","UK South","UK West","West US 2","West
-        Central US","South India","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","South India","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","South India","Canada Central","Canada East","UK South","UK West","West
-        US 2","West Central US","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Capacity","namespace":"Microsoft.Capacity","authorization":{"applicationId":"4d0ad6c7-f6c3-46d8-ab0d-1406d5e6c86b","roleDefinitionId":"FD9C0A9A-4DB9-4F41-8A61-98385DEB6E2D"},"resourceTypes":[{"resourceType":"resources","locations":["South
+        US 2","West Central US","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Capacity","namespace":"Microsoft.Capacity","authorization":{"applicationId":"4d0ad6c7-f6c3-46d8-ab0d-1406d5e6c86b","roleDefinitionId":"FD9C0A9A-4DB9-4F41-8A61-98385DEB6E2D"},"resourceTypes":[{"resourceType":"resources","locations":["South
         Central US"],"apiVersions":["2017-11-01"]},{"resourceType":"reservationOrders","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/reservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/reservations/revisions","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"catalogs","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"appliedReservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"checkOffers","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"checkScopes","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"calculatePrice","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/calculateRefund","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/return","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/split","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/merge","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"validateReservationOrder","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/availableScopes","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Cdn","namespace":"Microsoft.Cdn","resourceTypes":[{"resourceType":"profiles","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
@@ -1876,9 +1909,9 @@ http_interactions:
         2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/updateAccountsCreationSettings","locations":["West
         US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/accountsCreationSettings","locations":["West
         US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2016-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Commerce","namespace":"Microsoft.Commerce","resourceTypes":[{"resourceType":"UsageAggregates","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]},{"resourceType":"RateCard","locations":[],"apiVersions":["2016-08-31-preview","2015-06-01-preview","2015-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Consumption","namespace":"Microsoft.Consumption","resourceTypes":[{"resourceType":"ReservationSummaries","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationTransactions","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Balances","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Marketplaces","locations":[],"apiVersions":["2018-01-31"]},{"resourceType":"Pricesheets","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationDetails","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Budgets","locations":[],"apiVersions":["2018-01-31","2017-12-30-preview"]},{"resourceType":"Terms","locations":[],"apiVersions":["2018-01-31","2017-12-30-preview"]},{"resourceType":"UsageDetails","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview","2017-04-24-preview"]},{"resourceType":"Operations","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview","2017-04-24-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerInstance","namespace":"Microsoft.ContainerInstance","resourceTypes":[{"resourceType":"containerGroups","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/usages","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/operations","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/operations","locations":["West
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
         US"],"apiVersions":["2016-04-08"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.CustomerInsights","namespace":"Microsoft.CustomerInsights","authorization":{"applicationId":"38c77d00-5fcb-4cce-9d93-af4738258e3c","roleDefinitionId":"E006F9C7-F333-477C-8AD6-1F3A9FE87F55"},"resourceTypes":[{"resourceType":"hubs","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/profiles","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/interactions","locations":["East
@@ -1895,7 +1928,9 @@ http_interactions:
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"operations","locations":["East
         US 2"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Databricks","namespace":"Microsoft.Databricks","authorizations":[{"applicationId":"d9327919-6775-4843-9037-3fb0fb0473cb","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},{"applicationId":"2ff814a6-3304-4ab8-85cb-cd0e6f879c1d","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"}],"resourceTypes":[{"resourceType":"workspaces","locations":["West
         US","East US 2","West Europe","East US","North Europe","Southeast Asia","East
-        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]},{"resourceType":"locations","locations":["West
+        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2017-09-01-preview"]},{"resourceType":"workspaces/virtualNetworkPeerings","locations":["West
+        US","East US 2","West Europe","North Europe","East US","Southeast Asia","East
+        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01"]},{"resourceType":"locations","locations":["West
         US","East US 2","West Europe","North Europe","East US","Southeast Asia"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
         US","East US 2","West Europe","East US","North Europe","Southeast Asia","East
         Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataCatalog","namespace":"Microsoft.DataCatalog","resourceTypes":[{"resourceType":"catalogs","locations":["East
@@ -1919,23 +1954,26 @@ http_interactions:
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers/listSasTokens","locations":["East
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataLakeStore","namespace":"Microsoft.DataLakeStore","authorization":{"applicationId":"e9f49c6b-5ce5-44c8-925d-015017e9f7ad","roleDefinitionId":"17eb9cca-f08a-4499-b2d3-852d175f614f"},"resourceTypes":[{"resourceType":"accounts","locations":["East
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/firewallRules","locations":["East
-        US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataMigration","namespace":"Microsoft.DataMigration","authorization":{"applicationId":"a4bad4aa-bf02-4631-9f78-a64ffdba8150","roleDefinitionId":"b831a21d-db98-4760-89cb-bef871952df1","managedByRoleDefinitionId":"6256fb55-9e59-4018-a9e1-76b11c0a4c89"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services/projects","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationStatuses","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
+        US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataMigration","namespace":"Microsoft.DataMigration","authorization":{"applicationId":"a4bad4aa-bf02-4631-9f78-a64ffdba8150","roleDefinitionId":"b831a21d-db98-4760-89cb-bef871952df1","managedByRoleDefinitionId":"6256fb55-9e59-4018-a9e1-76b11c0a4c89"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services/projects","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationStatuses","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
-        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/recoverableServers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
@@ -1959,7 +1997,10 @@ http_interactions:
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
-        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/recoverableServers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
@@ -2015,12 +2056,7 @@ http_interactions:
         US 2","East US","West US","Central US","East US 2","West Central US","West
         Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
         US 2","East US","West US","Central US","East US 2","West Central US","West
-        Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","West
-        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
-        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
-        India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/consumergroups","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/disasterrecoveryconfigs","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
         US 2","South Central US","Central US","Australia Southeast","Central India","West
         Central US","West US 2","Canada East","Canada Central","Brazil South","UK
         South","UK West","East Asia","Australia East","Japan East","Japan West","North
@@ -2131,7 +2167,7 @@ http_interactions:
         West","Japan East","East Asia","Southeast Asia","West Europe","North Europe","East
         US","West US","Australia East","Australia Southeast","Central US","Brazil
         South","Central India","West India","South India","South Central US","Canada
-        Central","Canada East","West Central US","West US 2"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
+        Central","Canada East","West Central US","West US 2"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-05","2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
         Central US","East US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"operations","locations":["West
         Central US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
         Central US","East US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.PolicyInsights","namespace":"Microsoft.PolicyInsights","authorization":{"applicationId":"1d78a85d-813d-46f0-b496-dd72f50a3ec0","roleDefinitionId":"63d2b225-4c34-4641-8768-21a1f7c68ce8"},"resourceTypes":[{"resourceType":"policyEvents","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"policyStates","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
@@ -2163,12 +2199,12 @@ http_interactions:
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
         Central US","South Central US","North Europe","West Europe","East Asia","Southeast
         Asia","West US","East US","Japan West","Japan East","Brazil South","Central
         US","East US 2","Australia East","Australia Southeast","South India","Central
@@ -2208,40 +2244,50 @@ http_interactions:
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/clusterVersions","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"clusters/applications","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operations","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/clusterVersions","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/environments","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operations","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
         Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applianceDefinitions","locations":["West
         Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applications","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
-        Central US"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
+        Central US"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
         US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
         US","Canada Central","Canada East","Central US","East US 2","UK South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups","locations":["West
         US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
@@ -2332,10 +2378,10 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:20:46 GMT
+  recorded_at: Mon, 12 Mar 2018 09:38:00 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1?api-version=2018-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2349,86 +2395,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3NDQsIm5iZiI6MTUyMDQ1Mzc0NCwiZXhwIjoxNTIwNDU3NjQ0LCJhaW8iOiJZMk5nWURnd3hlVlFnaXVicisrQy8zbEdURW9XQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWGc1OTY1VGFOa0NlaVhCbjQzY0FBQSIsInZlciI6IjEuMCJ9.Hb3eiQ0l3ptAb6f8__A2kTEQEBrM6qo6k1lLTXs-51ZLWyA9iXIFHgLkrVFLNLPxOhIpZJnjSNyW479kaM1VOHGuqb-LzY__qn16PwOlAaliVdsXR2553kGtoEa5AtKAes8UwtUqzWcH9X13ZjYw_7-4q91g8Nj-sYkB2KuqaDV8wRgSZEOgLTvZwoh_nEELqYgzqqanqMMuLbEM6RNzoV5_aCJ6dQd_c7N-atFVskTda9NUfx2jChUly9XTyjvlpwkULlh4HbHupTH_T2XmuLKDYJIrtWpYWOEap5Z52rc53vTevmWA3ZrikvaAoEp2Dy6_rWwc671TC8wD3FteNg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/LowCostGet3Min;4709,Microsoft.Compute/LowCostGet30Min;37873
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
-      X-Ms-Request-Id:
-      - 07a127a9-10c9-48b7-836c-4f6ee95e676c
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14973'
-      X-Ms-Correlation-Request-Id:
-      - b0f14a11-1fa6-4f0b-84dc-6360f1f3ab1e
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202046Z:b0f14a11-1fa6-4f0b-84dc-6360f1f3ab1e
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:20:46 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"61b7c052-1d09-4898-b995-cce5676aaab0\",\r\n
-        \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Basic_A0\"\r\n    },\r\n
-        \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
-        \"RedHat\",\r\n        \"offer\": \"RHEL\",\r\n        \"sku\": \"7.3\",\r\n
-        \       \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
-        \"Linux\",\r\n        \"name\": \"miqazure-linux-managed_OsDisk_1_7b2bdf790a7d4379ace2846d307730cd\",\r\n
-        \       \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n
-        \       \"managedDisk\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/disks/miqazure-linux-managed_OsDisk_1_7b2bdf790a7d4379ace2846d307730cd\"\r\n
-        \       }\r\n      },\r\n      \"dataDisks\": [\r\n        {\r\n          \"lun\":
-        0,\r\n          \"name\": \"miqazure-linux-managed-data-disk\",\r\n          \"createOption\":
-        \"Attach\",\r\n          \"caching\": \"None\",\r\n          \"managedDisk\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/disks/miqazure-linux-managed-data-disk\"\r\n
-        \         }\r\n        }\r\n      ]\r\n    },\r\n    \"osProfile\": {\r\n
-        \     \"computerName\": \"miqazure-linux-managed\",\r\n      \"adminUsername\":
-        \"dberger\",\r\n      \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\":
-        false\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\":
-        {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944\"}]},\r\n
-        \   \"provisioningState\": \"Succeeded\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n
-        \ \"location\": \"eastus\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed\",\r\n
-        \ \"name\": \"miqazure-linux-managed\"\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:20:47 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3NDQsIm5iZiI6MTUyMDQ1Mzc0NCwiZXhwIjoxNTIwNDU3NjQ0LCJhaW8iOiJZMk5nWURnd3hlVlFnaXVicisrQy8zbEdURW9XQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWGc1OTY1VGFOa0NlaVhCbjQzY0FBQSIsInZlciI6IjEuMCJ9.Hb3eiQ0l3ptAb6f8__A2kTEQEBrM6qo6k1lLTXs-51ZLWyA9iXIFHgLkrVFLNLPxOhIpZJnjSNyW479kaM1VOHGuqb-LzY__qn16PwOlAaliVdsXR2553kGtoEa5AtKAes8UwtUqzWcH9X13ZjYw_7-4q91g8Nj-sYkB2KuqaDV8wRgSZEOgLTvZwoh_nEELqYgzqqanqMMuLbEM6RNzoV5_aCJ6dQd_c7N-atFVskTda9NUfx2jChUly9XTyjvlpwkULlh4HbHupTH_T2XmuLKDYJIrtWpYWOEap5Z52rc53vTevmWA3ZrikvaAoEp2Dy6_rWwc671TC8wD3FteNg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcxNzAsIm5iZiI6MTUyMDg0NzE3MCwiZXhwIjoxNTIwODUxMDcwLCJhaW8iOiJZMk5nWU9nMERWVFlkajBwTzZXYksrRFBlVWtSQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZVhrNGlhS0lnMFdWT1dqT3MtZ2tBQSIsInZlciI6IjEuMCJ9.emFcGC-VWC-Lld27ItZWJLk9UwzAHU9pH6Djmv3czLr2nlcn4oRAnzyobCBT-CZBihKM6sg9Z5-HBDsc3BlVPdvzRwWPglwFapKh6H4h9FT2EcLLCUZU3dftOHg8m8pAGJFiyocZ3EzY9cJFJ3t1-E172fYltCe95Mme21ockcumg4hE-0vT-94C-MZEw--4hB3_QxYb02Lcp1gYfcS0RBrvnjLnRXvixay8_jP99cI1zNviF2DOpqIdkNpRMinuWGZaoVr-kcWH7o_dWMTk10hpOaTYn923feYi0VkLqS96I-2eh-RmNVVOAWRaHRSHMF8XXYBYF1cdXLSGWEKhHw
   response:
     status:
       code: 200
@@ -2445,52 +2412,87 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"b6339880-8ead-4c9e-b5c0-f38c4f8612d5"
+      - W/"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 80cf7f54-eb1e-4bc7-8841-00be4ff56335
+      - 9753b64f-fac9-404c-873e-7ca4ec25d8ad
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14970'
+      - '14992'
       X-Ms-Correlation-Request-Id:
-      - 127061c2-4e2e-409b-b715-1d1a883b3743
+      - dc03e064-427f-430b-bad4-66d6f1f6114e
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202047Z:127061c2-4e2e-409b-b715-1d1a883b3743
+      - WESTEUROPE:20180312T093757Z:dc03e064-427f-430b-bad4-66d6f1f6114e
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:20:47 GMT
+      - Mon, 12 Mar 2018 09:37:56 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"miqazure-linux-manag944\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944\",\r\n
-        \ \"etag\": \"W/\\\"b6339880-8ead-4c9e-b5c0-f38c4f8612d5\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"c5e8b90e-5a78-49b0-b224-b70ed3fb45e5\",\r\n    \"ipConfigurations\":
-        [\r\n      {\r\n        \"name\": \"ipconfig1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944/ipConfigurations/ipconfig1\",\r\n
-        \       \"etag\": \"W/\\\"b6339880-8ead-4c9e-b5c0-f38c4f8612d5\\\"\",\r\n
+      string: "{\r\n  \"name\": \"rspec-lb1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1\",\r\n
+        \ \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"7ab88756-810f-4083-95db-8b05d50e38f2\",\r\n
+        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
+        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAddress\": \"172.25.0.4\",\r\n          \"privateIPAllocationMethod\":
-        \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqazure-linux-managed-ip\"\r\n
-        \         },\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2/subnets/default\"\r\n
-        \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
-        \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\":
-        [],\r\n      \"appliedDnsServers\": []\r\n    },\r\n    \"enableAcceleratedNetworking\":
-        false,\r\n    \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\":
-        {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg\"\r\n
-        \   },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed\"\r\n
-        \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
-        \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
+        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
+        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\"\r\n
+        \         },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
+        \           }\r\n          ],\r\n          \"inboundNatRules\": [\r\n            {\r\n
+        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
+        [\r\n      {\r\n        \"name\": \"rspec-lb-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\",\r\n
+        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"backendIPConfigurations\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\"\r\n
+        \           }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n
+        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\":
+        [\r\n      {\r\n        \"name\": \"rspec-lb1-rule\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\",\r\n
+        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
+        \         },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\":
+        80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
+        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
+        false,\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\":
+        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\"\r\n
+        \         },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\"\r\n
+        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n
+        \       \"name\": \"rspec-lb-probe\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\",\r\n
+        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
+        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
+        2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\":
+        [\r\n      {\r\n        \"name\": \"rspec-lb1-NAT\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\",\r\n
+        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
+        \         },\r\n          \"frontendPort\": 3441,\r\n          \"backendPort\":
+        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
+        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
+        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
+        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"outboundNatRules\":
+        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
+        \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:20:47 GMT
+  recorded_at: Mon, 12 Mar 2018 09:38:01 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups/miq-azure-test4?api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2?api-version=2018-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2504,7 +2506,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3NDQsIm5iZiI6MTUyMDQ1Mzc0NCwiZXhwIjoxNTIwNDU3NjQ0LCJhaW8iOiJZMk5nWURnd3hlVlFnaXVicisrQy8zbEdURW9XQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWGc1OTY1VGFOa0NlaVhCbjQzY0FBQSIsInZlciI6IjEuMCJ9.Hb3eiQ0l3ptAb6f8__A2kTEQEBrM6qo6k1lLTXs-51ZLWyA9iXIFHgLkrVFLNLPxOhIpZJnjSNyW479kaM1VOHGuqb-LzY__qn16PwOlAaliVdsXR2553kGtoEa5AtKAes8UwtUqzWcH9X13ZjYw_7-4q91g8Nj-sYkB2KuqaDV8wRgSZEOgLTvZwoh_nEELqYgzqqanqMMuLbEM6RNzoV5_aCJ6dQd_c7N-atFVskTda9NUfx2jChUly9XTyjvlpwkULlh4HbHupTH_T2XmuLKDYJIrtWpYWOEap5Z52rc53vTevmWA3ZrikvaAoEp2Dy6_rWwc671TC8wD3FteNg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcxNzAsIm5iZiI6MTUyMDg0NzE3MCwiZXhwIjoxNTIwODUxMDcwLCJhaW8iOiJZMk5nWU9nMERWVFlkajBwTzZXYksrRFBlVWtSQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZVhrNGlhS0lnMFdWT1dqT3MtZ2tBQSIsInZlciI6IjEuMCJ9.emFcGC-VWC-Lld27ItZWJLk9UwzAHU9pH6Djmv3czLr2nlcn4oRAnzyobCBT-CZBihKM6sg9Z5-HBDsc3BlVPdvzRwWPglwFapKh6H4h9FT2EcLLCUZU3dftOHg8m8pAGJFiyocZ3EzY9cJFJ3t1-E172fYltCe95Mme21ockcumg4hE-0vT-94C-MZEw--4hB3_QxYb02Lcp1gYfcS0RBrvnjLnRXvixay8_jP99cI1zNviF2DOpqIdkNpRMinuWGZaoVr-kcWH7o_dWMTk10hpOaTYn923feYi0VkLqS96I-2eh-RmNVVOAWRaHRSHMF8XXYBYF1cdXLSGWEKhHw
   response:
     status:
       code: 200
@@ -2514,36 +2516,64 @@ http_interactions:
       - no-cache
       Pragma:
       - no-cache
+      Transfer-Encoding:
+      - chunked
       Content-Type:
       - application/json; charset=utf-8
       Expires:
       - "-1"
+      Etag:
+      - W/"7a8e5fe7-f777-4435-992b-a54f28c2f28c"
       Vary:
       - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14971'
       X-Ms-Request-Id:
-      - 12c97445-e52a-41bb-96f2-0e207f5a0e64
-      X-Ms-Correlation-Request-Id:
-      - 12c97445-e52a-41bb-96f2-0e207f5a0e64
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202047Z:12c97445-e52a-41bb-96f2-0e207f5a0e64
+      - 2ead0eaa-0467-43b7-aec1-ca9aec0290e5
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14989'
+      X-Ms-Correlation-Request-Id:
+      - '0993cef1-a5ae-4476-83a6-fc75e19a6ed2'
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T093757Z:0993cef1-a5ae-4476-83a6-fc75e19a6ed2
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:20:47 GMT
-      Content-Length:
-      - '183'
+      - Mon, 12 Mar 2018 09:37:56 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4","name":"miq-azure-test4","location":"eastus","properties":{"provisioningState":"Succeeded"}}'
+      string: "{\r\n  \"name\": \"rspec-lb2\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2\",\r\n
+        \ \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"e2e30a77-f81b-43fc-9693-08303e43deed\",\r\n
+        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
+        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
+        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\"\r\n
+        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
+        [\r\n      {\r\n        \"name\": \"rspec-lb2-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/backendAddressPools/rspec-lb2-pool\",\r\n
+        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\r\n
+        \       }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\": [],\r\n    \"probes\":
+        [\r\n      {\r\n        \"name\": \"rspec-lb2-probe\",\r\n        \"id\":
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/probes/rspec-lb2-probe\",\r\n
+        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
+        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
+        2\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\": [],\r\n    \"outboundNatRules\":
+        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
+        \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:20:48 GMT
+  recorded_at: Mon, 12 Mar 2018 09:38:02 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute/locations/eastus/vmSizes?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a?api-version=2017-12-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2557,7 +2587,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3NDQsIm5iZiI6MTUyMDQ1Mzc0NCwiZXhwIjoxNTIwNDU3NjQ0LCJhaW8iOiJZMk5nWURnd3hlVlFnaXVicisrQy8zbEdURW9XQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWGc1OTY1VGFOa0NlaVhCbjQzY0FBQSIsInZlciI6IjEuMCJ9.Hb3eiQ0l3ptAb6f8__A2kTEQEBrM6qo6k1lLTXs-51ZLWyA9iXIFHgLkrVFLNLPxOhIpZJnjSNyW479kaM1VOHGuqb-LzY__qn16PwOlAaliVdsXR2553kGtoEa5AtKAes8UwtUqzWcH9X13ZjYw_7-4q91g8Nj-sYkB2KuqaDV8wRgSZEOgLTvZwoh_nEELqYgzqqanqMMuLbEM6RNzoV5_aCJ6dQd_c7N-atFVskTda9NUfx2jChUly9XTyjvlpwkULlh4HbHupTH_T2XmuLKDYJIrtWpYWOEap5Z52rc53vTevmWA3ZrikvaAoEp2Dy6_rWwc671TC8wD3FteNg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcxNzAsIm5iZiI6MTUyMDg0NzE3MCwiZXhwIjoxNTIwODUxMDcwLCJhaW8iOiJZMk5nWU9nMERWVFlkajBwTzZXYksrRFBlVWtSQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZVhrNGlhS0lnMFdWT1dqT3MtZ2tBQSIsInZlciI6IjEuMCJ9.emFcGC-VWC-Lld27ItZWJLk9UwzAHU9pH6Djmv3czLr2nlcn4oRAnzyobCBT-CZBihKM6sg9Z5-HBDsc3BlVPdvzRwWPglwFapKh6H4h9FT2EcLLCUZU3dftOHg8m8pAGJFiyocZ3EzY9cJFJ3t1-E172fYltCe95Mme21ockcumg4hE-0vT-94C-MZEw--4hB3_QxYb02Lcp1gYfcS0RBrvnjLnRXvixay8_jP99cI1zNviF2DOpqIdkNpRMinuWGZaoVr-kcWH7o_dWMTk10hpOaTYn923feYi0VkLqS96I-2eh-RmNVVOAWRaHRSHMF8XXYBYF1cdXLSGWEKhHw
   response:
     status:
       code: 200
@@ -2576,26 +2606,564 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/LowCostGet3Min;4706,Microsoft.Compute/LowCostGet30Min;37870
+      - Microsoft.Compute/LowCostGet3Min;4742,Microsoft.Compute/LowCostGet30Min;37875
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
       - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
       X-Ms-Request-Id:
-      - d257690e-22d8-43b0-8769-1a54166b5ed4
+      - 7dfe845d-4045-4121-a0a8-e1d821d37040
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14973'
+      - '14993'
       X-Ms-Correlation-Request-Id:
-      - 232893f3-02a0-45de-a2ab-4f5d85b6c7b5
+      - ffb65b1b-9b7c-463b-8366-f1c31147d0e0
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202048Z:232893f3-02a0-45de-a2ab-4f5d85b6c7b5
+      - WESTEUROPE:20180312T093758Z:ffb65b1b-9b7c-463b-8366-f1c31147d0e0
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:20:48 GMT
+      - Mon, 12 Mar 2018 09:37:58 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"23b0beab-16d2-4135-a01f-2fe713217fd0\",\r\n
+        \   \"availabilitySet\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/RSPEC-LB\"\r\n
+        \   },\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_F1s\"\r\n
+        \   },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
+        \"RedHat\",\r\n        \"offer\": \"RHEL\",\r\n        \"sku\": \"6.7\",\r\n
+        \       \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
+        \"Linux\",\r\n        \"name\": \"rspec-lb-a\",\r\n        \"createOption\":
+        \"FromImage\",\r\n        \"vhd\": {\r\n          \"uri\": \"https://rspeclb.blob.core.windows.net/vhds/rspec-lb-a201682122839.vhd\"\r\n
+        \       },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n      \"dataDisks\":
+        []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"rspec-lb-a\",\r\n
+        \     \"adminUsername\": \"bronaghs\",\r\n      \"linuxConfiguration\": {\r\n
+        \       \"disablePasswordAuthentication\": false\r\n      },\r\n      \"secrets\":
+        []\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670\"}]},\r\n
+        \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
+        true,\r\n        \"storageUri\": \"https://miqazuretest16487.blob.core.windows.net/\"\r\n
+        \     }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n
+        \ \"resources\": [\r\n    {\r\n      \"properties\": {\r\n        \"publisher\":
+        \"Microsoft.OSTCExtensions\",\r\n        \"type\": \"LinuxDiagnostic\",\r\n
+        \       \"typeHandlerVersion\": \"2.3\",\r\n        \"autoUpgradeMinorVersion\":
+        true,\r\n        \"settings\": {\"xmlCfg\":\"PFdhZENmZz48RGlhZ25vc3RpY01vbml0b3JDb25maWd1cmF0aW9uIG92ZXJhbGxRdW90YUluTUI9IjQwOTYiPjxEaWFnbm9zdGljSW5mcmFzdHJ1Y3R1cmVMb2dzIHNjaGVkdWxlZFRyYW5zZmVyUGVyaW9kPSJQVDFNIiBzY2hlZHVsZWRUcmFuc2ZlckxvZ0xldmVsRmlsdGVyPSJXYXJuaW5nIi8+PFBlcmZvcm1hbmNlQ291bnRlcnMgc2NoZWR1bGVkVHJhbnNmZXJQZXJpb2Q9IlBUMU0iPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlTWVtb3J5IiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQnl0ZXMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcUGVyY2VudEF2YWlsYWJsZU1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iTWVtb3J5IHVzZWQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50VXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgcGVyY2VudGFnZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkQnlDYWNoZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHVzZWQgYnkgY2FjaGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1BlclNlYyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50UGVyU2Vjb25kIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFnZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1JlYWRQZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2UgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1dyaXR0ZW5QZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2Ugd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iU3dhcCBhdmFpbGFibGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50QXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZFN3YXAiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlN3YXAgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRJZGxlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgaWRsZSB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFVzZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iUGVyY2VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkNQVSB1c2VyIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50TmljZVRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIG5pY2UgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRQcml2aWxlZ2VkVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgcHJpdmlsZWdlZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudEludGVycnVwdFRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIGludGVycnVwdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudERQQ1RpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIERQQyB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFByb2Nlc3NvclRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIHBlcmNlbnRhZ2UgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50SU9XYWl0VGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgSU8gd2FpdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xSZWFkQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCBndWVzdCBPUyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXFdyaXRlQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGUgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xUcmFuc2ZlcnNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXJzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcUmVhZHNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xXcml0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVJlYWRUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVdyaXRlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlNlY29uZHMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJEaXNrIHdyaXRlIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xBdmVyYWdlVHJhbnNmZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXIgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXEF2ZXJhZ2VEaXNrUXVldWVMZW5ndGgiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcXVldWUgbGVuZ3RoIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVHJhbnNtaXR0ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgb3V0IGd1ZXN0IE9TIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzUmVjZWl2ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgaW4gZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1RyYW5zbWl0dGVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHNlbnQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1JlY2VpdmVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHJlY2VpdmVkIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVG90YWwiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxSeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyByZWNlaXZlZCBlcnJvcnMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxUeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyBzZW50IGVycm9ycyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTmV0d29ya0ludGVyZmFjZVxUb3RhbENvbGxpc2lvbnMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgY29sbGlzaW9ucyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48L1BlcmZvcm1hbmNlQ291bnRlcnM+PE1ldHJpY3MgcmVzb3VyY2VJZD0iL3N1YnNjcmlwdGlvbnMvMjU4NmM2NGItMzhiNC00NTI3LWExNDAtMDEyZDQ5ZGZjMDJjL3Jlc291cmNlR3JvdXBzL21pcS1henVyZS10ZXN0MS9wcm92aWRlcnMvTWljcm9zb2Z0LkNvbXB1dGUvdmlydHVhbE1hY2hpbmVzL3JzcGVjLWxiLWEiPjxNZXRyaWNBZ2dyZWdhdGlvbiBzY2hlZHVsZWRUcmFuc2ZlclBlcmlvZD0iUFQxSCIvPjxNZXRyaWNBZ2dyZWdhdGlvbiBzY2hlZHVsZWRUcmFuc2ZlclBlcmlvZD0iUFQxTSIvPjwvTWV0cmljcz48L0RpYWdub3N0aWNNb25pdG9yQ29uZmlndXJhdGlvbj48L1dhZENmZz4=\",\"StorageAccount\":\"miqazuretest16487\"},\r\n
+        \       \"provisioningState\": \"Succeeded\"\r\n      },\r\n      \"type\":
+        \"Microsoft.Compute/virtualMachines/extensions\",\r\n      \"location\": \"eastus\",\r\n
+        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a/extensions/Microsoft.Insights.VMDiagnosticsSettings\",\r\n
+        \     \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n    }\r\n
+        \ ],\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\":
+        \"eastus\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a\",\r\n
+        \ \"name\": \"rspec-lb-a\"\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:38:02 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b?api-version=2017-12-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcxNzAsIm5iZiI6MTUyMDg0NzE3MCwiZXhwIjoxNTIwODUxMDcwLCJhaW8iOiJZMk5nWU9nMERWVFlkajBwTzZXYksrRFBlVWtSQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZVhrNGlhS0lnMFdWT1dqT3MtZ2tBQSIsInZlciI6IjEuMCJ9.emFcGC-VWC-Lld27ItZWJLk9UwzAHU9pH6Djmv3czLr2nlcn4oRAnzyobCBT-CZBihKM6sg9Z5-HBDsc3BlVPdvzRwWPglwFapKh6H4h9FT2EcLLCUZU3dftOHg8m8pAGJFiyocZ3EzY9cJFJ3t1-E172fYltCe95Mme21ockcumg4hE-0vT-94C-MZEw--4hB3_QxYb02Lcp1gYfcS0RBrvnjLnRXvixay8_jP99cI1zNviF2DOpqIdkNpRMinuWGZaoVr-kcWH7o_dWMTk10hpOaTYn923feYi0VkLqS96I-2eh-RmNVVOAWRaHRSHMF8XXYBYF1cdXLSGWEKhHw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/LowCostGet3Min;4741,Microsoft.Compute/LowCostGet30Min;37874
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      X-Ms-Request-Id:
+      - d7f0d198-a5ee-44e2-8c61-a4963b97822a
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14986'
+      X-Ms-Correlation-Request-Id:
+      - ffcbaf11-dc98-4bc3-b757-9ba67794d657
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T093758Z:ffcbaf11-dc98-4bc3-b757-9ba67794d657
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:37:57 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"834a70b5-868d-4466-9dda-14e0f6b2caaf\",\r\n
+        \   \"availabilitySet\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/RSPEC-LB\"\r\n
+        \   },\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n
+        \   },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
+        \"RedHat\",\r\n        \"offer\": \"RHEL\",\r\n        \"sku\": \"6.7\",\r\n
+        \       \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
+        \"Linux\",\r\n        \"name\": \"rspec-lb-b\",\r\n        \"createOption\":
+        \"FromImage\",\r\n        \"vhd\": {\r\n          \"uri\": \"https://rspeclb.blob.core.windows.net/vhds/rspec-lb-b201682123650.vhd\"\r\n
+        \       },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n      \"dataDisks\":
+        []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"rspec-lb-b\",\r\n
+        \     \"adminUsername\": \"bronaghs\",\r\n      \"linuxConfiguration\": {\r\n
+        \       \"disablePasswordAuthentication\": false\r\n      },\r\n      \"secrets\":
+        []\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843\"}]},\r\n
+        \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
+        true,\r\n        \"storageUri\": \"https://amissteastorage.blob.core.windows.net/\"\r\n
+        \     }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n
+        \ \"resources\": [\r\n    {\r\n      \"properties\": {\r\n        \"publisher\":
+        \"Microsoft.OSTCExtensions\",\r\n        \"type\": \"LinuxDiagnostic\",\r\n
+        \       \"typeHandlerVersion\": \"2.3\",\r\n        \"autoUpgradeMinorVersion\":
+        true,\r\n        \"settings\": {\"xmlCfg\":\"PFdhZENmZz48RGlhZ25vc3RpY01vbml0b3JDb25maWd1cmF0aW9uIG92ZXJhbGxRdW90YUluTUI9IjQwOTYiPjxEaWFnbm9zdGljSW5mcmFzdHJ1Y3R1cmVMb2dzIHNjaGVkdWxlZFRyYW5zZmVyUGVyaW9kPSJQVDFNIiBzY2hlZHVsZWRUcmFuc2ZlckxvZ0xldmVsRmlsdGVyPSJXYXJuaW5nIi8+PFBlcmZvcm1hbmNlQ291bnRlcnMgc2NoZWR1bGVkVHJhbnNmZXJQZXJpb2Q9IlBUMU0iPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlTWVtb3J5IiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQnl0ZXMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcUGVyY2VudEF2YWlsYWJsZU1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iTWVtb3J5IHVzZWQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50VXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgcGVyY2VudGFnZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkQnlDYWNoZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHVzZWQgYnkgY2FjaGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1BlclNlYyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50UGVyU2Vjb25kIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFnZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1JlYWRQZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2UgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1dyaXR0ZW5QZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2Ugd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iU3dhcCBhdmFpbGFibGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50QXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZFN3YXAiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlN3YXAgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRJZGxlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgaWRsZSB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFVzZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iUGVyY2VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkNQVSB1c2VyIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50TmljZVRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIG5pY2UgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRQcml2aWxlZ2VkVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgcHJpdmlsZWdlZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudEludGVycnVwdFRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIGludGVycnVwdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudERQQ1RpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIERQQyB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFByb2Nlc3NvclRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIHBlcmNlbnRhZ2UgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50SU9XYWl0VGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgSU8gd2FpdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xSZWFkQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCBndWVzdCBPUyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXFdyaXRlQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGUgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xUcmFuc2ZlcnNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXJzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcUmVhZHNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xXcml0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVJlYWRUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVdyaXRlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlNlY29uZHMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJEaXNrIHdyaXRlIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xBdmVyYWdlVHJhbnNmZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXIgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXEF2ZXJhZ2VEaXNrUXVldWVMZW5ndGgiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcXVldWUgbGVuZ3RoIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVHJhbnNtaXR0ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgb3V0IGd1ZXN0IE9TIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzUmVjZWl2ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgaW4gZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1RyYW5zbWl0dGVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHNlbnQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1JlY2VpdmVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHJlY2VpdmVkIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVG90YWwiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxSeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyByZWNlaXZlZCBlcnJvcnMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxUeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyBzZW50IGVycm9ycyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTmV0d29ya0ludGVyZmFjZVxUb3RhbENvbGxpc2lvbnMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgY29sbGlzaW9ucyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48L1BlcmZvcm1hbmNlQ291bnRlcnM+PE1ldHJpY3MgcmVzb3VyY2VJZD0iL3N1YnNjcmlwdGlvbnMvMjU4NmM2NGItMzhiNC00NTI3LWExNDAtMDEyZDQ5ZGZjMDJjL3Jlc291cmNlR3JvdXBzL21pcS1henVyZS10ZXN0MS9wcm92aWRlcnMvTWljcm9zb2Z0LkNvbXB1dGUvdmlydHVhbE1hY2hpbmVzL3JzcGVjLWxiLWIiPjxNZXRyaWNBZ2dyZWdhdGlvbiBzY2hlZHVsZWRUcmFuc2ZlclBlcmlvZD0iUFQxSCIvPjxNZXRyaWNBZ2dyZWdhdGlvbiBzY2hlZHVsZWRUcmFuc2ZlclBlcmlvZD0iUFQxTSIvPjwvTWV0cmljcz48L0RpYWdub3N0aWNNb25pdG9yQ29uZmlndXJhdGlvbj48L1dhZENmZz4=\",\"StorageAccount\":\"amissteastorage\"},\r\n
+        \       \"provisioningState\": \"Succeeded\"\r\n      },\r\n      \"type\":
+        \"Microsoft.Compute/virtualMachines/extensions\",\r\n      \"location\": \"eastus\",\r\n
+        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b/extensions/Microsoft.Insights.VMDiagnosticsSettings\",\r\n
+        \     \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n    }\r\n
+        \ ],\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\":
+        \"eastus\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b\",\r\n
+        \ \"name\": \"rspec-lb-b\"\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:38:03 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcxNzAsIm5iZiI6MTUyMDg0NzE3MCwiZXhwIjoxNTIwODUxMDcwLCJhaW8iOiJZMk5nWU9nMERWVFlkajBwTzZXYksrRFBlVWtSQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZVhrNGlhS0lnMFdWT1dqT3MtZ2tBQSIsInZlciI6IjEuMCJ9.emFcGC-VWC-Lld27ItZWJLk9UwzAHU9pH6Djmv3czLr2nlcn4oRAnzyobCBT-CZBihKM6sg9Z5-HBDsc3BlVPdvzRwWPglwFapKh6H4h9FT2EcLLCUZU3dftOHg8m8pAGJFiyocZ3EzY9cJFJ3t1-E172fYltCe95Mme21ockcumg4hE-0vT-94C-MZEw--4hB3_QxYb02Lcp1gYfcS0RBrvnjLnRXvixay8_jP99cI1zNviF2DOpqIdkNpRMinuWGZaoVr-kcWH7o_dWMTk10hpOaTYn923feYi0VkLqS96I-2eh-RmNVVOAWRaHRSHMF8XXYBYF1cdXLSGWEKhHw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"cf3a0b0d-d596-4f33-bc31-749f92ba4f00"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - a91e7483-f0ab-430b-a547-deeba9d3805f
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14988'
+      X-Ms-Correlation-Request-Id:
+      - 382939e1-1b39-4d57-9ced-018c7aa71e23
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T093759Z:382939e1-1b39-4d57-9ced-018c7aa71e23
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:37:58 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"rspec-lb-a670\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670\",\r\n
+        \ \"etag\": \"W/\\\"cf3a0b0d-d596-4f33-bc31-749f92ba4f00\\\"\",\r\n  \"location\":
+        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"46cb8216-786e-408e-9d86-c0855b357349\",\r\n    \"ipConfigurations\":
+        [\r\n      {\r\n        \"name\": \"ipconfig1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\",\r\n
+        \       \"etag\": \"W/\\\"cf3a0b0d-d596-4f33-bc31-749f92ba4f00\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"privateIPAddress\": \"10.16.0.6\",\r\n          \"privateIPAllocationMethod\":
+        \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-a-ip\"\r\n
+        \         },\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\"\r\n
+        \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
+        \"IPv4\",\r\n          \"loadBalancerBackendAddressPools\": [\r\n            {\r\n
+        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\"\r\n
+        \           }\r\n          ],\r\n          \"loadBalancerInboundNatRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\":
+        {\r\n      \"dnsServers\": [],\r\n      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\":
+        \"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net\"\r\n    },\r\n    \"enableAcceleratedNetworking\":
+        false,\r\n    \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\":
+        {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg\"\r\n
+        \   },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a\"\r\n
+        \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
+        \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:38:03 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcxNzAsIm5iZiI6MTUyMDg0NzE3MCwiZXhwIjoxNTIwODUxMDcwLCJhaW8iOiJZMk5nWU9nMERWVFlkajBwTzZXYksrRFBlVWtSQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZVhrNGlhS0lnMFdWT1dqT3MtZ2tBQSIsInZlciI6IjEuMCJ9.emFcGC-VWC-Lld27ItZWJLk9UwzAHU9pH6Djmv3czLr2nlcn4oRAnzyobCBT-CZBihKM6sg9Z5-HBDsc3BlVPdvzRwWPglwFapKh6H4h9FT2EcLLCUZU3dftOHg8m8pAGJFiyocZ3EzY9cJFJ3t1-E172fYltCe95Mme21ockcumg4hE-0vT-94C-MZEw--4hB3_QxYb02Lcp1gYfcS0RBrvnjLnRXvixay8_jP99cI1zNviF2DOpqIdkNpRMinuWGZaoVr-kcWH7o_dWMTk10hpOaTYn923feYi0VkLqS96I-2eh-RmNVVOAWRaHRSHMF8XXYBYF1cdXLSGWEKhHw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"76aabe0c-8678-43f0-81a5-2f15784a4b99"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - c98dfed5-aa66-4ee7-a2ed-477ae5f767cd
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Correlation-Request-Id:
+      - cc5b57ca-4580-4215-9e9d-05753a6e2b1f
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T093759Z:cc5b57ca-4580-4215-9e9d-05753a6e2b1f
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:37:59 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"rspec-lb-b843\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843\",\r\n
+        \ \"etag\": \"W/\\\"76aabe0c-8678-43f0-81a5-2f15784a4b99\\\"\",\r\n  \"location\":
+        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"3ef6fa01-ac34-43a1-8fd7-67c706b4d8ef\",\r\n    \"ipConfigurations\":
+        [\r\n      {\r\n        \"name\": \"ipconfig1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\",\r\n
+        \       \"etag\": \"W/\\\"76aabe0c-8678-43f0-81a5-2f15784a4b99\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"privateIPAddress\": \"10.16.0.11\",\r\n          \"privateIPAllocationMethod\":
+        \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-b-ip\"\r\n
+        \         },\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\"\r\n
+        \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
+        \"IPv4\",\r\n          \"loadBalancerBackendAddressPools\": [\r\n            {\r\n
+        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\":
+        {\r\n      \"dnsServers\": [],\r\n      \"appliedDnsServers\": []\r\n    },\r\n
+        \   \"enableAcceleratedNetworking\": false,\r\n    \"enableIPForwarding\":
+        false,\r\n    \"networkSecurityGroup\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg\"\r\n
+        \   },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b\"\r\n
+        \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
+        \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:38:04 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a/instanceView?api-version=2017-12-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcxNzAsIm5iZiI6MTUyMDg0NzE3MCwiZXhwIjoxNTIwODUxMDcwLCJhaW8iOiJZMk5nWU9nMERWVFlkajBwTzZXYksrRFBlVWtSQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZVhrNGlhS0lnMFdWT1dqT3MtZ2tBQSIsInZlciI6IjEuMCJ9.emFcGC-VWC-Lld27ItZWJLk9UwzAHU9pH6Djmv3czLr2nlcn4oRAnzyobCBT-CZBihKM6sg9Z5-HBDsc3BlVPdvzRwWPglwFapKh6H4h9FT2EcLLCUZU3dftOHg8m8pAGJFiyocZ3EzY9cJFJ3t1-E172fYltCe95Mme21ockcumg4hE-0vT-94C-MZEw--4hB3_QxYb02Lcp1gYfcS0RBrvnjLnRXvixay8_jP99cI1zNviF2DOpqIdkNpRMinuWGZaoVr-kcWH7o_dWMTk10hpOaTYn923feYi0VkLqS96I-2eh-RmNVVOAWRaHRSHMF8XXYBYF1cdXLSGWEKhHw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/GetInstanceView3Min;4795,Microsoft.Compute/GetInstanceView30Min;23910
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      X-Ms-Request-Id:
+      - 3855c862-d85b-4dd0-98ad-12756e9f2388
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Correlation-Request-Id:
+      - 1be24e94-2956-46a3-96e9-69f00c1946b6
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T093810Z:1be24e94-2956-46a3-96e9-69f00c1946b6
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:38:10 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"platformUpdateDomain\": 0,\r\n  \"platformFaultDomain\": 0,\r\n
+        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
+        [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
+        \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
+        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2018-03-12T09:38:02+00:00\"\r\n
+        \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"rspec-lb-a\",\r\n
+        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
+        succeeded\",\r\n          \"time\": \"2016-09-03T14:04:26.7359609+00:00\"\r\n
+        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
+        \"https://miqazuretest16487.blob.core.windows.net/bootdiagnostics-rspeclba-23b0beab-16d2-4135-a01f-2fe713217fd0/rspec-lb-a.23b0beab-16d2-4135-a01f-2fe713217fd0.screenshot.bmp\",\r\n
+        \   \"serialConsoleLogBlobUri\": \"https://miqazuretest16487.blob.core.windows.net/bootdiagnostics-rspeclba-23b0beab-16d2-4135-a01f-2fe713217fd0/rspec-lb-a.23b0beab-16d2-4135-a01f-2fe713217fd0.serialconsole.log\"\r\n
+        \ },\r\n  \"extensions\": [\r\n    {\r\n      \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n
+        \   }\r\n  ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n
+        \     \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n
+        \     \"time\": \"2016-09-03T14:04:26.7828345+00:00\"\r\n    },\r\n    {\r\n
+        \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
+        \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:38:14 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b/instanceView?api-version=2017-12-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcxNzAsIm5iZiI6MTUyMDg0NzE3MCwiZXhwIjoxNTIwODUxMDcwLCJhaW8iOiJZMk5nWU9nMERWVFlkajBwTzZXYksrRFBlVWtSQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZVhrNGlhS0lnMFdWT1dqT3MtZ2tBQSIsInZlciI6IjEuMCJ9.emFcGC-VWC-Lld27ItZWJLk9UwzAHU9pH6Djmv3czLr2nlcn4oRAnzyobCBT-CZBihKM6sg9Z5-HBDsc3BlVPdvzRwWPglwFapKh6H4h9FT2EcLLCUZU3dftOHg8m8pAGJFiyocZ3EzY9cJFJ3t1-E172fYltCe95Mme21ockcumg4hE-0vT-94C-MZEw--4hB3_QxYb02Lcp1gYfcS0RBrvnjLnRXvixay8_jP99cI1zNviF2DOpqIdkNpRMinuWGZaoVr-kcWH7o_dWMTk10hpOaTYn923feYi0VkLqS96I-2eh-RmNVVOAWRaHRSHMF8XXYBYF1cdXLSGWEKhHw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/GetInstanceView3Min;4794,Microsoft.Compute/GetInstanceView30Min;23909
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      X-Ms-Request-Id:
+      - 2c830c94-afd4-402d-b689-194cf727f722
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Correlation-Request-Id:
+      - be141811-02e8-49d7-918c-c57e3de052a3
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T093810Z:be141811-02e8-49d7-918c-c57e3de052a3
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:38:09 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"platformUpdateDomain\": 1,\r\n  \"platformFaultDomain\": 1,\r\n
+        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
+        [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
+        \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
+        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2018-03-12T09:38:10+00:00\"\r\n
+        \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"rspec-lb-b\",\r\n
+        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
+        succeeded\",\r\n          \"time\": \"2016-09-03T14:07:52.9377685+00:00\"\r\n
+        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
+        \"https://amissteastorage.blob.core.windows.net/bootdiagnostics-rspeclbb-834a70b5-868d-4466-9dda-14e0f6b2caaf/rspec-lb-b.834a70b5-868d-4466-9dda-14e0f6b2caaf.screenshot.bmp\",\r\n
+        \   \"serialConsoleLogBlobUri\": \"https://amissteastorage.blob.core.windows.net/bootdiagnostics-rspeclbb-834a70b5-868d-4466-9dda-14e0f6b2caaf/rspec-lb-b.834a70b5-868d-4466-9dda-14e0f6b2caaf.serialconsole.log\"\r\n
+        \ },\r\n  \"extensions\": [\r\n    {\r\n      \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n
+        \   }\r\n  ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n
+        \     \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n
+        \     \"time\": \"2016-09-03T14:07:52.9846158+00:00\"\r\n    },\r\n    {\r\n
+        \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
+        \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:38:15 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups/miq-azure-test1?api-version=2017-08-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcxNzAsIm5iZiI6MTUyMDg0NzE3MCwiZXhwIjoxNTIwODUxMDcwLCJhaW8iOiJZMk5nWU9nMERWVFlkajBwTzZXYksrRFBlVWtSQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZVhrNGlhS0lnMFdWT1dqT3MtZ2tBQSIsInZlciI6IjEuMCJ9.emFcGC-VWC-Lld27ItZWJLk9UwzAHU9pH6Djmv3czLr2nlcn4oRAnzyobCBT-CZBihKM6sg9Z5-HBDsc3BlVPdvzRwWPglwFapKh6H4h9FT2EcLLCUZU3dftOHg8m8pAGJFiyocZ3EzY9cJFJ3t1-E172fYltCe95Mme21ockcumg4hE-0vT-94C-MZEw--4hB3_QxYb02Lcp1gYfcS0RBrvnjLnRXvixay8_jP99cI1zNviF2DOpqIdkNpRMinuWGZaoVr-kcWH7o_dWMTk10hpOaTYn923feYi0VkLqS96I-2eh-RmNVVOAWRaHRSHMF8XXYBYF1cdXLSGWEKhHw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Request-Id:
+      - 7a048531-febd-4c85-af25-b136137a78ce
+      X-Ms-Correlation-Request-Id:
+      - 7a048531-febd-4c85-af25-b136137a78ce
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T093812Z:7a048531-febd-4c85-af25-b136137a78ce
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:38:11 GMT
+      Content-Length:
+      - '183'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1","name":"miq-azure-test1","location":"eastus","properties":{"provisioningState":"Succeeded"}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:38:16 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute/locations/eastus/vmSizes?api-version=2017-12-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcxNzAsIm5iZiI6MTUyMDg0NzE3MCwiZXhwIjoxNTIwODUxMDcwLCJhaW8iOiJZMk5nWU9nMERWVFlkajBwTzZXYksrRFBlVWtSQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZVhrNGlhS0lnMFdWT1dqT3MtZ2tBQSIsInZlciI6IjEuMCJ9.emFcGC-VWC-Lld27ItZWJLk9UwzAHU9pH6Djmv3czLr2nlcn4oRAnzyobCBT-CZBihKM6sg9Z5-HBDsc3BlVPdvzRwWPglwFapKh6H4h9FT2EcLLCUZU3dftOHg8m8pAGJFiyocZ3EzY9cJFJ3t1-E172fYltCe95Mme21ockcumg4hE-0vT-94C-MZEw--4hB3_QxYb02Lcp1gYfcS0RBrvnjLnRXvixay8_jP99cI1zNviF2DOpqIdkNpRMinuWGZaoVr-kcWH7o_dWMTk10hpOaTYn923feYi0VkLqS96I-2eh-RmNVVOAWRaHRSHMF8XXYBYF1cdXLSGWEKhHw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/LowCostGet3Min;4745,Microsoft.Compute/LowCostGet30Min;37870
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      X-Ms-Request-Id:
+      - d4dc14fc-e9a1-4205-bfe4-f7b19db35c1e
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14988'
+      X-Ms-Correlation-Request-Id:
+      - 9a16295f-d9a7-4e36-bfb6-28213346e13d
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T093812Z:9a16295f-d9a7-4e36-bfb6-28213346e13d
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:38:12 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"Standard_B1ms\",\r\n
@@ -3072,6 +3640,12 @@ http_interactions:
         \   },\r\n    {\r\n      \"name\": \"Standard_F72s_v2\",\r\n      \"numberOfCores\":
         72,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
         589824,\r\n      \"memoryInMB\": 147456,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_L8s_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1811981,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_L16s_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        3623962,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
         \   },\r\n    {\r\n      \"name\": \"Standard_ND6s\",\r\n      \"numberOfCores\":
         6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
         344064,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 12\r\n
@@ -3098,10 +3672,10 @@ http_interactions:
         391168,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
         \   }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:20:48 GMT
+  recorded_at: Mon, 12 Mar 2018 09:38:17 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd?api-version=2018-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3115,311 +3689,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3NDQsIm5iZiI6MTUyMDQ1Mzc0NCwiZXhwIjoxNTIwNDU3NjQ0LCJhaW8iOiJZMk5nWURnd3hlVlFnaXVicisrQy8zbEdURW9XQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWGc1OTY1VGFOa0NlaVhCbjQzY0FBQSIsInZlciI6IjEuMCJ9.Hb3eiQ0l3ptAb6f8__A2kTEQEBrM6qo6k1lLTXs-51ZLWyA9iXIFHgLkrVFLNLPxOhIpZJnjSNyW479kaM1VOHGuqb-LzY__qn16PwOlAaliVdsXR2553kGtoEa5AtKAes8UwtUqzWcH9X13ZjYw_7-4q91g8Nj-sYkB2KuqaDV8wRgSZEOgLTvZwoh_nEELqYgzqqanqMMuLbEM6RNzoV5_aCJ6dQd_c7N-atFVskTda9NUfx2jChUly9XTyjvlpwkULlh4HbHupTH_T2XmuLKDYJIrtWpYWOEap5Z52rc53vTevmWA3ZrikvaAoEp2Dy6_rWwc671TC8wD3FteNg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/LowCostGet3Min;4705,Microsoft.Compute/LowCostGet30Min;37869
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
-      X-Ms-Request-Id:
-      - 89a39b53-2013-45f8-8d05-26928f44be3b
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14972'
-      X-Ms-Correlation-Request-Id:
-      - af1ec520-ff87-4e6d-90f4-08d6f7c0a5ff
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202059Z:af1ec520-ff87-4e6d-90f4-08d6f7c0a5ff
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:20:58 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"61b7c052-1d09-4898-b995-cce5676aaab0\",\r\n
-        \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Basic_A0\"\r\n    },\r\n
-        \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
-        \"RedHat\",\r\n        \"offer\": \"RHEL\",\r\n        \"sku\": \"7.3\",\r\n
-        \       \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
-        \"Linux\",\r\n        \"name\": \"miqazure-linux-managed_OsDisk_1_7b2bdf790a7d4379ace2846d307730cd\",\r\n
-        \       \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n
-        \       \"managedDisk\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/disks/miqazure-linux-managed_OsDisk_1_7b2bdf790a7d4379ace2846d307730cd\"\r\n
-        \       }\r\n      },\r\n      \"dataDisks\": [\r\n        {\r\n          \"lun\":
-        0,\r\n          \"name\": \"miqazure-linux-managed-data-disk\",\r\n          \"createOption\":
-        \"Attach\",\r\n          \"caching\": \"None\",\r\n          \"managedDisk\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/disks/miqazure-linux-managed-data-disk\"\r\n
-        \         }\r\n        }\r\n      ]\r\n    },\r\n    \"osProfile\": {\r\n
-        \     \"computerName\": \"miqazure-linux-managed\",\r\n      \"adminUsername\":
-        \"dberger\",\r\n      \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\":
-        false\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\":
-        {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944\"}]},\r\n
-        \   \"provisioningState\": \"Succeeded\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n
-        \ \"location\": \"eastus\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed\",\r\n
-        \ \"name\": \"miqazure-linux-managed\"\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:20:59 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed/instanceView?api-version=2017-12-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3NDQsIm5iZiI6MTUyMDQ1Mzc0NCwiZXhwIjoxNTIwNDU3NjQ0LCJhaW8iOiJZMk5nWURnd3hlVlFnaXVicisrQy8zbEdURW9XQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWGc1OTY1VGFOa0NlaVhCbjQzY0FBQSIsInZlciI6IjEuMCJ9.Hb3eiQ0l3ptAb6f8__A2kTEQEBrM6qo6k1lLTXs-51ZLWyA9iXIFHgLkrVFLNLPxOhIpZJnjSNyW479kaM1VOHGuqb-LzY__qn16PwOlAaliVdsXR2553kGtoEa5AtKAes8UwtUqzWcH9X13ZjYw_7-4q91g8Nj-sYkB2KuqaDV8wRgSZEOgLTvZwoh_nEELqYgzqqanqMMuLbEM6RNzoV5_aCJ6dQd_c7N-atFVskTda9NUfx2jChUly9XTyjvlpwkULlh4HbHupTH_T2XmuLKDYJIrtWpYWOEap5Z52rc53vTevmWA3ZrikvaAoEp2Dy6_rWwc671TC8wD3FteNg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/GetInstanceView3Min;4792,Microsoft.Compute/GetInstanceView30Min;23913
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
-      X-Ms-Request-Id:
-      - c06c48ec-400b-40be-b38a-46c0fcbcb4bb
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14975'
-      X-Ms-Correlation-Request-Id:
-      - 66868439-c8b9-4d54-802a-61d6d199ea57
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202111Z:66868439-c8b9-4d54-802a-61d6d199ea57
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:21:10 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"miqazure-linux-managed_OsDisk_1_7b2bdf790a7d4379ace2846d307730cd\",\r\n
-        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
-        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"time\": \"2018-01-23T20:06:17.9818931+00:00\"\r\n
-        \       }\r\n      ]\r\n    },\r\n    {\r\n      \"name\": \"miqazure-linux-managed-data-disk\",\r\n
-        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
-        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"time\": \"2018-01-23T20:06:17.9818931+00:00\"\r\n
-        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\":
-        \"ProvisioningState/succeeded\",\r\n      \"level\": \"Info\",\r\n      \"displayStatus\":
-        \"Provisioning succeeded\",\r\n      \"time\": \"2018-01-23T20:06:17.9975145+00:00\"\r\n
-        \   },\r\n    {\r\n      \"code\": \"PowerState/deallocated\",\r\n      \"level\":
-        \"Info\",\r\n      \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:11 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Network/networkInterfaces?api-version=2017-11-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3NDQsIm5iZiI6MTUyMDQ1Mzc0NCwiZXhwIjoxNTIwNDU3NjQ0LCJhaW8iOiJZMk5nWURnd3hlVlFnaXVicisrQy8zbEdURW9XQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWGc1OTY1VGFOa0NlaVhCbjQzY0FBQSIsInZlciI6IjEuMCJ9.Hb3eiQ0l3ptAb6f8__A2kTEQEBrM6qo6k1lLTXs-51ZLWyA9iXIFHgLkrVFLNLPxOhIpZJnjSNyW479kaM1VOHGuqb-LzY__qn16PwOlAaliVdsXR2553kGtoEa5AtKAes8UwtUqzWcH9X13ZjYw_7-4q91g8Nj-sYkB2KuqaDV8wRgSZEOgLTvZwoh_nEELqYgzqqanqMMuLbEM6RNzoV5_aCJ6dQd_c7N-atFVskTda9NUfx2jChUly9XTyjvlpwkULlh4HbHupTH_T2XmuLKDYJIrtWpYWOEap5Z52rc53vTevmWA3ZrikvaAoEp2Dy6_rWwc671TC8wD3FteNg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 6bf0644d-cb70-48bd-83b1-2b7d4a939129
-      X-Ms-Correlation-Request-Id:
-      - 6bf0644d-cb70-48bd-83b1-2b7d4a939129
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202112Z:6bf0644d-cb70-48bd-83b1-2b7d4a939129
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:21:12 GMT
-      Content-Length:
-      - '31614'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[{"name":"miqazure-coreos1235","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235","etag":"W/\"4a6546ab-a4c0-4d27-bccd-f6ebf3c405a2\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"fb0a5e60-a6c2-4bb8-a2f5-0c16216a49b0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235/ipConfigurations/ipconfig1","etag":"W/\"4a6546ab-a4c0-4d27-bccd-f6ebf3c405a2\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.20.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/publicIPAddresses/miqazure-coreos1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/virtualNetworks/miq-azure-test3/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"rliadcyr3l1elbnsw4rabxqg1f.dx.internal.cloudapp.net"},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkSecurityGroups/miqazure-coreos1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Compute/virtualMachines/miqazure-coreos1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"dbergerprov1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/dbergerprov1","etag":"W/\"074dd836-918c-4e40-a118-94f0d366e175\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"ecdcd2f0-91bb-4c40-91cd-a3d76fc5e455","ipConfigurations":[{"name":"dbergerprov1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/dbergerprov1/ipConfigurations/dbergerprov1","etag":"W/\"074dd836-918c-4e40-a118-94f0d366e175\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.9","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/dbergerprov1-publicIp"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/virtualMachines/dbergerprov1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-rhel1390","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390","etag":"W/\"f006e6f9-0292-42cd-99fc-f72f194553c1\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"98853f48-2806-4065-be57-cf9159550440","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1","etag":"W/\"f006e6f9-0292-42cd-99fc-f72f194553c1\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"macAddress":"00-0D-3A-10-EB-AB","enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-ubuntu1989","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989","etag":"W/\"64e07488-15a2-4cec-b84a-6fd5ef04323c\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"134a6669-ac4a-4d08-a0db-387bc4c49537","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989/ipConfigurations/ipconfig1","etag":"W/\"64e07488-15a2-4cec-b84a-6fd5ef04323c\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.17.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-ubuntu1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest18687/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-win12610","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610","etag":"W/\"dd925ef5-33d1-402c-a0f4-18c78c2641f4\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"5c2eef2c-0b36-4277-a940-957ed4d13be0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610/ipConfigurations/ipconfig1","etag":"W/\"dd925ef5-33d1-402c-a0f4-18c78c2641f4\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.18.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-win12"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest19881/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-winimg241","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241","etag":"W/\"4a17a745-16a9-42d9-88c9-17a518959525\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"8ed2f3b0-4a4b-49ae-9f1d-ff7890dbd396","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241/ipConfigurations/ipconfig1","etag":"W/\"4a17a745-16a9-42d9-88c9-17a518959525\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.7","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqtestwinimg6202"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-centos1611","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611","etag":"W/\"26031ef6-bb55-4019-8185-2dd1edcb207c\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"f1760e49-9853-4fdc-acfc-4ea232b9ed76","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1","etag":"W/\"26031ef6-bb55-4019-8185-2dd1edcb207c\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.5","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqmismatch1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1","etag":"W/\"3a72d0c3-bfda-4da5-a61b-e8c33e43de79\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"23d804a8-b623-49e7-9c8d-1d64245bef1e","ipConfigurations":[{"name":"miqmismatch1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1/ipConfigurations/miqmismatch1","etag":"W/\"3a72d0c3-bfda-4da5-a61b-e8c33e43de79\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.8","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqmismatch1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqmismatch1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"rspec-lb-a670","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670","etag":"W/\"cf3a0b0d-d596-4f33-bc31-749f92ba4f00\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"46cb8216-786e-408e-9d86-c0855b357349","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1","etag":"W/\"cf3a0b0d-d596-4f33-bc31-749f92ba4f00\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.6","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-a-ip"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"rspec-lb-b843","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843","etag":"W/\"76aabe0c-8678-43f0-81a5-2f15784a4b99\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"3ef6fa01-ac34-43a1-8fd7-67c706b4d8ef","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1","etag":"W/\"76aabe0c-8678-43f0-81a5-2f15784a4b99\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.11","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-b-ip"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"spec0deply1nic0","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","etag":"W/\"b817491c-aab8-4aab-b41d-b07bfffa5639\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"80ad9866-071d-4e3f-91d0-d47954eccee0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1","etag":"W/\"b817491c-aab8-4aab-b41d-b07bfffa5639\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.4","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"spec0deply1nic1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","etag":"W/\"2ec58a0b-4c03-4d0a-b788-9daffd54e7b2\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"57bbf7aa-d6c4-4f56-8f6a-089d15334221","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1","etag":"W/\"2ec58a0b-4c03-4d0a-b788-9daffd54e7b2\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.5","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqmismatch2656","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqmismatch2656","etag":"W/\"fef6a836-2802-4897-90c3-b3d71f133384\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"969dde6c-73c0-4340-877d-2b5fe2060026","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqmismatch2656/ipConfigurations/ipconfig1","etag":"W/\"fef6a836-2802-4897-90c3-b3d71f133384\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"172.23.0.4","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/virtualNetworks/miqazuretest33606/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkSecurityGroups/miqmismatch2-nsg"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Compute/virtualMachines/miqmismatch2"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-linux-manag944","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944","etag":"W/\"b6339880-8ead-4c9e-b5c0-f38c4f8612d5\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"c5e8b90e-5a78-49b0-b224-b70ed3fb45e5","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944/ipConfigurations/ipconfig1","etag":"W/\"b6339880-8ead-4c9e-b5c0-f38c4f8612d5\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"172.25.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqazure-linux-managed-ip"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"jf-metrics-2751","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751","etag":"W/\"c5f6f02a-b17c-4f34-882b-11c7adef0b44\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"207a58d3-f18d-4dab-8168-919877297a52","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751/ipConfigurations/ipconfig1","etag":"W/\"c5f6f02a-b17c-4f34-882b-11c7adef0b44\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.7","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-2"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-2"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/jf-metrics-2"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"jf-metrics-3421","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421","etag":"W/\"0b6f160b-ad10-48f8-9d0c-657193bb823f\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"b8b345e8-a353-4700-992e-be48a717b4e2","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421/ipConfigurations/ipconfig1","etag":"W/\"0b6f160b-ad10-48f8-9d0c-657193bb823f\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.8","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-3"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-3"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/jf-metrics-3"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-oraclelinux310","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310","etag":"W/\"54cd4fe1-3ed5-4a8c-bc8d-527679c7a631\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"6a3fc1d7-4532-4ca0-b5c2-546cc8f7f313","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310/ipConfigurations/ipconfig1","etag":"W/\"54cd4fe1-3ed5-4a8c-bc8d-527679c7a631\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.5","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-oraclelinux993","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993","etag":"W/\"a9432274-7b40-4eb3-a64f-a04267a423ff\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"75d8ed14-e0ae-4d84-99f6-e3f43d073e76","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993/ipConfigurations/ipconfig1","etag":"W/\"a9432274-7b40-4eb3-a64f-a04267a423ff\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.6","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux2"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux2"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"}]}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:12 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Network/publicIPAddresses?api-version=2017-11-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3NDQsIm5iZiI6MTUyMDQ1Mzc0NCwiZXhwIjoxNTIwNDU3NjQ0LCJhaW8iOiJZMk5nWURnd3hlVlFnaXVicisrQy8zbEdURW9XQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWGc1OTY1VGFOa0NlaVhCbjQzY0FBQSIsInZlciI6IjEuMCJ9.Hb3eiQ0l3ptAb6f8__A2kTEQEBrM6qo6k1lLTXs-51ZLWyA9iXIFHgLkrVFLNLPxOhIpZJnjSNyW479kaM1VOHGuqb-LzY__qn16PwOlAaliVdsXR2553kGtoEa5AtKAes8UwtUqzWcH9X13ZjYw_7-4q91g8Nj-sYkB2KuqaDV8wRgSZEOgLTvZwoh_nEELqYgzqqanqMMuLbEM6RNzoV5_aCJ6dQd_c7N-atFVskTda9NUfx2jChUly9XTyjvlpwkULlh4HbHupTH_T2XmuLKDYJIrtWpYWOEap5Z52rc53vTevmWA3ZrikvaAoEp2Dy6_rWwc671TC8wD3FteNg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 9fab39cc-4cb0-4e10-b0ef-d6926ccec71d
-      X-Ms-Correlation-Request-Id:
-      - 9fab39cc-4cb0-4e10-b0ef-d6926ccec71d
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202118Z:9fab39cc-4cb0-4e10-b0ef-d6926ccec71d
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:21:18 GMT
-      Content-Length:
-      - '13978'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[{"name":"miqazure-coreos1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/publicIPAddresses/miqazure-coreos1","etag":"W/\"da64b64b-a755-4389-a2f3-5cba32f18c06\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"28617ed1-0270-4b39-873a-c3b48b3deef1","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"dbergerprov1-publicIp","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/dbergerprov1-publicIp","etag":"W/\"3d984c69-3f35-41ce-bdfc-8d207053a6a9\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"eb0e8804-e169-44ac-bb47-0929370977d2","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/dbergerprov1/ipConfigurations/dbergerprov1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"ladas_test","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/ladas_test","etag":"W/\"32e21623-9a1b-4c40-80f4-6a350aa237a7\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"3daa5f66-5a01-4242-b95b-c4e0ee8f0c36","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[]},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miq-test-rhel1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1","etag":"W/\"054052bb-11ff-4f6e-ac1a-3427c2fd17aa\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"f6cfc635-411e-48ce-a627-39a2fc0d3168","ipAddress":"52.224.165.15","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miq-test-ubuntu1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-ubuntu1","etag":"W/\"bcae50c5-146f-4fcb-a461-7c1030ba7b74\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"e272bd74-f661-484f-b223-88dd128a4049","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miq-test-win12","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-win12","etag":"W/\"56ce00f4-50d7-4682-9ee8-6836bf5c0ea6\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"b9200977-8147-40a5-83c2-d5892d5ddedc","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miqazure-centos1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1","etag":"W/\"734a3944-a880-444c-8c92-cace6e28e303\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"475a66f0-9e89-4226-a9f0-9baaaf31d619","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miqtestwinimg6202","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqtestwinimg6202","etag":"W/\"b656279a-26ff-4021-94bb-263420cf494e\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"fb942169-855b-44f8-b12f-fd63e961b140","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"rspec-lb-a-ip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-a-ip","etag":"W/\"3ba30997-7d2f-470c-96f6-301158e93b7c\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"3c605f75-23c0-46ab-ba2b-6fd4430140fd","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"rspec-lb-b-ip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-b-ip","etag":"W/\"cf6012c7-3d47-438f-84d7-332ad1ef4500\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"5d1a2425-a351-4c0f-bc87-37e6500bff22","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"rspec-lb1-LoadBalancerFrontEnd","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd","etag":"W/\"a38434c8-7b23-4092-b7c6-402238eac0dc\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"f28e0f25-b372-4edf-97d9-13a9e3b4ba2d","ipAddress":"40.71.82.83","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"rspec-lb2-publicip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip","etag":"W/\"cddd97d1-6111-4477-8a00-3dc885237a1d\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"83e7257d-ab94-4229-8eb5-4798f37ef28d","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"spec0deply1ip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip","etag":"W/\"2080997a-38a6-420d-ba86-e9582e1331c7\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"a08b891e-e45a-4970-aefc-f6c996989490","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"spec0deply1dns","fqdn":"spec0deply1dns.eastus.cloudapp.azure.com"},"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miqazure-linux-managed-ip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqazure-linux-managed-ip","etag":"W/\"0efc9684-fb7d-4fb7-b9b9-f33dbac04a28\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"6a2a9142-26e8-45cd-93bf-7318192f3528","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miqmismatch1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqmismatch1","etag":"W/\"9b8b1729-21c4-4c53-94f2-15715315ad73\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"a97c71d0-6b78-4ffe-8e5c-0be1ee653f8c","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"miqmismatch1","fqdn":"miqmismatch1.eastus.cloudapp.azure.com"},"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1/ipConfigurations/miqmismatch1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"jf-metrics-2","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-2","etag":"W/\"b43ebe01-574c-4454-87eb-3401fbcf36f2\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"e446f3e4-9410-4d7f-bb04-2652096359de","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"jf-metrics-3","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-3","etag":"W/\"a6ee7100-6202-4ae2-a2db-f828abec8af9\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"de5995a4-15c1-40ba-ad78-67e70a92654b","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miqazure-oraclelinux1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux1","etag":"W/\"98bee7b4-2fcc-471d-b5ce-92850e6c3d6b\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"f2ac7c18-520b-4b42-94e7-da264a842f41","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miqazure-oraclelinux2","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux2","etag":"W/\"0865cebc-95b9-49d2-9f10-21dbafb23cac\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"2f4e1091-46f0-474c-a697-8dbcea6ba2a6","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}}]}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:18 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute/disks?api-version=2017-03-30
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3NDQsIm5iZiI6MTUyMDQ1Mzc0NCwiZXhwIjoxNTIwNDU3NjQ0LCJhaW8iOiJZMk5nWURnd3hlVlFnaXVicisrQy8zbEdURW9XQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWGc1OTY1VGFOa0NlaVhCbjQzY0FBQSIsInZlciI6IjEuMCJ9.Hb3eiQ0l3ptAb6f8__A2kTEQEBrM6qo6k1lLTXs-51ZLWyA9iXIFHgLkrVFLNLPxOhIpZJnjSNyW479kaM1VOHGuqb-LzY__qn16PwOlAaliVdsXR2553kGtoEa5AtKAes8UwtUqzWcH9X13ZjYw_7-4q91g8Nj-sYkB2KuqaDV8wRgSZEOgLTvZwoh_nEELqYgzqqanqMMuLbEM6RNzoV5_aCJ6dQd_c7N-atFVskTda9NUfx2jChUly9XTyjvlpwkULlh4HbHupTH_T2XmuLKDYJIrtWpYWOEap5Z52rc53vTevmWA3ZrikvaAoEp2Dy6_rWwc671TC8wD3FteNg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - cae3d1c8-b265-4895-97f8-e98cfa07c4ac
-      X-Ms-Correlation-Request-Id:
-      - cae3d1c8-b265-4895-97f8-e98cfa07c4ac
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202120Z:cae3d1c8-b265-4895-97f8-e98cfa07c4ac
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:21:20 GMT
-      Content-Length:
-      - '2517'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[{"managedBy":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Compute/virtualMachines/miqmismatch2","sku":{"name":"Standard_LRS","tier":"Standard"},"properties":{"osType":"Linux","creationData":{"createOption":"FromImage","imageReference":{"id":"/Subscriptions/AZURE_SUBSCRIPTION_ID/Providers/Microsoft.Compute/Locations/eastus/Publishers/redhat/ArtifactTypes/VMImage/Offers/rhel-byol-preview/Skus/rhel74/Versions/7.4.0"}},"diskSizeGB":64,"timeCreated":"2017-10-20T18:43:28.8491982+00:00","provisioningState":"Succeeded","diskState":"Reserved"},"type":"Microsoft.Compute/disks","location":"eastus","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST3/providers/Microsoft.Compute/disks/miqmismatch2_OsDisk_1_a7515d62695740d88c0f6656166bad2e","name":"miqmismatch2_OsDisk_1_a7515d62695740d88c0f6656166bad2e"},{"managedBy":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed","sku":{"name":"Standard_LRS","tier":"Standard"},"properties":{"creationData":{"createOption":"Empty"},"diskSizeGB":1,"timeCreated":"2017-10-23T17:34:14.7022771+00:00","provisioningState":"Succeeded","diskState":"Reserved"},"type":"Microsoft.Compute/disks","location":"eastus","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/disks/miqazure-linux-managed-data-disk","name":"miqazure-linux-managed-data-disk"},{"managedBy":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed","sku":{"name":"Standard_LRS","tier":"Standard"},"properties":{"osType":"Linux","creationData":{"createOption":"FromImage","imageReference":{"id":"/Subscriptions/AZURE_SUBSCRIPTION_ID/Providers/Microsoft.Compute/Locations/eastus/Publishers/RedHat/ArtifactTypes/VMImage/Offers/RHEL/Skus/7.3/Versions/latest"}},"diskSizeGB":32,"timeCreated":"2017-05-04T21:21:55.7801928+00:00","provisioningState":"Succeeded","diskState":"Reserved"},"type":"Microsoft.Compute/disks","location":"eastus","tags":{"delete":"false"},"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/disks/miqazure-linux-managed_OsDisk_1_7b2bdf790a7d4379ace2846d307730cd","name":"miqazure-linux-managed_OsDisk_1_7b2bdf790a7d4379ace2846d307730cd"}]}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:21 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3NDQsIm5iZiI6MTUyMDQ1Mzc0NCwiZXhwIjoxNTIwNDU3NjQ0LCJhaW8iOiJZMk5nWURnd3hlVlFnaXVicisrQy8zbEdURW9XQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWGc1OTY1VGFOa0NlaVhCbjQzY0FBQSIsInZlciI6IjEuMCJ9.Hb3eiQ0l3ptAb6f8__A2kTEQEBrM6qo6k1lLTXs-51ZLWyA9iXIFHgLkrVFLNLPxOhIpZJnjSNyW479kaM1VOHGuqb-LzY__qn16PwOlAaliVdsXR2553kGtoEa5AtKAes8UwtUqzWcH9X13ZjYw_7-4q91g8Nj-sYkB2KuqaDV8wRgSZEOgLTvZwoh_nEELqYgzqqanqMMuLbEM6RNzoV5_aCJ6dQd_c7N-atFVskTda9NUfx2jChUly9XTyjvlpwkULlh4HbHupTH_T2XmuLKDYJIrtWpYWOEap5Z52rc53vTevmWA3ZrikvaAoEp2Dy6_rWwc671TC8wD3FteNg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcxNzAsIm5iZiI6MTUyMDg0NzE3MCwiZXhwIjoxNTIwODUxMDcwLCJhaW8iOiJZMk5nWU9nMERWVFlkajBwTzZXYksrRFBlVWtSQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZVhrNGlhS0lnMFdWT1dqT3MtZ2tBQSIsInZlciI6IjEuMCJ9.emFcGC-VWC-Lld27ItZWJLk9UwzAHU9pH6Djmv3czLr2nlcn4oRAnzyobCBT-CZBihKM6sg9Z5-HBDsc3BlVPdvzRwWPglwFapKh6H4h9FT2EcLLCUZU3dftOHg8m8pAGJFiyocZ3EzY9cJFJ3t1-E172fYltCe95Mme21ockcumg4hE-0vT-94C-MZEw--4hB3_QxYb02Lcp1gYfcS0RBrvnjLnRXvixay8_jP99cI1zNviF2DOpqIdkNpRMinuWGZaoVr-kcWH7o_dWMTk10hpOaTYn923feYi0VkLqS96I-2eh-RmNVVOAWRaHRSHMF8XXYBYF1cdXLSGWEKhHw
   response:
     status:
       code: 200
@@ -3436,35 +3706,586 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a"
+      - W/"a38434c8-7b23-4092-b7c6-402238eac0dc"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - a69e3922-75c1-41ba-ad3a-1c5b65037e07
+      - fe36a65d-9c34-4f7a-ae5f-9170f3ca7855
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14968'
+      - '14989'
       X-Ms-Correlation-Request-Id:
-      - f40b82d5-d01e-46d6-87c3-3056fc8927a7
+      - 035dcff1-da44-44c7-8f81-f57792ea0d55
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202121Z:f40b82d5-d01e-46d6-87c3-3056fc8927a7
+      - WESTEUROPE:20180312T093813Z:035dcff1-da44-44c7-8f81-f57792ea0d55
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:21:20 GMT
+      - Mon, 12 Mar 2018 09:38:12 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"miqazure-linux-managed-nsg\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg\",\r\n
-        \ \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n  \"type\":
+      string: "{\r\n  \"name\": \"rspec-lb1-LoadBalancerFrontEnd\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\",\r\n
+        \ \"etag\": \"W/\\\"a38434c8-7b23-4092-b7c6-402238eac0dc\\\"\",\r\n  \"location\":
+        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"f28e0f25-b372-4edf-97d9-13a9e3b4ba2d\",\r\n    \"ipAddress\":
+        \"40.71.82.83\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\":
+        \"Static\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipTags\": [],\r\n
+        \   \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
+        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
+        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:38:18 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcxNzAsIm5iZiI6MTUyMDg0NzE3MCwiZXhwIjoxNTIwODUxMDcwLCJhaW8iOiJZMk5nWU9nMERWVFlkajBwTzZXYksrRFBlVWtSQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZVhrNGlhS0lnMFdWT1dqT3MtZ2tBQSIsInZlciI6IjEuMCJ9.emFcGC-VWC-Lld27ItZWJLk9UwzAHU9pH6Djmv3czLr2nlcn4oRAnzyobCBT-CZBihKM6sg9Z5-HBDsc3BlVPdvzRwWPglwFapKh6H4h9FT2EcLLCUZU3dftOHg8m8pAGJFiyocZ3EzY9cJFJ3t1-E172fYltCe95Mme21ockcumg4hE-0vT-94C-MZEw--4hB3_QxYb02Lcp1gYfcS0RBrvnjLnRXvixay8_jP99cI1zNviF2DOpqIdkNpRMinuWGZaoVr-kcWH7o_dWMTk10hpOaTYn923feYi0VkLqS96I-2eh-RmNVVOAWRaHRSHMF8XXYBYF1cdXLSGWEKhHw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"cddd97d1-6111-4477-8a00-3dc885237a1d"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 29831524-cfa7-410b-8f71-bd2b92b48006
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14986'
+      X-Ms-Correlation-Request-Id:
+      - 98f36139-6a22-4907-a429-07bd653d7a54
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T093817Z:98f36139-6a22-4907-a429-07bd653d7a54
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:38:16 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"rspec-lb2-publicip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\",\r\n
+        \ \"etag\": \"W/\\\"cddd97d1-6111-4477-8a00-3dc885237a1d\\\"\",\r\n  \"location\":
+        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"83e7257d-ab94-4229-8eb5-4798f37ef28d\",\r\n    \"publicIPAddressVersion\":
+        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
+        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
+        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
+        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:38:22 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-a-ip?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcxNzAsIm5iZiI6MTUyMDg0NzE3MCwiZXhwIjoxNTIwODUxMDcwLCJhaW8iOiJZMk5nWU9nMERWVFlkajBwTzZXYksrRFBlVWtSQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZVhrNGlhS0lnMFdWT1dqT3MtZ2tBQSIsInZlciI6IjEuMCJ9.emFcGC-VWC-Lld27ItZWJLk9UwzAHU9pH6Djmv3czLr2nlcn4oRAnzyobCBT-CZBihKM6sg9Z5-HBDsc3BlVPdvzRwWPglwFapKh6H4h9FT2EcLLCUZU3dftOHg8m8pAGJFiyocZ3EzY9cJFJ3t1-E172fYltCe95Mme21ockcumg4hE-0vT-94C-MZEw--4hB3_QxYb02Lcp1gYfcS0RBrvnjLnRXvixay8_jP99cI1zNviF2DOpqIdkNpRMinuWGZaoVr-kcWH7o_dWMTk10hpOaTYn923feYi0VkLqS96I-2eh-RmNVVOAWRaHRSHMF8XXYBYF1cdXLSGWEKhHw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"3ba30997-7d2f-470c-96f6-301158e93b7c"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 31326089-b2ab-4d40-9d39-282b567e5b54
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Correlation-Request-Id:
+      - 4fd1daa3-ce8b-41bc-9434-68db3d8b9029
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T093818Z:4fd1daa3-ce8b-41bc-9434-68db3d8b9029
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:38:17 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"rspec-lb-a-ip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-a-ip\",\r\n
+        \ \"etag\": \"W/\\\"3ba30997-7d2f-470c-96f6-301158e93b7c\\\"\",\r\n  \"location\":
+        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"3c605f75-23c0-46ab-ba2b-6fd4430140fd\",\r\n    \"publicIPAddressVersion\":
+        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
+        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
+        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
+        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:38:23 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-b-ip?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcxNzAsIm5iZiI6MTUyMDg0NzE3MCwiZXhwIjoxNTIwODUxMDcwLCJhaW8iOiJZMk5nWU9nMERWVFlkajBwTzZXYksrRFBlVWtSQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZVhrNGlhS0lnMFdWT1dqT3MtZ2tBQSIsInZlciI6IjEuMCJ9.emFcGC-VWC-Lld27ItZWJLk9UwzAHU9pH6Djmv3czLr2nlcn4oRAnzyobCBT-CZBihKM6sg9Z5-HBDsc3BlVPdvzRwWPglwFapKh6H4h9FT2EcLLCUZU3dftOHg8m8pAGJFiyocZ3EzY9cJFJ3t1-E172fYltCe95Mme21ockcumg4hE-0vT-94C-MZEw--4hB3_QxYb02Lcp1gYfcS0RBrvnjLnRXvixay8_jP99cI1zNviF2DOpqIdkNpRMinuWGZaoVr-kcWH7o_dWMTk10hpOaTYn923feYi0VkLqS96I-2eh-RmNVVOAWRaHRSHMF8XXYBYF1cdXLSGWEKhHw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"cf6012c7-3d47-438f-84d7-332ad1ef4500"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 8c8b66e6-4368-411e-9d00-ed7eae85b8aa
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Correlation-Request-Id:
+      - 4648187e-e11e-4b51-9f66-67b82e29dcf8
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T093819Z:4648187e-e11e-4b51-9f66-67b82e29dcf8
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:38:18 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"rspec-lb-b-ip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-b-ip\",\r\n
+        \ \"etag\": \"W/\\\"cf6012c7-3d47-438f-84d7-332ad1ef4500\\\"\",\r\n  \"location\":
+        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"5d1a2425-a351-4c0f-bc87-37e6500bff22\",\r\n    \"publicIPAddressVersion\":
+        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
+        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\"\r\n
+        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
+        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:38:23 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb?api-version=2017-10-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcxNzAsIm5iZiI6MTUyMDg0NzE3MCwiZXhwIjoxNTIwODUxMDcwLCJhaW8iOiJZMk5nWU9nMERWVFlkajBwTzZXYksrRFBlVWtSQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZVhrNGlhS0lnMFdWT1dqT3MtZ2tBQSIsInZlciI6IjEuMCJ9.emFcGC-VWC-Lld27ItZWJLk9UwzAHU9pH6Djmv3czLr2nlcn4oRAnzyobCBT-CZBihKM6sg9Z5-HBDsc3BlVPdvzRwWPglwFapKh6H4h9FT2EcLLCUZU3dftOHg8m8pAGJFiyocZ3EzY9cJFJ3t1-E172fYltCe95Mme21ockcumg4hE-0vT-94C-MZEw--4hB3_QxYb02Lcp1gYfcS0RBrvnjLnRXvixay8_jP99cI1zNviF2DOpqIdkNpRMinuWGZaoVr-kcWH7o_dWMTk10hpOaTYn923feYi0VkLqS96I-2eh-RmNVVOAWRaHRSHMF8XXYBYF1cdXLSGWEKhHw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - ee889a51-abe3-451a-a30a-2fb55d73cd86
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14988'
+      X-Ms-Correlation-Request-Id:
+      - 74c5bb47-1420-4190-bc76-ad0b46da386f
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T093821Z:74c5bb47-1420-4190-bc76-ad0b46da386f
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:38:20 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"sku":{"name":"Premium_LRS","tier":"Premium"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb","name":"rspeclb","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-09-02T16:29:11.6823797Z","primaryEndpoints":{"blob":"https://rspeclb.blob.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:38:25 GMT
+- request:
+    method: post
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb/listKeys?api-version=2017-10-01
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcxNzAsIm5iZiI6MTUyMDg0NzE3MCwiZXhwIjoxNTIwODUxMDcwLCJhaW8iOiJZMk5nWU9nMERWVFlkajBwTzZXYksrRFBlVWtSQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZVhrNGlhS0lnMFdWT1dqT3MtZ2tBQSIsInZlciI6IjEuMCJ9.emFcGC-VWC-Lld27ItZWJLk9UwzAHU9pH6Djmv3czLr2nlcn4oRAnzyobCBT-CZBihKM6sg9Z5-HBDsc3BlVPdvzRwWPglwFapKh6H4h9FT2EcLLCUZU3dftOHg8m8pAGJFiyocZ3EzY9cJFJ3t1-E172fYltCe95Mme21ockcumg4hE-0vT-94C-MZEw--4hB3_QxYb02Lcp1gYfcS0RBrvnjLnRXvixay8_jP99cI1zNviF2DOpqIdkNpRMinuWGZaoVr-kcWH7o_dWMTk10hpOaTYn923feYi0VkLqS96I-2eh-RmNVVOAWRaHRSHMF8XXYBYF1cdXLSGWEKhHw
+      Content-Length:
+      - '0'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - eaf62505-9731-4217-b386-b62e7a0e5d20
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Writes:
+      - '1198'
+      X-Ms-Correlation-Request-Id:
+      - 79c665e9-ec20-4f4e-bd27-fe5688d2e1f9
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T093821Z:79c665e9-ec20-4f4e-bd27-fe5688d2e1f9
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:38:21 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"keys":[{"keyName":"key1","value":"xMvZwiumnKCZnYVJjdtGLqaO1c2v6ERPx4XPDZO7TM1l7/jM1TxAAgtfCMkRn72aRPhqLqwWAn8n5a1iSGRHtA==","permissions":"Full"},{"keyName":"key2","value":"3nDvKhjGAIAvgnH2reuv7tzyeb/0dddgVeUT13VODYD5xO/jeAvQ7tkF3JqP2BAuFrmQqMB4GLkB4/cW4veYeA==","permissions":"Full"}]}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:38:26 GMT
+- request:
+    method: head
+    uri: https://rspeclb.blob.core.windows.net/vhds/rspec-lb-a201682122839.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:38:26 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey rspeclb:iGv/lECm7DSf889VWO2wgwheLIPB1vKvD5Wn6UaGGL4=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '32212255232'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - 8BW5hqrnOLoQINlZ05odxA==
+      Last-Modified:
+      - Sat, 03 Sep 2016 14:03:15 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D3D4030CA0ABEF"'
+      Vary:
+      - Origin
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Copy-Id:
+      - f4d64e56-53ed-46e0-9c24-ebfa731c2ac1
+      X-Ms-Copy-Progress:
+      - 32212255232/32212255232
+      X-Ms-Copy-Source:
+      - https://ardfepirv2bl6prdstp02a.blob.core.windows.net/a879bbefc56a43abb0ce65052aac09f3/rhel-67-20160302?sv=2014-02-14&sr=b&si=PirCacheAccountPublisherContainerPolicy&sig=odWVC2Axkv74I6hSj89s9UTQavqFXr29heJIw9TFaCY%3D
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Completion-Time:
+      - Fri, 02 Sep 2016 16:29:41 GMT
+      X-Ms-Meta-Microsoftazurecompute-Diskid:
+      - ecdb0d00-e186-4df6-a7b6-ae626753f7bd
+      X-Ms-Meta-Microsoftazurecompute-Diskname:
+      - rspec-lb-a
+      X-Ms-Meta-Microsoftazurecompute-Disktype:
+      - OSDisk
+      X-Ms-Meta-Microsoftazurecompute-Resourcegroupname:
+      - miq-azure-test1
+      X-Ms-Meta-Microsoftazurecompute-Vmname:
+      - rspec-lb-a
+      X-Ms-Lease-State:
+      - leased
+      X-Ms-Lease-Duration:
+      - infinite
+      X-Ms-Lease-Status:
+      - locked
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '1'
+      X-Ms-Server-Encrypted:
+      - 'false'
+      X-Ms-Request-Id:
+      - 35c57d9a-601c-0020-56e5-b9090b000000
+      X-Ms-Version:
+      - '2016-05-31'
+      Date:
+      - Mon, 12 Mar 2018 09:38:21 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:38:26 GMT
+- request:
+    method: head
+    uri: https://rspeclb.blob.core.windows.net/vhds/rspec-lb-b201682123650.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:38:26 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey rspeclb:OjzHoxazovl7nLjHHJCrK8zh6qboNbp9LGqmac5V7uw=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '32212255232'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - 8BW5hqrnOLoQINlZ05odxA==
+      Last-Modified:
+      - Sat, 03 Sep 2016 14:05:40 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D3D40362FE3898"'
+      Vary:
+      - Origin
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Copy-Id:
+      - f64a314d-e573-457d-88d4-e16ecfbe2819
+      X-Ms-Copy-Progress:
+      - 32212255232/32212255232
+      X-Ms-Copy-Source:
+      - https://ardfepirv2bl6prdstp02a.blob.core.windows.net/a879bbefc56a43abb0ce65052aac09f3/rhel-67-20160302?sv=2014-02-14&sr=b&si=PirCacheAccountPublisherContainerPolicy&sig=odWVC2Axkv74I6hSj89s9UTQavqFXr29heJIw9TFaCY%3D
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Completion-Time:
+      - Fri, 02 Sep 2016 16:37:29 GMT
+      X-Ms-Meta-Microsoftazurecompute-Diskid:
+      - dbb822a3-53bf-49f9-808d-02390abcee67
+      X-Ms-Meta-Microsoftazurecompute-Diskname:
+      - rspec-lb-b
+      X-Ms-Meta-Microsoftazurecompute-Disktype:
+      - OSDisk
+      X-Ms-Meta-Microsoftazurecompute-Resourcegroupname:
+      - miq-azure-test1
+      X-Ms-Meta-Microsoftazurecompute-Vmname:
+      - rspec-lb-b
+      X-Ms-Lease-State:
+      - leased
+      X-Ms-Lease-Duration:
+      - infinite
+      X-Ms-Lease-Status:
+      - locked
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '1'
+      X-Ms-Server-Encrypted:
+      - 'false'
+      X-Ms-Request-Id:
+      - 34f2740d-a01c-005b-10e5-b962bb000000
+      X-Ms-Version:
+      - '2016-05-31'
+      Date:
+      - Mon, 12 Mar 2018 09:38:22 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:38:27 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcxNzAsIm5iZiI6MTUyMDg0NzE3MCwiZXhwIjoxNTIwODUxMDcwLCJhaW8iOiJZMk5nWU9nMERWVFlkajBwTzZXYksrRFBlVWtSQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZVhrNGlhS0lnMFdWT1dqT3MtZ2tBQSIsInZlciI6IjEuMCJ9.emFcGC-VWC-Lld27ItZWJLk9UwzAHU9pH6Djmv3czLr2nlcn4oRAnzyobCBT-CZBihKM6sg9Z5-HBDsc3BlVPdvzRwWPglwFapKh6H4h9FT2EcLLCUZU3dftOHg8m8pAGJFiyocZ3EzY9cJFJ3t1-E172fYltCe95Mme21ockcumg4hE-0vT-94C-MZEw--4hB3_QxYb02Lcp1gYfcS0RBrvnjLnRXvixay8_jP99cI1zNviF2DOpqIdkNpRMinuWGZaoVr-kcWH7o_dWMTk10hpOaTYn923feYi0VkLqS96I-2eh-RmNVVOAWRaHRSHMF8XXYBYF1cdXLSGWEKhHw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"1523bcb7-4597-4ae6-bcfc-ba8fc3826026"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - ddf5ffad-5b69-4d6f-85f8-288492d3e16d
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14989'
+      X-Ms-Correlation-Request-Id:
+      - 0a964a85-f882-4cdf-8799-160abc173671
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T093823Z:0a964a85-f882-4cdf-8799-160abc173671
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:38:22 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"rspec-lb-a-nsg\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg\",\r\n
+        \ \"etag\": \"W/\\\"1523bcb7-4597-4ae6-bcfc-ba8fc3826026\\\"\",\r\n  \"type\":
         \"Microsoft.Network/networkSecurityGroups\",\r\n  \"location\": \"eastus\",\r\n
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
-        \"b4611f96-94a8-4486-94c5-16bb6c7a5c84\",\r\n    \"securityRules\": [\r\n
-        \     {\r\n        \"name\": \"default-allow-ssh\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/securityRules/default-allow-ssh\",\r\n
-        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
+        \"63d15480-8c5a-4e18-9196-c43384932823\",\r\n    \"securityRules\": [\r\n
+        \     {\r\n        \"name\": \"default-allow-ssh\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg/securityRules/default-allow-ssh\",\r\n
+        \       \"etag\": \"W/\\\"1523bcb7-4597-4ae6-bcfc-ba8fc3826026\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"protocol\": \"TCP\",\r\n          \"sourcePortRange\": \"*\",\r\n
         \         \"destinationPortRange\": \"22\",\r\n          \"sourceAddressPrefix\":
@@ -3473,8 +4294,8 @@ http_interactions:
         \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
         [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
         []\r\n        }\r\n      }\r\n    ],\r\n    \"defaultSecurityRules\": [\r\n
-        \     {\r\n        \"name\": \"AllowVnetInBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/AllowVnetInBound\",\r\n
-        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
+        \     {\r\n        \"name\": \"AllowVnetInBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg/defaultSecurityRules/AllowVnetInBound\",\r\n
+        \       \"etag\": \"W/\\\"1523bcb7-4597-4ae6-bcfc-ba8fc3826026\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"description\": \"Allow inbound traffic from all VMs in VNET\",\r\n
         \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
@@ -3484,8 +4305,8 @@ http_interactions:
         \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
         [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
         []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowAzureLoadBalancerInBound\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/AllowAzureLoadBalancerInBound\",\r\n
-        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg/defaultSecurityRules/AllowAzureLoadBalancerInBound\",\r\n
+        \       \"etag\": \"W/\\\"1523bcb7-4597-4ae6-bcfc-ba8fc3826026\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"description\": \"Allow inbound traffic from azure load balancer\",\r\n
         \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
@@ -3495,8 +4316,8 @@ http_interactions:
         \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
         [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
         []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllInBound\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/DenyAllInBound\",\r\n
-        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg/defaultSecurityRules/DenyAllInBound\",\r\n
+        \       \"etag\": \"W/\\\"1523bcb7-4597-4ae6-bcfc-ba8fc3826026\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"description\": \"Deny all inbound traffic\",\r\n          \"protocol\":
         \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\":
@@ -3505,8 +4326,8 @@ http_interactions:
         \         \"direction\": \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n
         \         \"destinationPortRanges\": [],\r\n          \"sourceAddressPrefixes\":
         [],\r\n          \"destinationAddressPrefixes\": []\r\n        }\r\n      },\r\n
-        \     {\r\n        \"name\": \"AllowVnetOutBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/AllowVnetOutBound\",\r\n
-        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
+        \     {\r\n        \"name\": \"AllowVnetOutBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg/defaultSecurityRules/AllowVnetOutBound\",\r\n
+        \       \"etag\": \"W/\\\"1523bcb7-4597-4ae6-bcfc-ba8fc3826026\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"description\": \"Allow outbound traffic from all VMs to all VMs
         in VNET\",\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\":
@@ -3516,8 +4337,8 @@ http_interactions:
         \"Outbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
         [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
         []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowInternetOutBound\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/AllowInternetOutBound\",\r\n
-        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg/defaultSecurityRules/AllowInternetOutBound\",\r\n
+        \       \"etag\": \"W/\\\"1523bcb7-4597-4ae6-bcfc-ba8fc3826026\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"description\": \"Allow outbound traffic from all VMs to Internet\",\r\n
         \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
@@ -3527,8 +4348,8 @@ http_interactions:
         \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
         [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
         []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllOutBound\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/DenyAllOutBound\",\r\n
-        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg/defaultSecurityRules/DenyAllOutBound\",\r\n
+        \       \"etag\": \"W/\\\"1523bcb7-4597-4ae6-bcfc-ba8fc3826026\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"description\": \"Deny all outbound traffic\",\r\n          \"protocol\":
         \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\":
@@ -3537,13 +4358,13 @@ http_interactions:
         \         \"direction\": \"Outbound\",\r\n          \"sourcePortRanges\":
         [],\r\n          \"destinationPortRanges\": [],\r\n          \"sourceAddressPrefixes\":
         [],\r\n          \"destinationAddressPrefixes\": []\r\n        }\r\n      }\r\n
-        \   ],\r\n    \"networkInterfaces\": [\r\n      {\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944\"\r\n
+        \   ],\r\n    \"networkInterfaces\": [\r\n      {\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670\"\r\n
         \     }\r\n    ]\r\n  }\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:21 GMT
+  recorded_at: Mon, 12 Mar 2018 09:38:27 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg?api-version=2018-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3557,7 +4378,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3NDQsIm5iZiI6MTUyMDQ1Mzc0NCwiZXhwIjoxNTIwNDU3NjQ0LCJhaW8iOiJZMk5nWURnd3hlVlFnaXVicisrQy8zbEdURW9XQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWGc1OTY1VGFOa0NlaVhCbjQzY0FBQSIsInZlciI6IjEuMCJ9.Hb3eiQ0l3ptAb6f8__A2kTEQEBrM6qo6k1lLTXs-51ZLWyA9iXIFHgLkrVFLNLPxOhIpZJnjSNyW479kaM1VOHGuqb-LzY__qn16PwOlAaliVdsXR2553kGtoEa5AtKAes8UwtUqzWcH9X13ZjYw_7-4q91g8Nj-sYkB2KuqaDV8wRgSZEOgLTvZwoh_nEELqYgzqqanqMMuLbEM6RNzoV5_aCJ6dQd_c7N-atFVskTda9NUfx2jChUly9XTyjvlpwkULlh4HbHupTH_T2XmuLKDYJIrtWpYWOEap5Z52rc53vTevmWA3ZrikvaAoEp2Dy6_rWwc671TC8wD3FteNg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcxNzAsIm5iZiI6MTUyMDg0NzE3MCwiZXhwIjoxNTIwODUxMDcwLCJhaW8iOiJZMk5nWU9nMERWVFlkajBwTzZXYksrRFBlVWtSQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZVhrNGlhS0lnMFdWT1dqT3MtZ2tBQSIsInZlciI6IjEuMCJ9.emFcGC-VWC-Lld27ItZWJLk9UwzAHU9pH6Djmv3czLr2nlcn4oRAnzyobCBT-CZBihKM6sg9Z5-HBDsc3BlVPdvzRwWPglwFapKh6H4h9FT2EcLLCUZU3dftOHg8m8pAGJFiyocZ3EzY9cJFJ3t1-E172fYltCe95Mme21ockcumg4hE-0vT-94C-MZEw--4hB3_QxYb02Lcp1gYfcS0RBrvnjLnRXvixay8_jP99cI1zNviF2DOpqIdkNpRMinuWGZaoVr-kcWH7o_dWMTk10hpOaTYn923feYi0VkLqS96I-2eh-RmNVVOAWRaHRSHMF8XXYBYF1cdXLSGWEKhHw
   response:
     status:
       code: 200
@@ -3574,183 +4395,187 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"f5bbd20f-7ae4-4b6d-89c8-eb3481fcbe05"
+      - W/"80e6f7a1-78ee-48b4-9b28-a464ef94de09"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - bd7aaf5e-ee47-4b60-8700-745bb20e7627
+      - 1a466c2a-c876-4101-bb2c-75003fc76dfd
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14969'
+      - '14989'
       X-Ms-Correlation-Request-Id:
-      - 71bc3c8a-1cab-4efa-950c-c4b4cd1f38ab
+      - f9a931fe-e13b-44d0-a5fb-33ba46ea5e6b
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202121Z:71bc3c8a-1cab-4efa-950c-c4b4cd1f38ab
+      - WESTEUROPE:20180312T093823Z:f9a931fe-e13b-44d0-a5fb-33ba46ea5e6b
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:21:21 GMT
+      - Mon, 12 Mar 2018 09:38:22 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"miq-azure-test2\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2\",\r\n
-        \ \"etag\": \"W/\\\"f5bbd20f-7ae4-4b6d-89c8-eb3481fcbe05\\\"\",\r\n  \"type\":
+      string: "{\r\n  \"name\": \"rspec-lb-b-nsg\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg\",\r\n
+        \ \"etag\": \"W/\\\"80e6f7a1-78ee-48b4-9b28-a464ef94de09\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/networkSecurityGroups\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
+        \"4ee44ca4-a721-4149-ad87-74d4150b4c1e\",\r\n    \"securityRules\": [\r\n
+        \     {\r\n        \"name\": \"default-allow-ssh\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg/securityRules/default-allow-ssh\",\r\n
+        \       \"etag\": \"W/\\\"80e6f7a1-78ee-48b4-9b28-a464ef94de09\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"protocol\": \"TCP\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"22\",\r\n          \"sourceAddressPrefix\":
+        \"*\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n          \"access\":
+        \"Allow\",\r\n          \"priority\": 1000,\r\n          \"direction\": \"Inbound\",\r\n
+        \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      }\r\n    ],\r\n    \"defaultSecurityRules\": [\r\n
+        \     {\r\n        \"name\": \"AllowVnetInBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg/defaultSecurityRules/AllowVnetInBound\",\r\n
+        \       \"etag\": \"W/\\\"80e6f7a1-78ee-48b4-9b28-a464ef94de09\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow inbound traffic from all VMs in VNET\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"VirtualNetwork\",\r\n          \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n          \"direction\":
+        \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowAzureLoadBalancerInBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg/defaultSecurityRules/AllowAzureLoadBalancerInBound\",\r\n
+        \       \"etag\": \"W/\\\"80e6f7a1-78ee-48b4-9b28-a464ef94de09\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow inbound traffic from azure load balancer\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"AzureLoadBalancer\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65001,\r\n          \"direction\":
+        \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllInBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg/defaultSecurityRules/DenyAllInBound\",\r\n
+        \       \"etag\": \"W/\\\"80e6f7a1-78ee-48b4-9b28-a464ef94de09\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Deny all inbound traffic\",\r\n          \"protocol\":
+        \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\":
+        \"*\",\r\n          \"sourceAddressPrefix\": \"*\",\r\n          \"destinationAddressPrefix\":
+        \"*\",\r\n          \"access\": \"Deny\",\r\n          \"priority\": 65500,\r\n
+        \         \"direction\": \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n
+        \         \"destinationPortRanges\": [],\r\n          \"sourceAddressPrefixes\":
+        [],\r\n          \"destinationAddressPrefixes\": []\r\n        }\r\n      },\r\n
+        \     {\r\n        \"name\": \"AllowVnetOutBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg/defaultSecurityRules/AllowVnetOutBound\",\r\n
+        \       \"etag\": \"W/\\\"80e6f7a1-78ee-48b4-9b28-a464ef94de09\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow outbound traffic from all VMs to all VMs
+        in VNET\",\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\":
+        \"*\",\r\n          \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"VirtualNetwork\",\r\n          \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n          \"direction\":
+        \"Outbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowInternetOutBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg/defaultSecurityRules/AllowInternetOutBound\",\r\n
+        \       \"etag\": \"W/\\\"80e6f7a1-78ee-48b4-9b28-a464ef94de09\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow outbound traffic from all VMs to Internet\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"*\",\r\n          \"destinationAddressPrefix\": \"Internet\",\r\n          \"access\":
+        \"Allow\",\r\n          \"priority\": 65001,\r\n          \"direction\": \"Outbound\",\r\n
+        \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllOutBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg/defaultSecurityRules/DenyAllOutBound\",\r\n
+        \       \"etag\": \"W/\\\"80e6f7a1-78ee-48b4-9b28-a464ef94de09\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Deny all outbound traffic\",\r\n          \"protocol\":
+        \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\":
+        \"*\",\r\n          \"sourceAddressPrefix\": \"*\",\r\n          \"destinationAddressPrefix\":
+        \"*\",\r\n          \"access\": \"Deny\",\r\n          \"priority\": 65500,\r\n
+        \         \"direction\": \"Outbound\",\r\n          \"sourcePortRanges\":
+        [],\r\n          \"destinationPortRanges\": [],\r\n          \"sourceAddressPrefixes\":
+        [],\r\n          \"destinationAddressPrefixes\": []\r\n        }\r\n      }\r\n
+        \   ],\r\n    \"networkInterfaces\": [\r\n      {\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843\"\r\n
+        \     }\r\n    ]\r\n  }\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:38:28 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcxNzAsIm5iZiI6MTUyMDg0NzE3MCwiZXhwIjoxNTIwODUxMDcwLCJhaW8iOiJZMk5nWU9nMERWVFlkajBwTzZXYksrRFBlVWtSQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZVhrNGlhS0lnMFdWT1dqT3MtZ2tBQSIsInZlciI6IjEuMCJ9.emFcGC-VWC-Lld27ItZWJLk9UwzAHU9pH6Djmv3czLr2nlcn4oRAnzyobCBT-CZBihKM6sg9Z5-HBDsc3BlVPdvzRwWPglwFapKh6H4h9FT2EcLLCUZU3dftOHg8m8pAGJFiyocZ3EzY9cJFJ3t1-E172fYltCe95Mme21ockcumg4hE-0vT-94C-MZEw--4hB3_QxYb02Lcp1gYfcS0RBrvnjLnRXvixay8_jP99cI1zNviF2DOpqIdkNpRMinuWGZaoVr-kcWH7o_dWMTk10hpOaTYn923feYi0VkLqS96I-2eh-RmNVVOAWRaHRSHMF8XXYBYF1cdXLSGWEKhHw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"a8b09238-30fc-4b36-a58d-e3cc69e267c5"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - e512bc0c-58e7-4325-9600-0bdf27c00595
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Correlation-Request-Id:
+      - c1a3f6a3-c469-406e-816f-c9520fea8bc0
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T093823Z:c1a3f6a3-c469-406e-816f-c9520fea8bc0
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:38:23 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"miq-azure-test1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1\",\r\n
+        \ \"etag\": \"W/\\\"a8b09238-30fc-4b36-a58d-e3cc69e267c5\\\"\",\r\n  \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
-        \"f950a3cf-749a-49d5-a7fb-33a400b0e93c\",\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\":
-        [\r\n        \"172.25.0.0/16\"\r\n      ]\r\n    },\r\n    \"subnets\": [\r\n
-        \     {\r\n        \"name\": \"default\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2/subnets/default\",\r\n
-        \       \"etag\": \"W/\\\"f5bbd20f-7ae4-4b6d-89c8-eb3481fcbe05\\\"\",\r\n
+        \"d74c1e5f-50e4-4c8a-a7fe-78eaddc6b915\",\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\":
+        [\r\n        \"10.16.0.0/16\"\r\n      ]\r\n    },\r\n    \"subnets\": [\r\n
+        \     {\r\n        \"name\": \"default\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\",\r\n
+        \       \"etag\": \"W/\\\"a8b09238-30fc-4b36-a58d-e3cc69e267c5\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"addressPrefix\": \"172.25.0.0/24\",\r\n          \"ipConfigurations\":
-        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944/ipConfigurations/ipconfig1\"\r\n
+        \         \"addressPrefix\": \"10.16.0.0/24\",\r\n          \"ipConfigurations\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241/ipConfigurations/ipconfig1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1/ipConfigurations/miqmismatch1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/dbergerprov1/ipConfigurations/dbergerprov1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/ladas_test_1/ipConfigurations/ladas_test_1\"\r\n
         \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"virtualNetworkPeerings\":
         [],\r\n    \"enableDdosProtection\": false,\r\n    \"enableVmProtection\":
         false\r\n  }\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:21 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3NDQsIm5iZiI6MTUyMDQ1Mzc0NCwiZXhwIjoxNTIwNDU3NjQ0LCJhaW8iOiJZMk5nWURnd3hlVlFnaXVicisrQy8zbEdURW9XQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWGc1OTY1VGFOa0NlaVhCbjQzY0FBQSIsInZlciI6IjEuMCJ9.Hb3eiQ0l3ptAb6f8__A2kTEQEBrM6qo6k1lLTXs-51ZLWyA9iXIFHgLkrVFLNLPxOhIpZJnjSNyW479kaM1VOHGuqb-LzY__qn16PwOlAaliVdsXR2553kGtoEa5AtKAes8UwtUqzWcH9X13ZjYw_7-4q91g8Nj-sYkB2KuqaDV8wRgSZEOgLTvZwoh_nEELqYgzqqanqMMuLbEM6RNzoV5_aCJ6dQd_c7N-atFVskTda9NUfx2jChUly9XTyjvlpwkULlh4HbHupTH_T2XmuLKDYJIrtWpYWOEap5Z52rc53vTevmWA3ZrikvaAoEp2Dy6_rWwc671TC8wD3FteNg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"b6339880-8ead-4c9e-b5c0-f38c4f8612d5"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - '032974d4-2a61-423a-8486-6d10855e6878'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14971'
-      X-Ms-Correlation-Request-Id:
-      - 1c5362fe-6676-4156-872a-1fcfd2bc7c24
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202121Z:1c5362fe-6676-4156-872a-1fcfd2bc7c24
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:21:21 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"miqazure-linux-manag944\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944\",\r\n
-        \ \"etag\": \"W/\\\"b6339880-8ead-4c9e-b5c0-f38c4f8612d5\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"c5e8b90e-5a78-49b0-b224-b70ed3fb45e5\",\r\n    \"ipConfigurations\":
-        [\r\n      {\r\n        \"name\": \"ipconfig1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944/ipConfigurations/ipconfig1\",\r\n
-        \       \"etag\": \"W/\\\"b6339880-8ead-4c9e-b5c0-f38c4f8612d5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAddress\": \"172.25.0.4\",\r\n          \"privateIPAllocationMethod\":
-        \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqazure-linux-managed-ip\"\r\n
-        \         },\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2/subnets/default\"\r\n
-        \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
-        \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\":
-        [],\r\n      \"appliedDnsServers\": []\r\n    },\r\n    \"enableAcceleratedNetworking\":
-        false,\r\n    \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\":
-        {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg\"\r\n
-        \   },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed\"\r\n
-        \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
-        \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:22 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqazure-linux-managed-ip?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3NDQsIm5iZiI6MTUyMDQ1Mzc0NCwiZXhwIjoxNTIwNDU3NjQ0LCJhaW8iOiJZMk5nWURnd3hlVlFnaXVicisrQy8zbEdURW9XQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWGc1OTY1VGFOa0NlaVhCbjQzY0FBQSIsInZlciI6IjEuMCJ9.Hb3eiQ0l3ptAb6f8__A2kTEQEBrM6qo6k1lLTXs-51ZLWyA9iXIFHgLkrVFLNLPxOhIpZJnjSNyW479kaM1VOHGuqb-LzY__qn16PwOlAaliVdsXR2553kGtoEa5AtKAes8UwtUqzWcH9X13ZjYw_7-4q91g8Nj-sYkB2KuqaDV8wRgSZEOgLTvZwoh_nEELqYgzqqanqMMuLbEM6RNzoV5_aCJ6dQd_c7N-atFVskTda9NUfx2jChUly9XTyjvlpwkULlh4HbHupTH_T2XmuLKDYJIrtWpYWOEap5Z52rc53vTevmWA3ZrikvaAoEp2Dy6_rWwc671TC8wD3FteNg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"0efc9684-fb7d-4fb7-b9b9-f33dbac04a28"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 240895d4-92b7-4d00-a42c-df869e993a3a
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14970'
-      X-Ms-Correlation-Request-Id:
-      - d5b6c87a-66fe-4be0-96e5-b0b5c260b6d8
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202122Z:d5b6c87a-66fe-4be0-96e5-b0b5c260b6d8
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:21:22 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"miqazure-linux-managed-ip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqazure-linux-managed-ip\",\r\n
-        \ \"etag\": \"W/\\\"0efc9684-fb7d-4fb7-b9b9-f33dbac04a28\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"6a2a9142-26e8-45cd-93bf-7318192f3528\",\r\n    \"publicIPAddressVersion\":
-        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
-        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944/ipConfigurations/ipconfig1\"\r\n
-        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
-        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:22 GMT
+  recorded_at: Mon, 12 Mar 2018 09:38:28 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_0/lbs_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_0/lbs_refresh.yml
@@ -16,7 +16,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcyMTAsIm5iZiI6MTUyMDg0NzIxMCwiZXhwIjoxNTIwODUxMTEwLCJhaW8iOiJZMk5nWUpodFB0a2k2MFo1cHgyTHlWdHU5NzI3QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiS2tCZkxBZmtfMC1zeUgwaDZRb2pBQSIsInZlciI6IjEuMCJ9.Vfp8xCOV2qO_lW6yNVyfhqgGpT2ZG_Z3Nj79KQIrcAD9IDe8IaKlPoG_nmf3qLcXuKGG2QgEZe28-uL17_Yumns3TDPYvaCyONJ7HR4WOz6Sj-_DrXX3lUyHFe6HcaWli0q0eu4QpLcTUTRe6LkQ-u7jfsgw-ovI2FqwrL_lXv7TNhE7ZX-QvZJni2QYDvFGGZW6i2Y4TCOMQmqmWVu-VTfxHXZ_JJMGfiNXaV3Io_zjY8XkGKvXMHjdcpqM4b4fluhxYp-LJ2LkV1VNf7yIi8KrGtLWZzC1a0KC3gqNWxCYV08j1UAZxEVEZycyUQeJsaEHR9WDgll6xt8KR85KgQ
   response:
     status:
       code: 200
@@ -35,26 +35,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14997'
+      - '14998'
       X-Ms-Request-Id:
-      - cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - 4f795e6f-e6a8-441e-8267-ce9d87968e12
       X-Ms-Correlation-Request-Id:
-      - cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - 4f795e6f-e6a8-441e-8267-ce9d87968e12
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102417Z:cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - WESTEUROPE:20180312T093858Z:4f795e6f-e6a8-441e-8267-ce9d87968e12
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:17 GMT
+      - Mon, 12 Mar 2018 09:38:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID","subscriptionId":"AZURE_SUBSCRIPTION_ID","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:22 GMT
+  recorded_at: Mon, 12 Mar 2018 09:39:03 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers?api-version=2015-01-01
@@ -71,7 +71,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcyMTAsIm5iZiI6MTUyMDg0NzIxMCwiZXhwIjoxNTIwODUxMTEwLCJhaW8iOiJZMk5nWUpodFB0a2k2MFo1cHgyTHlWdHU5NzI3QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiS2tCZkxBZmtfMC1zeUgwaDZRb2pBQSIsInZlciI6IjEuMCJ9.Vfp8xCOV2qO_lW6yNVyfhqgGpT2ZG_Z3Nj79KQIrcAD9IDe8IaKlPoG_nmf3qLcXuKGG2QgEZe28-uL17_Yumns3TDPYvaCyONJ7HR4WOz6Sj-_DrXX3lUyHFe6HcaWli0q0eu4QpLcTUTRe6LkQ-u7jfsgw-ovI2FqwrL_lXv7TNhE7ZX-QvZJni2QYDvFGGZW6i2Y4TCOMQmqmWVu-VTfxHXZ_JJMGfiNXaV3Io_zjY8XkGKvXMHjdcpqM4b4fluhxYp-LJ2LkV1VNf7yIi8KrGtLWZzC1a0KC3gqNWxCYV08j1UAZxEVEZycyUQeJsaEHR9WDgll6xt8KR85KgQ
   response:
     status:
       code: 200
@@ -88,19 +88,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - '14986'
       X-Ms-Request-Id:
-      - fe3532ca-59a2-474e-9094-8a3697b82bef
+      - aa6e1f63-c3eb-4a80-ab57-dc2b89d577fc
       X-Ms-Correlation-Request-Id:
-      - fe3532ca-59a2-474e-9094-8a3697b82bef
+      - aa6e1f63-c3eb-4a80-ab57-dc2b89d577fc
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102419Z:fe3532ca-59a2-474e-9094-8a3697b82bef
+      - WESTEUROPE:20180312T093903Z:aa6e1f63-c3eb-4a80-ab57-dc2b89d577fc
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:18 GMT
+      - Mon, 12 Mar 2018 09:39:03 GMT
       Content-Length:
       - '320853'
     body:
@@ -2322,7 +2322,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:23 GMT
+  recorded_at: Mon, 12 Mar 2018 09:39:07 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1?api-version=2018-01-01
@@ -2339,7 +2339,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcyMTAsIm5iZiI6MTUyMDg0NzIxMCwiZXhwIjoxNTIwODUxMTEwLCJhaW8iOiJZMk5nWUpodFB0a2k2MFo1cHgyTHlWdHU5NzI3QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiS2tCZkxBZmtfMC1zeUgwaDZRb2pBQSIsInZlciI6IjEuMCJ9.Vfp8xCOV2qO_lW6yNVyfhqgGpT2ZG_Z3Nj79KQIrcAD9IDe8IaKlPoG_nmf3qLcXuKGG2QgEZe28-uL17_Yumns3TDPYvaCyONJ7HR4WOz6Sj-_DrXX3lUyHFe6HcaWli0q0eu4QpLcTUTRe6LkQ-u7jfsgw-ovI2FqwrL_lXv7TNhE7ZX-QvZJni2QYDvFGGZW6i2Y4TCOMQmqmWVu-VTfxHXZ_JJMGfiNXaV3Io_zjY8XkGKvXMHjdcpqM4b4fluhxYp-LJ2LkV1VNf7yIi8KrGtLWZzC1a0KC3gqNWxCYV08j1UAZxEVEZycyUQeJsaEHR9WDgll6xt8KR85KgQ
   response:
     status:
       code: 200
@@ -2360,7 +2360,7 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - '080de667-081e-4d58-9e94-9e7243d4200e'
+      - eaa2b6d1-dc1a-43f9-9dcf-a8be89224df8
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
@@ -2369,13 +2369,13 @@ http_interactions:
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
       - '14986'
       X-Ms-Correlation-Request-Id:
-      - '093d49ac-c85f-440e-956b-955b6698dd19'
+      - e792f37c-df8f-41da-b8d3-f5ac8d6e8132
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102419Z:093d49ac-c85f-440e-956b-955b6698dd19
+      - WESTEUROPE:20180312T093904Z:e792f37c-df8f-41da-b8d3-f5ac8d6e8132
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:19 GMT
+      - Mon, 12 Mar 2018 09:39:03 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"rspec-lb1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1\",\r\n
@@ -2433,7 +2433,7 @@ http_interactions:
         [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
         \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:24 GMT
+  recorded_at: Mon, 12 Mar 2018 09:39:08 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2?api-version=2018-01-01
@@ -2450,7 +2450,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcyMTAsIm5iZiI6MTUyMDg0NzIxMCwiZXhwIjoxNTIwODUxMTEwLCJhaW8iOiJZMk5nWUpodFB0a2k2MFo1cHgyTHlWdHU5NzI3QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiS2tCZkxBZmtfMC1zeUgwaDZRb2pBQSIsInZlciI6IjEuMCJ9.Vfp8xCOV2qO_lW6yNVyfhqgGpT2ZG_Z3Nj79KQIrcAD9IDe8IaKlPoG_nmf3qLcXuKGG2QgEZe28-uL17_Yumns3TDPYvaCyONJ7HR4WOz6Sj-_DrXX3lUyHFe6HcaWli0q0eu4QpLcTUTRe6LkQ-u7jfsgw-ovI2FqwrL_lXv7TNhE7ZX-QvZJni2QYDvFGGZW6i2Y4TCOMQmqmWVu-VTfxHXZ_JJMGfiNXaV3Io_zjY8XkGKvXMHjdcpqM4b4fluhxYp-LJ2LkV1VNf7yIi8KrGtLWZzC1a0KC3gqNWxCYV08j1UAZxEVEZycyUQeJsaEHR9WDgll6xt8KR85KgQ
   response:
     status:
       code: 200
@@ -2471,22 +2471,22 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - bd22ca22-a01f-4ecf-9230-a4558fb66931
+      - 2bb27d37-d49a-46f1-83da-2e5fa19805db
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
+      - '14984'
       X-Ms-Correlation-Request-Id:
-      - 19c674a8-c8da-4b5e-8265-5ebc21926459
+      - f397d4e0-d2a4-4645-9ac3-8530bdc692dd
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102420Z:19c674a8-c8da-4b5e-8265-5ebc21926459
+      - WESTEUROPE:20180312T093908Z:f397d4e0-d2a4-4645-9ac3-8530bdc692dd
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:19 GMT
+      - Mon, 12 Mar 2018 09:39:08 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"rspec-lb2\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2\",\r\n
@@ -2514,7 +2514,7 @@ http_interactions:
         [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
         \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:25 GMT
+  recorded_at: Mon, 12 Mar 2018 09:39:13 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd?api-version=2018-01-01
@@ -2531,7 +2531,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcyMTAsIm5iZiI6MTUyMDg0NzIxMCwiZXhwIjoxNTIwODUxMTEwLCJhaW8iOiJZMk5nWUpodFB0a2k2MFo1cHgyTHlWdHU5NzI3QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiS2tCZkxBZmtfMC1zeUgwaDZRb2pBQSIsInZlciI6IjEuMCJ9.Vfp8xCOV2qO_lW6yNVyfhqgGpT2ZG_Z3Nj79KQIrcAD9IDe8IaKlPoG_nmf3qLcXuKGG2QgEZe28-uL17_Yumns3TDPYvaCyONJ7HR4WOz6Sj-_DrXX3lUyHFe6HcaWli0q0eu4QpLcTUTRe6LkQ-u7jfsgw-ovI2FqwrL_lXv7TNhE7ZX-QvZJni2QYDvFGGZW6i2Y4TCOMQmqmWVu-VTfxHXZ_JJMGfiNXaV3Io_zjY8XkGKvXMHjdcpqM4b4fluhxYp-LJ2LkV1VNf7yIi8KrGtLWZzC1a0KC3gqNWxCYV08j1UAZxEVEZycyUQeJsaEHR9WDgll6xt8KR85KgQ
   response:
     status:
       code: 200
@@ -2552,22 +2552,22 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 0fd15240-6a1c-4b39-a4f6-aa53fd8591c2
+      - c5aba4cf-d801-4ad0-829b-790ec52d9d5e
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
+      - '14988'
       X-Ms-Correlation-Request-Id:
-      - 5cc03163-922e-41a1-9601-dba2d7cf2a81
+      - fa16088e-ba35-43d4-a3b4-60f3fffc3b82
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102421Z:5cc03163-922e-41a1-9601-dba2d7cf2a81
+      - WESTEUROPE:20180312T093909Z:fa16088e-ba35-43d4-a3b4-60f3fffc3b82
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:20 GMT
+      - Mon, 12 Mar 2018 09:39:09 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"rspec-lb1-LoadBalancerFrontEnd\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\",\r\n
@@ -2580,7 +2580,7 @@ http_interactions:
         \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
         \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:25 GMT
+  recorded_at: Mon, 12 Mar 2018 09:39:14 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip?api-version=2018-01-01
@@ -2597,7 +2597,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcyMTAsIm5iZiI6MTUyMDg0NzIxMCwiZXhwIjoxNTIwODUxMTEwLCJhaW8iOiJZMk5nWUpodFB0a2k2MFo1cHgyTHlWdHU5NzI3QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiS2tCZkxBZmtfMC1zeUgwaDZRb2pBQSIsInZlciI6IjEuMCJ9.Vfp8xCOV2qO_lW6yNVyfhqgGpT2ZG_Z3Nj79KQIrcAD9IDe8IaKlPoG_nmf3qLcXuKGG2QgEZe28-uL17_Yumns3TDPYvaCyONJ7HR4WOz6Sj-_DrXX3lUyHFe6HcaWli0q0eu4QpLcTUTRe6LkQ-u7jfsgw-ovI2FqwrL_lXv7TNhE7ZX-QvZJni2QYDvFGGZW6i2Y4TCOMQmqmWVu-VTfxHXZ_JJMGfiNXaV3Io_zjY8XkGKvXMHjdcpqM4b4fluhxYp-LJ2LkV1VNf7yIi8KrGtLWZzC1a0KC3gqNWxCYV08j1UAZxEVEZycyUQeJsaEHR9WDgll6xt8KR85KgQ
   response:
     status:
       code: 200
@@ -2618,7 +2618,7 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 1403e5b6-8fa0-4cd3-89b1-76b6c4fd805b
+      - 377686dc-1e3c-42f9-9e26-ac2658243066
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
@@ -2627,13 +2627,13 @@ http_interactions:
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
       - '14988'
       X-Ms-Correlation-Request-Id:
-      - e4a5f369-a742-466f-bd8f-42e17eaaf9c9
+      - 9c440548-4ec3-4fcb-b035-ef40ece57828
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102421Z:e4a5f369-a742-466f-bd8f-42e17eaaf9c9
+      - WESTEUROPE:20180312T093909Z:9c440548-4ec3-4fcb-b035-ef40ece57828
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:21 GMT
+      - Mon, 12 Mar 2018 09:39:09 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"rspec-lb2-publicip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\",\r\n
@@ -2645,5 +2645,5 @@ http_interactions:
         \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
         \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:26 GMT
+  recorded_at: Mon, 12 Mar 2018 09:39:14 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_0/multiple_targets_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_0/multiple_targets_refresh.yml
@@ -37,25 +37,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - bc5fe702-5285-441c-af1b-28bb1f620000
+      - 36370914-2f4f-43f1-8d56-5e158ec52a00
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzr5uao9ay2XJ79satAWdf6c_Uah2OkNMUYwm6q3Kl4NSWvg0ARYMqKlPxlDj5hq3rvhRaf7n7-uXbidqxNnqeLzl1ZKX6iha3AY5mPqYDkXE5-Gfkp7mN5NgUcEB3Zg_qZy_wVUrAMHHyNPeCNu9qAs9f9MZfuc-TejKmlEwV0z4gAA;
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzqFgzlGZrLZI_nuZCB9N6_JP2PefsVLNGKLPd-1SqpC3xBinQzfTmCNXrKUNEuV_Nyv0SXCYBXvUurTGNovbntXAzih2Q6OwBjIE6t06E29RHB5B4_J9-nboBcvG1-jGOgJaCFI-YxNmyNylDeFkPqD0EX1h6G8OBSQyHWCyuA-QgAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=006; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=008; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Wed, 07 Mar 2018 20:17:22 GMT
+      - Mon, 12 Mar 2018 13:27:11 GMT
       Content-Length:
       - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1520457443","not_before":"1520453543","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1NDMsIm5iZiI6MTUyMDQ1MzU0MywiZXhwIjoxNTIwNDU3NDQzLCJhaW8iOiJZMk5nWUtnVTcxZFYzaEY3dGlIOFI4YzcyODZyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQXVkZnZJVlNIRVN2R3lpN0gySUFBQSIsInZlciI6IjEuMCJ9.DIpJSVBILdjgWTsPUuSjfYAwOg3J39WtKpji-H2_QiIDtP9TwVbFGnsY0qCNBvHBZJiEuXbpkNkRR_y2XGl6TT7BJe6jR9wqMEM3514u4JpwBgWH2aCbnLTjOo8JdqbphalN38iEWVwiUH2p4k7G3zDvZM6LsO9UGllA4K_AfRYfBosdPxqJjWgH3ZfgbBMMIvY5Z-Lr8-Z_AE_erdyYmIRc2mzUpWbQWdgzmm-PjH1-TaP4yzKckX5lnY34x5NHv8Hw55wiWxTPrWliHDnXNg-PAubyLnXwHQqDJqOUyNjgaa26Ru8nhB5XSlpRR19x4NVnosl2DIOgtF63sHTbnw"}'
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1520864832","not_before":"1520860932","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA5MzIsIm5iZiI6MTUyMDg2MDkzMiwiZXhwIjoxNTIwODY0ODMyLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRkFrM05rOHY4VU9OVmw0VmpzVXFBQSIsInZlciI6IjEuMCJ9.mNP_fcyGqvirg-gch_0gqMTkq6GfQsKJYWlu-tLV-aK6g_6NJPo9B4VM9tg_qRwhMb28-Cclixrg_u0pk2XwmYLHcOWHmw_WHOyqGFFglMG-sHX_VDBRXwSv2mjqkp43jdA0e4mZTg68NduEKev_voIdGn_CpOdmkOt7Q01iimz-aSv7m5JWIoZ8jiTgbW1okmkEyN2t7vAxPsqvVBsD6j-XXtvJ7XFmCPnPJ_kSIfioc5wW3FGyHlGjYD_uXZK1NxKEJMY0xAZSNytK83ZeFsE2MR8TKFrjOPya6VZN010Q3JVVPqYsD-Kme9UMpV5dIXoHbsqjnyfS7u1mKLEKWA"}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:17:23 GMT
+  recorded_at: Mon, 12 Mar 2018 13:27:12 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -72,7 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1NDMsIm5iZiI6MTUyMDQ1MzU0MywiZXhwIjoxNTIwNDU3NDQzLCJhaW8iOiJZMk5nWUtnVTcxZFYzaEY3dGlIOFI4YzcyODZyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQXVkZnZJVlNIRVN2R3lpN0gySUFBQSIsInZlciI6IjEuMCJ9.DIpJSVBILdjgWTsPUuSjfYAwOg3J39WtKpji-H2_QiIDtP9TwVbFGnsY0qCNBvHBZJiEuXbpkNkRR_y2XGl6TT7BJe6jR9wqMEM3514u4JpwBgWH2aCbnLTjOo8JdqbphalN38iEWVwiUH2p4k7G3zDvZM6LsO9UGllA4K_AfRYfBosdPxqJjWgH3ZfgbBMMIvY5Z-Lr8-Z_AE_erdyYmIRc2mzUpWbQWdgzmm-PjH1-TaP4yzKckX5lnY34x5NHv8Hw55wiWxTPrWliHDnXNg-PAubyLnXwHQqDJqOUyNjgaa26Ru8nhB5XSlpRR19x4NVnosl2DIOgtF63sHTbnw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA5MzIsIm5iZiI6MTUyMDg2MDkzMiwiZXhwIjoxNTIwODY0ODMyLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRkFrM05rOHY4VU9OVmw0VmpzVXFBQSIsInZlciI6IjEuMCJ9.mNP_fcyGqvirg-gch_0gqMTkq6GfQsKJYWlu-tLV-aK6g_6NJPo9B4VM9tg_qRwhMb28-Cclixrg_u0pk2XwmYLHcOWHmw_WHOyqGFFglMG-sHX_VDBRXwSv2mjqkp43jdA0e4mZTg68NduEKev_voIdGn_CpOdmkOt7Q01iimz-aSv7m5JWIoZ8jiTgbW1okmkEyN2t7vAxPsqvVBsD6j-XXtvJ7XFmCPnPJ_kSIfioc5wW3FGyHlGjYD_uXZK1NxKEJMY0xAZSNytK83ZeFsE2MR8TKFrjOPya6VZN010Q3JVVPqYsD-Kme9UMpV5dIXoHbsqjnyfS7u1mKLEKWA
   response:
     status:
       code: 200
@@ -93,24 +93,24 @@ http_interactions:
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
       - '14999'
       X-Ms-Request-Id:
-      - aa81ffb5-1675-4d1a-b95e-3b20f473d23d
+      - a6b9f1e6-701b-465b-8481-562beb525792
       X-Ms-Correlation-Request-Id:
-      - aa81ffb5-1675-4d1a-b95e-3b20f473d23d
+      - a6b9f1e6-701b-465b-8481-562beb525792
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201723Z:aa81ffb5-1675-4d1a-b95e-3b20f473d23d
+      - WESTEUROPE:20180312T132713Z:a6b9f1e6-701b-465b-8481-562beb525792
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:17:23 GMT
+      - Mon, 12 Mar 2018 13:27:12 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID","subscriptionId":"AZURE_SUBSCRIPTION_ID","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:17:23 GMT
+  recorded_at: Mon, 12 Mar 2018 13:27:13 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers?api-version=2015-01-01
@@ -127,7 +127,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1NDMsIm5iZiI6MTUyMDQ1MzU0MywiZXhwIjoxNTIwNDU3NDQzLCJhaW8iOiJZMk5nWUtnVTcxZFYzaEY3dGlIOFI4YzcyODZyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQXVkZnZJVlNIRVN2R3lpN0gySUFBQSIsInZlciI6IjEuMCJ9.DIpJSVBILdjgWTsPUuSjfYAwOg3J39WtKpji-H2_QiIDtP9TwVbFGnsY0qCNBvHBZJiEuXbpkNkRR_y2XGl6TT7BJe6jR9wqMEM3514u4JpwBgWH2aCbnLTjOo8JdqbphalN38iEWVwiUH2p4k7G3zDvZM6LsO9UGllA4K_AfRYfBosdPxqJjWgH3ZfgbBMMIvY5Z-Lr8-Z_AE_erdyYmIRc2mzUpWbQWdgzmm-PjH1-TaP4yzKckX5lnY34x5NHv8Hw55wiWxTPrWliHDnXNg-PAubyLnXwHQqDJqOUyNjgaa26Ru8nhB5XSlpRR19x4NVnosl2DIOgtF63sHTbnw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA5MzIsIm5iZiI6MTUyMDg2MDkzMiwiZXhwIjoxNTIwODY0ODMyLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRkFrM05rOHY4VU9OVmw0VmpzVXFBQSIsInZlciI6IjEuMCJ9.mNP_fcyGqvirg-gch_0gqMTkq6GfQsKJYWlu-tLV-aK6g_6NJPo9B4VM9tg_qRwhMb28-Cclixrg_u0pk2XwmYLHcOWHmw_WHOyqGFFglMG-sHX_VDBRXwSv2mjqkp43jdA0e4mZTg68NduEKev_voIdGn_CpOdmkOt7Q01iimz-aSv7m5JWIoZ8jiTgbW1okmkEyN2t7vAxPsqvVBsD6j-XXtvJ7XFmCPnPJ_kSIfioc5wW3FGyHlGjYD_uXZK1NxKEJMY0xAZSNytK83ZeFsE2MR8TKFrjOPya6VZN010Q3JVVPqYsD-Kme9UMpV5dIXoHbsqjnyfS7u1mKLEKWA
   response:
     status:
       code: 200
@@ -144,39 +144,37 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14976'
+      - '14997'
       X-Ms-Request-Id:
-      - c4cb6256-02b7-4410-b51c-c2d711046274
+      - 57236cc6-3584-40a7-b5fc-61571908cc96
       X-Ms-Correlation-Request-Id:
-      - c4cb6256-02b7-4410-b51c-c2d711046274
+      - 57236cc6-3584-40a7-b5fc-61571908cc96
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201725Z:c4cb6256-02b7-4410-b51c-c2d711046274
+      - WESTEUROPE:20180312T132714Z:57236cc6-3584-40a7-b5fc-61571908cc96
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:17:25 GMT
+      - Mon, 12 Mar 2018 13:27:14 GMT
       Content-Length:
-      - '310901'
+      - '320853'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"},{"applicationId":"d87dcbc6-a371-462e-88e3-28ad15ec4e64","roleDefinitionId":"861776c5-e0df-4f95-be4f-ac1eec193323"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
+      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"},{"applicationId":"d87dcbc6-a371-462e-88e3-28ad15ec4e64","roleDefinitionId":"861776c5-e0df-4f95-be4f-ac1eec193323"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["East
+        Asia","Southeast Asia","Australia East","Australia Southeast","Japan East","Japan
+        West","Central India","South India","West India","West Europe","North Europe","Canada
+        Central","Canada East","Brazil South","West US","Central US","East US","South
+        Central US","East US 2","West Central US","North Central US","West US 2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
         US","Central US","East US","South Central US","West Europe","North Europe","East
         Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
         Central US","North Central US","Japan East","Japan West","Brazil South","Central
         India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"operations","locations":["West
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["East
+        Asia","Southeast Asia","Australia East","Australia Southeast","Japan East","Japan
+        West","Central India","South India","West India","West Europe","North Europe","Canada
+        Central","Canada East","Brazil South","West US","Central US","East US","South
+        Central US","East US 2","West Central US","North Central US","West US 2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"operations","locations":["West
         US","Central US","East US","South Central US","West Europe","North Europe","East
         Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
         Central US","North Central US","Japan East","Japan West","Brazil South","Central
@@ -232,177 +230,177 @@ http_interactions:
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/internalLoadBalancers","locations":[],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"domainNames/slots/roles/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"domainNames/slots/roles/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"domainNames/capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"domainNames/serviceCertificates","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
         US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
         Central","Canada East","UK South","UK West","West US","Central US","South
         Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
-        East","Australia Southeast","West US 2","West Central US","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        East","Australia Southeast","West US 2","West Central US","France Central","South
+        India","Central India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
         US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
         Central","Canada East","UK South","UK West","West US","Central US","South
         Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
-        East","Australia Southeast","West US 2","West Central US","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metrics","locations":["North
+        East","Australia Southeast","West US 2","West Central US","France Central","South
+        India","Central India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metrics","locations":["North
         Central US","South Central US","East US","East US 2","Canada Central","Canada
         East","West US","West US 2","West Central US","Central US","East Asia","Southeast
         Asia","North Europe","West Europe","UK South","UK West","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"resourceTypes","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"moveSubscriptionResources","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"validateSubscriptionMoveAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operationStatuses","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operatingSystems","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"operatingSystemFamilies","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicNetwork","namespace":"Microsoft.ClassicNetwork","resourceTypes":[{"resourceType":"virtualNetworks","locations":["East
+        India","West India","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"resourceTypes","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"moveSubscriptionResources","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"validateSubscriptionMoveAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operationStatuses","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operatingSystems","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"operatingSystemFamilies","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicNetwork","namespace":"Microsoft.ClassicNetwork","resourceTypes":[{"resourceType":"virtualNetworks","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"virtualNetworks/remoteVirtualNetworkPeeringProxies","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01"]},{"resourceType":"virtualNetworks/remoteVirtualNetworkPeeringProxies","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"reservedIps","locations":["East
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01"]},{"resourceType":"reservedIps","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"gatewaySupportedDevices","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"networkSecurityGroups","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"gatewaySupportedDevices","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"networkSecurityGroups","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicStorage","namespace":"Microsoft.ClassicStorage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"expressRouteCrossConnections","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"expressRouteCrossConnections/peerings","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicStorage","namespace":"Microsoft.ClassicStorage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkStorageAccountAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"storageAccounts/services","locations":["West
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkStorageAccountAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"storageAccounts/services","locations":["West
         US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
         Asia","Australia East","Australia Southeast","South India","Central India","West
         India","West US 2","West Central US","East US","East US 2","North Central
         US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
-        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/diagnosticSettings","locations":["West
+        South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/diagnosticSettings","locations":["West
         US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
         Asia","Australia East","Australia Southeast","South India","Central India","West
         India","West US 2","West Central US","East US","East US 2","North Central
         US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
-        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"disks","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"images","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"vmImages","locations":[],"apiVersions":["2016-11-01"]},{"resourceType":"publicImages","locations":[],"apiVersions":["2016-11-01","2016-04-01"]},{"resourceType":"osImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"osPlatformImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute","namespace":"Microsoft.Compute","authorizations":[{"applicationId":"60e6cd67-9c8c-4951-9b3c-23c25a2169af","roleDefinitionId":"e4770acb-272e-4dc8-87f3-12f44a612224"},{"applicationId":"a303894e-f1d8-4a37-bf10-67aa654a0596","roleDefinitionId":"903ac751-8ad5-4e5a-bfc2-5e49f450a241"},{"applicationId":"a8b6bf88-1d1a-4626-b040-9a729ea93c65","roleDefinitionId":"45c8267c-80ba-4b96-9a43-115b8f49fccd"}],"resourceTypes":[{"resourceType":"availabilitySets","locations":["East
+        South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"disks","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"images","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"vmImages","locations":[],"apiVersions":["2016-11-01"]},{"resourceType":"storageAccounts/vmImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"publicImages","locations":[],"apiVersions":["2016-11-01","2016-04-01"]},{"resourceType":"osImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"osPlatformImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute","namespace":"Microsoft.Compute","authorizations":[{"applicationId":"60e6cd67-9c8c-4951-9b3c-23c25a2169af","roleDefinitionId":"e4770acb-272e-4dc8-87f3-12f44a612224"},{"applicationId":"a303894e-f1d8-4a37-bf10-67aa654a0596","roleDefinitionId":"903ac751-8ad5-4e5a-bfc2-5e49f450a241"},{"applicationId":"a8b6bf88-1d1a-4626-b040-9a729ea93c65","roleDefinitionId":"45c8267c-80ba-4b96-9a43-115b8f49fccd"}],"resourceTypes":[{"resourceType":"availabilitySets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations/usages","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations/usages","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"sharedVMImages","locations":["West
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"sharedVMImages","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"sharedVMImages/versions","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"locations/capsoperations","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"disks","locations":["Southeast
@@ -410,27 +408,27 @@ http_interactions:
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"snapshots","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"snapshots","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"locations/diskoperations","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"locations/diskoperations","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"images","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"images","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"]},{"resourceType":"locations/logAnalytics","locations":["East
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"]},{"resourceType":"locations/logAnalytics","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
         US","East US","South Central US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
@@ -547,7 +545,12 @@ http_interactions:
         US","East Asia","East US","East US 2","Japan East","Japan West","North Central
         US","North Europe","South Central US","South India","Southeast Asia","West
         Central US","West Europe","West India","West US","West US 2","UK West","UK
-        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"},{"applicationId":"f5c26e74-f226-4ae8-85f0-b4af0080ac9e","roleDefinitionId":"529d7ae6-e892-4d43-809d-8547aeb90643"}],"resourceTypes":[{"resourceType":"components","locations":["East
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/consumergroups","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/disasterrecoveryconfigs","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"},{"applicationId":"f5c26e74-f226-4ae8-85f0-b4af0080ac9e","roleDefinitionId":"529d7ae6-e892-4d43-809d-8547aeb90643"}],"resourceTypes":[{"resourceType":"components","locations":["East
         US","South Central US","North Europe","West Europe","Southeast Asia","West
         US 2"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
         US","South Central US","North Europe","West Europe","Southeast Asia","West
@@ -614,32 +617,32 @@ http_interactions:
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/accessPolicies","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"vaults/accessPolicies","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-10-01","2015-06-01","2014-12-19-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"deletedVaults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01","2014-12-19-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"deletedVaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-10-01"]},{"resourceType":"locations/deletedVaults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations/deletedVaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
         Central US","West Europe","Southeast Asia","Japan East","West Central US"],"apiVersions":["2016-04-01"]},{"resourceType":"webServices","locations":["South
         Central US","West Europe","Southeast Asia","Japan East","East US 2","West
         Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"operations","locations":["South
@@ -665,97 +668,97 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"networkWatchers/lenses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"networkWatchers/lenses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","West
         US 2","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
@@ -846,7 +849,7 @@ http_interactions:
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
         West","Korea Central","Korea South"],"apiVersions":["2017-07-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ResourceHealth","namespace":"Microsoft.ResourceHealth","authorizations":[{"applicationId":"8bdebf23-c0fe-4187-a378-717ad86f6a53","roleDefinitionId":"cc026344-c8b1-4561-83ba-59eba84b27cc"}],"resourceTypes":[{"resourceType":"availabilityStatuses","locations":[],"apiVersions":["2017-07-01","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"notifications","locations":["Australia
-        Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Security","namespace":"Microsoft.Security","authorization":{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
+        Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Security","namespace":"Microsoft.Security","authorizations":[{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},{"applicationId":"fc780465-2017-40d4-a0c5-307022471b92"}],"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatuses","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/virtualMachines","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/endpoints","locations":["Central
@@ -898,565 +901,595 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Central India","South
         India"],"apiVersions":["2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Sql","namespace":"Microsoft.Sql","authorizations":[{"applicationId":"e4ab13ed-33cb-41b4-9140-6e264582cf85","roleDefinitionId":"ec3ddc95-44dc-47a2-9926-5e9f5ffd44ec"},{"applicationId":"0130cc9f-7ac5-4026-bd5f-80a08a54e6d9","roleDefinitionId":"45e8abf8-0ec4-44f3-9c37-cff4f7779302"},{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},{"applicationId":"76c7f279-7959-468f-8943-3954880e0d8c","roleDefinitionId":"7f7513a8-73f9-4c5f-97a2-c41f0ea783ef"}],"resourceTypes":[{"resourceType":"operations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/capabilities","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/databaseAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/databaseOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverKeyOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/keys","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/encryptionProtector","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/usages","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01","2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/communicationLinks","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administrators","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administratorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/restorableDroppedDatabases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recoverableDatabases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/geoBackupPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/importExportOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/operationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/backupLongTermRetentionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/automaticTuning","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/automaticTuning","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/databases/transparentDataEncryption","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recommendedElasticPools","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/auditingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/connectionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/connectionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies/rules","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/securityAlertPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/securityAlertPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/auditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/extendedAuditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/elasticpools","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-09-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/jobAgentOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/jobAgentAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/disasterRecoveryConfiguration","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/dnsAliases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/failoverGroups","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/virtualNetworkRules","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/virtualNetworkRulesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/virtualNetworkRulesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/databaseRestoreAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metricDefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/aggregatedDatabaseMetrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metricdefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries/queryText","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPools/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/extensions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPoolEstimates","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditRecords","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentScans","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/vulnerabilityAssessments","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessment","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/syncGroups","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups/syncMembers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/syncAgents","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"managedInstances/administrators","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/databases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metricDefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/administratorAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/administratorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncMemberOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncAgentOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncDatabaseIds","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorizations":[{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},{"applicationId":"e406a681-f3d4-42a8-90b6-c2b029497af1"}],"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/capabilities","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/databaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"locations/databaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverKeyOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/keys","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/encryptionProtector","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01","2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/communicationLinks","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/restorableDroppedDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recoverableDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/geoBackupPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/importExportOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/operationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/backupLongTermRetentionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/databases/transparentDataEncryption","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recommendedElasticPools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies/rules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/extendedAuditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/elasticPoolAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/elasticPoolOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/elasticpools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-09-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/jobAgentOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/jobAgentAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/disasterRecoveryConfiguration","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/dnsAliases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/failoverGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/virtualNetworkRules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/virtualNetworkRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/virtualNetworkRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/databaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/aggregatedDatabaseMetrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metricdefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries/queryText","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPools/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/extensions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPoolEstimates","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditRecords","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentScans","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/vulnerabilityAssessments","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessment","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/syncGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups/syncMembers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/syncAgents","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"managedInstances/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/administratorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncMemberOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncAgentOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncDatabaseIds","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/longTermRetentionPolicyOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionPolicyAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionBackupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionBackupAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorizations":[{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},{"applicationId":"e406a681-f3d4-42a8-90b6-c2b029497af1"}],"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
@@ -1795,12 +1828,12 @@ http_interactions:
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","Canada Central","Canada East","UK South","UK West","West US 2","West
-        Central US","South India","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","South India","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","South India","Canada Central","Canada East","UK South","UK West","West
-        US 2","West Central US","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Capacity","namespace":"Microsoft.Capacity","authorization":{"applicationId":"4d0ad6c7-f6c3-46d8-ab0d-1406d5e6c86b","roleDefinitionId":"FD9C0A9A-4DB9-4F41-8A61-98385DEB6E2D"},"resourceTypes":[{"resourceType":"resources","locations":["South
+        US 2","West Central US","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Capacity","namespace":"Microsoft.Capacity","authorization":{"applicationId":"4d0ad6c7-f6c3-46d8-ab0d-1406d5e6c86b","roleDefinitionId":"FD9C0A9A-4DB9-4F41-8A61-98385DEB6E2D"},"resourceTypes":[{"resourceType":"resources","locations":["South
         Central US"],"apiVersions":["2017-11-01"]},{"resourceType":"reservationOrders","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/reservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/reservations/revisions","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"catalogs","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"appliedReservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"checkOffers","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"checkScopes","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"calculatePrice","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/calculateRefund","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/return","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/split","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/merge","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"validateReservationOrder","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/availableScopes","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Cdn","namespace":"Microsoft.Cdn","resourceTypes":[{"resourceType":"profiles","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
@@ -1876,9 +1909,9 @@ http_interactions:
         2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/updateAccountsCreationSettings","locations":["West
         US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/accountsCreationSettings","locations":["West
         US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2016-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Commerce","namespace":"Microsoft.Commerce","resourceTypes":[{"resourceType":"UsageAggregates","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]},{"resourceType":"RateCard","locations":[],"apiVersions":["2016-08-31-preview","2015-06-01-preview","2015-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Consumption","namespace":"Microsoft.Consumption","resourceTypes":[{"resourceType":"ReservationSummaries","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationTransactions","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Balances","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Marketplaces","locations":[],"apiVersions":["2018-01-31"]},{"resourceType":"Pricesheets","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationDetails","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Budgets","locations":[],"apiVersions":["2018-01-31","2017-12-30-preview"]},{"resourceType":"Terms","locations":[],"apiVersions":["2018-01-31","2017-12-30-preview"]},{"resourceType":"UsageDetails","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview","2017-04-24-preview"]},{"resourceType":"Operations","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview","2017-04-24-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerInstance","namespace":"Microsoft.ContainerInstance","resourceTypes":[{"resourceType":"containerGroups","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/usages","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/operations","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/operations","locations":["West
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
         US"],"apiVersions":["2016-04-08"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.CustomerInsights","namespace":"Microsoft.CustomerInsights","authorization":{"applicationId":"38c77d00-5fcb-4cce-9d93-af4738258e3c","roleDefinitionId":"E006F9C7-F333-477C-8AD6-1F3A9FE87F55"},"resourceTypes":[{"resourceType":"hubs","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/profiles","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/interactions","locations":["East
@@ -1895,7 +1928,9 @@ http_interactions:
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"operations","locations":["East
         US 2"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Databricks","namespace":"Microsoft.Databricks","authorizations":[{"applicationId":"d9327919-6775-4843-9037-3fb0fb0473cb","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},{"applicationId":"2ff814a6-3304-4ab8-85cb-cd0e6f879c1d","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"}],"resourceTypes":[{"resourceType":"workspaces","locations":["West
         US","East US 2","West Europe","East US","North Europe","Southeast Asia","East
-        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]},{"resourceType":"locations","locations":["West
+        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2017-09-01-preview"]},{"resourceType":"workspaces/virtualNetworkPeerings","locations":["West
+        US","East US 2","West Europe","North Europe","East US","Southeast Asia","East
+        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01"]},{"resourceType":"locations","locations":["West
         US","East US 2","West Europe","North Europe","East US","Southeast Asia"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
         US","East US 2","West Europe","East US","North Europe","Southeast Asia","East
         Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataCatalog","namespace":"Microsoft.DataCatalog","resourceTypes":[{"resourceType":"catalogs","locations":["East
@@ -1919,23 +1954,26 @@ http_interactions:
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers/listSasTokens","locations":["East
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataLakeStore","namespace":"Microsoft.DataLakeStore","authorization":{"applicationId":"e9f49c6b-5ce5-44c8-925d-015017e9f7ad","roleDefinitionId":"17eb9cca-f08a-4499-b2d3-852d175f614f"},"resourceTypes":[{"resourceType":"accounts","locations":["East
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/firewallRules","locations":["East
-        US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataMigration","namespace":"Microsoft.DataMigration","authorization":{"applicationId":"a4bad4aa-bf02-4631-9f78-a64ffdba8150","roleDefinitionId":"b831a21d-db98-4760-89cb-bef871952df1","managedByRoleDefinitionId":"6256fb55-9e59-4018-a9e1-76b11c0a4c89"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services/projects","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationStatuses","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
+        US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataMigration","namespace":"Microsoft.DataMigration","authorization":{"applicationId":"a4bad4aa-bf02-4631-9f78-a64ffdba8150","roleDefinitionId":"b831a21d-db98-4760-89cb-bef871952df1","managedByRoleDefinitionId":"6256fb55-9e59-4018-a9e1-76b11c0a4c89"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services/projects","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationStatuses","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
-        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/recoverableServers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
@@ -1959,7 +1997,10 @@ http_interactions:
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
-        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/recoverableServers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
@@ -2015,12 +2056,7 @@ http_interactions:
         US 2","East US","West US","Central US","East US 2","West Central US","West
         Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
         US 2","East US","West US","Central US","East US 2","West Central US","West
-        Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","West
-        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
-        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
-        India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/consumergroups","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/disasterrecoveryconfigs","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
         US 2","South Central US","Central US","Australia Southeast","Central India","West
         Central US","West US 2","Canada East","Canada Central","Brazil South","UK
         South","UK West","East Asia","Australia East","Japan East","Japan West","North
@@ -2131,7 +2167,7 @@ http_interactions:
         West","Japan East","East Asia","Southeast Asia","West Europe","North Europe","East
         US","West US","Australia East","Australia Southeast","Central US","Brazil
         South","Central India","West India","South India","South Central US","Canada
-        Central","Canada East","West Central US","West US 2"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
+        Central","Canada East","West Central US","West US 2"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-05","2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
         Central US","East US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"operations","locations":["West
         Central US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
         Central US","East US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.PolicyInsights","namespace":"Microsoft.PolicyInsights","authorization":{"applicationId":"1d78a85d-813d-46f0-b496-dd72f50a3ec0","roleDefinitionId":"63d2b225-4c34-4641-8768-21a1f7c68ce8"},"resourceTypes":[{"resourceType":"policyEvents","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"policyStates","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
@@ -2163,12 +2199,12 @@ http_interactions:
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
         Central US","South Central US","North Europe","West Europe","East Asia","Southeast
         Asia","West US","East US","Japan West","Japan East","Brazil South","Central
         US","East US 2","Australia East","Australia Southeast","South India","Central
@@ -2208,40 +2244,50 @@ http_interactions:
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/clusterVersions","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"clusters/applications","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operations","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/clusterVersions","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/environments","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operations","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
         Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applianceDefinitions","locations":["West
         Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applications","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
-        Central US"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
+        Central US"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
         US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
         US","Canada Central","Canada East","Central US","East US 2","UK South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups","locations":["West
         US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
@@ -2332,10 +2378,10 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:17:25 GMT
+  recorded_at: Mon, 12 Mar 2018 13:27:14 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/non_existent?api-version=2017-08-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2349,79 +2395,47 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1NDMsIm5iZiI6MTUyMDQ1MzU0MywiZXhwIjoxNTIwNDU3NDQzLCJhaW8iOiJZMk5nWUtnVTcxZFYzaEY3dGlIOFI4YzcyODZyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQXVkZnZJVlNIRVN2R3lpN0gySUFBQSIsInZlciI6IjEuMCJ9.DIpJSVBILdjgWTsPUuSjfYAwOg3J39WtKpji-H2_QiIDtP9TwVbFGnsY0qCNBvHBZJiEuXbpkNkRR_y2XGl6TT7BJe6jR9wqMEM3514u4JpwBgWH2aCbnLTjOo8JdqbphalN38iEWVwiUH2p4k7G3zDvZM6LsO9UGllA4K_AfRYfBosdPxqJjWgH3ZfgbBMMIvY5Z-Lr8-Z_AE_erdyYmIRc2mzUpWbQWdgzmm-PjH1-TaP4yzKckX5lnY34x5NHv8Hw55wiWxTPrWliHDnXNg-PAubyLnXwHQqDJqOUyNjgaa26Ru8nhB5XSlpRR19x4NVnosl2DIOgtF63sHTbnw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA5MzIsIm5iZiI6MTUyMDg2MDkzMiwiZXhwIjoxNTIwODY0ODMyLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRkFrM05rOHY4VU9OVmw0VmpzVXFBQSIsInZlciI6IjEuMCJ9.mNP_fcyGqvirg-gch_0gqMTkq6GfQsKJYWlu-tLV-aK6g_6NJPo9B4VM9tg_qRwhMb28-Cclixrg_u0pk2XwmYLHcOWHmw_WHOyqGFFglMG-sHX_VDBRXwSv2mjqkp43jdA0e4mZTg68NduEKev_voIdGn_CpOdmkOt7Q01iimz-aSv7m5JWIoZ8jiTgbW1okmkEyN2t7vAxPsqvVBsD6j-XXtvJ7XFmCPnPJ_kSIfioc5wW3FGyHlGjYD_uXZK1NxKEJMY0xAZSNytK83ZeFsE2MR8TKFrjOPya6VZN010Q3JVVPqYsD-Kme9UMpV5dIXoHbsqjnyfS7u1mKLEKWA
   response:
     status:
-      code: 200
-      message: OK
+      code: 404
+      message: Not Found
     headers:
       Cache-Control:
       - no-cache
       Pragma:
       - no-cache
-      Transfer-Encoding:
-      - chunked
       Content-Type:
       - application/json; charset=utf-8
       Expires:
       - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/LowCostGet3Min;4732,Microsoft.Compute/LowCostGet30Min;37896
+      X-Ms-Failure-Cause:
+      - gateway
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14997'
+      X-Ms-Request-Id:
+      - 61081c1e-dc9d-4529-b6c0-f6d14d65f2bd
+      X-Ms-Correlation-Request-Id:
+      - 61081c1e-dc9d-4529-b6c0-f6d14d65f2bd
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T132715Z:61081c1e-dc9d-4529-b6c0-f6d14d65f2bd
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
-      X-Ms-Request-Id:
-      - 859b55f6-b7c9-4c59-8559-c1cd12a95423
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14976'
-      X-Ms-Correlation-Request-Id:
-      - 2bc59020-8cb6-4ed2-9df1-15a59310305c
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201726Z:2bc59020-8cb6-4ed2-9df1-15a59310305c
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:17:26 GMT
+      - Mon, 12 Mar 2018 13:27:14 GMT
+      Content-Length:
+      - '97'
     body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"23b0beab-16d2-4135-a01f-2fe713217fd0\",\r\n
-        \   \"availabilitySet\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/RSPEC-LB\"\r\n
-        \   },\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_F1s\"\r\n
-        \   },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
-        \"RedHat\",\r\n        \"offer\": \"RHEL\",\r\n        \"sku\": \"6.7\",\r\n
-        \       \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
-        \"Linux\",\r\n        \"name\": \"rspec-lb-a\",\r\n        \"createOption\":
-        \"FromImage\",\r\n        \"vhd\": {\r\n          \"uri\": \"https://rspeclb.blob.core.windows.net/vhds/rspec-lb-a201682122839.vhd\"\r\n
-        \       },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n      \"dataDisks\":
-        []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"rspec-lb-a\",\r\n
-        \     \"adminUsername\": \"bronaghs\",\r\n      \"linuxConfiguration\": {\r\n
-        \       \"disablePasswordAuthentication\": false\r\n      },\r\n      \"secrets\":
-        []\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670\"}]},\r\n
-        \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
-        true,\r\n        \"storageUri\": \"https://miqazuretest16487.blob.core.windows.net/\"\r\n
-        \     }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n
-        \ \"resources\": [\r\n    {\r\n      \"properties\": {\r\n        \"publisher\":
-        \"Microsoft.OSTCExtensions\",\r\n        \"type\": \"LinuxDiagnostic\",\r\n
-        \       \"typeHandlerVersion\": \"2.3\",\r\n        \"autoUpgradeMinorVersion\":
-        true,\r\n        \"settings\": {\"xmlCfg\":\"PFdhZENmZz48RGlhZ25vc3RpY01vbml0b3JDb25maWd1cmF0aW9uIG92ZXJhbGxRdW90YUluTUI9IjQwOTYiPjxEaWFnbm9zdGljSW5mcmFzdHJ1Y3R1cmVMb2dzIHNjaGVkdWxlZFRyYW5zZmVyUGVyaW9kPSJQVDFNIiBzY2hlZHVsZWRUcmFuc2ZlckxvZ0xldmVsRmlsdGVyPSJXYXJuaW5nIi8+PFBlcmZvcm1hbmNlQ291bnRlcnMgc2NoZWR1bGVkVHJhbnNmZXJQZXJpb2Q9IlBUMU0iPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlTWVtb3J5IiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQnl0ZXMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcUGVyY2VudEF2YWlsYWJsZU1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iTWVtb3J5IHVzZWQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50VXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgcGVyY2VudGFnZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkQnlDYWNoZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHVzZWQgYnkgY2FjaGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1BlclNlYyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50UGVyU2Vjb25kIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFnZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1JlYWRQZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2UgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1dyaXR0ZW5QZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2Ugd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iU3dhcCBhdmFpbGFibGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50QXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZFN3YXAiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlN3YXAgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRJZGxlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgaWRsZSB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFVzZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iUGVyY2VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkNQVSB1c2VyIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50TmljZVRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIG5pY2UgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRQcml2aWxlZ2VkVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgcHJpdmlsZWdlZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudEludGVycnVwdFRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIGludGVycnVwdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudERQQ1RpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIERQQyB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFByb2Nlc3NvclRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIHBlcmNlbnRhZ2UgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50SU9XYWl0VGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgSU8gd2FpdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xSZWFkQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCBndWVzdCBPUyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXFdyaXRlQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGUgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xUcmFuc2ZlcnNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXJzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcUmVhZHNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xXcml0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVJlYWRUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVdyaXRlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlNlY29uZHMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJEaXNrIHdyaXRlIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xBdmVyYWdlVHJhbnNmZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXIgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXEF2ZXJhZ2VEaXNrUXVldWVMZW5ndGgiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcXVldWUgbGVuZ3RoIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVHJhbnNtaXR0ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgb3V0IGd1ZXN0IE9TIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzUmVjZWl2ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgaW4gZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1RyYW5zbWl0dGVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHNlbnQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1JlY2VpdmVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHJlY2VpdmVkIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVG90YWwiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxSeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyByZWNlaXZlZCBlcnJvcnMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxUeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyBzZW50IGVycm9ycyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTmV0d29ya0ludGVyZmFjZVxUb3RhbENvbGxpc2lvbnMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgY29sbGlzaW9ucyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48L1BlcmZvcm1hbmNlQ291bnRlcnM+PE1ldHJpY3MgcmVzb3VyY2VJZD0iL3N1YnNjcmlwdGlvbnMvMjU4NmM2NGItMzhiNC00NTI3LWExNDAtMDEyZDQ5ZGZjMDJjL3Jlc291cmNlR3JvdXBzL21pcS1henVyZS10ZXN0MS9wcm92aWRlcnMvTWljcm9zb2Z0LkNvbXB1dGUvdmlydHVhbE1hY2hpbmVzL3JzcGVjLWxiLWEiPjxNZXRyaWNBZ2dyZWdhdGlvbiBzY2hlZHVsZWRUcmFuc2ZlclBlcmlvZD0iUFQxSCIvPjxNZXRyaWNBZ2dyZWdhdGlvbiBzY2hlZHVsZWRUcmFuc2ZlclBlcmlvZD0iUFQxTSIvPjwvTWV0cmljcz48L0RpYWdub3N0aWNNb25pdG9yQ29uZmlndXJhdGlvbj48L1dhZENmZz4=\",\"StorageAccount\":\"miqazuretest16487\"},\r\n
-        \       \"provisioningState\": \"Succeeded\"\r\n      },\r\n      \"type\":
-        \"Microsoft.Compute/virtualMachines/extensions\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a/extensions/Microsoft.Insights.VMDiagnosticsSettings\",\r\n
-        \     \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n    }\r\n
-        \ ],\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\":
-        \"eastus\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a\",\r\n
-        \ \"name\": \"rspec-lb-a\"\r\n}"
+      encoding: UTF-8
+      string: '{"error":{"code":"DeploymentNotFound","message":"Deployment ''non_existent''
+        could not be found."}}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:17:27 GMT
+  recorded_at: Mon, 12 Mar 2018 13:27:15 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb?api-version=2018-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2435,93 +2449,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1NDMsIm5iZiI6MTUyMDQ1MzU0MywiZXhwIjoxNTIwNDU3NDQzLCJhaW8iOiJZMk5nWUtnVTcxZFYzaEY3dGlIOFI4YzcyODZyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQXVkZnZJVlNIRVN2R3lpN0gySUFBQSIsInZlciI6IjEuMCJ9.DIpJSVBILdjgWTsPUuSjfYAwOg3J39WtKpji-H2_QiIDtP9TwVbFGnsY0qCNBvHBZJiEuXbpkNkRR_y2XGl6TT7BJe6jR9wqMEM3514u4JpwBgWH2aCbnLTjOo8JdqbphalN38iEWVwiUH2p4k7G3zDvZM6LsO9UGllA4K_AfRYfBosdPxqJjWgH3ZfgbBMMIvY5Z-Lr8-Z_AE_erdyYmIRc2mzUpWbQWdgzmm-PjH1-TaP4yzKckX5lnY34x5NHv8Hw55wiWxTPrWliHDnXNg-PAubyLnXwHQqDJqOUyNjgaa26Ru8nhB5XSlpRR19x4NVnosl2DIOgtF63sHTbnw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/LowCostGet3Min;4731,Microsoft.Compute/LowCostGet30Min;37895
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
-      X-Ms-Request-Id:
-      - 8848bf70-1985-4ce2-83cb-26b335b8202e
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14976'
-      X-Ms-Correlation-Request-Id:
-      - 2ec60cac-7f45-4fbf-a272-82edc2204d99
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201727Z:2ec60cac-7f45-4fbf-a272-82edc2204d99
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:17:27 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"834a70b5-868d-4466-9dda-14e0f6b2caaf\",\r\n
-        \   \"availabilitySet\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/RSPEC-LB\"\r\n
-        \   },\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n
-        \   },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
-        \"RedHat\",\r\n        \"offer\": \"RHEL\",\r\n        \"sku\": \"6.7\",\r\n
-        \       \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
-        \"Linux\",\r\n        \"name\": \"rspec-lb-b\",\r\n        \"createOption\":
-        \"FromImage\",\r\n        \"vhd\": {\r\n          \"uri\": \"https://rspeclb.blob.core.windows.net/vhds/rspec-lb-b201682123650.vhd\"\r\n
-        \       },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n      \"dataDisks\":
-        []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"rspec-lb-b\",\r\n
-        \     \"adminUsername\": \"bronaghs\",\r\n      \"linuxConfiguration\": {\r\n
-        \       \"disablePasswordAuthentication\": false\r\n      },\r\n      \"secrets\":
-        []\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843\"}]},\r\n
-        \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
-        true,\r\n        \"storageUri\": \"https://amissteastorage.blob.core.windows.net/\"\r\n
-        \     }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n
-        \ \"resources\": [\r\n    {\r\n      \"properties\": {\r\n        \"publisher\":
-        \"Microsoft.OSTCExtensions\",\r\n        \"type\": \"LinuxDiagnostic\",\r\n
-        \       \"typeHandlerVersion\": \"2.3\",\r\n        \"autoUpgradeMinorVersion\":
-        true,\r\n        \"settings\": {\"xmlCfg\":\"PFdhZENmZz48RGlhZ25vc3RpY01vbml0b3JDb25maWd1cmF0aW9uIG92ZXJhbGxRdW90YUluTUI9IjQwOTYiPjxEaWFnbm9zdGljSW5mcmFzdHJ1Y3R1cmVMb2dzIHNjaGVkdWxlZFRyYW5zZmVyUGVyaW9kPSJQVDFNIiBzY2hlZHVsZWRUcmFuc2ZlckxvZ0xldmVsRmlsdGVyPSJXYXJuaW5nIi8+PFBlcmZvcm1hbmNlQ291bnRlcnMgc2NoZWR1bGVkVHJhbnNmZXJQZXJpb2Q9IlBUMU0iPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlTWVtb3J5IiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQnl0ZXMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcUGVyY2VudEF2YWlsYWJsZU1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iTWVtb3J5IHVzZWQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50VXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgcGVyY2VudGFnZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkQnlDYWNoZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHVzZWQgYnkgY2FjaGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1BlclNlYyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50UGVyU2Vjb25kIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFnZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1JlYWRQZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2UgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1dyaXR0ZW5QZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2Ugd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iU3dhcCBhdmFpbGFibGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50QXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZFN3YXAiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlN3YXAgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRJZGxlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgaWRsZSB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFVzZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iUGVyY2VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkNQVSB1c2VyIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50TmljZVRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIG5pY2UgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRQcml2aWxlZ2VkVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgcHJpdmlsZWdlZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudEludGVycnVwdFRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIGludGVycnVwdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudERQQ1RpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIERQQyB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFByb2Nlc3NvclRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIHBlcmNlbnRhZ2UgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50SU9XYWl0VGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgSU8gd2FpdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xSZWFkQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCBndWVzdCBPUyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXFdyaXRlQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGUgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xUcmFuc2ZlcnNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXJzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcUmVhZHNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xXcml0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVJlYWRUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVdyaXRlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlNlY29uZHMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJEaXNrIHdyaXRlIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xBdmVyYWdlVHJhbnNmZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXIgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXEF2ZXJhZ2VEaXNrUXVldWVMZW5ndGgiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcXVldWUgbGVuZ3RoIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVHJhbnNtaXR0ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgb3V0IGd1ZXN0IE9TIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzUmVjZWl2ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgaW4gZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1RyYW5zbWl0dGVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHNlbnQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1JlY2VpdmVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHJlY2VpdmVkIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVG90YWwiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxSeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyByZWNlaXZlZCBlcnJvcnMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxUeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyBzZW50IGVycm9ycyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTmV0d29ya0ludGVyZmFjZVxUb3RhbENvbGxpc2lvbnMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgY29sbGlzaW9ucyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48L1BlcmZvcm1hbmNlQ291bnRlcnM+PE1ldHJpY3MgcmVzb3VyY2VJZD0iL3N1YnNjcmlwdGlvbnMvMjU4NmM2NGItMzhiNC00NTI3LWExNDAtMDEyZDQ5ZGZjMDJjL3Jlc291cmNlR3JvdXBzL21pcS1henVyZS10ZXN0MS9wcm92aWRlcnMvTWljcm9zb2Z0LkNvbXB1dGUvdmlydHVhbE1hY2hpbmVzL3JzcGVjLWxiLWIiPjxNZXRyaWNBZ2dyZWdhdGlvbiBzY2hlZHVsZWRUcmFuc2ZlclBlcmlvZD0iUFQxSCIvPjxNZXRyaWNBZ2dyZWdhdGlvbiBzY2hlZHVsZWRUcmFuc2ZlclBlcmlvZD0iUFQxTSIvPjwvTWV0cmljcz48L0RpYWdub3N0aWNNb25pdG9yQ29uZmlndXJhdGlvbj48L1dhZENmZz4=\",\"StorageAccount\":\"amissteastorage\"},\r\n
-        \       \"provisioningState\": \"Succeeded\"\r\n      },\r\n      \"type\":
-        \"Microsoft.Compute/virtualMachines/extensions\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b/extensions/Microsoft.Insights.VMDiagnosticsSettings\",\r\n
-        \     \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n    }\r\n
-        \ ],\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\":
-        \"eastus\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b\",\r\n
-        \ \"name\": \"rspec-lb-b\"\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:17:27 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1NDMsIm5iZiI6MTUyMDQ1MzU0MywiZXhwIjoxNTIwNDU3NDQzLCJhaW8iOiJZMk5nWUtnVTcxZFYzaEY3dGlIOFI4YzcyODZyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQXVkZnZJVlNIRVN2R3lpN0gySUFBQSIsInZlciI6IjEuMCJ9.DIpJSVBILdjgWTsPUuSjfYAwOg3J39WtKpji-H2_QiIDtP9TwVbFGnsY0qCNBvHBZJiEuXbpkNkRR_y2XGl6TT7BJe6jR9wqMEM3514u4JpwBgWH2aCbnLTjOo8JdqbphalN38iEWVwiUH2p4k7G3zDvZM6LsO9UGllA4K_AfRYfBosdPxqJjWgH3ZfgbBMMIvY5Z-Lr8-Z_AE_erdyYmIRc2mzUpWbQWdgzmm-PjH1-TaP4yzKckX5lnY34x5NHv8Hw55wiWxTPrWliHDnXNg-PAubyLnXwHQqDJqOUyNjgaa26Ru8nhB5XSlpRR19x4NVnosl2DIOgtF63sHTbnw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA5MzIsIm5iZiI6MTUyMDg2MDkzMiwiZXhwIjoxNTIwODY0ODMyLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRkFrM05rOHY4VU9OVmw0VmpzVXFBQSIsInZlciI6IjEuMCJ9.mNP_fcyGqvirg-gch_0gqMTkq6GfQsKJYWlu-tLV-aK6g_6NJPo9B4VM9tg_qRwhMb28-Cclixrg_u0pk2XwmYLHcOWHmw_WHOyqGFFglMG-sHX_VDBRXwSv2mjqkp43jdA0e4mZTg68NduEKev_voIdGn_CpOdmkOt7Q01iimz-aSv7m5JWIoZ8jiTgbW1okmkEyN2t7vAxPsqvVBsD6j-XXtvJ7XFmCPnPJ_kSIfioc5wW3FGyHlGjYD_uXZK1NxKEJMY0xAZSNytK83ZeFsE2MR8TKFrjOPya6VZN010Q3JVVPqYsD-Kme9UMpV5dIXoHbsqjnyfS7u1mKLEKWA
   response:
     status:
       code: 200
@@ -2538,57 +2466,528 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"cf3a0b0d-d596-4f33-bc31-749f92ba4f00"
+      - W/"92982330-0f29-406e-bba9-ad19198579a5"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 694d57b1-cfca-4d1d-9ed4-2241fb062f9a
+      - cd0b22d9-66f5-4a70-a3d6-b0f6bc78e7cf
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14976'
+      - '14997'
       X-Ms-Correlation-Request-Id:
-      - 811ed410-702d-4a68-885a-e25532c056c5
+      - 6a2699d9-8f03-4bc1-ad3a-b0f477048295
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201728Z:811ed410-702d-4a68-885a-e25532c056c5
+      - WESTEUROPE:20180312T132715Z:6a2699d9-8f03-4bc1-ad3a-b0f477048295
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:17:27 GMT
+      - Mon, 12 Mar 2018 13:27:15 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb-a670\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670\",\r\n
-        \ \"etag\": \"W/\\\"cf3a0b0d-d596-4f33-bc31-749f92ba4f00\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"46cb8216-786e-408e-9d86-c0855b357349\",\r\n    \"ipConfigurations\":
-        [\r\n      {\r\n        \"name\": \"ipconfig1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\",\r\n
-        \       \"etag\": \"W/\\\"cf3a0b0d-d596-4f33-bc31-749f92ba4f00\\\"\",\r\n
+      string: "{\r\n  \"name\": \"spec0deply1lb\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb\",\r\n
+        \ \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"8cd72f7c-03bd-4584-abc6-d9ce77ae6202\",\r\n
+        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
+        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAddress\": \"10.16.0.6\",\r\n          \"privateIPAllocationMethod\":
-        \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-a-ip\"\r\n
-        \         },\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\"\r\n
+        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
+        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip\"\r\n
+        \         },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
+        \           }\r\n          ],\r\n          \"inboundNatRules\": [\r\n            {\r\n
+        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
+        [\r\n      {\r\n        \"name\": \"BackendPool1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\",\r\n
+        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"backendIPConfigurations\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1\"\r\n
+        \           }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n
+        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\":
+        [\r\n      {\r\n        \"name\": \"LBRule\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\",\r\n
+        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
+        \         },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\":
+        80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
+        5,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
+        false,\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\":
+        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\"\r\n
+        \         },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/probes/tcpProbe\"\r\n
+        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n
+        \       \"name\": \"tcpProbe\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/probes/tcpProbe\",\r\n
+        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"protocol\": \"Tcp\",\r\n          \"port\": 80,\r\n          \"intervalInSeconds\":
+        5,\r\n          \"numberOfProbes\": 2,\r\n          \"loadBalancingRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\":
+        [\r\n      {\r\n        \"name\": \"RDP-VM0\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0\",\r\n
+        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
+        \         },\r\n          \"frontendPort\": 50001,\r\n          \"backendPort\":
+        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
+        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
+        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1\"\r\n
+        \         }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"RDP-VM1\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1\",\r\n
+        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
+        \         },\r\n          \"frontendPort\": 50002,\r\n          \"backendPort\":
+        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
+        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
+        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1\"\r\n
+        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"outboundNatRules\":
+        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
+        \"Basic\"\r\n  }\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:27:15 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/non_existent_lb?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA5MzIsIm5iZiI6MTUyMDg2MDkzMiwiZXhwIjoxNTIwODY0ODMyLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRkFrM05rOHY4VU9OVmw0VmpzVXFBQSIsInZlciI6IjEuMCJ9.mNP_fcyGqvirg-gch_0gqMTkq6GfQsKJYWlu-tLV-aK6g_6NJPo9B4VM9tg_qRwhMb28-Cclixrg_u0pk2XwmYLHcOWHmw_WHOyqGFFglMG-sHX_VDBRXwSv2mjqkp43jdA0e4mZTg68NduEKev_voIdGn_CpOdmkOt7Q01iimz-aSv7m5JWIoZ8jiTgbW1okmkEyN2t7vAxPsqvVBsD6j-XXtvJ7XFmCPnPJ_kSIfioc5wW3FGyHlGjYD_uXZK1NxKEJMY0xAZSNytK83ZeFsE2MR8TKFrjOPya6VZN010Q3JVVPqYsD-Kme9UMpV5dIXoHbsqjnyfS7u1mKLEKWA
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      X-Ms-Failure-Cause:
+      - gateway
+      X-Ms-Request-Id:
+      - 87566e63-fe78-4859-b6bf-5de074d892d4
+      X-Ms-Correlation-Request-Id:
+      - 87566e63-fe78-4859-b6bf-5de074d892d4
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T132716Z:87566e63-fe78-4859-b6bf-5de074d892d4
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:27:15 GMT
+      Content-Length:
+      - '166'
+    body:
+      encoding: UTF-8
+      string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Network/loadBalancers/non_existent_lb''
+        under resource group ''miq-azure-test1'' was not found."}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:27:16 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed?api-version=2017-12-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA5MzIsIm5iZiI6MTUyMDg2MDkzMiwiZXhwIjoxNTIwODY0ODMyLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRkFrM05rOHY4VU9OVmw0VmpzVXFBQSIsInZlciI6IjEuMCJ9.mNP_fcyGqvirg-gch_0gqMTkq6GfQsKJYWlu-tLV-aK6g_6NJPo9B4VM9tg_qRwhMb28-Cclixrg_u0pk2XwmYLHcOWHmw_WHOyqGFFglMG-sHX_VDBRXwSv2mjqkp43jdA0e4mZTg68NduEKev_voIdGn_CpOdmkOt7Q01iimz-aSv7m5JWIoZ8jiTgbW1okmkEyN2t7vAxPsqvVBsD6j-XXtvJ7XFmCPnPJ_kSIfioc5wW3FGyHlGjYD_uXZK1NxKEJMY0xAZSNytK83ZeFsE2MR8TKFrjOPya6VZN010Q3JVVPqYsD-Kme9UMpV5dIXoHbsqjnyfS7u1mKLEKWA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/LowCostGet3Min;4791,Microsoft.Compute/LowCostGet30Min;38356
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      X-Ms-Request-Id:
+      - 13dfc59f-5a05-4fcc-8660-734c6b9a02ca
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Correlation-Request-Id:
+      - 5ba9d407-fec5-4dba-a494-e22af3bda328
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T132716Z:5ba9d407-fec5-4dba-a494-e22af3bda328
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:27:16 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"61b7c052-1d09-4898-b995-cce5676aaab0\",\r\n
+        \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Basic_A0\"\r\n    },\r\n
+        \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
+        \"RedHat\",\r\n        \"offer\": \"RHEL\",\r\n        \"sku\": \"7.3\",\r\n
+        \       \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
+        \"Linux\",\r\n        \"name\": \"miqazure-linux-managed_OsDisk_1_7b2bdf790a7d4379ace2846d307730cd\",\r\n
+        \       \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n
+        \       \"managedDisk\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/disks/miqazure-linux-managed_OsDisk_1_7b2bdf790a7d4379ace2846d307730cd\"\r\n
+        \       }\r\n      },\r\n      \"dataDisks\": [\r\n        {\r\n          \"lun\":
+        0,\r\n          \"name\": \"miqazure-linux-managed-data-disk\",\r\n          \"createOption\":
+        \"Attach\",\r\n          \"caching\": \"None\",\r\n          \"managedDisk\":
+        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/disks/miqazure-linux-managed-data-disk\"\r\n
+        \         }\r\n        }\r\n      ]\r\n    },\r\n    \"osProfile\": {\r\n
+        \     \"computerName\": \"miqazure-linux-managed\",\r\n      \"adminUsername\":
+        \"dberger\",\r\n      \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\":
+        false\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\":
+        {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944\"}]},\r\n
+        \   \"provisioningState\": \"Succeeded\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n
+        \ \"location\": \"eastus\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed\",\r\n
+        \ \"name\": \"miqazure-linux-managed\"\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:27:16 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1?api-version=2017-12-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA5MzIsIm5iZiI6MTUyMDg2MDkzMiwiZXhwIjoxNTIwODY0ODMyLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRkFrM05rOHY4VU9OVmw0VmpzVXFBQSIsInZlciI6IjEuMCJ9.mNP_fcyGqvirg-gch_0gqMTkq6GfQsKJYWlu-tLV-aK6g_6NJPo9B4VM9tg_qRwhMb28-Cclixrg_u0pk2XwmYLHcOWHmw_WHOyqGFFglMG-sHX_VDBRXwSv2mjqkp43jdA0e4mZTg68NduEKev_voIdGn_CpOdmkOt7Q01iimz-aSv7m5JWIoZ8jiTgbW1okmkEyN2t7vAxPsqvVBsD6j-XXtvJ7XFmCPnPJ_kSIfioc5wW3FGyHlGjYD_uXZK1NxKEJMY0xAZSNytK83ZeFsE2MR8TKFrjOPya6VZN010Q3JVVPqYsD-Kme9UMpV5dIXoHbsqjnyfS7u1mKLEKWA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/LowCostGet3Min;4790,Microsoft.Compute/LowCostGet30Min;38355
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      X-Ms-Request-Id:
+      - ff5454d3-b4ed-450f-b6eb-20b61f875824
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Correlation-Request-Id:
+      - d5f937d7-7807-4950-b871-8d5f72dd8693
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T132717Z:d5f937d7-7807-4950-b871-8d5f72dd8693
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:27:16 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"03e8467b-baab-4867-9cc4-157336b7e2e4\",\r\n
+        \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Basic_A0\"\r\n    },\r\n
+        \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
+        \"RedHat\",\r\n        \"offer\": \"RHEL\",\r\n        \"sku\": \"7.2\",\r\n
+        \       \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
+        \"Linux\",\r\n        \"name\": \"miq-test-rhel1\",\r\n        \"createOption\":
+        \"FromImage\",\r\n        \"vhd\": {\r\n          \"uri\": \"https://miqazuretest18686.blob.core.windows.net/vhds/miq-test-rhel12016218112243.vhd\"\r\n
+        \       },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n      \"dataDisks\":
+        []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"miq-test-rhel1\",\r\n
+        \     \"adminUsername\": \"dberger\",\r\n      \"linuxConfiguration\": {\r\n
+        \       \"disablePasswordAuthentication\": false\r\n      },\r\n      \"secrets\":
+        []\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390\"}]},\r\n
+        \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
+        true,\r\n        \"storageUri\": \"https://miqazuretest18686.blob.core.windows.net/\"\r\n
+        \     }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n
+        \ \"resources\": [\r\n    {\r\n      \"properties\": {\r\n        \"publisher\":
+        \"Microsoft.OSTCExtensions\",\r\n        \"type\": \"LinuxDiagnostic\",\r\n
+        \       \"typeHandlerVersion\": \"2.0\",\r\n        \"autoUpgradeMinorVersion\":
+        true,\r\n        \"settings\": {\"xmlCfg\":\"PFdhZENmZz48RGlhZ25vc3RpY01vbml0b3JDb25maWd1cmF0aW9uIG92ZXJhbGxRdW90YUluTUI9IjQwOTYiPjxEaWFnbm9zdGljSW5mcmFzdHJ1Y3R1cmVMb2dzIHNjaGVkdWxlZFRyYW5zZmVyUGVyaW9kPSJQVDFNIiBzY2hlZHVsZWRUcmFuc2ZlckxvZ0xldmVsRmlsdGVyPSJXYXJuaW5nIi8+PFBlcmZvcm1hbmNlQ291bnRlcnMgc2NoZWR1bGVkVHJhbnNmZXJQZXJpb2Q9IlBUMU0iPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlTWVtb3J5IiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQnl0ZXMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcUGVyY2VudEF2YWlsYWJsZU1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iTWVtb3J5IHVzZWQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50VXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgcGVyY2VudGFnZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkQnlDYWNoZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHVzZWQgYnkgY2FjaGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1BlclNlYyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50UGVyU2Vjb25kIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFnZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1JlYWRQZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2UgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1dyaXR0ZW5QZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2Ugd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iU3dhcCBhdmFpbGFibGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50QXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZFN3YXAiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlN3YXAgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRJZGxlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgaWRsZSB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFVzZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iUGVyY2VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkNQVSB1c2VyIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50TmljZVRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIG5pY2UgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRQcml2aWxlZ2VkVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgcHJpdmlsZWdlZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudEludGVycnVwdFRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIGludGVycnVwdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudERQQ1RpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIERQQyB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFByb2Nlc3NvclRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIHBlcmNlbnRhZ2UgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50SU9XYWl0VGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgSU8gd2FpdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xSZWFkQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCBndWVzdCBPUyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXFdyaXRlQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGUgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xUcmFuc2ZlcnNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXJzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcUmVhZHNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xXcml0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVJlYWRUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVdyaXRlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlNlY29uZHMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJEaXNrIHdyaXRlIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xBdmVyYWdlVHJhbnNmZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXIgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXEF2ZXJhZ2VEaXNrUXVldWVMZW5ndGgiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcXVldWUgbGVuZ3RoIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVHJhbnNtaXR0ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgb3V0IGd1ZXN0IE9TIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzUmVjZWl2ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgaW4gZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1RyYW5zbWl0dGVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHNlbnQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1JlY2VpdmVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHJlY2VpdmVkIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVG90YWwiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxSeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyByZWNlaXZlZCBlcnJvcnMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxUeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyBzZW50IGVycm9ycyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTmV0d29ya0ludGVyZmFjZVxUb3RhbENvbGxpc2lvbnMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgY29sbGlzaW9ucyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48L1BlcmZvcm1hbmNlQ291bnRlcnM+PE1ldHJpY3MgcmVzb3VyY2VJZD0iL3N1YnNjcmlwdGlvbnMvMjU4NmM2NGItMzhiNC00NTI3LWExNDAtMDEyZDQ5ZGZjMDJjL3Jlc291cmNlR3JvdXBzL21pcS1henVyZS10ZXN0MS9wcm92aWRlcnMvTWljcm9zb2Z0LkNvbXB1dGUvdmlydHVhbE1hY2hpbmVzL21pcS10ZXN0LXJoZWwxIj48TWV0cmljQWdncmVnYXRpb24gc2NoZWR1bGVkVHJhbnNmZXJQZXJpb2Q9IlBUMUgiLz48TWV0cmljQWdncmVnYXRpb24gc2NoZWR1bGVkVHJhbnNmZXJQZXJpb2Q9IlBUMU0iLz48L01ldHJpY3M+PC9EaWFnbm9zdGljTW9uaXRvckNvbmZpZ3VyYXRpb24+PC9XYWRDZmc+\",\"StorageAccount\":\"miqazuretest18686\"},\r\n
+        \       \"provisioningState\": \"Succeeded\"\r\n      },\r\n      \"type\":
+        \"Microsoft.Compute/virtualMachines/extensions\",\r\n      \"location\": \"eastus\",\r\n
+        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/extensions/Microsoft.Insights.VMDiagnosticsSettings\",\r\n
+        \     \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n    }\r\n
+        \ ],\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\":
+        \"eastus\",\r\n  \"tags\": {\r\n    \"Shutdown\": \"true\"\r\n  },\r\n  \"id\":
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1\",\r\n
+        \ \"name\": \"miq-test-rhel1\"\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:27:17 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1?api-version=2017-12-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA5MzIsIm5iZiI6MTUyMDg2MDkzMiwiZXhwIjoxNTIwODY0ODMyLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRkFrM05rOHY4VU9OVmw0VmpzVXFBQSIsInZlciI6IjEuMCJ9.mNP_fcyGqvirg-gch_0gqMTkq6GfQsKJYWlu-tLV-aK6g_6NJPo9B4VM9tg_qRwhMb28-Cclixrg_u0pk2XwmYLHcOWHmw_WHOyqGFFglMG-sHX_VDBRXwSv2mjqkp43jdA0e4mZTg68NduEKev_voIdGn_CpOdmkOt7Q01iimz-aSv7m5JWIoZ8jiTgbW1okmkEyN2t7vAxPsqvVBsD6j-XXtvJ7XFmCPnPJ_kSIfioc5wW3FGyHlGjYD_uXZK1NxKEJMY0xAZSNytK83ZeFsE2MR8TKFrjOPya6VZN010Q3JVVPqYsD-Kme9UMpV5dIXoHbsqjnyfS7u1mKLEKWA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/LowCostGet3Min;4789,Microsoft.Compute/LowCostGet30Min;38354
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      X-Ms-Request-Id:
+      - a52ba158-5f06-4958-9c09-7c09e4794337
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Correlation-Request-Id:
+      - 5e277f7a-0784-4868-8c90-322eb5928ff0
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T132718Z:5e277f7a-0784-4868-8c90-322eb5928ff0
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:27:17 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"796c5bcc-338a-448d-b61c-165279a7fb3e\",\r\n
+        \   \"availabilitySet\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/MIQAZURE-AVAILSET-EAST\"\r\n
+        \   },\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Basic_A0\"\r\n
+        \   },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
+        \"OpenLogic\",\r\n        \"offer\": \"CentOS\",\r\n        \"sku\": \"7.1\",\r\n
+        \       \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
+        \"Linux\",\r\n        \"name\": \"miqazure-centos1\",\r\n        \"createOption\":
+        \"FromImage\",\r\n        \"vhd\": {\r\n          \"uri\": \"https://miqazuretest14047.blob.core.windows.net/vhds/miqazure-centos12016221104946.vhd\"\r\n
+        \       },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n      \"dataDisks\":
+        []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"miqazure-centos1\",\r\n
+        \     \"adminUsername\": \"dberger\",\r\n      \"linuxConfiguration\": {\r\n
+        \       \"disablePasswordAuthentication\": false\r\n      },\r\n      \"secrets\":
+        []\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611\"}]},\r\n
+        \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
+        true,\r\n        \"storageUri\": \"https://miqazuretest14047.blob.core.windows.net/\"\r\n
+        \     }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n
+        \ \"resources\": [\r\n    {\r\n      \"properties\": {\r\n        \"publisher\":
+        \"Microsoft.OSTCExtensions\",\r\n        \"type\": \"LinuxDiagnostic\",\r\n
+        \       \"typeHandlerVersion\": \"2.0\",\r\n        \"autoUpgradeMinorVersion\":
+        true,\r\n        \"settings\": {\"xmlCfg\":\"PFdhZENmZz48RGlhZ25vc3RpY01vbml0b3JDb25maWd1cmF0aW9uIG92ZXJhbGxRdW90YUluTUI9IjQwOTYiPjxEaWFnbm9zdGljSW5mcmFzdHJ1Y3R1cmVMb2dzIHNjaGVkdWxlZFRyYW5zZmVyUGVyaW9kPSJQVDFNIiBzY2hlZHVsZWRUcmFuc2ZlckxvZ0xldmVsRmlsdGVyPSJXYXJuaW5nIi8+PFBlcmZvcm1hbmNlQ291bnRlcnMgc2NoZWR1bGVkVHJhbnNmZXJQZXJpb2Q9IlBUMU0iPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlTWVtb3J5IiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQnl0ZXMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcUGVyY2VudEF2YWlsYWJsZU1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iTWVtb3J5IHVzZWQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50VXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgcGVyY2VudGFnZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkQnlDYWNoZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHVzZWQgYnkgY2FjaGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1BlclNlYyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50UGVyU2Vjb25kIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFnZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1JlYWRQZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2UgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1dyaXR0ZW5QZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2Ugd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iU3dhcCBhdmFpbGFibGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50QXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZFN3YXAiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlN3YXAgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRJZGxlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgaWRsZSB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFVzZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iUGVyY2VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkNQVSB1c2VyIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50TmljZVRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIG5pY2UgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRQcml2aWxlZ2VkVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgcHJpdmlsZWdlZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudEludGVycnVwdFRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIGludGVycnVwdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudERQQ1RpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIERQQyB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFByb2Nlc3NvclRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIHBlcmNlbnRhZ2UgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50SU9XYWl0VGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgSU8gd2FpdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xSZWFkQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCBndWVzdCBPUyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXFdyaXRlQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGUgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xUcmFuc2ZlcnNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXJzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcUmVhZHNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xXcml0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVJlYWRUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVdyaXRlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlNlY29uZHMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJEaXNrIHdyaXRlIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xBdmVyYWdlVHJhbnNmZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXIgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXEF2ZXJhZ2VEaXNrUXVldWVMZW5ndGgiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcXVldWUgbGVuZ3RoIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVHJhbnNtaXR0ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgb3V0IGd1ZXN0IE9TIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzUmVjZWl2ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgaW4gZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1RyYW5zbWl0dGVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHNlbnQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1JlY2VpdmVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHJlY2VpdmVkIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVG90YWwiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxSeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyByZWNlaXZlZCBlcnJvcnMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxUeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyBzZW50IGVycm9ycyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTmV0d29ya0ludGVyZmFjZVxUb3RhbENvbGxpc2lvbnMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgY29sbGlzaW9ucyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48L1BlcmZvcm1hbmNlQ291bnRlcnM+PE1ldHJpY3MgcmVzb3VyY2VJZD0iL3N1YnNjcmlwdGlvbnMvMjU4NmM2NGItMzhiNC00NTI3LWExNDAtMDEyZDQ5ZGZjMDJjL3Jlc291cmNlR3JvdXBzL21pcS1henVyZS10ZXN0MS9wcm92aWRlcnMvTWljcm9zb2Z0LkNvbXB1dGUvdmlydHVhbE1hY2hpbmVzL21pcWF6dXJlLWNlbnRvczEiPjxNZXRyaWNBZ2dyZWdhdGlvbiBzY2hlZHVsZWRUcmFuc2ZlclBlcmlvZD0iUFQxSCIvPjxNZXRyaWNBZ2dyZWdhdGlvbiBzY2hlZHVsZWRUcmFuc2ZlclBlcmlvZD0iUFQxTSIvPjwvTWV0cmljcz48L0RpYWdub3N0aWNNb25pdG9yQ29uZmlndXJhdGlvbj48L1dhZENmZz4=\",\"StorageAccount\":\"miqazuretest14047\"},\r\n
+        \       \"provisioningState\": \"Succeeded\"\r\n      },\r\n      \"type\":
+        \"Microsoft.Compute/virtualMachines/extensions\",\r\n      \"location\": \"eastus\",\r\n
+        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1/extensions/Microsoft.Insights.VMDiagnosticsSettings\",\r\n
+        \     \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n    }\r\n
+        \ ],\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\":
+        \"eastus\",\r\n  \"tags\": {\r\n    \"Shutdown\": \"true\"\r\n  },\r\n  \"id\":
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1\",\r\n
+        \ \"name\": \"miqazure-centos1\"\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:27:18 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/non_existent_vm_that_does_not_exist?api-version=2017-12-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA5MzIsIm5iZiI6MTUyMDg2MDkzMiwiZXhwIjoxNTIwODY0ODMyLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRkFrM05rOHY4VU9OVmw0VmpzVXFBQSIsInZlciI6IjEuMCJ9.mNP_fcyGqvirg-gch_0gqMTkq6GfQsKJYWlu-tLV-aK6g_6NJPo9B4VM9tg_qRwhMb28-Cclixrg_u0pk2XwmYLHcOWHmw_WHOyqGFFglMG-sHX_VDBRXwSv2mjqkp43jdA0e4mZTg68NduEKev_voIdGn_CpOdmkOt7Q01iimz-aSv7m5JWIoZ8jiTgbW1okmkEyN2t7vAxPsqvVBsD6j-XXtvJ7XFmCPnPJ_kSIfioc5wW3FGyHlGjYD_uXZK1NxKEJMY0xAZSNytK83ZeFsE2MR8TKFrjOPya6VZN010Q3JVVPqYsD-Kme9UMpV5dIXoHbsqjnyfS7u1mKLEKWA
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      X-Ms-Failure-Cause:
+      - gateway
+      X-Ms-Request-Id:
+      - c16ca312-ac9b-41fd-960d-44fc0b2a8207
+      X-Ms-Correlation-Request-Id:
+      - c16ca312-ac9b-41fd-960d-44fc0b2a8207
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T132718Z:c16ca312-ac9b-41fd-960d-44fc0b2a8207
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:27:18 GMT
+      Content-Length:
+      - '188'
+    body:
+      encoding: UTF-8
+      string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Compute/virtualMachines/non_existent_vm_that_does_not_exist''
+        under resource group ''miq-azure-test4'' was not found."}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:27:18 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA5MzIsIm5iZiI6MTUyMDg2MDkzMiwiZXhwIjoxNTIwODY0ODMyLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRkFrM05rOHY4VU9OVmw0VmpzVXFBQSIsInZlciI6IjEuMCJ9.mNP_fcyGqvirg-gch_0gqMTkq6GfQsKJYWlu-tLV-aK6g_6NJPo9B4VM9tg_qRwhMb28-Cclixrg_u0pk2XwmYLHcOWHmw_WHOyqGFFglMG-sHX_VDBRXwSv2mjqkp43jdA0e4mZTg68NduEKev_voIdGn_CpOdmkOt7Q01iimz-aSv7m5JWIoZ8jiTgbW1okmkEyN2t7vAxPsqvVBsD6j-XXtvJ7XFmCPnPJ_kSIfioc5wW3FGyHlGjYD_uXZK1NxKEJMY0xAZSNytK83ZeFsE2MR8TKFrjOPya6VZN010Q3JVVPqYsD-Kme9UMpV5dIXoHbsqjnyfS7u1mKLEKWA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"b6339880-8ead-4c9e-b5c0-f38c4f8612d5"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 36c13426-ca2e-4c74-a934-4fe08b239c25
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Correlation-Request-Id:
+      - adacb33c-2ecf-4526-bc19-08bb5bae352a
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T132719Z:adacb33c-2ecf-4526-bc19-08bb5bae352a
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:27:18 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"miqazure-linux-manag944\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944\",\r\n
+        \ \"etag\": \"W/\\\"b6339880-8ead-4c9e-b5c0-f38c4f8612d5\\\"\",\r\n  \"location\":
+        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"c5e8b90e-5a78-49b0-b224-b70ed3fb45e5\",\r\n    \"ipConfigurations\":
+        [\r\n      {\r\n        \"name\": \"ipconfig1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944/ipConfigurations/ipconfig1\",\r\n
+        \       \"etag\": \"W/\\\"b6339880-8ead-4c9e-b5c0-f38c4f8612d5\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"privateIPAddress\": \"172.25.0.4\",\r\n          \"privateIPAllocationMethod\":
+        \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqazure-linux-managed-ip\"\r\n
+        \         },\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2/subnets/default\"\r\n
         \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
-        \"IPv4\",\r\n          \"loadBalancerBackendAddressPools\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\"\r\n
-        \           }\r\n          ],\r\n          \"loadBalancerInboundNatRules\":
-        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\":
-        {\r\n      \"dnsServers\": [],\r\n      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\":
-        \"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net\"\r\n    },\r\n    \"enableAcceleratedNetworking\":
+        \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\":
+        [],\r\n      \"appliedDnsServers\": []\r\n    },\r\n    \"enableAcceleratedNetworking\":
         false,\r\n    \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\":
-        {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg\"\r\n
+        {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg\"\r\n
         \   },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a\"\r\n
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed\"\r\n
         \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
         \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:17:28 GMT
+  recorded_at: Mon, 12 Mar 2018 13:27:19 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/non_existent?api-version=2018-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2602,7 +3001,59 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1NDMsIm5iZiI6MTUyMDQ1MzU0MywiZXhwIjoxNTIwNDU3NDQzLCJhaW8iOiJZMk5nWUtnVTcxZFYzaEY3dGlIOFI4YzcyODZyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQXVkZnZJVlNIRVN2R3lpN0gySUFBQSIsInZlciI6IjEuMCJ9.DIpJSVBILdjgWTsPUuSjfYAwOg3J39WtKpji-H2_QiIDtP9TwVbFGnsY0qCNBvHBZJiEuXbpkNkRR_y2XGl6TT7BJe6jR9wqMEM3514u4JpwBgWH2aCbnLTjOo8JdqbphalN38iEWVwiUH2p4k7G3zDvZM6LsO9UGllA4K_AfRYfBosdPxqJjWgH3ZfgbBMMIvY5Z-Lr8-Z_AE_erdyYmIRc2mzUpWbQWdgzmm-PjH1-TaP4yzKckX5lnY34x5NHv8Hw55wiWxTPrWliHDnXNg-PAubyLnXwHQqDJqOUyNjgaa26Ru8nhB5XSlpRR19x4NVnosl2DIOgtF63sHTbnw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA5MzIsIm5iZiI6MTUyMDg2MDkzMiwiZXhwIjoxNTIwODY0ODMyLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRkFrM05rOHY4VU9OVmw0VmpzVXFBQSIsInZlciI6IjEuMCJ9.mNP_fcyGqvirg-gch_0gqMTkq6GfQsKJYWlu-tLV-aK6g_6NJPo9B4VM9tg_qRwhMb28-Cclixrg_u0pk2XwmYLHcOWHmw_WHOyqGFFglMG-sHX_VDBRXwSv2mjqkp43jdA0e4mZTg68NduEKev_voIdGn_CpOdmkOt7Q01iimz-aSv7m5JWIoZ8jiTgbW1okmkEyN2t7vAxPsqvVBsD6j-XXtvJ7XFmCPnPJ_kSIfioc5wW3FGyHlGjYD_uXZK1NxKEJMY0xAZSNytK83ZeFsE2MR8TKFrjOPya6VZN010Q3JVVPqYsD-Kme9UMpV5dIXoHbsqjnyfS7u1mKLEKWA
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      X-Ms-Failure-Cause:
+      - gateway
+      X-Ms-Request-Id:
+      - c3f744c4-954f-412f-9750-0412457d704d
+      X-Ms-Correlation-Request-Id:
+      - c3f744c4-954f-412f-9750-0412457d704d
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T132720Z:c3f744c4-954f-412f-9750-0412457d704d
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:27:20 GMT
+      Content-Length:
+      - '167'
+    body:
+      encoding: UTF-8
+      string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Network/networkInterfaces/non_existent''
+        under resource group ''miq-azure-test4'' was not found."}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:27:20 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA5MzIsIm5iZiI6MTUyMDg2MDkzMiwiZXhwIjoxNTIwODY0ODMyLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRkFrM05rOHY4VU9OVmw0VmpzVXFBQSIsInZlciI6IjEuMCJ9.mNP_fcyGqvirg-gch_0gqMTkq6GfQsKJYWlu-tLV-aK6g_6NJPo9B4VM9tg_qRwhMb28-Cclixrg_u0pk2XwmYLHcOWHmw_WHOyqGFFglMG-sHX_VDBRXwSv2mjqkp43jdA0e4mZTg68NduEKev_voIdGn_CpOdmkOt7Q01iimz-aSv7m5JWIoZ8jiTgbW1okmkEyN2t7vAxPsqvVBsD6j-XXtvJ7XFmCPnPJ_kSIfioc5wW3FGyHlGjYD_uXZK1NxKEJMY0xAZSNytK83ZeFsE2MR8TKFrjOPya6VZN010Q3JVVPqYsD-Kme9UMpV5dIXoHbsqjnyfS7u1mKLEKWA
   response:
     status:
       code: 200
@@ -2619,51 +3070,413 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"76aabe0c-8678-43f0-81a5-2f15784a4b99"
+      - W/"f006e6f9-0292-42cd-99fc-f72f194553c1"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 5d411c39-aa9e-4576-8163-9417113dc013
+      - 1f63aa4f-0065-45ef-8033-49df3589119f
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14981'
+      - '14995'
       X-Ms-Correlation-Request-Id:
-      - 6da87caf-1acb-42cd-9a69-ad311513e12d
+      - 9c81dc47-1d2a-4ff7-b471-09cc62089913
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201728Z:6da87caf-1acb-42cd-9a69-ad311513e12d
+      - WESTEUROPE:20180312T132721Z:9c81dc47-1d2a-4ff7-b471-09cc62089913
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:17:28 GMT
+      - Mon, 12 Mar 2018 13:27:20 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb-b843\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843\",\r\n
-        \ \"etag\": \"W/\\\"76aabe0c-8678-43f0-81a5-2f15784a4b99\\\"\",\r\n  \"location\":
+      string: "{\r\n  \"name\": \"miq-test-rhel1390\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390\",\r\n
+        \ \"etag\": \"W/\\\"f006e6f9-0292-42cd-99fc-f72f194553c1\\\"\",\r\n  \"location\":
         \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"3ef6fa01-ac34-43a1-8fd7-67c706b4d8ef\",\r\n    \"ipConfigurations\":
-        [\r\n      {\r\n        \"name\": \"ipconfig1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\",\r\n
-        \       \"etag\": \"W/\\\"76aabe0c-8678-43f0-81a5-2f15784a4b99\\\"\",\r\n
+        \   \"resourceGuid\": \"98853f48-2806-4065-be57-cf9159550440\",\r\n    \"ipConfigurations\":
+        [\r\n      {\r\n        \"name\": \"ipconfig1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1\",\r\n
+        \       \"etag\": \"W/\\\"f006e6f9-0292-42cd-99fc-f72f194553c1\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAddress\": \"10.16.0.11\",\r\n          \"privateIPAllocationMethod\":
-        \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-b-ip\"\r\n
+        \         \"privateIPAddress\": \"10.16.0.4\",\r\n          \"privateIPAllocationMethod\":
+        \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1\"\r\n
         \         },\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\"\r\n
         \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
-        \"IPv4\",\r\n          \"loadBalancerBackendAddressPools\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\":
-        {\r\n      \"dnsServers\": [],\r\n      \"appliedDnsServers\": []\r\n    },\r\n
-        \   \"enableAcceleratedNetworking\": false,\r\n    \"enableIPForwarding\":
-        false,\r\n    \"networkSecurityGroup\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg\"\r\n
+        \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\":
+        [],\r\n      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\":
+        \"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net\"\r\n    },\r\n    \"macAddress\":
+        \"00-0D-3A-10-EB-AB\",\r\n    \"enableAcceleratedNetworking\": false,\r\n
+        \   \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\": {\r\n
+        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1\"\r\n
         \   },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b\"\r\n
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1\"\r\n
         \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
         \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:17:29 GMT
+  recorded_at: Mon, 12 Mar 2018 13:27:21 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA5MzIsIm5iZiI6MTUyMDg2MDkzMiwiZXhwIjoxNTIwODY0ODMyLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRkFrM05rOHY4VU9OVmw0VmpzVXFBQSIsInZlciI6IjEuMCJ9.mNP_fcyGqvirg-gch_0gqMTkq6GfQsKJYWlu-tLV-aK6g_6NJPo9B4VM9tg_qRwhMb28-Cclixrg_u0pk2XwmYLHcOWHmw_WHOyqGFFglMG-sHX_VDBRXwSv2mjqkp43jdA0e4mZTg68NduEKev_voIdGn_CpOdmkOt7Q01iimz-aSv7m5JWIoZ8jiTgbW1okmkEyN2t7vAxPsqvVBsD6j-XXtvJ7XFmCPnPJ_kSIfioc5wW3FGyHlGjYD_uXZK1NxKEJMY0xAZSNytK83ZeFsE2MR8TKFrjOPya6VZN010Q3JVVPqYsD-Kme9UMpV5dIXoHbsqjnyfS7u1mKLEKWA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"26031ef6-bb55-4019-8185-2dd1edcb207c"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 45e8832f-2f39-406a-89f8-4a402c8a3880
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Correlation-Request-Id:
+      - 131540bf-bbd5-4435-a2f8-44e18701dd55
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T132721Z:131540bf-bbd5-4435-a2f8-44e18701dd55
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:27:20 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"miqazure-centos1611\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611\",\r\n
+        \ \"etag\": \"W/\\\"26031ef6-bb55-4019-8185-2dd1edcb207c\\\"\",\r\n  \"location\":
+        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"f1760e49-9853-4fdc-acfc-4ea232b9ed76\",\r\n    \"ipConfigurations\":
+        [\r\n      {\r\n        \"name\": \"ipconfig1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1\",\r\n
+        \       \"etag\": \"W/\\\"26031ef6-bb55-4019-8185-2dd1edcb207c\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"privateIPAddress\": \"10.16.0.5\",\r\n          \"privateIPAllocationMethod\":
+        \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1\"\r\n
+        \         },\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\"\r\n
+        \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
+        \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\":
+        [],\r\n      \"appliedDnsServers\": []\r\n    },\r\n    \"enableAcceleratedNetworking\":
+        false,\r\n    \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\":
+        {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1\"\r\n
+        \   },\r\n    \"virtualMachine\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1\"\r\n
+        \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
+        \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:27:21 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed/instanceView?api-version=2017-12-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA5MzIsIm5iZiI6MTUyMDg2MDkzMiwiZXhwIjoxNTIwODY0ODMyLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRkFrM05rOHY4VU9OVmw0VmpzVXFBQSIsInZlciI6IjEuMCJ9.mNP_fcyGqvirg-gch_0gqMTkq6GfQsKJYWlu-tLV-aK6g_6NJPo9B4VM9tg_qRwhMb28-Cclixrg_u0pk2XwmYLHcOWHmw_WHOyqGFFglMG-sHX_VDBRXwSv2mjqkp43jdA0e4mZTg68NduEKev_voIdGn_CpOdmkOt7Q01iimz-aSv7m5JWIoZ8jiTgbW1okmkEyN2t7vAxPsqvVBsD6j-XXtvJ7XFmCPnPJ_kSIfioc5wW3FGyHlGjYD_uXZK1NxKEJMY0xAZSNytK83ZeFsE2MR8TKFrjOPya6VZN010Q3JVVPqYsD-Kme9UMpV5dIXoHbsqjnyfS7u1mKLEKWA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/GetInstanceView3Min;4796,Microsoft.Compute/GetInstanceView30Min;23846
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      X-Ms-Request-Id:
+      - 8a323ffd-65d5-481f-bdb7-aa92f40e7cec
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Correlation-Request-Id:
+      - 82b1140c-4ec3-41c5-9b73-6a2b5c86479c
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T132728Z:82b1140c-4ec3-41c5-9b73-6a2b5c86479c
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:27:28 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"miqazure-linux-managed_OsDisk_1_7b2bdf790a7d4379ace2846d307730cd\",\r\n
+        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
+        succeeded\",\r\n          \"time\": \"2018-01-23T20:06:17.9818931+00:00\"\r\n
+        \       }\r\n      ]\r\n    },\r\n    {\r\n      \"name\": \"miqazure-linux-managed-data-disk\",\r\n
+        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
+        succeeded\",\r\n          \"time\": \"2018-01-23T20:06:17.9818931+00:00\"\r\n
+        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\":
+        \"ProvisioningState/succeeded\",\r\n      \"level\": \"Info\",\r\n      \"displayStatus\":
+        \"Provisioning succeeded\",\r\n      \"time\": \"2018-01-23T20:06:17.9975145+00:00\"\r\n
+        \   },\r\n    {\r\n      \"code\": \"PowerState/deallocated\",\r\n      \"level\":
+        \"Info\",\r\n      \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:27:28 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/instanceView?api-version=2017-12-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA5MzIsIm5iZiI6MTUyMDg2MDkzMiwiZXhwIjoxNTIwODY0ODMyLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRkFrM05rOHY4VU9OVmw0VmpzVXFBQSIsInZlciI6IjEuMCJ9.mNP_fcyGqvirg-gch_0gqMTkq6GfQsKJYWlu-tLV-aK6g_6NJPo9B4VM9tg_qRwhMb28-Cclixrg_u0pk2XwmYLHcOWHmw_WHOyqGFFglMG-sHX_VDBRXwSv2mjqkp43jdA0e4mZTg68NduEKev_voIdGn_CpOdmkOt7Q01iimz-aSv7m5JWIoZ8jiTgbW1okmkEyN2t7vAxPsqvVBsD6j-XXtvJ7XFmCPnPJ_kSIfioc5wW3FGyHlGjYD_uXZK1NxKEJMY0xAZSNytK83ZeFsE2MR8TKFrjOPya6VZN010Q3JVVPqYsD-Kme9UMpV5dIXoHbsqjnyfS7u1mKLEKWA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/GetInstanceView3Min;4795,Microsoft.Compute/GetInstanceView30Min;23845
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      X-Ms-Request-Id:
+      - 4ca570b3-b3ff-4ae4-a215-6b9f7e6e77fa
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Correlation-Request-Id:
+      - 8a1b0aa1-42aa-4343-80c9-d581741ca18c
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T132741Z:8a1b0aa1-42aa-4343-80c9-d581741ca18c
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:27:41 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"vmAgent\": {\r\n    \"vmAgentVersion\": \"WALinuxAgent-2.0.16\",\r\n
+        \   \"statuses\": [\r\n      {\r\n        \"code\": \"ProvisioningState/succeeded\",\r\n
+        \       \"level\": \"Info\",\r\n        \"displayStatus\": \"Ready\",\r\n
+        \       \"message\": \"GuestAgent is running and accepting new configurations.\",\r\n
+        \       \"time\": \"2018-03-12T13:27:10+00:00\"\r\n      }\r\n    ],\r\n    \"extensionHandlers\":
+        [\r\n      {\r\n        \"type\": \"Microsoft.OSTCExtensions.LinuxDiagnostic\",\r\n
+        \       \"typeHandlerVersion\": \"2.3.9027\",\r\n        \"status\": {\r\n
+        \         \"code\": \"ProvisioningState/succeeded\",\r\n          \"level\":
+        \"Info\",\r\n          \"displayStatus\": \"Ready\"\r\n        }\r\n      }\r\n
+        \   ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"miq-test-rhel1\",\r\n
+        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
+        succeeded\",\r\n          \"time\": \"2018-01-17T18:00:29.9011002+00:00\"\r\n
+        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
+        \"https://miqazuretest18686.blob.core.windows.net/bootdiagnostics-miqtestrh-03e8467b-baab-4867-9cc4-157336b7e2e4/miq-test-rhel1.03e8467b-baab-4867-9cc4-157336b7e2e4.screenshot.bmp\",\r\n
+        \   \"serialConsoleLogBlobUri\": \"https://miqazuretest18686.blob.core.windows.net/bootdiagnostics-miqtestrh-03e8467b-baab-4867-9cc4-157336b7e2e4/miq-test-rhel1.03e8467b-baab-4867-9cc4-157336b7e2e4.serialconsole.log\"\r\n
+        \ },\r\n  \"extensions\": [\r\n    {\r\n      \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\",\r\n
+        \     \"type\": \"Microsoft.OSTCExtensions.LinuxDiagnostic\",\r\n      \"typeHandlerVersion\":
+        \"2.3.9027\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\":
+        \"ProvisioningState/succeeded\",\r\n          \"level\": \"Info\",\r\n          \"displayStatus\":
+        \"Provisioning succeeded\",\r\n          \"message\": \"Enable succeeded\"\r\n
+        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\":
+        \"ProvisioningState/succeeded\",\r\n      \"level\": \"Info\",\r\n      \"displayStatus\":
+        \"Provisioning succeeded\",\r\n      \"time\": \"2018-01-17T18:02:26.9167163+00:00\"\r\n
+        \   },\r\n    {\r\n      \"code\": \"PowerState/running\",\r\n      \"level\":
+        \"Info\",\r\n      \"displayStatus\": \"VM running\"\r\n    }\r\n  ]\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:27:41 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1/instanceView?api-version=2017-12-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA5MzIsIm5iZiI6MTUyMDg2MDkzMiwiZXhwIjoxNTIwODY0ODMyLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRkFrM05rOHY4VU9OVmw0VmpzVXFBQSIsInZlciI6IjEuMCJ9.mNP_fcyGqvirg-gch_0gqMTkq6GfQsKJYWlu-tLV-aK6g_6NJPo9B4VM9tg_qRwhMb28-Cclixrg_u0pk2XwmYLHcOWHmw_WHOyqGFFglMG-sHX_VDBRXwSv2mjqkp43jdA0e4mZTg68NduEKev_voIdGn_CpOdmkOt7Q01iimz-aSv7m5JWIoZ8jiTgbW1okmkEyN2t7vAxPsqvVBsD6j-XXtvJ7XFmCPnPJ_kSIfioc5wW3FGyHlGjYD_uXZK1NxKEJMY0xAZSNytK83ZeFsE2MR8TKFrjOPya6VZN010Q3JVVPqYsD-Kme9UMpV5dIXoHbsqjnyfS7u1mKLEKWA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/GetInstanceView3Min;4794,Microsoft.Compute/GetInstanceView30Min;23844
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      X-Ms-Request-Id:
+      - 43ea2123-1766-40aa-8cd2-cd347e3dcc5f
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Correlation-Request-Id:
+      - b1ed33b5-c22d-4d72-bd1d-232bb90e86d7
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T132742Z:b1ed33b5-c22d-4d72-bd1d-232bb90e86d7
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:27:42 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"platformUpdateDomain\": 0,\r\n  \"platformFaultDomain\": 0,\r\n
+        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
+        [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
+        \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
+        \"Failed to fetch the VM status.\",\r\n        \"time\": \"2018-03-12T13:27:42+00:00\"\r\n
+        \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"miqazure-centos1\",\r\n
+        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
+        succeeded\",\r\n          \"time\": \"2016-06-22T21:18:47.2011229+00:00\"\r\n
+        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
+        \"https://miqazuretest14047.blob.core.windows.net/bootdiagnostics-miqazurec-796c5bcc-338a-448d-b61c-165279a7fb3e/miqazure-centos1.796c5bcc-338a-448d-b61c-165279a7fb3e.screenshot.bmp\",\r\n
+        \   \"serialConsoleLogBlobUri\": \"https://miqazuretest14047.blob.core.windows.net/bootdiagnostics-miqazurec-796c5bcc-338a-448d-b61c-165279a7fb3e/miqazure-centos1.796c5bcc-338a-448d-b61c-165279a7fb3e.serialconsole.log\"\r\n
+        \ },\r\n  \"extensions\": [\r\n    {\r\n      \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n
+        \   }\r\n  ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n
+        \     \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n
+        \     \"time\": \"2016-06-22T21:18:47.2636196+00:00\"\r\n    },\r\n    {\r\n
+        \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
+        \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:27:42 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups/miq-azure-test4?api-version=2017-08-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA5MzIsIm5iZiI6MTUyMDg2MDkzMiwiZXhwIjoxNTIwODY0ODMyLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRkFrM05rOHY4VU9OVmw0VmpzVXFBQSIsInZlciI6IjEuMCJ9.mNP_fcyGqvirg-gch_0gqMTkq6GfQsKJYWlu-tLV-aK6g_6NJPo9B4VM9tg_qRwhMb28-Cclixrg_u0pk2XwmYLHcOWHmw_WHOyqGFFglMG-sHX_VDBRXwSv2mjqkp43jdA0e4mZTg68NduEKev_voIdGn_CpOdmkOt7Q01iimz-aSv7m5JWIoZ8jiTgbW1okmkEyN2t7vAxPsqvVBsD6j-XXtvJ7XFmCPnPJ_kSIfioc5wW3FGyHlGjYD_uXZK1NxKEJMY0xAZSNytK83ZeFsE2MR8TKFrjOPya6VZN010Q3JVVPqYsD-Kme9UMpV5dIXoHbsqjnyfS7u1mKLEKWA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Request-Id:
+      - a6240a31-d3ab-4f81-a7b0-a4d6ce2daf74
+      X-Ms-Correlation-Request-Id:
+      - a6240a31-d3ab-4f81-a7b0-a4d6ce2daf74
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T132743Z:a6240a31-d3ab-4f81-a7b0-a4d6ce2daf74
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:27:43 GMT
+      Content-Length:
+      - '183'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4","name":"miq-azure-test4","location":"eastus","properties":{"provisioningState":"Succeeded"}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:27:43 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups/miq-azure-test1?api-version=2017-08-01
@@ -2680,7 +3493,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1NDMsIm5iZiI6MTUyMDQ1MzU0MywiZXhwIjoxNTIwNDU3NDQzLCJhaW8iOiJZMk5nWUtnVTcxZFYzaEY3dGlIOFI4YzcyODZyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQXVkZnZJVlNIRVN2R3lpN0gySUFBQSIsInZlciI6IjEuMCJ9.DIpJSVBILdjgWTsPUuSjfYAwOg3J39WtKpji-H2_QiIDtP9TwVbFGnsY0qCNBvHBZJiEuXbpkNkRR_y2XGl6TT7BJe6jR9wqMEM3514u4JpwBgWH2aCbnLTjOo8JdqbphalN38iEWVwiUH2p4k7G3zDvZM6LsO9UGllA4K_AfRYfBosdPxqJjWgH3ZfgbBMMIvY5Z-Lr8-Z_AE_erdyYmIRc2mzUpWbQWdgzmm-PjH1-TaP4yzKckX5lnY34x5NHv8Hw55wiWxTPrWliHDnXNg-PAubyLnXwHQqDJqOUyNjgaa26Ru8nhB5XSlpRR19x4NVnosl2DIOgtF63sHTbnw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA5MzIsIm5iZiI6MTUyMDg2MDkzMiwiZXhwIjoxNTIwODY0ODMyLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRkFrM05rOHY4VU9OVmw0VmpzVXFBQSIsInZlciI6IjEuMCJ9.mNP_fcyGqvirg-gch_0gqMTkq6GfQsKJYWlu-tLV-aK6g_6NJPo9B4VM9tg_qRwhMb28-Cclixrg_u0pk2XwmYLHcOWHmw_WHOyqGFFglMG-sHX_VDBRXwSv2mjqkp43jdA0e4mZTg68NduEKev_voIdGn_CpOdmkOt7Q01iimz-aSv7m5JWIoZ8jiTgbW1okmkEyN2t7vAxPsqvVBsD6j-XXtvJ7XFmCPnPJ_kSIfioc5wW3FGyHlGjYD_uXZK1NxKEJMY0xAZSNytK83ZeFsE2MR8TKFrjOPya6VZN010Q3JVVPqYsD-Kme9UMpV5dIXoHbsqjnyfS7u1mKLEKWA
   response:
     status:
       code: 200
@@ -2697,26 +3510,79 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14984'
+      - '14996'
       X-Ms-Request-Id:
-      - b5e832b0-dbf3-42d7-ad05-bbeb860d3d5d
+      - 99f0b48d-2a20-4b8d-a7fc-1db628b6e276
       X-Ms-Correlation-Request-Id:
-      - b5e832b0-dbf3-42d7-ad05-bbeb860d3d5d
+      - 99f0b48d-2a20-4b8d-a7fc-1db628b6e276
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201729Z:b5e832b0-dbf3-42d7-ad05-bbeb860d3d5d
+      - WESTEUROPE:20180312T132743Z:99f0b48d-2a20-4b8d-a7fc-1db628b6e276
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:17:29 GMT
+      - Mon, 12 Mar 2018 13:27:42 GMT
       Content-Length:
       - '183'
     body:
       encoding: ASCII-8BIT
       string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1","name":"miq-azure-test1","location":"eastus","properties":{"provisioningState":"Succeeded"}}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:17:29 GMT
+  recorded_at: Mon, 12 Mar 2018 13:27:43 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups/miq-azure-test4?api-version=2017-08-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA5MzIsIm5iZiI6MTUyMDg2MDkzMiwiZXhwIjoxNTIwODY0ODMyLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRkFrM05rOHY4VU9OVmw0VmpzVXFBQSIsInZlciI6IjEuMCJ9.mNP_fcyGqvirg-gch_0gqMTkq6GfQsKJYWlu-tLV-aK6g_6NJPo9B4VM9tg_qRwhMb28-Cclixrg_u0pk2XwmYLHcOWHmw_WHOyqGFFglMG-sHX_VDBRXwSv2mjqkp43jdA0e4mZTg68NduEKev_voIdGn_CpOdmkOt7Q01iimz-aSv7m5JWIoZ8jiTgbW1okmkEyN2t7vAxPsqvVBsD6j-XXtvJ7XFmCPnPJ_kSIfioc5wW3FGyHlGjYD_uXZK1NxKEJMY0xAZSNytK83ZeFsE2MR8TKFrjOPya6VZN010Q3JVVPqYsD-Kme9UMpV5dIXoHbsqjnyfS7u1mKLEKWA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Request-Id:
+      - fc7b8113-acaa-4ecb-9444-ecb387bb7e54
+      X-Ms-Correlation-Request-Id:
+      - fc7b8113-acaa-4ecb-9444-ecb387bb7e54
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T132743Z:fc7b8113-acaa-4ecb-9444-ecb387bb7e54
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:27:43 GMT
+      Content-Length:
+      - '183'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4","name":"miq-azure-test4","location":"eastus","properties":{"provisioningState":"Succeeded"}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:27:43 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute/locations/eastus/vmSizes?api-version=2017-12-01
@@ -2733,7 +3599,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1NDMsIm5iZiI6MTUyMDQ1MzU0MywiZXhwIjoxNTIwNDU3NDQzLCJhaW8iOiJZMk5nWUtnVTcxZFYzaEY3dGlIOFI4YzcyODZyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQXVkZnZJVlNIRVN2R3lpN0gySUFBQSIsInZlciI6IjEuMCJ9.DIpJSVBILdjgWTsPUuSjfYAwOg3J39WtKpji-H2_QiIDtP9TwVbFGnsY0qCNBvHBZJiEuXbpkNkRR_y2XGl6TT7BJe6jR9wqMEM3514u4JpwBgWH2aCbnLTjOo8JdqbphalN38iEWVwiUH2p4k7G3zDvZM6LsO9UGllA4K_AfRYfBosdPxqJjWgH3ZfgbBMMIvY5Z-Lr8-Z_AE_erdyYmIRc2mzUpWbQWdgzmm-PjH1-TaP4yzKckX5lnY34x5NHv8Hw55wiWxTPrWliHDnXNg-PAubyLnXwHQqDJqOUyNjgaa26Ru8nhB5XSlpRR19x4NVnosl2DIOgtF63sHTbnw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA5MzIsIm5iZiI6MTUyMDg2MDkzMiwiZXhwIjoxNTIwODY0ODMyLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRkFrM05rOHY4VU9OVmw0VmpzVXFBQSIsInZlciI6IjEuMCJ9.mNP_fcyGqvirg-gch_0gqMTkq6GfQsKJYWlu-tLV-aK6g_6NJPo9B4VM9tg_qRwhMb28-Cclixrg_u0pk2XwmYLHcOWHmw_WHOyqGFFglMG-sHX_VDBRXwSv2mjqkp43jdA0e4mZTg68NduEKev_voIdGn_CpOdmkOt7Q01iimz-aSv7m5JWIoZ8jiTgbW1okmkEyN2t7vAxPsqvVBsD6j-XXtvJ7XFmCPnPJ_kSIfioc5wW3FGyHlGjYD_uXZK1NxKEJMY0xAZSNytK83ZeFsE2MR8TKFrjOPya6VZN010Q3JVVPqYsD-Kme9UMpV5dIXoHbsqjnyfS7u1mKLEKWA
   response:
     status:
       code: 200
@@ -2752,26 +3618,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/LowCostGet3Min;4729,Microsoft.Compute/LowCostGet30Min;37893
+      - Microsoft.Compute/LowCostGet3Min;4785,Microsoft.Compute/LowCostGet30Min;38349
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
       - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
       X-Ms-Request-Id:
-      - 903e96fd-db0b-4ad7-bc33-191c515a2de6
+      - f481b08a-f448-46e1-82c3-eb8af220da53
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - '14995'
       X-Ms-Correlation-Request-Id:
-      - 558ba8f0-ef23-4512-8723-608595f2822f
+      - 16a50c58-ca66-4d77-bd4e-65ed419541f1
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201730Z:558ba8f0-ef23-4512-8723-608595f2822f
+      - WESTEUROPE:20180312T132744Z:16a50c58-ca66-4d77-bd4e-65ed419541f1
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:17:29 GMT
+      - Mon, 12 Mar 2018 13:27:44 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"Standard_B1ms\",\r\n
@@ -3248,6 +4114,12 @@ http_interactions:
         \   },\r\n    {\r\n      \"name\": \"Standard_F72s_v2\",\r\n      \"numberOfCores\":
         72,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
         589824,\r\n      \"memoryInMB\": 147456,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_L8s_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1811981,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_L16s_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        3623962,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
         \   },\r\n    {\r\n      \"name\": \"Standard_ND6s\",\r\n      \"numberOfCores\":
         6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
         344064,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 12\r\n
@@ -3274,10 +4146,10 @@ http_interactions:
         391168,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
         \   }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:17:30 GMT
+  recorded_at: Mon, 12 Mar 2018 13:27:44 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/non_existent?api-version=2017-08-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3291,7 +4163,378 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1NDMsIm5iZiI6MTUyMDQ1MzU0MywiZXhwIjoxNTIwNDU3NDQzLCJhaW8iOiJZMk5nWUtnVTcxZFYzaEY3dGlIOFI4YzcyODZyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQXVkZnZJVlNIRVN2R3lpN0gySUFBQSIsInZlciI6IjEuMCJ9.DIpJSVBILdjgWTsPUuSjfYAwOg3J39WtKpji-H2_QiIDtP9TwVbFGnsY0qCNBvHBZJiEuXbpkNkRR_y2XGl6TT7BJe6jR9wqMEM3514u4JpwBgWH2aCbnLTjOo8JdqbphalN38iEWVwiUH2p4k7G3zDvZM6LsO9UGllA4K_AfRYfBosdPxqJjWgH3ZfgbBMMIvY5Z-Lr8-Z_AE_erdyYmIRc2mzUpWbQWdgzmm-PjH1-TaP4yzKckX5lnY34x5NHv8Hw55wiWxTPrWliHDnXNg-PAubyLnXwHQqDJqOUyNjgaa26Ru8nhB5XSlpRR19x4NVnosl2DIOgtF63sHTbnw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA5MzIsIm5iZiI6MTUyMDg2MDkzMiwiZXhwIjoxNTIwODY0ODMyLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRkFrM05rOHY4VU9OVmw0VmpzVXFBQSIsInZlciI6IjEuMCJ9.mNP_fcyGqvirg-gch_0gqMTkq6GfQsKJYWlu-tLV-aK6g_6NJPo9B4VM9tg_qRwhMb28-Cclixrg_u0pk2XwmYLHcOWHmw_WHOyqGFFglMG-sHX_VDBRXwSv2mjqkp43jdA0e4mZTg68NduEKev_voIdGn_CpOdmkOt7Q01iimz-aSv7m5JWIoZ8jiTgbW1okmkEyN2t7vAxPsqvVBsD6j-XXtvJ7XFmCPnPJ_kSIfioc5wW3FGyHlGjYD_uXZK1NxKEJMY0xAZSNytK83ZeFsE2MR8TKFrjOPya6VZN010Q3JVVPqYsD-Kme9UMpV5dIXoHbsqjnyfS7u1mKLEKWA
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      X-Ms-Failure-Cause:
+      - gateway
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Request-Id:
+      - c9e0d42c-b1be-432f-8ed3-bab900bd4487
+      X-Ms-Correlation-Request-Id:
+      - c9e0d42c-b1be-432f-8ed3-bab900bd4487
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T132745Z:c9e0d42c-b1be-432f-8ed3-bab900bd4487
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:27:45 GMT
+      Content-Length:
+      - '97'
+    body:
+      encoding: UTF-8
+      string: '{"error":{"code":"DeploymentNotFound","message":"Deployment ''non_existent''
+        could not be found."}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:27:45 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/non_existent?api-version=2017-08-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA5MzIsIm5iZiI6MTUyMDg2MDkzMiwiZXhwIjoxNTIwODY0ODMyLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRkFrM05rOHY4VU9OVmw0VmpzVXFBQSIsInZlciI6IjEuMCJ9.mNP_fcyGqvirg-gch_0gqMTkq6GfQsKJYWlu-tLV-aK6g_6NJPo9B4VM9tg_qRwhMb28-Cclixrg_u0pk2XwmYLHcOWHmw_WHOyqGFFglMG-sHX_VDBRXwSv2mjqkp43jdA0e4mZTg68NduEKev_voIdGn_CpOdmkOt7Q01iimz-aSv7m5JWIoZ8jiTgbW1okmkEyN2t7vAxPsqvVBsD6j-XXtvJ7XFmCPnPJ_kSIfioc5wW3FGyHlGjYD_uXZK1NxKEJMY0xAZSNytK83ZeFsE2MR8TKFrjOPya6VZN010Q3JVVPqYsD-Kme9UMpV5dIXoHbsqjnyfS7u1mKLEKWA
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      X-Ms-Failure-Cause:
+      - gateway
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Request-Id:
+      - 3639cfa5-5e0a-41b9-bc24-7c6648ce2679
+      X-Ms-Correlation-Request-Id:
+      - 3639cfa5-5e0a-41b9-bc24-7c6648ce2679
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T132745Z:3639cfa5-5e0a-41b9-bc24-7c6648ce2679
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:27:45 GMT
+      Content-Length:
+      - '97'
+    body:
+      encoding: UTF-8
+      string: '{"error":{"code":"DeploymentNotFound","message":"Deployment ''non_existent''
+        could not be found."}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:27:46 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA5MzIsIm5iZiI6MTUyMDg2MDkzMiwiZXhwIjoxNTIwODY0ODMyLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRkFrM05rOHY4VU9OVmw0VmpzVXFBQSIsInZlciI6IjEuMCJ9.mNP_fcyGqvirg-gch_0gqMTkq6GfQsKJYWlu-tLV-aK6g_6NJPo9B4VM9tg_qRwhMb28-Cclixrg_u0pk2XwmYLHcOWHmw_WHOyqGFFglMG-sHX_VDBRXwSv2mjqkp43jdA0e4mZTg68NduEKev_voIdGn_CpOdmkOt7Q01iimz-aSv7m5JWIoZ8jiTgbW1okmkEyN2t7vAxPsqvVBsD6j-XXtvJ7XFmCPnPJ_kSIfioc5wW3FGyHlGjYD_uXZK1NxKEJMY0xAZSNytK83ZeFsE2MR8TKFrjOPya6VZN010Q3JVVPqYsD-Kme9UMpV5dIXoHbsqjnyfS7u1mKLEKWA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"2080997a-38a6-420d-ba86-e9582e1331c7"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 97ea91c5-afae-4e4d-afc5-691ac31ecfd9
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Correlation-Request-Id:
+      - c5a82c1a-ea2a-45c8-b7af-1485007e2cb4
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T132746Z:c5a82c1a-ea2a-45c8-b7af-1485007e2cb4
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:27:46 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"spec0deply1ip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip\",\r\n
+        \ \"etag\": \"W/\\\"2080997a-38a6-420d-ba86-e9582e1331c7\\\"\",\r\n  \"location\":
+        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"a08b891e-e45a-4970-aefc-f6c996989490\",\r\n    \"publicIPAddressVersion\":
+        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
+        4,\r\n    \"dnsSettings\": {\r\n      \"domainNameLabel\": \"spec0deply1dns\",\r\n
+        \     \"fqdn\": \"spec0deply1dns.eastus.cloudapp.azure.com\"\r\n    },\r\n
+        \   \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
+        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
+        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:27:46 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqazure-linux-managed-ip?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA5MzIsIm5iZiI6MTUyMDg2MDkzMiwiZXhwIjoxNTIwODY0ODMyLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRkFrM05rOHY4VU9OVmw0VmpzVXFBQSIsInZlciI6IjEuMCJ9.mNP_fcyGqvirg-gch_0gqMTkq6GfQsKJYWlu-tLV-aK6g_6NJPo9B4VM9tg_qRwhMb28-Cclixrg_u0pk2XwmYLHcOWHmw_WHOyqGFFglMG-sHX_VDBRXwSv2mjqkp43jdA0e4mZTg68NduEKev_voIdGn_CpOdmkOt7Q01iimz-aSv7m5JWIoZ8jiTgbW1okmkEyN2t7vAxPsqvVBsD6j-XXtvJ7XFmCPnPJ_kSIfioc5wW3FGyHlGjYD_uXZK1NxKEJMY0xAZSNytK83ZeFsE2MR8TKFrjOPya6VZN010Q3JVVPqYsD-Kme9UMpV5dIXoHbsqjnyfS7u1mKLEKWA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"0efc9684-fb7d-4fb7-b9b9-f33dbac04a28"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 1d3b37b0-dd06-4092-9b1a-7fa252a0ebac
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Correlation-Request-Id:
+      - e860bb9e-9522-423c-a7cf-6dff28c66084
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T132747Z:e860bb9e-9522-423c-a7cf-6dff28c66084
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:27:46 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"miqazure-linux-managed-ip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqazure-linux-managed-ip\",\r\n
+        \ \"etag\": \"W/\\\"0efc9684-fb7d-4fb7-b9b9-f33dbac04a28\\\"\",\r\n  \"location\":
+        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"6a2a9142-26e8-45cd-93bf-7318192f3528\",\r\n    \"publicIPAddressVersion\":
+        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
+        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944/ipConfigurations/ipconfig1\"\r\n
+        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
+        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:27:47 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA5MzIsIm5iZiI6MTUyMDg2MDkzMiwiZXhwIjoxNTIwODY0ODMyLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRkFrM05rOHY4VU9OVmw0VmpzVXFBQSIsInZlciI6IjEuMCJ9.mNP_fcyGqvirg-gch_0gqMTkq6GfQsKJYWlu-tLV-aK6g_6NJPo9B4VM9tg_qRwhMb28-Cclixrg_u0pk2XwmYLHcOWHmw_WHOyqGFFglMG-sHX_VDBRXwSv2mjqkp43jdA0e4mZTg68NduEKev_voIdGn_CpOdmkOt7Q01iimz-aSv7m5JWIoZ8jiTgbW1okmkEyN2t7vAxPsqvVBsD6j-XXtvJ7XFmCPnPJ_kSIfioc5wW3FGyHlGjYD_uXZK1NxKEJMY0xAZSNytK83ZeFsE2MR8TKFrjOPya6VZN010Q3JVVPqYsD-Kme9UMpV5dIXoHbsqjnyfS7u1mKLEKWA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"054052bb-11ff-4f6e-ac1a-3427c2fd17aa"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 601069cc-64eb-4f85-9cb5-f785323e86a1
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Correlation-Request-Id:
+      - 742c992c-6039-486b-bd61-c91daad1d424
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T132747Z:742c992c-6039-486b-bd61-c91daad1d424
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:27:46 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"miq-test-rhel1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1\",\r\n
+        \ \"etag\": \"W/\\\"054052bb-11ff-4f6e-ac1a-3427c2fd17aa\\\"\",\r\n  \"location\":
+        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"f6cfc635-411e-48ce-a627-39a2fc0d3168\",\r\n    \"ipAddress\":
+        \"52.224.165.15\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\":
+        \"Dynamic\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipTags\": [],\r\n
+        \   \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1\"\r\n
+        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
+        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:27:47 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA5MzIsIm5iZiI6MTUyMDg2MDkzMiwiZXhwIjoxNTIwODY0ODMyLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRkFrM05rOHY4VU9OVmw0VmpzVXFBQSIsInZlciI6IjEuMCJ9.mNP_fcyGqvirg-gch_0gqMTkq6GfQsKJYWlu-tLV-aK6g_6NJPo9B4VM9tg_qRwhMb28-Cclixrg_u0pk2XwmYLHcOWHmw_WHOyqGFFglMG-sHX_VDBRXwSv2mjqkp43jdA0e4mZTg68NduEKev_voIdGn_CpOdmkOt7Q01iimz-aSv7m5JWIoZ8jiTgbW1okmkEyN2t7vAxPsqvVBsD6j-XXtvJ7XFmCPnPJ_kSIfioc5wW3FGyHlGjYD_uXZK1NxKEJMY0xAZSNytK83ZeFsE2MR8TKFrjOPya6VZN010Q3JVVPqYsD-Kme9UMpV5dIXoHbsqjnyfS7u1mKLEKWA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"734a3944-a880-444c-8c92-cace6e28e303"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - f71be6fb-78bf-41d2-a914-0fcf5423d26f
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Correlation-Request-Id:
+      - 1d0cb818-6d5c-4929-9929-d352a803ef40
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T132747Z:1d0cb818-6d5c-4929-9929-d352a803ef40
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:27:47 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"miqazure-centos1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1\",\r\n
+        \ \"etag\": \"W/\\\"734a3944-a880-444c-8c92-cace6e28e303\\\"\",\r\n  \"location\":
+        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"475a66f0-9e89-4226-a9f0-9baaaf31d619\",\r\n    \"publicIPAddressVersion\":
+        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
+        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1\"\r\n
+        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
+        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:27:47 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/disks/miqazure-linux-managed-data-disk?api-version=2017-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA5MzIsIm5iZiI6MTUyMDg2MDkzMiwiZXhwIjoxNTIwODY0ODMyLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRkFrM05rOHY4VU9OVmw0VmpzVXFBQSIsInZlciI6IjEuMCJ9.mNP_fcyGqvirg-gch_0gqMTkq6GfQsKJYWlu-tLV-aK6g_6NJPo9B4VM9tg_qRwhMb28-Cclixrg_u0pk2XwmYLHcOWHmw_WHOyqGFFglMG-sHX_VDBRXwSv2mjqkp43jdA0e4mZTg68NduEKev_voIdGn_CpOdmkOt7Q01iimz-aSv7m5JWIoZ8jiTgbW1okmkEyN2t7vAxPsqvVBsD6j-XXtvJ7XFmCPnPJ_kSIfioc5wW3FGyHlGjYD_uXZK1NxKEJMY0xAZSNytK83ZeFsE2MR8TKFrjOPya6VZN010Q3JVVPqYsD-Kme9UMpV5dIXoHbsqjnyfS7u1mKLEKWA
   response:
     status:
       code: 200
@@ -3310,60 +4553,41 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/LowCostGet3Min;4739,Microsoft.Compute/LowCostGet30Min;37892
+      - Microsoft.Compute/LowCostGet3Min;4997,Microsoft.Compute/LowCostGet30Min;19997
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131626781321631045
       X-Ms-Request-Id:
-      - 1dc68f1d-fb11-4295-ae7f-f1a62bf1b675
+      - 1c773d84-3343-470b-93f6-f8e012af7789
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14974'
+      - '14995'
       X-Ms-Correlation-Request-Id:
-      - 679d4fb9-0f84-4a6f-96b7-452c4c04d08e
+      - b9bbd0ff-8438-4ad2-bafd-c736268d03f4
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201739Z:679d4fb9-0f84-4a6f-96b7-452c4c04d08e
+      - WESTEUROPE:20180312T132748Z:b9bbd0ff-8438-4ad2-bafd-c736268d03f4
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:17:38 GMT
+      - Mon, 12 Mar 2018 13:27:47 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"23b0beab-16d2-4135-a01f-2fe713217fd0\",\r\n
-        \   \"availabilitySet\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/RSPEC-LB\"\r\n
-        \   },\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_F1s\"\r\n
-        \   },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
-        \"RedHat\",\r\n        \"offer\": \"RHEL\",\r\n        \"sku\": \"6.7\",\r\n
-        \       \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
-        \"Linux\",\r\n        \"name\": \"rspec-lb-a\",\r\n        \"createOption\":
-        \"FromImage\",\r\n        \"vhd\": {\r\n          \"uri\": \"https://rspeclb.blob.core.windows.net/vhds/rspec-lb-a201682122839.vhd\"\r\n
-        \       },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n      \"dataDisks\":
-        []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"rspec-lb-a\",\r\n
-        \     \"adminUsername\": \"bronaghs\",\r\n      \"linuxConfiguration\": {\r\n
-        \       \"disablePasswordAuthentication\": false\r\n      },\r\n      \"secrets\":
-        []\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670\"}]},\r\n
-        \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
-        true,\r\n        \"storageUri\": \"https://miqazuretest16487.blob.core.windows.net/\"\r\n
-        \     }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n
-        \ \"resources\": [\r\n    {\r\n      \"properties\": {\r\n        \"publisher\":
-        \"Microsoft.OSTCExtensions\",\r\n        \"type\": \"LinuxDiagnostic\",\r\n
-        \       \"typeHandlerVersion\": \"2.3\",\r\n        \"autoUpgradeMinorVersion\":
-        true,\r\n        \"settings\": {\"xmlCfg\":\"PFdhZENmZz48RGlhZ25vc3RpY01vbml0b3JDb25maWd1cmF0aW9uIG92ZXJhbGxRdW90YUluTUI9IjQwOTYiPjxEaWFnbm9zdGljSW5mcmFzdHJ1Y3R1cmVMb2dzIHNjaGVkdWxlZFRyYW5zZmVyUGVyaW9kPSJQVDFNIiBzY2hlZHVsZWRUcmFuc2ZlckxvZ0xldmVsRmlsdGVyPSJXYXJuaW5nIi8+PFBlcmZvcm1hbmNlQ291bnRlcnMgc2NoZWR1bGVkVHJhbnNmZXJQZXJpb2Q9IlBUMU0iPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlTWVtb3J5IiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQnl0ZXMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcUGVyY2VudEF2YWlsYWJsZU1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iTWVtb3J5IHVzZWQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50VXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgcGVyY2VudGFnZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkQnlDYWNoZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHVzZWQgYnkgY2FjaGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1BlclNlYyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50UGVyU2Vjb25kIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFnZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1JlYWRQZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2UgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1dyaXR0ZW5QZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2Ugd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iU3dhcCBhdmFpbGFibGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50QXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZFN3YXAiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlN3YXAgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRJZGxlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgaWRsZSB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFVzZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iUGVyY2VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkNQVSB1c2VyIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50TmljZVRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIG5pY2UgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRQcml2aWxlZ2VkVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgcHJpdmlsZWdlZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudEludGVycnVwdFRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIGludGVycnVwdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudERQQ1RpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIERQQyB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFByb2Nlc3NvclRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIHBlcmNlbnRhZ2UgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50SU9XYWl0VGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgSU8gd2FpdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xSZWFkQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCBndWVzdCBPUyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXFdyaXRlQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGUgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xUcmFuc2ZlcnNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXJzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcUmVhZHNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xXcml0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVJlYWRUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVdyaXRlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlNlY29uZHMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJEaXNrIHdyaXRlIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xBdmVyYWdlVHJhbnNmZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXIgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXEF2ZXJhZ2VEaXNrUXVldWVMZW5ndGgiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcXVldWUgbGVuZ3RoIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVHJhbnNtaXR0ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgb3V0IGd1ZXN0IE9TIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzUmVjZWl2ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgaW4gZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1RyYW5zbWl0dGVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHNlbnQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1JlY2VpdmVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHJlY2VpdmVkIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVG90YWwiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxSeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyByZWNlaXZlZCBlcnJvcnMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxUeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyBzZW50IGVycm9ycyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTmV0d29ya0ludGVyZmFjZVxUb3RhbENvbGxpc2lvbnMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgY29sbGlzaW9ucyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48L1BlcmZvcm1hbmNlQ291bnRlcnM+PE1ldHJpY3MgcmVzb3VyY2VJZD0iL3N1YnNjcmlwdGlvbnMvMjU4NmM2NGItMzhiNC00NTI3LWExNDAtMDEyZDQ5ZGZjMDJjL3Jlc291cmNlR3JvdXBzL21pcS1henVyZS10ZXN0MS9wcm92aWRlcnMvTWljcm9zb2Z0LkNvbXB1dGUvdmlydHVhbE1hY2hpbmVzL3JzcGVjLWxiLWEiPjxNZXRyaWNBZ2dyZWdhdGlvbiBzY2hlZHVsZWRUcmFuc2ZlclBlcmlvZD0iUFQxSCIvPjxNZXRyaWNBZ2dyZWdhdGlvbiBzY2hlZHVsZWRUcmFuc2ZlclBlcmlvZD0iUFQxTSIvPjwvTWV0cmljcz48L0RpYWdub3N0aWNNb25pdG9yQ29uZmlndXJhdGlvbj48L1dhZENmZz4=\",\"StorageAccount\":\"miqazuretest16487\"},\r\n
-        \       \"provisioningState\": \"Succeeded\"\r\n      },\r\n      \"type\":
-        \"Microsoft.Compute/virtualMachines/extensions\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a/extensions/Microsoft.Insights.VMDiagnosticsSettings\",\r\n
-        \     \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n    }\r\n
-        \ ],\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\":
-        \"eastus\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a\",\r\n
-        \ \"name\": \"rspec-lb-a\"\r\n}"
+      string: "{\r\n  \"managedBy\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed\",\r\n
+        \ \"sku\": {\r\n    \"name\": \"Standard_LRS\",\r\n    \"tier\": \"Standard\"\r\n
+        \ },\r\n  \"properties\": {\r\n    \"creationData\": {\r\n      \"createOption\":
+        \"Empty\"\r\n    },\r\n    \"diskSizeGB\": 1,\r\n    \"timeCreated\": \"2017-10-23T17:34:14.7022771+00:00\",\r\n
+        \   \"provisioningState\": \"Succeeded\",\r\n    \"diskState\": \"Reserved\"\r\n
+        \ },\r\n  \"type\": \"Microsoft.Compute/disks\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/disks/miqazure-linux-managed-data-disk\",\r\n
+        \ \"name\": \"miqazure-linux-managed-data-disk\"\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:17:39 GMT
+  recorded_at: Mon, 12 Mar 2018 13:27:48 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/disks/miqazure-linux-managed_OsDisk_1_7b2bdf790a7d4379ace2846d307730cd?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -3377,7 +4601,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1NDMsIm5iZiI6MTUyMDQ1MzU0MywiZXhwIjoxNTIwNDU3NDQzLCJhaW8iOiJZMk5nWUtnVTcxZFYzaEY3dGlIOFI4YzcyODZyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQXVkZnZJVlNIRVN2R3lpN0gySUFBQSIsInZlciI6IjEuMCJ9.DIpJSVBILdjgWTsPUuSjfYAwOg3J39WtKpji-H2_QiIDtP9TwVbFGnsY0qCNBvHBZJiEuXbpkNkRR_y2XGl6TT7BJe6jR9wqMEM3514u4JpwBgWH2aCbnLTjOo8JdqbphalN38iEWVwiUH2p4k7G3zDvZM6LsO9UGllA4K_AfRYfBosdPxqJjWgH3ZfgbBMMIvY5Z-Lr8-Z_AE_erdyYmIRc2mzUpWbQWdgzmm-PjH1-TaP4yzKckX5lnY34x5NHv8Hw55wiWxTPrWliHDnXNg-PAubyLnXwHQqDJqOUyNjgaa26Ru8nhB5XSlpRR19x4NVnosl2DIOgtF63sHTbnw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA5MzIsIm5iZiI6MTUyMDg2MDkzMiwiZXhwIjoxNTIwODY0ODMyLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRkFrM05rOHY4VU9OVmw0VmpzVXFBQSIsInZlciI6IjEuMCJ9.mNP_fcyGqvirg-gch_0gqMTkq6GfQsKJYWlu-tLV-aK6g_6NJPo9B4VM9tg_qRwhMb28-Cclixrg_u0pk2XwmYLHcOWHmw_WHOyqGFFglMG-sHX_VDBRXwSv2mjqkp43jdA0e4mZTg68NduEKev_voIdGn_CpOdmkOt7Q01iimz-aSv7m5JWIoZ8jiTgbW1okmkEyN2t7vAxPsqvVBsD6j-XXtvJ7XFmCPnPJ_kSIfioc5wW3FGyHlGjYD_uXZK1NxKEJMY0xAZSNytK83ZeFsE2MR8TKFrjOPya6VZN010Q3JVVPqYsD-Kme9UMpV5dIXoHbsqjnyfS7u1mKLEKWA
   response:
     status:
       code: 200
@@ -3396,60 +4620,43 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/LowCostGet3Min;4735,Microsoft.Compute/LowCostGet30Min;37888
+      - Microsoft.Compute/LowCostGet3Min;4996,Microsoft.Compute/LowCostGet30Min;19996
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131626781321631045
       X-Ms-Request-Id:
-      - e13fa78e-84fa-4a60-9d11-0e5d9b718cf3
+      - 6b7db838-e1f9-4a41-8c55-3510d65427d7
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14974'
+      - '14995'
       X-Ms-Correlation-Request-Id:
-      - 3c99bef9-ca55-482e-be44-ccf01f324236
+      - 1db31bc7-8736-440f-8e4e-89fda3011675
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201739Z:3c99bef9-ca55-482e-be44-ccf01f324236
+      - WESTEUROPE:20180312T132748Z:1db31bc7-8736-440f-8e4e-89fda3011675
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:17:39 GMT
+      - Mon, 12 Mar 2018 13:27:48 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"834a70b5-868d-4466-9dda-14e0f6b2caaf\",\r\n
-        \   \"availabilitySet\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/RSPEC-LB\"\r\n
-        \   },\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n
-        \   },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
-        \"RedHat\",\r\n        \"offer\": \"RHEL\",\r\n        \"sku\": \"6.7\",\r\n
-        \       \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
-        \"Linux\",\r\n        \"name\": \"rspec-lb-b\",\r\n        \"createOption\":
-        \"FromImage\",\r\n        \"vhd\": {\r\n          \"uri\": \"https://rspeclb.blob.core.windows.net/vhds/rspec-lb-b201682123650.vhd\"\r\n
-        \       },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n      \"dataDisks\":
-        []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"rspec-lb-b\",\r\n
-        \     \"adminUsername\": \"bronaghs\",\r\n      \"linuxConfiguration\": {\r\n
-        \       \"disablePasswordAuthentication\": false\r\n      },\r\n      \"secrets\":
-        []\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843\"}]},\r\n
-        \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
-        true,\r\n        \"storageUri\": \"https://amissteastorage.blob.core.windows.net/\"\r\n
-        \     }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n
-        \ \"resources\": [\r\n    {\r\n      \"properties\": {\r\n        \"publisher\":
-        \"Microsoft.OSTCExtensions\",\r\n        \"type\": \"LinuxDiagnostic\",\r\n
-        \       \"typeHandlerVersion\": \"2.3\",\r\n        \"autoUpgradeMinorVersion\":
-        true,\r\n        \"settings\": {\"xmlCfg\":\"PFdhZENmZz48RGlhZ25vc3RpY01vbml0b3JDb25maWd1cmF0aW9uIG92ZXJhbGxRdW90YUluTUI9IjQwOTYiPjxEaWFnbm9zdGljSW5mcmFzdHJ1Y3R1cmVMb2dzIHNjaGVkdWxlZFRyYW5zZmVyUGVyaW9kPSJQVDFNIiBzY2hlZHVsZWRUcmFuc2ZlckxvZ0xldmVsRmlsdGVyPSJXYXJuaW5nIi8+PFBlcmZvcm1hbmNlQ291bnRlcnMgc2NoZWR1bGVkVHJhbnNmZXJQZXJpb2Q9IlBUMU0iPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlTWVtb3J5IiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQnl0ZXMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcUGVyY2VudEF2YWlsYWJsZU1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iTWVtb3J5IHVzZWQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50VXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgcGVyY2VudGFnZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkQnlDYWNoZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHVzZWQgYnkgY2FjaGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1BlclNlYyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50UGVyU2Vjb25kIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFnZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1JlYWRQZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2UgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1dyaXR0ZW5QZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2Ugd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iU3dhcCBhdmFpbGFibGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50QXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZFN3YXAiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlN3YXAgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRJZGxlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgaWRsZSB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFVzZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iUGVyY2VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkNQVSB1c2VyIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50TmljZVRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIG5pY2UgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRQcml2aWxlZ2VkVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgcHJpdmlsZWdlZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudEludGVycnVwdFRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIGludGVycnVwdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudERQQ1RpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIERQQyB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFByb2Nlc3NvclRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIHBlcmNlbnRhZ2UgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50SU9XYWl0VGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgSU8gd2FpdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xSZWFkQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCBndWVzdCBPUyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXFdyaXRlQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGUgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xUcmFuc2ZlcnNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXJzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcUmVhZHNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xXcml0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVJlYWRUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVdyaXRlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlNlY29uZHMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJEaXNrIHdyaXRlIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xBdmVyYWdlVHJhbnNmZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXIgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXEF2ZXJhZ2VEaXNrUXVldWVMZW5ndGgiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcXVldWUgbGVuZ3RoIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVHJhbnNtaXR0ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgb3V0IGd1ZXN0IE9TIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzUmVjZWl2ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgaW4gZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1RyYW5zbWl0dGVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHNlbnQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1JlY2VpdmVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHJlY2VpdmVkIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVG90YWwiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxSeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyByZWNlaXZlZCBlcnJvcnMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxUeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyBzZW50IGVycm9ycyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTmV0d29ya0ludGVyZmFjZVxUb3RhbENvbGxpc2lvbnMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgY29sbGlzaW9ucyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48L1BlcmZvcm1hbmNlQ291bnRlcnM+PE1ldHJpY3MgcmVzb3VyY2VJZD0iL3N1YnNjcmlwdGlvbnMvMjU4NmM2NGItMzhiNC00NTI3LWExNDAtMDEyZDQ5ZGZjMDJjL3Jlc291cmNlR3JvdXBzL21pcS1henVyZS10ZXN0MS9wcm92aWRlcnMvTWljcm9zb2Z0LkNvbXB1dGUvdmlydHVhbE1hY2hpbmVzL3JzcGVjLWxiLWIiPjxNZXRyaWNBZ2dyZWdhdGlvbiBzY2hlZHVsZWRUcmFuc2ZlclBlcmlvZD0iUFQxSCIvPjxNZXRyaWNBZ2dyZWdhdGlvbiBzY2hlZHVsZWRUcmFuc2ZlclBlcmlvZD0iUFQxTSIvPjwvTWV0cmljcz48L0RpYWdub3N0aWNNb25pdG9yQ29uZmlndXJhdGlvbj48L1dhZENmZz4=\",\"StorageAccount\":\"amissteastorage\"},\r\n
-        \       \"provisioningState\": \"Succeeded\"\r\n      },\r\n      \"type\":
-        \"Microsoft.Compute/virtualMachines/extensions\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b/extensions/Microsoft.Insights.VMDiagnosticsSettings\",\r\n
-        \     \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n    }\r\n
-        \ ],\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\":
-        \"eastus\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b\",\r\n
-        \ \"name\": \"rspec-lb-b\"\r\n}"
+      string: "{\r\n  \"managedBy\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed\",\r\n
+        \ \"sku\": {\r\n    \"name\": \"Standard_LRS\",\r\n    \"tier\": \"Standard\"\r\n
+        \ },\r\n  \"properties\": {\r\n    \"osType\": \"Linux\",\r\n    \"creationData\":
+        {\r\n      \"createOption\": \"FromImage\",\r\n      \"imageReference\": {\r\n
+        \       \"id\": \"/Subscriptions/AZURE_SUBSCRIPTION_ID/Providers/Microsoft.Compute/Locations/eastus/Publishers/RedHat/ArtifactTypes/VMImage/Offers/RHEL/Skus/7.3/Versions/latest\"\r\n
+        \     }\r\n    },\r\n    \"diskSizeGB\": 32,\r\n    \"timeCreated\": \"2017-05-04T21:21:55.7801928+00:00\",\r\n
+        \   \"provisioningState\": \"Succeeded\",\r\n    \"diskState\": \"Reserved\"\r\n
+        \ },\r\n  \"type\": \"Microsoft.Compute/disks\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"tags\": {\r\n    \"delete\": \"false\"\r\n  },\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/disks/miqazure-linux-managed_OsDisk_1_7b2bdf790a7d4379ace2846d307730cd\",\r\n
+        \ \"name\": \"miqazure-linux-managed_OsDisk_1_7b2bdf790a7d4379ace2846d307730cd\"\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:17:39 GMT
+  recorded_at: Mon, 12 Mar 2018 13:27:48 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a/instanceView?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686?api-version=2017-10-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3463,7 +4670,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1NDMsIm5iZiI6MTUyMDQ1MzU0MywiZXhwIjoxNTIwNDU3NDQzLCJhaW8iOiJZMk5nWUtnVTcxZFYzaEY3dGlIOFI4YzcyODZyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQXVkZnZJVlNIRVN2R3lpN0gySUFBQSIsInZlciI6IjEuMCJ9.DIpJSVBILdjgWTsPUuSjfYAwOg3J39WtKpji-H2_QiIDtP9TwVbFGnsY0qCNBvHBZJiEuXbpkNkRR_y2XGl6TT7BJe6jR9wqMEM3514u4JpwBgWH2aCbnLTjOo8JdqbphalN38iEWVwiUH2p4k7G3zDvZM6LsO9UGllA4K_AfRYfBosdPxqJjWgH3ZfgbBMMIvY5Z-Lr8-Z_AE_erdyYmIRc2mzUpWbQWdgzmm-PjH1-TaP4yzKckX5lnY34x5NHv8Hw55wiWxTPrWliHDnXNg-PAubyLnXwHQqDJqOUyNjgaa26Ru8nhB5XSlpRR19x4NVnosl2DIOgtF63sHTbnw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA5MzIsIm5iZiI6MTUyMDg2MDkzMiwiZXhwIjoxNTIwODY0ODMyLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRkFrM05rOHY4VU9OVmw0VmpzVXFBQSIsInZlciI6IjEuMCJ9.mNP_fcyGqvirg-gch_0gqMTkq6GfQsKJYWlu-tLV-aK6g_6NJPo9B4VM9tg_qRwhMb28-Cclixrg_u0pk2XwmYLHcOWHmw_WHOyqGFFglMG-sHX_VDBRXwSv2mjqkp43jdA0e4mZTg68NduEKev_voIdGn_CpOdmkOt7Q01iimz-aSv7m5JWIoZ8jiTgbW1okmkEyN2t7vAxPsqvVBsD6j-XXtvJ7XFmCPnPJ_kSIfioc5wW3FGyHlGjYD_uXZK1NxKEJMY0xAZSNytK83ZeFsE2MR8TKFrjOPya6VZN010Q3JVVPqYsD-Kme9UMpV5dIXoHbsqjnyfS7u1mKLEKWA
   response:
     status:
       code: 200
@@ -3476,57 +4683,35 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Content-Type:
-      - application/json; charset=utf-8
+      - application/json
       Expires:
       - "-1"
       Vary:
       - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/GetInstanceView3Min;4793,Microsoft.Compute/GetInstanceView30Min;23922
+      X-Ms-Request-Id:
+      - 380f93dc-c307-4f5a-9914-e927f098444c
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
-      X-Ms-Request-Id:
-      - 8b7df9c4-0209-4a39-87f0-b73264503062
       Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14985'
+      - '14995'
       X-Ms-Correlation-Request-Id:
-      - 321cab20-4d8f-4c86-9c90-146ed4e4e97b
+      - 4bb0c144-bf3b-4755-8541-f09a0f13048c
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201751Z:321cab20-4d8f-4c86-9c90-146ed4e4e97b
+      - WESTEUROPE:20180312T132749Z:4bb0c144-bf3b-4755-8541-f09a0f13048c
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:17:50 GMT
+      - Mon, 12 Mar 2018 13:27:48 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"platformUpdateDomain\": 0,\r\n  \"platformFaultDomain\": 0,\r\n
-        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
-        [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
-        \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
-        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2018-03-07T20:17:40+00:00\"\r\n
-        \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"rspec-lb-a\",\r\n
-        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
-        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"time\": \"2016-09-03T14:04:26.7359609+00:00\"\r\n
-        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
-        \"https://miqazuretest16487.blob.core.windows.net/bootdiagnostics-rspeclba-23b0beab-16d2-4135-a01f-2fe713217fd0/rspec-lb-a.23b0beab-16d2-4135-a01f-2fe713217fd0.screenshot.bmp\",\r\n
-        \   \"serialConsoleLogBlobUri\": \"https://miqazuretest16487.blob.core.windows.net/bootdiagnostics-rspeclba-23b0beab-16d2-4135-a01f-2fe713217fd0/rspec-lb-a.23b0beab-16d2-4135-a01f-2fe713217fd0.serialconsole.log\"\r\n
-        \ },\r\n  \"extensions\": [\r\n    {\r\n      \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n
-        \   }\r\n  ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n
-        \     \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n
-        \     \"time\": \"2016-09-03T14:04:26.7828345+00:00\"\r\n    },\r\n    {\r\n
-        \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
-        \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","name":"miqazuretest18686","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T17:22:54.7808677Z","primaryEndpoints":{"blob":"https://miqazuretest18686.blob.core.windows.net/","queue":"https://miqazuretest18686.queue.core.windows.net/","table":"https://miqazuretest18686.table.core.windows.net/","file":"https://miqazuretest18686.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:17:51 GMT
+  recorded_at: Mon, 12 Mar 2018 13:27:49 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Network/networkInterfaces?api-version=2017-11-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047?api-version=2017-10-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3540,7 +4725,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1NDMsIm5iZiI6MTUyMDQ1MzU0MywiZXhwIjoxNTIwNDU3NDQzLCJhaW8iOiJZMk5nWUtnVTcxZFYzaEY3dGlIOFI4YzcyODZyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQXVkZnZJVlNIRVN2R3lpN0gySUFBQSIsInZlciI6IjEuMCJ9.DIpJSVBILdjgWTsPUuSjfYAwOg3J39WtKpji-H2_QiIDtP9TwVbFGnsY0qCNBvHBZJiEuXbpkNkRR_y2XGl6TT7BJe6jR9wqMEM3514u4JpwBgWH2aCbnLTjOo8JdqbphalN38iEWVwiUH2p4k7G3zDvZM6LsO9UGllA4K_AfRYfBosdPxqJjWgH3ZfgbBMMIvY5Z-Lr8-Z_AE_erdyYmIRc2mzUpWbQWdgzmm-PjH1-TaP4yzKckX5lnY34x5NHv8Hw55wiWxTPrWliHDnXNg-PAubyLnXwHQqDJqOUyNjgaa26Ru8nhB5XSlpRR19x4NVnosl2DIOgtF63sHTbnw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA5MzIsIm5iZiI6MTUyMDg2MDkzMiwiZXhwIjoxNTIwODY0ODMyLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRkFrM05rOHY4VU9OVmw0VmpzVXFBQSIsInZlciI6IjEuMCJ9.mNP_fcyGqvirg-gch_0gqMTkq6GfQsKJYWlu-tLV-aK6g_6NJPo9B4VM9tg_qRwhMb28-Cclixrg_u0pk2XwmYLHcOWHmw_WHOyqGFFglMG-sHX_VDBRXwSv2mjqkp43jdA0e4mZTg68NduEKev_voIdGn_CpOdmkOt7Q01iimz-aSv7m5JWIoZ8jiTgbW1okmkEyN2t7vAxPsqvVBsD6j-XXtvJ7XFmCPnPJ_kSIfioc5wW3FGyHlGjYD_uXZK1NxKEJMY0xAZSNytK83ZeFsE2MR8TKFrjOPya6VZN010Q3JVVPqYsD-Kme9UMpV5dIXoHbsqjnyfS7u1mKLEKWA
   response:
     status:
       code: 200
@@ -3550,136 +4735,38 @@ http_interactions:
       - no-cache
       Pragma:
       - no-cache
+      Transfer-Encoding:
+      - chunked
       Content-Type:
-      - application/json; charset=utf-8
+      - application/json
       Expires:
       - "-1"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 7b9bbc84-8587-46a9-921f-2396f3390041
-      X-Ms-Correlation-Request-Id:
-      - 7b9bbc84-8587-46a9-921f-2396f3390041
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201753Z:7b9bbc84-8587-46a9-921f-2396f3390041
+      - 779cf264-d7ad-45ef-ad90-4914076062ec
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Correlation-Request-Id:
+      - 24a02146-5046-42e3-9f2b-df60f0113ffd
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T132749Z:24a02146-5046-42e3-9f2b-df60f0113ffd
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:17:52 GMT
-      Content-Length:
-      - '31614'
+      - Mon, 12 Mar 2018 13:27:49 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"name":"miqazure-coreos1235","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235","etag":"W/\"4a6546ab-a4c0-4d27-bccd-f6ebf3c405a2\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"fb0a5e60-a6c2-4bb8-a2f5-0c16216a49b0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235/ipConfigurations/ipconfig1","etag":"W/\"4a6546ab-a4c0-4d27-bccd-f6ebf3c405a2\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.20.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/publicIPAddresses/miqazure-coreos1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/virtualNetworks/miq-azure-test3/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"rliadcyr3l1elbnsw4rabxqg1f.dx.internal.cloudapp.net"},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkSecurityGroups/miqazure-coreos1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Compute/virtualMachines/miqazure-coreos1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"dbergerprov1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/dbergerprov1","etag":"W/\"074dd836-918c-4e40-a118-94f0d366e175\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"ecdcd2f0-91bb-4c40-91cd-a3d76fc5e455","ipConfigurations":[{"name":"dbergerprov1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/dbergerprov1/ipConfigurations/dbergerprov1","etag":"W/\"074dd836-918c-4e40-a118-94f0d366e175\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.9","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/dbergerprov1-publicIp"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/virtualMachines/dbergerprov1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-rhel1390","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390","etag":"W/\"f006e6f9-0292-42cd-99fc-f72f194553c1\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"98853f48-2806-4065-be57-cf9159550440","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1","etag":"W/\"f006e6f9-0292-42cd-99fc-f72f194553c1\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"macAddress":"00-0D-3A-10-EB-AB","enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-ubuntu1989","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989","etag":"W/\"64e07488-15a2-4cec-b84a-6fd5ef04323c\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"134a6669-ac4a-4d08-a0db-387bc4c49537","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989/ipConfigurations/ipconfig1","etag":"W/\"64e07488-15a2-4cec-b84a-6fd5ef04323c\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.17.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-ubuntu1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest18687/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-win12610","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610","etag":"W/\"dd925ef5-33d1-402c-a0f4-18c78c2641f4\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"5c2eef2c-0b36-4277-a940-957ed4d13be0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610/ipConfigurations/ipconfig1","etag":"W/\"dd925ef5-33d1-402c-a0f4-18c78c2641f4\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.18.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-win12"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest19881/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-winimg241","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241","etag":"W/\"4a17a745-16a9-42d9-88c9-17a518959525\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"8ed2f3b0-4a4b-49ae-9f1d-ff7890dbd396","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241/ipConfigurations/ipconfig1","etag":"W/\"4a17a745-16a9-42d9-88c9-17a518959525\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.7","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqtestwinimg6202"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-centos1611","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611","etag":"W/\"26031ef6-bb55-4019-8185-2dd1edcb207c\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"f1760e49-9853-4fdc-acfc-4ea232b9ed76","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1","etag":"W/\"26031ef6-bb55-4019-8185-2dd1edcb207c\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.5","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqmismatch1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1","etag":"W/\"3a72d0c3-bfda-4da5-a61b-e8c33e43de79\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"23d804a8-b623-49e7-9c8d-1d64245bef1e","ipConfigurations":[{"name":"miqmismatch1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1/ipConfigurations/miqmismatch1","etag":"W/\"3a72d0c3-bfda-4da5-a61b-e8c33e43de79\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.8","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqmismatch1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqmismatch1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"rspec-lb-a670","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670","etag":"W/\"cf3a0b0d-d596-4f33-bc31-749f92ba4f00\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"46cb8216-786e-408e-9d86-c0855b357349","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1","etag":"W/\"cf3a0b0d-d596-4f33-bc31-749f92ba4f00\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.6","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-a-ip"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"rspec-lb-b843","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843","etag":"W/\"76aabe0c-8678-43f0-81a5-2f15784a4b99\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"3ef6fa01-ac34-43a1-8fd7-67c706b4d8ef","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1","etag":"W/\"76aabe0c-8678-43f0-81a5-2f15784a4b99\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.11","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-b-ip"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"spec0deply1nic0","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","etag":"W/\"b817491c-aab8-4aab-b41d-b07bfffa5639\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"80ad9866-071d-4e3f-91d0-d47954eccee0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1","etag":"W/\"b817491c-aab8-4aab-b41d-b07bfffa5639\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.4","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"spec0deply1nic1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","etag":"W/\"2ec58a0b-4c03-4d0a-b788-9daffd54e7b2\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"57bbf7aa-d6c4-4f56-8f6a-089d15334221","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1","etag":"W/\"2ec58a0b-4c03-4d0a-b788-9daffd54e7b2\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.5","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqmismatch2656","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqmismatch2656","etag":"W/\"fef6a836-2802-4897-90c3-b3d71f133384\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"969dde6c-73c0-4340-877d-2b5fe2060026","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqmismatch2656/ipConfigurations/ipconfig1","etag":"W/\"fef6a836-2802-4897-90c3-b3d71f133384\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"172.23.0.4","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/virtualNetworks/miqazuretest33606/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkSecurityGroups/miqmismatch2-nsg"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Compute/virtualMachines/miqmismatch2"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-linux-manag944","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944","etag":"W/\"b6339880-8ead-4c9e-b5c0-f38c4f8612d5\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"c5e8b90e-5a78-49b0-b224-b70ed3fb45e5","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944/ipConfigurations/ipconfig1","etag":"W/\"b6339880-8ead-4c9e-b5c0-f38c4f8612d5\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"172.25.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqazure-linux-managed-ip"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"jf-metrics-2751","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751","etag":"W/\"c5f6f02a-b17c-4f34-882b-11c7adef0b44\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"207a58d3-f18d-4dab-8168-919877297a52","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751/ipConfigurations/ipconfig1","etag":"W/\"c5f6f02a-b17c-4f34-882b-11c7adef0b44\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.7","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-2"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-2"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/jf-metrics-2"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"jf-metrics-3421","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421","etag":"W/\"0b6f160b-ad10-48f8-9d0c-657193bb823f\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"b8b345e8-a353-4700-992e-be48a717b4e2","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421/ipConfigurations/ipconfig1","etag":"W/\"0b6f160b-ad10-48f8-9d0c-657193bb823f\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.8","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-3"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-3"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/jf-metrics-3"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-oraclelinux310","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310","etag":"W/\"54cd4fe1-3ed5-4a8c-bc8d-527679c7a631\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"6a3fc1d7-4532-4ca0-b5c2-546cc8f7f313","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310/ipConfigurations/ipconfig1","etag":"W/\"54cd4fe1-3ed5-4a8c-bc8d-527679c7a631\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.5","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-oraclelinux993","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993","etag":"W/\"a9432274-7b40-4eb3-a64f-a04267a423ff\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"75d8ed14-e0ae-4d84-99f6-e3f43d073e76","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993/ipConfigurations/ipconfig1","etag":"W/\"a9432274-7b40-4eb3-a64f-a04267a423ff\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.6","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux2"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux2"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"}]}'
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","name":"miqazuretest14047","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T17:30:25.7028008Z","primaryEndpoints":{"blob":"https://miqazuretest14047.blob.core.windows.net/","queue":"https://miqazuretest14047.queue.core.windows.net/","table":"https://miqazuretest14047.table.core.windows.net/","file":"https://miqazuretest14047.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:17:53 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Network/publicIPAddresses?api-version=2017-11-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1NDMsIm5iZiI6MTUyMDQ1MzU0MywiZXhwIjoxNTIwNDU3NDQzLCJhaW8iOiJZMk5nWUtnVTcxZFYzaEY3dGlIOFI4YzcyODZyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQXVkZnZJVlNIRVN2R3lpN0gySUFBQSIsInZlciI6IjEuMCJ9.DIpJSVBILdjgWTsPUuSjfYAwOg3J39WtKpji-H2_QiIDtP9TwVbFGnsY0qCNBvHBZJiEuXbpkNkRR_y2XGl6TT7BJe6jR9wqMEM3514u4JpwBgWH2aCbnLTjOo8JdqbphalN38iEWVwiUH2p4k7G3zDvZM6LsO9UGllA4K_AfRYfBosdPxqJjWgH3ZfgbBMMIvY5Z-Lr8-Z_AE_erdyYmIRc2mzUpWbQWdgzmm-PjH1-TaP4yzKckX5lnY34x5NHv8Hw55wiWxTPrWliHDnXNg-PAubyLnXwHQqDJqOUyNjgaa26Ru8nhB5XSlpRR19x4NVnosl2DIOgtF63sHTbnw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - ac6e7d6c-07bd-4770-9743-9c61d88e4da3
-      X-Ms-Correlation-Request-Id:
-      - ac6e7d6c-07bd-4770-9743-9c61d88e4da3
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201755Z:ac6e7d6c-07bd-4770-9743-9c61d88e4da3
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:17:55 GMT
-      Content-Length:
-      - '13978'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[{"name":"miqazure-coreos1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/publicIPAddresses/miqazure-coreos1","etag":"W/\"da64b64b-a755-4389-a2f3-5cba32f18c06\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"28617ed1-0270-4b39-873a-c3b48b3deef1","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"dbergerprov1-publicIp","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/dbergerprov1-publicIp","etag":"W/\"3d984c69-3f35-41ce-bdfc-8d207053a6a9\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"eb0e8804-e169-44ac-bb47-0929370977d2","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/dbergerprov1/ipConfigurations/dbergerprov1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"ladas_test","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/ladas_test","etag":"W/\"32e21623-9a1b-4c40-80f4-6a350aa237a7\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"3daa5f66-5a01-4242-b95b-c4e0ee8f0c36","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[]},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miq-test-rhel1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1","etag":"W/\"054052bb-11ff-4f6e-ac1a-3427c2fd17aa\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"f6cfc635-411e-48ce-a627-39a2fc0d3168","ipAddress":"52.224.165.15","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miq-test-ubuntu1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-ubuntu1","etag":"W/\"bcae50c5-146f-4fcb-a461-7c1030ba7b74\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"e272bd74-f661-484f-b223-88dd128a4049","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miq-test-win12","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-win12","etag":"W/\"56ce00f4-50d7-4682-9ee8-6836bf5c0ea6\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"b9200977-8147-40a5-83c2-d5892d5ddedc","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miqazure-centos1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1","etag":"W/\"734a3944-a880-444c-8c92-cace6e28e303\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"475a66f0-9e89-4226-a9f0-9baaaf31d619","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miqtestwinimg6202","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqtestwinimg6202","etag":"W/\"b656279a-26ff-4021-94bb-263420cf494e\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"fb942169-855b-44f8-b12f-fd63e961b140","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"rspec-lb-a-ip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-a-ip","etag":"W/\"3ba30997-7d2f-470c-96f6-301158e93b7c\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"3c605f75-23c0-46ab-ba2b-6fd4430140fd","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"rspec-lb-b-ip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-b-ip","etag":"W/\"cf6012c7-3d47-438f-84d7-332ad1ef4500\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"5d1a2425-a351-4c0f-bc87-37e6500bff22","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"rspec-lb1-LoadBalancerFrontEnd","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd","etag":"W/\"a38434c8-7b23-4092-b7c6-402238eac0dc\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"f28e0f25-b372-4edf-97d9-13a9e3b4ba2d","ipAddress":"40.71.82.83","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"rspec-lb2-publicip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip","etag":"W/\"cddd97d1-6111-4477-8a00-3dc885237a1d\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"83e7257d-ab94-4229-8eb5-4798f37ef28d","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"spec0deply1ip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip","etag":"W/\"2080997a-38a6-420d-ba86-e9582e1331c7\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"a08b891e-e45a-4970-aefc-f6c996989490","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"spec0deply1dns","fqdn":"spec0deply1dns.eastus.cloudapp.azure.com"},"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miqazure-linux-managed-ip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqazure-linux-managed-ip","etag":"W/\"0efc9684-fb7d-4fb7-b9b9-f33dbac04a28\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"6a2a9142-26e8-45cd-93bf-7318192f3528","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miqmismatch1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqmismatch1","etag":"W/\"9b8b1729-21c4-4c53-94f2-15715315ad73\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"a97c71d0-6b78-4ffe-8e5c-0be1ee653f8c","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"miqmismatch1","fqdn":"miqmismatch1.eastus.cloudapp.azure.com"},"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1/ipConfigurations/miqmismatch1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"jf-metrics-2","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-2","etag":"W/\"b43ebe01-574c-4454-87eb-3401fbcf36f2\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"e446f3e4-9410-4d7f-bb04-2652096359de","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"jf-metrics-3","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-3","etag":"W/\"a6ee7100-6202-4ae2-a2db-f828abec8af9\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"de5995a4-15c1-40ba-ad78-67e70a92654b","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miqazure-oraclelinux1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux1","etag":"W/\"98bee7b4-2fcc-471d-b5ce-92850e6c3d6b\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"f2ac7c18-520b-4b42-94e7-da264a842f41","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miqazure-oraclelinux2","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux2","etag":"W/\"0865cebc-95b9-49d2-9f10-21dbafb23cac\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"2f4e1091-46f0-474c-a697-8dbcea6ba2a6","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}}]}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:17:55 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Storage/storageAccounts?api-version=2017-10-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1NDMsIm5iZiI6MTUyMDQ1MzU0MywiZXhwIjoxNTIwNDU3NDQzLCJhaW8iOiJZMk5nWUtnVTcxZFYzaEY3dGlIOFI4YzcyODZyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQXVkZnZJVlNIRVN2R3lpN0gySUFBQSIsInZlciI6IjEuMCJ9.DIpJSVBILdjgWTsPUuSjfYAwOg3J39WtKpji-H2_QiIDtP9TwVbFGnsY0qCNBvHBZJiEuXbpkNkRR_y2XGl6TT7BJe6jR9wqMEM3514u4JpwBgWH2aCbnLTjOo8JdqbphalN38iEWVwiUH2p4k7G3zDvZM6LsO9UGllA4K_AfRYfBosdPxqJjWgH3ZfgbBMMIvY5Z-Lr8-Z_AE_erdyYmIRc2mzUpWbQWdgzmm-PjH1-TaP4yzKckX5lnY34x5NHv8Hw55wiWxTPrWliHDnXNg-PAubyLnXwHQqDJqOUyNjgaa26Ru8nhB5XSlpRR19x4NVnosl2DIOgtF63sHTbnw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 65d36ec7-f957-40b4-8ec2-132dcb3d5994
-      X-Ms-Correlation-Request-Id:
-      - 65d36ec7-f957-40b4-8ec2-132dcb3d5994
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201758Z:65d36ec7-f957-40b4-8ec2-132dcb3d5994
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:17:57 GMT
-      Content-Length:
-      - '8649'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","name":"miqazuretest18686","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T17:22:54.7808677Z","primaryEndpoints":{"blob":"https://miqazuretest18686.blob.core.windows.net/","queue":"https://miqazuretest18686.queue.core.windows.net/","table":"https://miqazuretest18686.table.core.windows.net/","file":"https://miqazuretest18686.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","name":"miqazuretest14047","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T17:30:25.7028008Z","primaryEndpoints":{"blob":"https://miqazuretest14047.blob.core.windows.net/","queue":"https://miqazuretest14047.queue.core.windows.net/","table":"https://miqazuretest14047.table.core.windows.net/","file":"https://miqazuretest14047.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Premium_LRS","tier":"Premium"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb","name":"rspeclb","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-09-02T16:29:11.6823797Z","primaryEndpoints":{"blob":"https://rspeclb.blob.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","name":"spec0deply1stor","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-04-04T23:05:07.8274794Z","primaryEndpoints":{"blob":"https://spec0deply1stor.blob.core.windows.net/","queue":"https://spec0deply1stor.queue.core.windows.net/","table":"https://spec0deply1stor.table.core.windows.net/","file":"https://spec0deply1stor.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Storage/storageAccounts/miqazuretest26611","name":"miqazuretest26611","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2211656Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2211656Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-05-02T18:01:29.2743021Z","primaryEndpoints":{"blob":"https://miqazuretest26611.blob.core.windows.net/","queue":"https://miqazuretest26611.queue.core.windows.net/","table":"https://miqazuretest26611.table.core.windows.net/","file":"https://miqazuretest26611.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","name":"miqazuretest16487","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T17:26:55.3231669Z","primaryEndpoints":{"blob":"https://miqazuretest16487.blob.core.windows.net/","queue":"https://miqazuretest16487.queue.core.windows.net/","table":"https://miqazuretest16487.table.core.windows.net/","file":"https://miqazuretest16487.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Storage/storageAccounts/miqazuretest32946","name":"miqazuretest32946","type":"Microsoft.Storage/storageAccounts","location":"westus","tags":{"delete":"false"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.0404359Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.0404359Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T21:18:37.0793411Z","primaryEndpoints":{"blob":"https://miqazuretest32946.blob.core.windows.net/","queue":"https://miqazuretest32946.queue.core.windows.net/","table":"https://miqazuretest32946.table.core.windows.net/","file":"https://miqazuretest32946.file.core.windows.net/"},"primaryLocation":"westus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Storage/storageAccounts/miqazureshared1","name":"miqazureshared1","type":"Microsoft.Storage/storageAccounts","location":"centralus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.1935084Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.1935084Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T20:42:52.498085Z","primaryEndpoints":{"blob":"https://miqazureshared1.blob.core.windows.net/","queue":"https://miqazureshared1.queue.core.windows.net/","table":"https://miqazureshared1.table.core.windows.net/","file":"https://miqazureshared1.file.core.windows.net/"},"primaryLocation":"centralus","statusOfPrimary":"available","secondaryLocation":"eastus2","statusOfSecondary":"available","secondaryEndpoints":{"blob":"https://miqazureshared1-secondary.blob.core.windows.net/","queue":"https://miqazureshared1-secondary.queue.core.windows.net/","table":"https://miqazureshared1-secondary.table.core.windows.net/"}}}]}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:17:58 GMT
+  recorded_at: Mon, 12 Mar 2018 13:27:49 GMT
 - request:
     method: post
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb/listKeys?api-version=2017-10-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686/listKeys?api-version=2017-10-01
     body:
       encoding: ASCII-8BIT
       string: ''
@@ -3693,7 +4780,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1NDMsIm5iZiI6MTUyMDQ1MzU0MywiZXhwIjoxNTIwNDU3NDQzLCJhaW8iOiJZMk5nWUtnVTcxZFYzaEY3dGlIOFI4YzcyODZyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQXVkZnZJVlNIRVN2R3lpN0gySUFBQSIsInZlciI6IjEuMCJ9.DIpJSVBILdjgWTsPUuSjfYAwOg3J39WtKpji-H2_QiIDtP9TwVbFGnsY0qCNBvHBZJiEuXbpkNkRR_y2XGl6TT7BJe6jR9wqMEM3514u4JpwBgWH2aCbnLTjOo8JdqbphalN38iEWVwiUH2p4k7G3zDvZM6LsO9UGllA4K_AfRYfBosdPxqJjWgH3ZfgbBMMIvY5Z-Lr8-Z_AE_erdyYmIRc2mzUpWbQWdgzmm-PjH1-TaP4yzKckX5lnY34x5NHv8Hw55wiWxTPrWliHDnXNg-PAubyLnXwHQqDJqOUyNjgaa26Ru8nhB5XSlpRR19x4NVnosl2DIOgtF63sHTbnw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA5MzIsIm5iZiI6MTUyMDg2MDkzMiwiZXhwIjoxNTIwODY0ODMyLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRkFrM05rOHY4VU9OVmw0VmpzVXFBQSIsInZlciI6IjEuMCJ9.mNP_fcyGqvirg-gch_0gqMTkq6GfQsKJYWlu-tLV-aK6g_6NJPo9B4VM9tg_qRwhMb28-Cclixrg_u0pk2XwmYLHcOWHmw_WHOyqGFFglMG-sHX_VDBRXwSv2mjqkp43jdA0e4mZTg68NduEKev_voIdGn_CpOdmkOt7Q01iimz-aSv7m5JWIoZ8jiTgbW1okmkEyN2t7vAxPsqvVBsD6j-XXtvJ7XFmCPnPJ_kSIfioc5wW3FGyHlGjYD_uXZK1NxKEJMY0xAZSNytK83ZeFsE2MR8TKFrjOPya6VZN010Q3JVVPqYsD-Kme9UMpV5dIXoHbsqjnyfS7u1mKLEKWA
       Content-Length:
       - '0'
   response:
@@ -3714,7 +4801,7 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - d3dff485-0c55-4a03-8070-9ad880853d79
+      - 5214c77b-3096-402d-89fe-dac89c6a965c
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
@@ -3722,187 +4809,21 @@ http_interactions:
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
       - '1199'
       X-Ms-Correlation-Request-Id:
-      - 15dbe7ab-76e6-4911-a198-6f7ab037b6f6
+      - cfcb821f-4003-4d58-91fd-1efea7356d1d
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201758Z:15dbe7ab-76e6-4911-a198-6f7ab037b6f6
+      - WESTEUROPE:20180312T132749Z:cfcb821f-4003-4d58-91fd-1efea7356d1d
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:17:58 GMT
+      - Mon, 12 Mar 2018 13:27:49 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"keys":[{"keyName":"key1","value":"xMvZwiumnKCZnYVJjdtGLqaO1c2v6ERPx4XPDZO7TM1l7/jM1TxAAgtfCMkRn72aRPhqLqwWAn8n5a1iSGRHtA==","permissions":"Full"},{"keyName":"key2","value":"3nDvKhjGAIAvgnH2reuv7tzyeb/0dddgVeUT13VODYD5xO/jeAvQ7tkF3JqP2BAuFrmQqMB4GLkB4/cW4veYeA==","permissions":"Full"}]}'
+      string: '{"keys":[{"keyName":"key1","value":"32PV5jeBt8nw1XvFbZokY26SXchbD6H2tw/YrteEYVE0kpMLKrZ74VrwaIjDyucdi/RxDaAlf7dJIilLS7muNw==","permissions":"Full"},{"keyName":"key2","value":"Eo5x9CQJL1/wl6Tkj5N7M5eEdw6Hym6AeyTt3xjcDl30sV8Iadro6ywZzOHQwNDlmrDaBF6x2a9ZFL7zswxQ7w==","permissions":"Full"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:17:59 GMT
-- request:
-    method: head
-    uri: https://rspeclb.blob.core.windows.net/vhds/rspec-lb-a201682122839.vhd
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - ''
-      X-Ms-Date:
-      - Wed, 07 Mar 2018 20:17:59 GMT
-      X-Ms-Version:
-      - '2016-05-31'
-      Auth-String:
-      - 'true'
-      Verb:
-      - HEAD
-      Authorization:
-      - SharedKey rspeclb:WOH+G0PsHzE/JdIFM8GNGtxAI7p3+0JeXgaWU+8E1FA=
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Length:
-      - '32212255232'
-      Content-Type:
-      - application/octet-stream
-      Content-Md5:
-      - 8BW5hqrnOLoQINlZ05odxA==
-      Last-Modified:
-      - Sat, 03 Sep 2016 14:03:15 GMT
-      Accept-Ranges:
-      - bytes
-      Etag:
-      - '"0x8D3D4030CA0ABEF"'
-      Vary:
-      - Origin
-      Server:
-      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
-      X-Ms-Copy-Id:
-      - f4d64e56-53ed-46e0-9c24-ebfa731c2ac1
-      X-Ms-Copy-Progress:
-      - 32212255232/32212255232
-      X-Ms-Copy-Source:
-      - https://ardfepirv2bl6prdstp02a.blob.core.windows.net/a879bbefc56a43abb0ce65052aac09f3/rhel-67-20160302?sv=2014-02-14&sr=b&si=PirCacheAccountPublisherContainerPolicy&sig=odWVC2Axkv74I6hSj89s9UTQavqFXr29heJIw9TFaCY%3D
-      X-Ms-Copy-Status:
-      - success
-      X-Ms-Copy-Completion-Time:
-      - Fri, 02 Sep 2016 16:29:41 GMT
-      X-Ms-Meta-Microsoftazurecompute-Diskid:
-      - ecdb0d00-e186-4df6-a7b6-ae626753f7bd
-      X-Ms-Meta-Microsoftazurecompute-Diskname:
-      - rspec-lb-a
-      X-Ms-Meta-Microsoftazurecompute-Disktype:
-      - OSDisk
-      X-Ms-Meta-Microsoftazurecompute-Resourcegroupname:
-      - miq-azure-test1
-      X-Ms-Meta-Microsoftazurecompute-Vmname:
-      - rspec-lb-a
-      X-Ms-Lease-State:
-      - leased
-      X-Ms-Lease-Duration:
-      - infinite
-      X-Ms-Lease-Status:
-      - locked
-      X-Ms-Blob-Type:
-      - PageBlob
-      X-Ms-Blob-Sequence-Number:
-      - '1'
-      X-Ms-Server-Encrypted:
-      - 'false'
-      X-Ms-Request-Id:
-      - 82fd0492-f01c-006a-0351-b6396c000000
-      X-Ms-Version:
-      - '2016-05-31'
-      Date:
-      - Wed, 07 Mar 2018 20:17:59 GMT
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:17:59 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b/instanceView?api-version=2017-12-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1NDMsIm5iZiI6MTUyMDQ1MzU0MywiZXhwIjoxNTIwNDU3NDQzLCJhaW8iOiJZMk5nWUtnVTcxZFYzaEY3dGlIOFI4YzcyODZyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQXVkZnZJVlNIRVN2R3lpN0gySUFBQSIsInZlciI6IjEuMCJ9.DIpJSVBILdjgWTsPUuSjfYAwOg3J39WtKpji-H2_QiIDtP9TwVbFGnsY0qCNBvHBZJiEuXbpkNkRR_y2XGl6TT7BJe6jR9wqMEM3514u4JpwBgWH2aCbnLTjOo8JdqbphalN38iEWVwiUH2p4k7G3zDvZM6LsO9UGllA4K_AfRYfBosdPxqJjWgH3ZfgbBMMIvY5Z-Lr8-Z_AE_erdyYmIRc2mzUpWbQWdgzmm-PjH1-TaP4yzKckX5lnY34x5NHv8Hw55wiWxTPrWliHDnXNg-PAubyLnXwHQqDJqOUyNjgaa26Ru8nhB5XSlpRR19x4NVnosl2DIOgtF63sHTbnw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/GetInstanceView3Min;4792,Microsoft.Compute/GetInstanceView30Min;23921
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
-      X-Ms-Request-Id:
-      - e7dbf285-c8f9-4982-9727-a400227576fa
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14973'
-      X-Ms-Correlation-Request-Id:
-      - bd82860c-4b8c-4259-bb55-0290abe10f07
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201759Z:bd82860c-4b8c-4259-bb55-0290abe10f07
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:17:59 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"platformUpdateDomain\": 1,\r\n  \"platformFaultDomain\": 1,\r\n
-        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
-        [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
-        \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
-        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2018-03-07T20:17:59+00:00\"\r\n
-        \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"rspec-lb-b\",\r\n
-        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
-        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"time\": \"2016-09-03T14:07:52.9377685+00:00\"\r\n
-        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
-        \"https://amissteastorage.blob.core.windows.net/bootdiagnostics-rspeclbb-834a70b5-868d-4466-9dda-14e0f6b2caaf/rspec-lb-b.834a70b5-868d-4466-9dda-14e0f6b2caaf.screenshot.bmp\",\r\n
-        \   \"serialConsoleLogBlobUri\": \"https://amissteastorage.blob.core.windows.net/bootdiagnostics-rspeclbb-834a70b5-868d-4466-9dda-14e0f6b2caaf/rspec-lb-b.834a70b5-868d-4466-9dda-14e0f6b2caaf.serialconsole.log\"\r\n
-        \ },\r\n  \"extensions\": [\r\n    {\r\n      \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n
-        \   }\r\n  ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n
-        \     \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n
-        \     \"time\": \"2016-09-03T14:07:52.9846158+00:00\"\r\n    },\r\n    {\r\n
-        \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
-        \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:00 GMT
+  recorded_at: Mon, 12 Mar 2018 13:27:49 GMT
 - request:
     method: post
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb/listKeys?api-version=2017-10-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047/listKeys?api-version=2017-10-01
     body:
       encoding: ASCII-8BIT
       string: ''
@@ -3916,7 +4837,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1NDMsIm5iZiI6MTUyMDQ1MzU0MywiZXhwIjoxNTIwNDU3NDQzLCJhaW8iOiJZMk5nWUtnVTcxZFYzaEY3dGlIOFI4YzcyODZyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQXVkZnZJVlNIRVN2R3lpN0gySUFBQSIsInZlciI6IjEuMCJ9.DIpJSVBILdjgWTsPUuSjfYAwOg3J39WtKpji-H2_QiIDtP9TwVbFGnsY0qCNBvHBZJiEuXbpkNkRR_y2XGl6TT7BJe6jR9wqMEM3514u4JpwBgWH2aCbnLTjOo8JdqbphalN38iEWVwiUH2p4k7G3zDvZM6LsO9UGllA4K_AfRYfBosdPxqJjWgH3ZfgbBMMIvY5Z-Lr8-Z_AE_erdyYmIRc2mzUpWbQWdgzmm-PjH1-TaP4yzKckX5lnY34x5NHv8Hw55wiWxTPrWliHDnXNg-PAubyLnXwHQqDJqOUyNjgaa26Ru8nhB5XSlpRR19x4NVnosl2DIOgtF63sHTbnw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA5MzIsIm5iZiI6MTUyMDg2MDkzMiwiZXhwIjoxNTIwODY0ODMyLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRkFrM05rOHY4VU9OVmw0VmpzVXFBQSIsInZlciI6IjEuMCJ9.mNP_fcyGqvirg-gch_0gqMTkq6GfQsKJYWlu-tLV-aK6g_6NJPo9B4VM9tg_qRwhMb28-Cclixrg_u0pk2XwmYLHcOWHmw_WHOyqGFFglMG-sHX_VDBRXwSv2mjqkp43jdA0e4mZTg68NduEKev_voIdGn_CpOdmkOt7Q01iimz-aSv7m5JWIoZ8jiTgbW1okmkEyN2t7vAxPsqvVBsD6j-XXtvJ7XFmCPnPJ_kSIfioc5wW3FGyHlGjYD_uXZK1NxKEJMY0xAZSNytK83ZeFsE2MR8TKFrjOPya6VZN010Q3JVVPqYsD-Kme9UMpV5dIXoHbsqjnyfS7u1mKLEKWA
       Content-Length:
       - '0'
   response:
@@ -3937,29 +4858,29 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 4bc53bb1-f660-4dea-b2cf-f1d477f6cc35
+      - 6287f138-8b84-459b-a837-a039d127fe30
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1196'
+      - '1199'
       X-Ms-Correlation-Request-Id:
-      - 507d8e55-a39a-4495-9f8c-7b149aca2481
+      - 229879b9-d51f-431d-87c3-0cd55fa2bc25
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201800Z:507d8e55-a39a-4495-9f8c-7b149aca2481
+      - WESTEUROPE:20180312T132752Z:229879b9-d51f-431d-87c3-0cd55fa2bc25
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:17:59 GMT
+      - Mon, 12 Mar 2018 13:27:51 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"keys":[{"keyName":"key1","value":"xMvZwiumnKCZnYVJjdtGLqaO1c2v6ERPx4XPDZO7TM1l7/jM1TxAAgtfCMkRn72aRPhqLqwWAn8n5a1iSGRHtA==","permissions":"Full"},{"keyName":"key2","value":"3nDvKhjGAIAvgnH2reuv7tzyeb/0dddgVeUT13VODYD5xO/jeAvQ7tkF3JqP2BAuFrmQqMB4GLkB4/cW4veYeA==","permissions":"Full"}]}'
+      string: '{"keys":[{"keyName":"key1","value":"9hGLwV9mjvAc1ARzeGwpsS9oZPLqOBzHCCHjeixyt1wpPYVn32cXmm3Gs9ogFPXZhDH61PAXxud0Dg/qwOnJ1w==","permissions":"Full"},{"keyName":"key2","value":"FfW8btVjJE2LkKHvN8Prr3FDX71BrS4SnMkONq2fLVPPm6x7vqqjeDSWDh17aI4CBLYf3Y1pc6njkbz53HdMYg==","permissions":"Full"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:00 GMT
+  recorded_at: Mon, 12 Mar 2018 13:27:52 GMT
 - request:
     method: head
-    uri: https://rspeclb.blob.core.windows.net/vhds/rspec-lb-b201682123650.vhd
+    uri: https://miqazuretest18686.blob.core.windows.net/vhds/miq-test-rhel12016218112243.vhd
     body:
       encoding: US-ASCII
       string: ''
@@ -3973,7 +4894,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:18:00 GMT
+      - Mon, 12 Mar 2018 13:27:52 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -3981,7 +4902,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey rspeclb:7SBl8DP5I3zuAD3O4UTyLRJWzsQWWDsTkjHojNG52wY=
+      - SharedKey miqazuretest18686:Vh/azmgtYHAwEHYb4nqsym2cFAsqg1PwVKkKTp4qzsQ=
   response:
     status:
       code: 200
@@ -3992,63 +4913,148 @@ http_interactions:
       Content-Type:
       - application/octet-stream
       Content-Md5:
-      - 8BW5hqrnOLoQINlZ05odxA==
+      - dQL+XHjFNPdoMEweI63fwQ==
       Last-Modified:
-      - Sat, 03 Sep 2016 14:05:40 GMT
+      - Mon, 12 Mar 2018 13:22:59 GMT
       Accept-Ranges:
       - bytes
       Etag:
-      - '"0x8D3D40362FE3898"'
-      Vary:
-      - Origin
+      - '"0x8D5881C60249D9B"'
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
-      X-Ms-Copy-Id:
-      - f64a314d-e573-457d-88d4-e16ecfbe2819
-      X-Ms-Copy-Progress:
-      - 32212255232/32212255232
-      X-Ms-Copy-Source:
-      - https://ardfepirv2bl6prdstp02a.blob.core.windows.net/a879bbefc56a43abb0ce65052aac09f3/rhel-67-20160302?sv=2014-02-14&sr=b&si=PirCacheAccountPublisherContainerPolicy&sig=odWVC2Axkv74I6hSj89s9UTQavqFXr29heJIw9TFaCY%3D
-      X-Ms-Copy-Status:
-      - success
-      X-Ms-Copy-Completion-Time:
-      - Fri, 02 Sep 2016 16:37:29 GMT
-      X-Ms-Meta-Microsoftazurecompute-Diskid:
-      - dbb822a3-53bf-49f9-808d-02390abcee67
-      X-Ms-Meta-Microsoftazurecompute-Diskname:
-      - rspec-lb-b
-      X-Ms-Meta-Microsoftazurecompute-Disktype:
-      - OSDisk
+      X-Ms-Request-Id:
+      - 301ba9a5-001e-00b3-3705-badcf8000000
+      X-Ms-Version:
+      - '2016-05-31'
       X-Ms-Meta-Microsoftazurecompute-Resourcegroupname:
       - miq-azure-test1
       X-Ms-Meta-Microsoftazurecompute-Vmname:
-      - rspec-lb-b
+      - miq-test-rhel1
+      X-Ms-Meta-Microsoftazurecompute-Diskid:
+      - 0ea91415-9058-46c6-9792-3afcb4da976f
+      X-Ms-Meta-Microsoftazurecompute-Diskname:
+      - miq-test-rhel1
+      X-Ms-Meta-Microsoftazurecompute-Disktype:
+      - OSDisk
+      X-Ms-Lease-Status:
+      - locked
       X-Ms-Lease-State:
       - leased
       X-Ms-Lease-Duration:
       - infinite
-      X-Ms-Lease-Status:
-      - locked
       X-Ms-Blob-Type:
       - PageBlob
       X-Ms-Blob-Sequence-Number:
-      - '1'
+      - '372'
+      X-Ms-Copy-Id:
+      - b967ea05-82a2-405a-8df9-4615d59df4eb
+      X-Ms-Copy-Source:
+      - https://ardfepirv2bl5prdstr06.blob.core.windows.net/a879bbefc56a43abb0ce65052aac09f3/rhel-72-20160302?sv=2014-02-14&sr=b&si=PirCacheAccountPublisherContainerPolicy&sig=2TQ3SKHqVnqe4jVKB4qMCBOphv2nYelKworI7pfckrs%3D
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 32212255232/32212255232
+      X-Ms-Copy-Completion-Time:
+      - Fri, 18 Mar 2016 17:23:28 GMT
       X-Ms-Server-Encrypted:
       - 'false'
-      X-Ms-Request-Id:
-      - 504f5d55-501c-006c-1151-b6ce14000000
-      X-Ms-Version:
-      - '2016-05-31'
       Date:
-      - Wed, 07 Mar 2018 20:18:00 GMT
+      - Mon, 12 Mar 2018 13:27:52 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:00 GMT
+  recorded_at: Mon, 12 Mar 2018 13:27:52 GMT
+- request:
+    method: head
+    uri: https://miqazuretest14047.blob.core.windows.net/vhds/miqazure-centos12016221104946.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 13:27:52 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey miqazuretest14047:MePcpCKHUXw1cwSD+Ah8ZyRwg+yfSRODAW1nyHry+LU=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '32212255232'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - bLK7rgT7IgMNX2YxL9BCyg==
+      Last-Modified:
+      - Fri, 22 Apr 2016 19:05:58 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D36AE123954B35"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 43633fa0-001e-007b-5505-ba4dcf000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Meta-Microsoftazurecompute-Resourcegroupname:
+      - miq-azure-test1
+      X-Ms-Meta-Microsoftazurecompute-Vmname:
+      - miqazure-centos1
+      X-Ms-Meta-Microsoftazurecompute-Diskid:
+      - 66656abf-e460-45ac-a6f0-851d0a50b23a
+      X-Ms-Meta-Microsoftazurecompute-Diskname:
+      - miqazure-centos1
+      X-Ms-Meta-Microsoftazurecompute-Disktype:
+      - OSDisk
+      X-Ms-Lease-Status:
+      - locked
+      X-Ms-Lease-State:
+      - leased
+      X-Ms-Lease-Duration:
+      - infinite
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '1'
+      X-Ms-Copy-Id:
+      - 549dd428-4055-4337-a425-05293b903858
+      X-Ms-Copy-Source:
+      - https://ardfepirv2bl5prdstr06.blob.core.windows.net/5112500ae3b842c8b9c604889f8753c3/OpenLogic-CentOS-71-20160308?sv=2014-02-14&sr=b&si=PirCacheAccountPublisherContainerPolicy&sig=fxe20jiCl%2Foys9OSvljXlookVPi76KM8FYlTr%2BSY4IQ%3D
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 32212255232/32212255232
+      X-Ms-Copy-Completion-Time:
+      - Mon, 21 Mar 2016 16:50:14 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Mon, 12 Mar 2018 13:27:52 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:27:53 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg?api-version=2018-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -4062,7 +5068,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1NDMsIm5iZiI6MTUyMDQ1MzU0MywiZXhwIjoxNTIwNDU3NDQzLCJhaW8iOiJZMk5nWUtnVTcxZFYzaEY3dGlIOFI4YzcyODZyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQXVkZnZJVlNIRVN2R3lpN0gySUFBQSIsInZlciI6IjEuMCJ9.DIpJSVBILdjgWTsPUuSjfYAwOg3J39WtKpji-H2_QiIDtP9TwVbFGnsY0qCNBvHBZJiEuXbpkNkRR_y2XGl6TT7BJe6jR9wqMEM3514u4JpwBgWH2aCbnLTjOo8JdqbphalN38iEWVwiUH2p4k7G3zDvZM6LsO9UGllA4K_AfRYfBosdPxqJjWgH3ZfgbBMMIvY5Z-Lr8-Z_AE_erdyYmIRc2mzUpWbQWdgzmm-PjH1-TaP4yzKckX5lnY34x5NHv8Hw55wiWxTPrWliHDnXNg-PAubyLnXwHQqDJqOUyNjgaa26Ru8nhB5XSlpRR19x4NVnosl2DIOgtF63sHTbnw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA5MzIsIm5iZiI6MTUyMDg2MDkzMiwiZXhwIjoxNTIwODY0ODMyLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRkFrM05rOHY4VU9OVmw0VmpzVXFBQSIsInZlciI6IjEuMCJ9.mNP_fcyGqvirg-gch_0gqMTkq6GfQsKJYWlu-tLV-aK6g_6NJPo9B4VM9tg_qRwhMb28-Cclixrg_u0pk2XwmYLHcOWHmw_WHOyqGFFglMG-sHX_VDBRXwSv2mjqkp43jdA0e4mZTg68NduEKev_voIdGn_CpOdmkOt7Q01iimz-aSv7m5JWIoZ8jiTgbW1okmkEyN2t7vAxPsqvVBsD6j-XXtvJ7XFmCPnPJ_kSIfioc5wW3FGyHlGjYD_uXZK1NxKEJMY0xAZSNytK83ZeFsE2MR8TKFrjOPya6VZN010Q3JVVPqYsD-Kme9UMpV5dIXoHbsqjnyfS7u1mKLEKWA
   response:
     status:
       code: 200
@@ -4079,35 +5085,35 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"1523bcb7-4597-4ae6-bcfc-ba8fc3826026"
+      - W/"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 3b858e96-ea31-4c08-9552-03dc15538fbd
+      - 2e76e225-f68a-4552-a4ba-4da8c1d72515
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14974'
+      - '14989'
       X-Ms-Correlation-Request-Id:
-      - 240bd171-f789-4032-aab3-90035ce53c34
+      - a06db8ac-5200-4577-822b-a04ef98457eb
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201801Z:240bd171-f789-4032-aab3-90035ce53c34
+      - WESTEUROPE:20180312T132753Z:a06db8ac-5200-4577-822b-a04ef98457eb
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:18:00 GMT
+      - Mon, 12 Mar 2018 13:27:53 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb-a-nsg\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg\",\r\n
-        \ \"etag\": \"W/\\\"1523bcb7-4597-4ae6-bcfc-ba8fc3826026\\\"\",\r\n  \"type\":
+      string: "{\r\n  \"name\": \"miqazure-linux-managed-nsg\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg\",\r\n
+        \ \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n  \"type\":
         \"Microsoft.Network/networkSecurityGroups\",\r\n  \"location\": \"eastus\",\r\n
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
-        \"63d15480-8c5a-4e18-9196-c43384932823\",\r\n    \"securityRules\": [\r\n
-        \     {\r\n        \"name\": \"default-allow-ssh\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg/securityRules/default-allow-ssh\",\r\n
-        \       \"etag\": \"W/\\\"1523bcb7-4597-4ae6-bcfc-ba8fc3826026\\\"\",\r\n
+        \"b4611f96-94a8-4486-94c5-16bb6c7a5c84\",\r\n    \"securityRules\": [\r\n
+        \     {\r\n        \"name\": \"default-allow-ssh\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/securityRules/default-allow-ssh\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"protocol\": \"TCP\",\r\n          \"sourcePortRange\": \"*\",\r\n
         \         \"destinationPortRange\": \"22\",\r\n          \"sourceAddressPrefix\":
@@ -4116,8 +5122,8 @@ http_interactions:
         \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
         [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
         []\r\n        }\r\n      }\r\n    ],\r\n    \"defaultSecurityRules\": [\r\n
-        \     {\r\n        \"name\": \"AllowVnetInBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg/defaultSecurityRules/AllowVnetInBound\",\r\n
-        \       \"etag\": \"W/\\\"1523bcb7-4597-4ae6-bcfc-ba8fc3826026\\\"\",\r\n
+        \     {\r\n        \"name\": \"AllowVnetInBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/AllowVnetInBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"description\": \"Allow inbound traffic from all VMs in VNET\",\r\n
         \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
@@ -4127,8 +5133,8 @@ http_interactions:
         \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
         [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
         []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowAzureLoadBalancerInBound\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg/defaultSecurityRules/AllowAzureLoadBalancerInBound\",\r\n
-        \       \"etag\": \"W/\\\"1523bcb7-4597-4ae6-bcfc-ba8fc3826026\\\"\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/AllowAzureLoadBalancerInBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"description\": \"Allow inbound traffic from azure load balancer\",\r\n
         \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
@@ -4138,8 +5144,8 @@ http_interactions:
         \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
         [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
         []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllInBound\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg/defaultSecurityRules/DenyAllInBound\",\r\n
-        \       \"etag\": \"W/\\\"1523bcb7-4597-4ae6-bcfc-ba8fc3826026\\\"\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/DenyAllInBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"description\": \"Deny all inbound traffic\",\r\n          \"protocol\":
         \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\":
@@ -4148,8 +5154,8 @@ http_interactions:
         \         \"direction\": \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n
         \         \"destinationPortRanges\": [],\r\n          \"sourceAddressPrefixes\":
         [],\r\n          \"destinationAddressPrefixes\": []\r\n        }\r\n      },\r\n
-        \     {\r\n        \"name\": \"AllowVnetOutBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg/defaultSecurityRules/AllowVnetOutBound\",\r\n
-        \       \"etag\": \"W/\\\"1523bcb7-4597-4ae6-bcfc-ba8fc3826026\\\"\",\r\n
+        \     {\r\n        \"name\": \"AllowVnetOutBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/AllowVnetOutBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"description\": \"Allow outbound traffic from all VMs to all VMs
         in VNET\",\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\":
@@ -4159,8 +5165,8 @@ http_interactions:
         \"Outbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
         [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
         []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowInternetOutBound\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg/defaultSecurityRules/AllowInternetOutBound\",\r\n
-        \       \"etag\": \"W/\\\"1523bcb7-4597-4ae6-bcfc-ba8fc3826026\\\"\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/AllowInternetOutBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"description\": \"Allow outbound traffic from all VMs to Internet\",\r\n
         \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
@@ -4170,8 +5176,8 @@ http_interactions:
         \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
         [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
         []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllOutBound\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg/defaultSecurityRules/DenyAllOutBound\",\r\n
-        \       \"etag\": \"W/\\\"1523bcb7-4597-4ae6-bcfc-ba8fc3826026\\\"\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/DenyAllOutBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"description\": \"Deny all outbound traffic\",\r\n          \"protocol\":
         \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\":
@@ -4180,13 +5186,13 @@ http_interactions:
         \         \"direction\": \"Outbound\",\r\n          \"sourcePortRanges\":
         [],\r\n          \"destinationPortRanges\": [],\r\n          \"sourceAddressPrefixes\":
         [],\r\n          \"destinationAddressPrefixes\": []\r\n        }\r\n      }\r\n
-        \   ],\r\n    \"networkInterfaces\": [\r\n      {\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670\"\r\n
+        \   ],\r\n    \"networkInterfaces\": [\r\n      {\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944\"\r\n
         \     }\r\n    ]\r\n  }\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:01 GMT
+  recorded_at: Mon, 12 Mar 2018 13:27:53 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/non_existent?api-version=2018-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -4200,7 +5206,59 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1NDMsIm5iZiI6MTUyMDQ1MzU0MywiZXhwIjoxNTIwNDU3NDQzLCJhaW8iOiJZMk5nWUtnVTcxZFYzaEY3dGlIOFI4YzcyODZyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQXVkZnZJVlNIRVN2R3lpN0gySUFBQSIsInZlciI6IjEuMCJ9.DIpJSVBILdjgWTsPUuSjfYAwOg3J39WtKpji-H2_QiIDtP9TwVbFGnsY0qCNBvHBZJiEuXbpkNkRR_y2XGl6TT7BJe6jR9wqMEM3514u4JpwBgWH2aCbnLTjOo8JdqbphalN38iEWVwiUH2p4k7G3zDvZM6LsO9UGllA4K_AfRYfBosdPxqJjWgH3ZfgbBMMIvY5Z-Lr8-Z_AE_erdyYmIRc2mzUpWbQWdgzmm-PjH1-TaP4yzKckX5lnY34x5NHv8Hw55wiWxTPrWliHDnXNg-PAubyLnXwHQqDJqOUyNjgaa26Ru8nhB5XSlpRR19x4NVnosl2DIOgtF63sHTbnw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA5MzIsIm5iZiI6MTUyMDg2MDkzMiwiZXhwIjoxNTIwODY0ODMyLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRkFrM05rOHY4VU9OVmw0VmpzVXFBQSIsInZlciI6IjEuMCJ9.mNP_fcyGqvirg-gch_0gqMTkq6GfQsKJYWlu-tLV-aK6g_6NJPo9B4VM9tg_qRwhMb28-Cclixrg_u0pk2XwmYLHcOWHmw_WHOyqGFFglMG-sHX_VDBRXwSv2mjqkp43jdA0e4mZTg68NduEKev_voIdGn_CpOdmkOt7Q01iimz-aSv7m5JWIoZ8jiTgbW1okmkEyN2t7vAxPsqvVBsD6j-XXtvJ7XFmCPnPJ_kSIfioc5wW3FGyHlGjYD_uXZK1NxKEJMY0xAZSNytK83ZeFsE2MR8TKFrjOPya6VZN010Q3JVVPqYsD-Kme9UMpV5dIXoHbsqjnyfS7u1mKLEKWA
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      X-Ms-Failure-Cause:
+      - gateway
+      X-Ms-Request-Id:
+      - ff4f2d59-51e2-4c7d-b4ac-86edd00c4955
+      X-Ms-Correlation-Request-Id:
+      - ff4f2d59-51e2-4c7d-b4ac-86edd00c4955
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T132757Z:ff4f2d59-51e2-4c7d-b4ac-86edd00c4955
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:27:57 GMT
+      Content-Length:
+      - '171'
+    body:
+      encoding: UTF-8
+      string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Network/networkSecurityGroups/non_existent''
+        under resource group ''miq-azure-test4'' was not found."}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:27:57 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA5MzIsIm5iZiI6MTUyMDg2MDkzMiwiZXhwIjoxNTIwODY0ODMyLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRkFrM05rOHY4VU9OVmw0VmpzVXFBQSIsInZlciI6IjEuMCJ9.mNP_fcyGqvirg-gch_0gqMTkq6GfQsKJYWlu-tLV-aK6g_6NJPo9B4VM9tg_qRwhMb28-Cclixrg_u0pk2XwmYLHcOWHmw_WHOyqGFFglMG-sHX_VDBRXwSv2mjqkp43jdA0e4mZTg68NduEKev_voIdGn_CpOdmkOt7Q01iimz-aSv7m5JWIoZ8jiTgbW1okmkEyN2t7vAxPsqvVBsD6j-XXtvJ7XFmCPnPJ_kSIfioc5wW3FGyHlGjYD_uXZK1NxKEJMY0xAZSNytK83ZeFsE2MR8TKFrjOPya6VZN010Q3JVVPqYsD-Kme9UMpV5dIXoHbsqjnyfS7u1mKLEKWA
   response:
     status:
       code: 200
@@ -4217,45 +5275,66 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"80e6f7a1-78ee-48b4-9b28-a464ef94de09"
+      - W/"5ad0e691-263e-42ca-8a93-833bd4dbf13f"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 2fd1145d-2abb-4824-a8bb-bae1ea18c08d
+      - 21bce9df-ce10-4dbe-8454-07dfa985855c
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14982'
+      - '14991'
       X-Ms-Correlation-Request-Id:
-      - f614cba5-b9ec-42af-9aa9-c659a4fa6fbe
+      - 45014f83-e410-40e5-905a-49c864782049
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201801Z:f614cba5-b9ec-42af-9aa9-c659a4fa6fbe
+      - WESTEUROPE:20180312T132800Z:45014f83-e410-40e5-905a-49c864782049
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:18:01 GMT
+      - Mon, 12 Mar 2018 13:27:59 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb-b-nsg\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg\",\r\n
-        \ \"etag\": \"W/\\\"80e6f7a1-78ee-48b4-9b28-a464ef94de09\\\"\",\r\n  \"type\":
+      string: "{\r\n  \"name\": \"miq-test-rhel1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1\",\r\n
+        \ \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n  \"type\":
         \"Microsoft.Network/networkSecurityGroups\",\r\n  \"location\": \"eastus\",\r\n
-        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
-        \"4ee44ca4-a721-4149-ad87-74d4150b4c1e\",\r\n    \"securityRules\": [\r\n
-        \     {\r\n        \"name\": \"default-allow-ssh\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg/securityRules/default-allow-ssh\",\r\n
-        \       \"etag\": \"W/\\\"80e6f7a1-78ee-48b4-9b28-a464ef94de09\\\"\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"f4a4a6a5-e2e8-47bd-b46f-00592f8fce53\",\r\n    \"securityRules\":
+        [\r\n      {\r\n        \"name\": \"default-allow-ssh\",\r\n        \"id\":
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/securityRules/default-allow-ssh\",\r\n
+        \       \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"TCP\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"protocol\": \"Tcp\",\r\n          \"sourcePortRange\": \"*\",\r\n
         \         \"destinationPortRange\": \"22\",\r\n          \"sourceAddressPrefix\":
         \"*\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n          \"access\":
         \"Allow\",\r\n          \"priority\": 1000,\r\n          \"direction\": \"Inbound\",\r\n
         \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
         [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"rhel1-inbound1\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/securityRules/rhel1-inbound1\",\r\n
+        \       \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"protocol\": \"Tcp\",\r\n          \"sourcePortRange\": \"80\",\r\n
+        \         \"destinationPortRange\": \"80\",\r\n          \"sourceAddressPrefix\":
+        \"*\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n          \"access\":
+        \"Allow\",\r\n          \"priority\": 100,\r\n          \"direction\": \"Inbound\",\r\n
+        \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"rhel1-inbound2\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/securityRules/rhel1-inbound2\",\r\n
+        \       \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"protocol\": \"Tcp\",\r\n          \"sourcePortRange\": \"443\",\r\n
+        \         \"destinationPortRange\": \"443\",\r\n          \"sourceAddressPrefix\":
+        \"*\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n          \"access\":
+        \"Allow\",\r\n          \"priority\": 200,\r\n          \"direction\": \"Inbound\",\r\n
+        \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
         []\r\n        }\r\n      }\r\n    ],\r\n    \"defaultSecurityRules\": [\r\n
-        \     {\r\n        \"name\": \"AllowVnetInBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg/defaultSecurityRules/AllowVnetInBound\",\r\n
-        \       \"etag\": \"W/\\\"80e6f7a1-78ee-48b4-9b28-a464ef94de09\\\"\",\r\n
+        \     {\r\n        \"name\": \"AllowVnetInBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/defaultSecurityRules/AllowVnetInBound\",\r\n
+        \       \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"description\": \"Allow inbound traffic from all VMs in VNET\",\r\n
         \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
@@ -4265,8 +5344,8 @@ http_interactions:
         \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
         [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
         []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowAzureLoadBalancerInBound\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg/defaultSecurityRules/AllowAzureLoadBalancerInBound\",\r\n
-        \       \"etag\": \"W/\\\"80e6f7a1-78ee-48b4-9b28-a464ef94de09\\\"\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/defaultSecurityRules/AllowAzureLoadBalancerInBound\",\r\n
+        \       \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"description\": \"Allow inbound traffic from azure load balancer\",\r\n
         \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
@@ -4276,8 +5355,8 @@ http_interactions:
         \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
         [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
         []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllInBound\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg/defaultSecurityRules/DenyAllInBound\",\r\n
-        \       \"etag\": \"W/\\\"80e6f7a1-78ee-48b4-9b28-a464ef94de09\\\"\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/defaultSecurityRules/DenyAllInBound\",\r\n
+        \       \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"description\": \"Deny all inbound traffic\",\r\n          \"protocol\":
         \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\":
@@ -4286,8 +5365,8 @@ http_interactions:
         \         \"direction\": \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n
         \         \"destinationPortRanges\": [],\r\n          \"sourceAddressPrefixes\":
         [],\r\n          \"destinationAddressPrefixes\": []\r\n        }\r\n      },\r\n
-        \     {\r\n        \"name\": \"AllowVnetOutBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg/defaultSecurityRules/AllowVnetOutBound\",\r\n
-        \       \"etag\": \"W/\\\"80e6f7a1-78ee-48b4-9b28-a464ef94de09\\\"\",\r\n
+        \     {\r\n        \"name\": \"AllowVnetOutBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/defaultSecurityRules/AllowVnetOutBound\",\r\n
+        \       \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"description\": \"Allow outbound traffic from all VMs to all VMs
         in VNET\",\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\":
@@ -4297,8 +5376,8 @@ http_interactions:
         \"Outbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
         [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
         []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowInternetOutBound\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg/defaultSecurityRules/AllowInternetOutBound\",\r\n
-        \       \"etag\": \"W/\\\"80e6f7a1-78ee-48b4-9b28-a464ef94de09\\\"\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/defaultSecurityRules/AllowInternetOutBound\",\r\n
+        \       \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"description\": \"Allow outbound traffic from all VMs to Internet\",\r\n
         \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
@@ -4308,8 +5387,8 @@ http_interactions:
         \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
         [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
         []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllOutBound\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg/defaultSecurityRules/DenyAllOutBound\",\r\n
-        \       \"etag\": \"W/\\\"80e6f7a1-78ee-48b4-9b28-a464ef94de09\\\"\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/defaultSecurityRules/DenyAllOutBound\",\r\n
+        \       \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"description\": \"Deny all outbound traffic\",\r\n          \"protocol\":
         \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\":
@@ -4318,10 +5397,271 @@ http_interactions:
         \         \"direction\": \"Outbound\",\r\n          \"sourcePortRanges\":
         [],\r\n          \"destinationPortRanges\": [],\r\n          \"sourceAddressPrefixes\":
         [],\r\n          \"destinationAddressPrefixes\": []\r\n        }\r\n      }\r\n
-        \   ],\r\n    \"networkInterfaces\": [\r\n      {\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843\"\r\n
+        \   ],\r\n    \"networkInterfaces\": [\r\n      {\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390\"\r\n
         \     }\r\n    ]\r\n  }\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:01 GMT
+  recorded_at: Mon, 12 Mar 2018 13:28:00 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA5MzIsIm5iZiI6MTUyMDg2MDkzMiwiZXhwIjoxNTIwODY0ODMyLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRkFrM05rOHY4VU9OVmw0VmpzVXFBQSIsInZlciI6IjEuMCJ9.mNP_fcyGqvirg-gch_0gqMTkq6GfQsKJYWlu-tLV-aK6g_6NJPo9B4VM9tg_qRwhMb28-Cclixrg_u0pk2XwmYLHcOWHmw_WHOyqGFFglMG-sHX_VDBRXwSv2mjqkp43jdA0e4mZTg68NduEKev_voIdGn_CpOdmkOt7Q01iimz-aSv7m5JWIoZ8jiTgbW1okmkEyN2t7vAxPsqvVBsD6j-XXtvJ7XFmCPnPJ_kSIfioc5wW3FGyHlGjYD_uXZK1NxKEJMY0xAZSNytK83ZeFsE2MR8TKFrjOPya6VZN010Q3JVVPqYsD-Kme9UMpV5dIXoHbsqjnyfS7u1mKLEKWA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"f1907e14-fcad-4f75-8faa-ab325bf879d9"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 5484b888-4d36-48c4-bf45-0e9e1d2dd0df
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Correlation-Request-Id:
+      - 715ff5e8-3397-44d1-b6e9-9117e34eca79
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T132802Z:715ff5e8-3397-44d1-b6e9-9117e34eca79
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:28:01 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"miqazure-centos1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1\",\r\n
+        \ \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/networkSecurityGroups\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
+        \"9ca49a93-6f7d-464c-b23d-e61e847ce2d6\",\r\n    \"securityRules\": [\r\n
+        \     {\r\n        \"name\": \"default-allow-ssh\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/securityRules/default-allow-ssh\",\r\n
+        \       \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"protocol\": \"Tcp\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"22\",\r\n          \"sourceAddressPrefix\":
+        \"*\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n          \"access\":
+        \"Allow\",\r\n          \"priority\": 1000,\r\n          \"direction\": \"Inbound\",\r\n
+        \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      }\r\n    ],\r\n    \"defaultSecurityRules\": [\r\n
+        \     {\r\n        \"name\": \"AllowVnetInBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/defaultSecurityRules/AllowVnetInBound\",\r\n
+        \       \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow inbound traffic from all VMs in VNET\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"VirtualNetwork\",\r\n          \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n          \"direction\":
+        \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowAzureLoadBalancerInBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/defaultSecurityRules/AllowAzureLoadBalancerInBound\",\r\n
+        \       \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow inbound traffic from azure load balancer\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"AzureLoadBalancer\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65001,\r\n          \"direction\":
+        \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllInBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/defaultSecurityRules/DenyAllInBound\",\r\n
+        \       \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Deny all inbound traffic\",\r\n          \"protocol\":
+        \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\":
+        \"*\",\r\n          \"sourceAddressPrefix\": \"*\",\r\n          \"destinationAddressPrefix\":
+        \"*\",\r\n          \"access\": \"Deny\",\r\n          \"priority\": 65500,\r\n
+        \         \"direction\": \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n
+        \         \"destinationPortRanges\": [],\r\n          \"sourceAddressPrefixes\":
+        [],\r\n          \"destinationAddressPrefixes\": []\r\n        }\r\n      },\r\n
+        \     {\r\n        \"name\": \"AllowVnetOutBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/defaultSecurityRules/AllowVnetOutBound\",\r\n
+        \       \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow outbound traffic from all VMs to all VMs
+        in VNET\",\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\":
+        \"*\",\r\n          \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"VirtualNetwork\",\r\n          \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n          \"direction\":
+        \"Outbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowInternetOutBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/defaultSecurityRules/AllowInternetOutBound\",\r\n
+        \       \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow outbound traffic from all VMs to Internet\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"*\",\r\n          \"destinationAddressPrefix\": \"Internet\",\r\n          \"access\":
+        \"Allow\",\r\n          \"priority\": 65001,\r\n          \"direction\": \"Outbound\",\r\n
+        \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllOutBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/defaultSecurityRules/DenyAllOutBound\",\r\n
+        \       \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Deny all outbound traffic\",\r\n          \"protocol\":
+        \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\":
+        \"*\",\r\n          \"sourceAddressPrefix\": \"*\",\r\n          \"destinationAddressPrefix\":
+        \"*\",\r\n          \"access\": \"Deny\",\r\n          \"priority\": 65500,\r\n
+        \         \"direction\": \"Outbound\",\r\n          \"sourcePortRanges\":
+        [],\r\n          \"destinationPortRanges\": [],\r\n          \"sourceAddressPrefixes\":
+        [],\r\n          \"destinationAddressPrefixes\": []\r\n        }\r\n      }\r\n
+        \   ],\r\n    \"networkInterfaces\": [\r\n      {\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611\"\r\n
+        \     }\r\n    ]\r\n  }\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:28:02 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA5MzIsIm5iZiI6MTUyMDg2MDkzMiwiZXhwIjoxNTIwODY0ODMyLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRkFrM05rOHY4VU9OVmw0VmpzVXFBQSIsInZlciI6IjEuMCJ9.mNP_fcyGqvirg-gch_0gqMTkq6GfQsKJYWlu-tLV-aK6g_6NJPo9B4VM9tg_qRwhMb28-Cclixrg_u0pk2XwmYLHcOWHmw_WHOyqGFFglMG-sHX_VDBRXwSv2mjqkp43jdA0e4mZTg68NduEKev_voIdGn_CpOdmkOt7Q01iimz-aSv7m5JWIoZ8jiTgbW1okmkEyN2t7vAxPsqvVBsD6j-XXtvJ7XFmCPnPJ_kSIfioc5wW3FGyHlGjYD_uXZK1NxKEJMY0xAZSNytK83ZeFsE2MR8TKFrjOPya6VZN010Q3JVVPqYsD-Kme9UMpV5dIXoHbsqjnyfS7u1mKLEKWA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"f5bbd20f-7ae4-4b6d-89c8-eb3481fcbe05"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - af2d0e50-7234-4fbc-89db-39284aee390d
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Correlation-Request-Id:
+      - 8116f2b5-4f01-40ad-89d8-72bea758afb2
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T132803Z:8116f2b5-4f01-40ad-89d8-72bea758afb2
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:28:02 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"miq-azure-test2\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2\",\r\n
+        \ \"etag\": \"W/\\\"f5bbd20f-7ae4-4b6d-89c8-eb3481fcbe05\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
+        \"f950a3cf-749a-49d5-a7fb-33a400b0e93c\",\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\":
+        [\r\n        \"172.25.0.0/16\"\r\n      ]\r\n    },\r\n    \"subnets\": [\r\n
+        \     {\r\n        \"name\": \"default\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2/subnets/default\",\r\n
+        \       \"etag\": \"W/\\\"f5bbd20f-7ae4-4b6d-89c8-eb3481fcbe05\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"addressPrefix\": \"172.25.0.0/24\",\r\n          \"ipConfigurations\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944/ipConfigurations/ipconfig1\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"virtualNetworkPeerings\":
+        [],\r\n    \"enableDdosProtection\": false,\r\n    \"enableVmProtection\":
+        false\r\n  }\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:28:03 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/non_existent?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA5MzIsIm5iZiI6MTUyMDg2MDkzMiwiZXhwIjoxNTIwODY0ODMyLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRkFrM05rOHY4VU9OVmw0VmpzVXFBQSIsInZlciI6IjEuMCJ9.mNP_fcyGqvirg-gch_0gqMTkq6GfQsKJYWlu-tLV-aK6g_6NJPo9B4VM9tg_qRwhMb28-Cclixrg_u0pk2XwmYLHcOWHmw_WHOyqGFFglMG-sHX_VDBRXwSv2mjqkp43jdA0e4mZTg68NduEKev_voIdGn_CpOdmkOt7Q01iimz-aSv7m5JWIoZ8jiTgbW1okmkEyN2t7vAxPsqvVBsD6j-XXtvJ7XFmCPnPJ_kSIfioc5wW3FGyHlGjYD_uXZK1NxKEJMY0xAZSNytK83ZeFsE2MR8TKFrjOPya6VZN010Q3JVVPqYsD-Kme9UMpV5dIXoHbsqjnyfS7u1mKLEKWA
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      X-Ms-Failure-Cause:
+      - gateway
+      X-Ms-Request-Id:
+      - ee85111c-656d-4971-b64d-d5638d7632dd
+      X-Ms-Correlation-Request-Id:
+      - ee85111c-656d-4971-b64d-d5638d7632dd
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T132804Z:ee85111c-656d-4971-b64d-d5638d7632dd
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:28:03 GMT
+      Content-Length:
+      - '165'
+    body:
+      encoding: UTF-8
+      string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Network/virtualNetworks/non_existent''
+        under resource group ''miq-azure-test2'' was not found."}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:28:04 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1?api-version=2018-01-01
@@ -4338,7 +5678,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1NDMsIm5iZiI6MTUyMDQ1MzU0MywiZXhwIjoxNTIwNDU3NDQzLCJhaW8iOiJZMk5nWUtnVTcxZFYzaEY3dGlIOFI4YzcyODZyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQXVkZnZJVlNIRVN2R3lpN0gySUFBQSIsInZlciI6IjEuMCJ9.DIpJSVBILdjgWTsPUuSjfYAwOg3J39WtKpji-H2_QiIDtP9TwVbFGnsY0qCNBvHBZJiEuXbpkNkRR_y2XGl6TT7BJe6jR9wqMEM3514u4JpwBgWH2aCbnLTjOo8JdqbphalN38iEWVwiUH2p4k7G3zDvZM6LsO9UGllA4K_AfRYfBosdPxqJjWgH3ZfgbBMMIvY5Z-Lr8-Z_AE_erdyYmIRc2mzUpWbQWdgzmm-PjH1-TaP4yzKckX5lnY34x5NHv8Hw55wiWxTPrWliHDnXNg-PAubyLnXwHQqDJqOUyNjgaa26Ru8nhB5XSlpRR19x4NVnosl2DIOgtF63sHTbnw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA5MzIsIm5iZiI6MTUyMDg2MDkzMiwiZXhwIjoxNTIwODY0ODMyLCJhaW8iOiJZMk5nWUZndEpkaTZRK0o1ajBsbTlaL2licFUyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRkFrM05rOHY4VU9OVmw0VmpzVXFBQSIsInZlciI6IjEuMCJ9.mNP_fcyGqvirg-gch_0gqMTkq6GfQsKJYWlu-tLV-aK6g_6NJPo9B4VM9tg_qRwhMb28-Cclixrg_u0pk2XwmYLHcOWHmw_WHOyqGFFglMG-sHX_VDBRXwSv2mjqkp43jdA0e4mZTg68NduEKev_voIdGn_CpOdmkOt7Q01iimz-aSv7m5JWIoZ8jiTgbW1okmkEyN2t7vAxPsqvVBsD6j-XXtvJ7XFmCPnPJ_kSIfioc5wW3FGyHlGjYD_uXZK1NxKEJMY0xAZSNytK83ZeFsE2MR8TKFrjOPya6VZN010Q3JVVPqYsD-Kme9UMpV5dIXoHbsqjnyfS7u1mKLEKWA
   response:
     status:
       code: 200
@@ -4355,36 +5695,36 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"fceae1ac-4620-482a-bc6d-79c867179ae5"
+      - W/"a8b09238-30fc-4b36-a58d-e3cc69e267c5"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 1a67862b-0e26-412f-87c2-7451cac102d6
+      - c38b25e0-af51-4e72-ac35-92b5a962963b
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14970'
+      - '14994'
       X-Ms-Correlation-Request-Id:
-      - 99ac6861-c482-4c1f-a6a8-50200a567127
+      - ea6e4644-2694-4f29-a873-3d6eb6f0f584
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201802Z:99ac6861-c482-4c1f-a6a8-50200a567127
+      - WESTEUROPE:20180312T132805Z:ea6e4644-2694-4f29-a873-3d6eb6f0f584
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:18:01 GMT
+      - Mon, 12 Mar 2018 13:28:04 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"miq-azure-test1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1\",\r\n
-        \ \"etag\": \"W/\\\"fceae1ac-4620-482a-bc6d-79c867179ae5\\\"\",\r\n  \"type\":
+        \ \"etag\": \"W/\\\"a8b09238-30fc-4b36-a58d-e3cc69e267c5\\\"\",\r\n  \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
         \"d74c1e5f-50e4-4c8a-a7fe-78eaddc6b915\",\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\":
         [\r\n        \"10.16.0.0/16\"\r\n      ]\r\n    },\r\n    \"subnets\": [\r\n
         \     {\r\n        \"name\": \"default\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\",\r\n
-        \       \"etag\": \"W/\\\"fceae1ac-4620-482a-bc6d-79c867179ae5\\\"\",\r\n
+        \       \"etag\": \"W/\\\"a8b09238-30fc-4b36-a58d-e3cc69e267c5\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"addressPrefix\": \"10.16.0.0/24\",\r\n          \"ipConfigurations\":
         [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1\"\r\n
@@ -4394,298 +5734,10 @@ http_interactions:
         \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/dbergerprov1/ipConfigurations/dbergerprov1\"\r\n
         \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
         \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/ladas_test_1/ipConfigurations/ladas_test_1\"\r\n
         \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"virtualNetworkPeerings\":
         [],\r\n    \"enableDdosProtection\": false,\r\n    \"enableVmProtection\":
         false\r\n  }\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:02 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1NDMsIm5iZiI6MTUyMDQ1MzU0MywiZXhwIjoxNTIwNDU3NDQzLCJhaW8iOiJZMk5nWUtnVTcxZFYzaEY3dGlIOFI4YzcyODZyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQXVkZnZJVlNIRVN2R3lpN0gySUFBQSIsInZlciI6IjEuMCJ9.DIpJSVBILdjgWTsPUuSjfYAwOg3J39WtKpji-H2_QiIDtP9TwVbFGnsY0qCNBvHBZJiEuXbpkNkRR_y2XGl6TT7BJe6jR9wqMEM3514u4JpwBgWH2aCbnLTjOo8JdqbphalN38iEWVwiUH2p4k7G3zDvZM6LsO9UGllA4K_AfRYfBosdPxqJjWgH3ZfgbBMMIvY5Z-Lr8-Z_AE_erdyYmIRc2mzUpWbQWdgzmm-PjH1-TaP4yzKckX5lnY34x5NHv8Hw55wiWxTPrWliHDnXNg-PAubyLnXwHQqDJqOUyNjgaa26Ru8nhB5XSlpRR19x4NVnosl2DIOgtF63sHTbnw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"cf3a0b0d-d596-4f33-bc31-749f92ba4f00"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 0be1909a-3926-4680-886d-d7778dd8f0e7
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14980'
-      X-Ms-Correlation-Request-Id:
-      - 99f22e3a-c6bb-421d-9c4c-f5bab24b64b7
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201802Z:99f22e3a-c6bb-421d-9c4c-f5bab24b64b7
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:18:02 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb-a670\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670\",\r\n
-        \ \"etag\": \"W/\\\"cf3a0b0d-d596-4f33-bc31-749f92ba4f00\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"46cb8216-786e-408e-9d86-c0855b357349\",\r\n    \"ipConfigurations\":
-        [\r\n      {\r\n        \"name\": \"ipconfig1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\",\r\n
-        \       \"etag\": \"W/\\\"cf3a0b0d-d596-4f33-bc31-749f92ba4f00\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAddress\": \"10.16.0.6\",\r\n          \"privateIPAllocationMethod\":
-        \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-a-ip\"\r\n
-        \         },\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\"\r\n
-        \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
-        \"IPv4\",\r\n          \"loadBalancerBackendAddressPools\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\"\r\n
-        \           }\r\n          ],\r\n          \"loadBalancerInboundNatRules\":
-        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\":
-        {\r\n      \"dnsServers\": [],\r\n      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\":
-        \"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net\"\r\n    },\r\n    \"enableAcceleratedNetworking\":
-        false,\r\n    \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\":
-        {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg\"\r\n
-        \   },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a\"\r\n
-        \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
-        \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:02 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1NDMsIm5iZiI6MTUyMDQ1MzU0MywiZXhwIjoxNTIwNDU3NDQzLCJhaW8iOiJZMk5nWUtnVTcxZFYzaEY3dGlIOFI4YzcyODZyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQXVkZnZJVlNIRVN2R3lpN0gySUFBQSIsInZlciI6IjEuMCJ9.DIpJSVBILdjgWTsPUuSjfYAwOg3J39WtKpji-H2_QiIDtP9TwVbFGnsY0qCNBvHBZJiEuXbpkNkRR_y2XGl6TT7BJe6jR9wqMEM3514u4JpwBgWH2aCbnLTjOo8JdqbphalN38iEWVwiUH2p4k7G3zDvZM6LsO9UGllA4K_AfRYfBosdPxqJjWgH3ZfgbBMMIvY5Z-Lr8-Z_AE_erdyYmIRc2mzUpWbQWdgzmm-PjH1-TaP4yzKckX5lnY34x5NHv8Hw55wiWxTPrWliHDnXNg-PAubyLnXwHQqDJqOUyNjgaa26Ru8nhB5XSlpRR19x4NVnosl2DIOgtF63sHTbnw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"76aabe0c-8678-43f0-81a5-2f15784a4b99"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - d77e4efa-2c3c-4f30-9fb8-a084839841ee
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14772'
-      X-Ms-Correlation-Request-Id:
-      - 95d6596f-22e2-439a-ab55-07e4fd92d127
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201803Z:95d6596f-22e2-439a-ab55-07e4fd92d127
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:18:02 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb-b843\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843\",\r\n
-        \ \"etag\": \"W/\\\"76aabe0c-8678-43f0-81a5-2f15784a4b99\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"3ef6fa01-ac34-43a1-8fd7-67c706b4d8ef\",\r\n    \"ipConfigurations\":
-        [\r\n      {\r\n        \"name\": \"ipconfig1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\",\r\n
-        \       \"etag\": \"W/\\\"76aabe0c-8678-43f0-81a5-2f15784a4b99\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAddress\": \"10.16.0.11\",\r\n          \"privateIPAllocationMethod\":
-        \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-b-ip\"\r\n
-        \         },\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\"\r\n
-        \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
-        \"IPv4\",\r\n          \"loadBalancerBackendAddressPools\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\":
-        {\r\n      \"dnsServers\": [],\r\n      \"appliedDnsServers\": []\r\n    },\r\n
-        \   \"enableAcceleratedNetworking\": false,\r\n    \"enableIPForwarding\":
-        false,\r\n    \"networkSecurityGroup\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg\"\r\n
-        \   },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b\"\r\n
-        \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
-        \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:03 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-a-ip?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1NDMsIm5iZiI6MTUyMDQ1MzU0MywiZXhwIjoxNTIwNDU3NDQzLCJhaW8iOiJZMk5nWUtnVTcxZFYzaEY3dGlIOFI4YzcyODZyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQXVkZnZJVlNIRVN2R3lpN0gySUFBQSIsInZlciI6IjEuMCJ9.DIpJSVBILdjgWTsPUuSjfYAwOg3J39WtKpji-H2_QiIDtP9TwVbFGnsY0qCNBvHBZJiEuXbpkNkRR_y2XGl6TT7BJe6jR9wqMEM3514u4JpwBgWH2aCbnLTjOo8JdqbphalN38iEWVwiUH2p4k7G3zDvZM6LsO9UGllA4K_AfRYfBosdPxqJjWgH3ZfgbBMMIvY5Z-Lr8-Z_AE_erdyYmIRc2mzUpWbQWdgzmm-PjH1-TaP4yzKckX5lnY34x5NHv8Hw55wiWxTPrWliHDnXNg-PAubyLnXwHQqDJqOUyNjgaa26Ru8nhB5XSlpRR19x4NVnosl2DIOgtF63sHTbnw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"3ba30997-7d2f-470c-96f6-301158e93b7c"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - a4e929f0-f77e-413a-bf34-31044e880caf
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14872'
-      X-Ms-Correlation-Request-Id:
-      - 684ebaeb-97cd-489c-9927-9d4af309d9f3
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201803Z:684ebaeb-97cd-489c-9927-9d4af309d9f3
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:18:03 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb-a-ip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-a-ip\",\r\n
-        \ \"etag\": \"W/\\\"3ba30997-7d2f-470c-96f6-301158e93b7c\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"3c605f75-23c0-46ab-ba2b-6fd4430140fd\",\r\n    \"publicIPAddressVersion\":
-        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
-        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
-        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:03 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-b-ip?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1NDMsIm5iZiI6MTUyMDQ1MzU0MywiZXhwIjoxNTIwNDU3NDQzLCJhaW8iOiJZMk5nWUtnVTcxZFYzaEY3dGlIOFI4YzcyODZyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQXVkZnZJVlNIRVN2R3lpN0gySUFBQSIsInZlciI6IjEuMCJ9.DIpJSVBILdjgWTsPUuSjfYAwOg3J39WtKpji-H2_QiIDtP9TwVbFGnsY0qCNBvHBZJiEuXbpkNkRR_y2XGl6TT7BJe6jR9wqMEM3514u4JpwBgWH2aCbnLTjOo8JdqbphalN38iEWVwiUH2p4k7G3zDvZM6LsO9UGllA4K_AfRYfBosdPxqJjWgH3ZfgbBMMIvY5Z-Lr8-Z_AE_erdyYmIRc2mzUpWbQWdgzmm-PjH1-TaP4yzKckX5lnY34x5NHv8Hw55wiWxTPrWliHDnXNg-PAubyLnXwHQqDJqOUyNjgaa26Ru8nhB5XSlpRR19x4NVnosl2DIOgtF63sHTbnw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"cf6012c7-3d47-438f-84d7-332ad1ef4500"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - a9d1cd78-f17d-4376-8297-373ff524ffe8
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14972'
-      X-Ms-Correlation-Request-Id:
-      - 79e20a20-b7f5-4c97-8965-0069bf22802a
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201804Z:79e20a20-b7f5-4c97-8965-0069bf22802a
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:18:03 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb-b-ip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-b-ip\",\r\n
-        \ \"etag\": \"W/\\\"cf6012c7-3d47-438f-84d7-332ad1ef4500\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"5d1a2425-a351-4c0f-bc87-37e6500bff22\",\r\n    \"publicIPAddressVersion\":
-        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
-        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\"\r\n
-        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
-        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:04 GMT
+  recorded_at: Mon, 12 Mar 2018 13:28:05 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_0/network_port_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_0/network_port_refresh.yml
@@ -1,6 +1,62 @@
 ---
 http_interactions:
 - request:
+    method: post
+    uri: https://login.microsoftonline.com/AZURE_TENANT_ID/oauth2/token
+    body:
+      encoding: UTF-8
+      string: grant_type=client_credentials&client_id=AZURE_CLIENT_ID&client_secret=AZURE_CLIENT_SECRET&resource=https%3A%2F%2Fmanagement.azure.com%2F
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Server:
+      - Microsoft-IIS/10.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Request-Id:
+      - 35573a74-f318-4a78-b1ec-7a1c14482f00
+      P3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Set-Cookie:
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzJnaDKICO3j16CH63_T1SNvXSaV2PGZ8evMWrKORCBpcsCLu6GwOD0kpJTr4AhtfTU7pi6W7U9PQ-ENLuLjUujgf8P7jaayvgpDLjY-YupQEi_5M61dYkZHesNPFaen94LKSkfk24baUZevMgSND5JfkHK4SmcoYipnzkS0G0ph8gAA;
+        domain=.login.microsoftonline.com; path=/; secure; HttpOnly
+      - stsservicecookie=ests; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=006; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Tue, 13 Mar 2018 09:01:04 GMT
+      Content-Length:
+      - '1505'
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"Bearer","expires_in":"3600","ext_expires_in":"0","expires_on":"1520935264","not_before":"1520931364","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA5MzEzNjQsIm5iZiI6MTUyMDkzMTM2NCwiZXhwIjoxNTIwOTM1MjY0LCJhaW8iOiJZMk5nWU5qQnVUVng5OU1Kai9QZUY0akhQV2xXQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZERwWE5SanplRXF4N0hvY0ZFZ3ZBQSIsInZlciI6IjEuMCJ9.Q0olXkHqdxEw9vVdlY5VEnB6bcJsIxXS0HDMS0__6I_S6Zu0WZmMy0tGCLxQtKgZqcS18Y2J7rtCPgl3RvlnKbuL6SOpU-4rciaY2Z5kv3QFK8lRy9Ea0zYvrgWPkzxglreLRLrfLe95Jt_fTG5VSd6s_bnkfezCsGMz2oirGzayre0s5t_yor9f1Y8RGtJ7xdn-nJFXRhBOX9f4mOKbH6A3_7TotOU47tJ2GBhwqSWdO8BMo5f3VXXDxTtPTGuXgjUQ7nVqry5Zoa3FInESDB7D6NsnhGMTsNC8vS-HTxDuRoq_somRri34BZuWoHJ1zGfT9go-Gnn2JR2oqb4Hlw"}'
+    http_version: 
+  recorded_at: Tue, 13 Mar 2018 09:01:05 GMT
+- request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
     body:
@@ -16,7 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA5MzEzNjQsIm5iZiI6MTUyMDkzMTM2NCwiZXhwIjoxNTIwOTM1MjY0LCJhaW8iOiJZMk5nWU5qQnVUVng5OU1Kai9QZUY0akhQV2xXQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZERwWE5SanplRXF4N0hvY0ZFZ3ZBQSIsInZlciI6IjEuMCJ9.Q0olXkHqdxEw9vVdlY5VEnB6bcJsIxXS0HDMS0__6I_S6Zu0WZmMy0tGCLxQtKgZqcS18Y2J7rtCPgl3RvlnKbuL6SOpU-4rciaY2Z5kv3QFK8lRy9Ea0zYvrgWPkzxglreLRLrfLe95Jt_fTG5VSd6s_bnkfezCsGMz2oirGzayre0s5t_yor9f1Y8RGtJ7xdn-nJFXRhBOX9f4mOKbH6A3_7TotOU47tJ2GBhwqSWdO8BMo5f3VXXDxTtPTGuXgjUQ7nVqry5Zoa3FInESDB7D6NsnhGMTsNC8vS-HTxDuRoq_somRri34BZuWoHJ1zGfT9go-Gnn2JR2oqb4Hlw
   response:
     status:
       code: 200
@@ -35,26 +91,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14997'
+      - '14999'
       X-Ms-Request-Id:
-      - cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - ef3fc161-eccf-4547-95b2-5d6cb51d695e
       X-Ms-Correlation-Request-Id:
-      - cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - ef3fc161-eccf-4547-95b2-5d6cb51d695e
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102417Z:cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - WESTEUROPE:20180313T090105Z:ef3fc161-eccf-4547-95b2-5d6cb51d695e
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:17 GMT
+      - Tue, 13 Mar 2018 09:01:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID","subscriptionId":"AZURE_SUBSCRIPTION_ID","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:22 GMT
+  recorded_at: Tue, 13 Mar 2018 09:01:05 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers?api-version=2015-01-01
@@ -71,7 +127,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA5MzEzNjQsIm5iZiI6MTUyMDkzMTM2NCwiZXhwIjoxNTIwOTM1MjY0LCJhaW8iOiJZMk5nWU5qQnVUVng5OU1Kai9QZUY0akhQV2xXQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZERwWE5SanplRXF4N0hvY0ZFZ3ZBQSIsInZlciI6IjEuMCJ9.Q0olXkHqdxEw9vVdlY5VEnB6bcJsIxXS0HDMS0__6I_S6Zu0WZmMy0tGCLxQtKgZqcS18Y2J7rtCPgl3RvlnKbuL6SOpU-4rciaY2Z5kv3QFK8lRy9Ea0zYvrgWPkzxglreLRLrfLe95Jt_fTG5VSd6s_bnkfezCsGMz2oirGzayre0s5t_yor9f1Y8RGtJ7xdn-nJFXRhBOX9f4mOKbH6A3_7TotOU47tJ2GBhwqSWdO8BMo5f3VXXDxTtPTGuXgjUQ7nVqry5Zoa3FInESDB7D6NsnhGMTsNC8vS-HTxDuRoq_somRri34BZuWoHJ1zGfT9go-Gnn2JR2oqb4Hlw
   response:
     status:
       code: 200
@@ -88,21 +144,21 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - '14933'
       X-Ms-Request-Id:
-      - fe3532ca-59a2-474e-9094-8a3697b82bef
+      - d10ad7fc-0d33-4f54-8910-762ba4557d4a
       X-Ms-Correlation-Request-Id:
-      - fe3532ca-59a2-474e-9094-8a3697b82bef
+      - d10ad7fc-0d33-4f54-8910-762ba4557d4a
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102419Z:fe3532ca-59a2-474e-9094-8a3697b82bef
+      - WESTEUROPE:20180313T090106Z:d10ad7fc-0d33-4f54-8910-762ba4557d4a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:18 GMT
+      - Tue, 13 Mar 2018 09:01:06 GMT
       Content-Length:
-      - '320853'
+      - '322992'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"},{"applicationId":"d87dcbc6-a371-462e-88e3-28ad15ec4e64","roleDefinitionId":"861776c5-e0df-4f95-be4f-ac1eec193323"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["East
@@ -442,7 +498,10 @@ http_interactions:
         Central US","West Europe","North Europe","East US","UK West","UK South","West
         Central US","West US 2","South India","Central India","West India","Canada
         East","Canada Central","Korea South","Korea Central"],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"managedClusters","locations":["East
-        US","West Europe","Central US","Canada Central","Canada East"],"apiVersions":["2017-08-31"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
+        US","West Europe","Central US","Canada Central","Canada East"],"apiVersions":["2017-08-31"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operationresults","locations":["East
+        US","West Europe","Central US","UK West","UK South","West Central US","West
+        US 2","South India","Central India","West India","Canada East","Canada Central","Korea
+        South","Korea Central"],"apiVersions":["2017-08-31","2016-03-30"]},{"resourceType":"locations/operations","locations":["Japan
         East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
@@ -510,7 +569,7 @@ http_interactions:
         US","South Central US","North Europe","West Europe","Southeast Asia","West
         US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"listMigrationdate","locations":["East
         US","South Central US","North Europe","West Europe","Southeast Asia","West
-        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2018-03-01","2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
@@ -612,47 +671,47 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"networkWatchers/lenses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"networkWatchers/lenses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -662,47 +721,52 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2018-02-01","2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"ddosProtectionPlans","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","West
         US 2","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
@@ -1438,57 +1502,57 @@ http_interactions:
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/asyncoperations","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/asyncoperations","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/listAccountSas","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/listAccountSas","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/listServiceSas","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/listServiceSas","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/blobServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/blobServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/tableServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/tableServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/queueServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/queueServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/fileServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/fileServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01","2016-01-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01","2016-01-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
         US","West US","West Europe","North Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":["East
         US","West US","West Europe","North Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.visualstudio","namespace":"microsoft.visualstudio","authorization":{"applicationId":"499b84ac-1321-427f-aa17-267ca6975798","roleDefinitionId":"6a18f445-86f0-4e2e-b8a9-6b9b5677e3d8"},"resourceTypes":[{"resourceType":"account","locations":["North
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.visualstudio","namespace":"microsoft.visualstudio","authorization":{"applicationId":"499b84ac-1321-427f-aa17-267ca6975798","roleDefinitionId":"6a18f445-86f0-4e2e-b8a9-6b9b5677e3d8"},"resourceTypes":[{"resourceType":"account","locations":["North
         Central US","South Central US","East US","West US","Central US","North Europe","West
         Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
         East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/project","locations":["North
@@ -2173,7 +2237,8 @@ http_interactions:
         US","West US 2","East US","East US 2","North Europe","West Europe","Southeast
         Asia","East Asia","North Central US","South Central US","Japan West","Australia
         East","Brazil South","Central India","West Central US","Canada Central","UK
-        South"],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ServiceBus","namespace":"Microsoft.ServiceBus","authorization":{"applicationId":"80a10ef9-8168-493d-abf9-3297c4ef6e3c","roleDefinitionId":"2b7763f7-bbe2-4e19-befe-28c79f1cf7f7"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        South"],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.SecurityGraph","namespace":"Microsoft.SecurityGraph","resourceTypes":[{"resourceType":"operations","locations":["West
+        US"],"apiVersions":["2017-04-01-preview"]},{"resourceType":"diagnosticSettings","locations":[],"apiVersions":["2017-04-01-preview"]},{"resourceType":"diagnosticSettingsCategories","locations":[],"apiVersions":["2017-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ServiceBus","namespace":"Microsoft.ServiceBus","authorization":{"applicationId":"80a10ef9-8168-493d-abf9-3297c4ef6e3c","roleDefinitionId":"2b7763f7-bbe2-4e19-befe-28c79f1cf7f7"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US 2","West
         US","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
@@ -2322,10 +2387,10 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:23 GMT
+  recorded_at: Tue, 13 Mar 2018 09:01:07 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944?api-version=2018-03-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2339,7 +2404,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA5MzEzNjQsIm5iZiI6MTUyMDkzMTM2NCwiZXhwIjoxNTIwOTM1MjY0LCJhaW8iOiJZMk5nWU5qQnVUVng5OU1Kai9QZUY0akhQV2xXQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZERwWE5SanplRXF4N0hvY0ZFZ3ZBQSIsInZlciI6IjEuMCJ9.Q0olXkHqdxEw9vVdlY5VEnB6bcJsIxXS0HDMS0__6I_S6Zu0WZmMy0tGCLxQtKgZqcS18Y2J7rtCPgl3RvlnKbuL6SOpU-4rciaY2Z5kv3QFK8lRy9Ea0zYvrgWPkzxglreLRLrfLe95Jt_fTG5VSd6s_bnkfezCsGMz2oirGzayre0s5t_yor9f1Y8RGtJ7xdn-nJFXRhBOX9f4mOKbH6A3_7TotOU47tJ2GBhwqSWdO8BMo5f3VXXDxTtPTGuXgjUQ7nVqry5Zoa3FInESDB7D6NsnhGMTsNC8vS-HTxDuRoq_somRri34BZuWoHJ1zGfT9go-Gnn2JR2oqb4Hlw
   response:
     status:
       code: 200
@@ -2356,234 +2421,52 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67"
+      - W/"b6339880-8ead-4c9e-b5c0-f38c4f8612d5"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - '080de667-081e-4d58-9e94-9e7243d4200e'
+      - 4e01acae-500c-4857-beac-1ee61020779d
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
+      - '14920'
       X-Ms-Correlation-Request-Id:
-      - '093d49ac-c85f-440e-956b-955b6698dd19'
+      - 781c1b7a-5b22-40d1-a00b-c2cf53968014
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102419Z:093d49ac-c85f-440e-956b-955b6698dd19
+      - WESTEUROPE:20180313T090107Z:781c1b7a-5b22-40d1-a00b-c2cf53968014
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:19 GMT
+      - Tue, 13 Mar 2018 09:01:07 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1\",\r\n
-        \ \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"7ab88756-810f-4083-95db-8b05d50e38f2\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ],\r\n          \"inboundNatRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"backendIPConfigurations\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\"\r\n
-        \           }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-rule\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\":
-        80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\"\r\n
-        \         },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n
-        \       \"name\": \"rspec-lb-probe\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-NAT\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 3441,\r\n          \"backendPort\":
-        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:24 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"7a8e5fe7-f777-4435-992b-a54f28c2f28c"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - bd22ca22-a01f-4ecf-9230-a4558fb66931
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Correlation-Request-Id:
-      - 19c674a8-c8da-4b5e-8265-5ebc21926459
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102420Z:19c674a8-c8da-4b5e-8265-5ebc21926459
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Mon, 12 Mar 2018 10:24:19 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb2\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2\",\r\n
-        \ \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"e2e30a77-f81b-43fc-9693-08303e43deed\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/backendAddressPools/rspec-lb2-pool\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\r\n
-        \       }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\": [],\r\n    \"probes\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-probe\",\r\n        \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/probes/rspec-lb2-probe\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\": [],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:25 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"a38434c8-7b23-4092-b7c6-402238eac0dc"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 0fd15240-6a1c-4b39-a4f6-aa53fd8591c2
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Correlation-Request-Id:
-      - 5cc03163-922e-41a1-9601-dba2d7cf2a81
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102421Z:5cc03163-922e-41a1-9601-dba2d7cf2a81
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Mon, 12 Mar 2018 10:24:20 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb1-LoadBalancerFrontEnd\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\",\r\n
-        \ \"etag\": \"W/\\\"a38434c8-7b23-4092-b7c6-402238eac0dc\\\"\",\r\n  \"location\":
+      string: "{\r\n  \"name\": \"miqazure-linux-manag944\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944\",\r\n
+        \ \"etag\": \"W/\\\"b6339880-8ead-4c9e-b5c0-f38c4f8612d5\\\"\",\r\n  \"location\":
         \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"f28e0f25-b372-4edf-97d9-13a9e3b4ba2d\",\r\n    \"ipAddress\":
-        \"40.71.82.83\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\":
-        \"Static\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipTags\": [],\r\n
-        \   \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
-        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
+        \   \"resourceGuid\": \"c5e8b90e-5a78-49b0-b224-b70ed3fb45e5\",\r\n    \"ipConfigurations\":
+        [\r\n      {\r\n        \"name\": \"ipconfig1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944/ipConfigurations/ipconfig1\",\r\n
+        \       \"etag\": \"W/\\\"b6339880-8ead-4c9e-b5c0-f38c4f8612d5\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"privateIPAddress\": \"172.25.0.4\",\r\n          \"privateIPAllocationMethod\":
+        \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqazure-linux-managed-ip\"\r\n
+        \         },\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2/subnets/default\"\r\n
+        \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
+        \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\":
+        [],\r\n      \"appliedDnsServers\": []\r\n    },\r\n    \"enableAcceleratedNetworking\":
+        false,\r\n    \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\":
+        {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg\"\r\n
+        \   },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed\"\r\n
+        \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
+        \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:25 GMT
+  recorded_at: Tue, 13 Mar 2018 09:01:08 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg?api-version=2018-03-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2597,7 +2480,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA5MzEzNjQsIm5iZiI6MTUyMDkzMTM2NCwiZXhwIjoxNTIwOTM1MjY0LCJhaW8iOiJZMk5nWU5qQnVUVng5OU1Kai9QZUY0akhQV2xXQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZERwWE5SanplRXF4N0hvY0ZFZ3ZBQSIsInZlciI6IjEuMCJ9.Q0olXkHqdxEw9vVdlY5VEnB6bcJsIxXS0HDMS0__6I_S6Zu0WZmMy0tGCLxQtKgZqcS18Y2J7rtCPgl3RvlnKbuL6SOpU-4rciaY2Z5kv3QFK8lRy9Ea0zYvrgWPkzxglreLRLrfLe95Jt_fTG5VSd6s_bnkfezCsGMz2oirGzayre0s5t_yor9f1Y8RGtJ7xdn-nJFXRhBOX9f4mOKbH6A3_7TotOU47tJ2GBhwqSWdO8BMo5f3VXXDxTtPTGuXgjUQ7nVqry5Zoa3FInESDB7D6NsnhGMTsNC8vS-HTxDuRoq_somRri34BZuWoHJ1zGfT9go-Gnn2JR2oqb4Hlw
   response:
     status:
       code: 200
@@ -2614,36 +2497,245 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"cddd97d1-6111-4477-8a00-3dc885237a1d"
+      - W/"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 1403e5b6-8fa0-4cd3-89b1-76b6c4fd805b
+      - ad241f8d-e546-459e-bc2b-e6d412ce54cf
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - '14948'
       X-Ms-Correlation-Request-Id:
-      - e4a5f369-a742-466f-bd8f-42e17eaaf9c9
+      - bfe895bf-9257-4c54-8f75-ace0e9114e07
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102421Z:e4a5f369-a742-466f-bd8f-42e17eaaf9c9
+      - WESTEUROPE:20180313T090108Z:bfe895bf-9257-4c54-8f75-ace0e9114e07
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:21 GMT
+      - Tue, 13 Mar 2018 09:01:08 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb2-publicip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\",\r\n
-        \ \"etag\": \"W/\\\"cddd97d1-6111-4477-8a00-3dc885237a1d\\\"\",\r\n  \"location\":
+      string: "{\r\n  \"name\": \"miqazure-linux-managed-nsg\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg\",\r\n
+        \ \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/networkSecurityGroups\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
+        \"b4611f96-94a8-4486-94c5-16bb6c7a5c84\",\r\n    \"securityRules\": [\r\n
+        \     {\r\n        \"name\": \"default-allow-ssh\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/securityRules/default-allow-ssh\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"protocol\": \"TCP\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"22\",\r\n          \"sourceAddressPrefix\":
+        \"*\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n          \"access\":
+        \"Allow\",\r\n          \"priority\": 1000,\r\n          \"direction\": \"Inbound\",\r\n
+        \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      }\r\n    ],\r\n    \"defaultSecurityRules\": [\r\n
+        \     {\r\n        \"name\": \"AllowVnetInBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/AllowVnetInBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow inbound traffic from all VMs in VNET\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"VirtualNetwork\",\r\n          \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n          \"direction\":
+        \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowAzureLoadBalancerInBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/AllowAzureLoadBalancerInBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow inbound traffic from azure load balancer\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"AzureLoadBalancer\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65001,\r\n          \"direction\":
+        \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllInBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/DenyAllInBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Deny all inbound traffic\",\r\n          \"protocol\":
+        \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\":
+        \"*\",\r\n          \"sourceAddressPrefix\": \"*\",\r\n          \"destinationAddressPrefix\":
+        \"*\",\r\n          \"access\": \"Deny\",\r\n          \"priority\": 65500,\r\n
+        \         \"direction\": \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n
+        \         \"destinationPortRanges\": [],\r\n          \"sourceAddressPrefixes\":
+        [],\r\n          \"destinationAddressPrefixes\": []\r\n        }\r\n      },\r\n
+        \     {\r\n        \"name\": \"AllowVnetOutBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/AllowVnetOutBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow outbound traffic from all VMs to all VMs
+        in VNET\",\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\":
+        \"*\",\r\n          \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"VirtualNetwork\",\r\n          \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n          \"direction\":
+        \"Outbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowInternetOutBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/AllowInternetOutBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow outbound traffic from all VMs to Internet\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"*\",\r\n          \"destinationAddressPrefix\": \"Internet\",\r\n          \"access\":
+        \"Allow\",\r\n          \"priority\": 65001,\r\n          \"direction\": \"Outbound\",\r\n
+        \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllOutBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/DenyAllOutBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Deny all outbound traffic\",\r\n          \"protocol\":
+        \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\":
+        \"*\",\r\n          \"sourceAddressPrefix\": \"*\",\r\n          \"destinationAddressPrefix\":
+        \"*\",\r\n          \"access\": \"Deny\",\r\n          \"priority\": 65500,\r\n
+        \         \"direction\": \"Outbound\",\r\n          \"sourcePortRanges\":
+        [],\r\n          \"destinationPortRanges\": [],\r\n          \"sourceAddressPrefixes\":
+        [],\r\n          \"destinationAddressPrefixes\": []\r\n        }\r\n      }\r\n
+        \   ],\r\n    \"networkInterfaces\": [\r\n      {\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944\"\r\n
+        \     }\r\n    ]\r\n  }\r\n}"
+    http_version: 
+  recorded_at: Tue, 13 Mar 2018 09:01:08 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2?api-version=2018-03-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA5MzEzNjQsIm5iZiI6MTUyMDkzMTM2NCwiZXhwIjoxNTIwOTM1MjY0LCJhaW8iOiJZMk5nWU5qQnVUVng5OU1Kai9QZUY0akhQV2xXQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZERwWE5SanplRXF4N0hvY0ZFZ3ZBQSIsInZlciI6IjEuMCJ9.Q0olXkHqdxEw9vVdlY5VEnB6bcJsIxXS0HDMS0__6I_S6Zu0WZmMy0tGCLxQtKgZqcS18Y2J7rtCPgl3RvlnKbuL6SOpU-4rciaY2Z5kv3QFK8lRy9Ea0zYvrgWPkzxglreLRLrfLe95Jt_fTG5VSd6s_bnkfezCsGMz2oirGzayre0s5t_yor9f1Y8RGtJ7xdn-nJFXRhBOX9f4mOKbH6A3_7TotOU47tJ2GBhwqSWdO8BMo5f3VXXDxTtPTGuXgjUQ7nVqry5Zoa3FInESDB7D6NsnhGMTsNC8vS-HTxDuRoq_somRri34BZuWoHJ1zGfT9go-Gnn2JR2oqb4Hlw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"f5bbd20f-7ae4-4b6d-89c8-eb3481fcbe05"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 11321c2a-56bb-4cb6-a789-645b6c6be7a5
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14925'
+      X-Ms-Correlation-Request-Id:
+      - '03829caa-88a3-4a0e-a653-a8e166da6355'
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180313T090109Z:03829caa-88a3-4a0e-a653-a8e166da6355
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Tue, 13 Mar 2018 09:01:08 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"miq-azure-test2\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2\",\r\n
+        \ \"etag\": \"W/\\\"f5bbd20f-7ae4-4b6d-89c8-eb3481fcbe05\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
+        \"f950a3cf-749a-49d5-a7fb-33a400b0e93c\",\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\":
+        [\r\n        \"172.25.0.0/16\"\r\n      ]\r\n    },\r\n    \"subnets\": [\r\n
+        \     {\r\n        \"name\": \"default\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2/subnets/default\",\r\n
+        \       \"etag\": \"W/\\\"f5bbd20f-7ae4-4b6d-89c8-eb3481fcbe05\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"addressPrefix\": \"172.25.0.0/24\",\r\n          \"ipConfigurations\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944/ipConfigurations/ipconfig1\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"virtualNetworkPeerings\":
+        [],\r\n    \"enableDdosProtection\": false,\r\n    \"enableVmProtection\":
+        false\r\n  }\r\n}"
+    http_version: 
+  recorded_at: Tue, 13 Mar 2018 09:01:09 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqazure-linux-managed-ip?api-version=2018-03-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA5MzEzNjQsIm5iZiI6MTUyMDkzMTM2NCwiZXhwIjoxNTIwOTM1MjY0LCJhaW8iOiJZMk5nWU5qQnVUVng5OU1Kai9QZUY0akhQV2xXQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZERwWE5SanplRXF4N0hvY0ZFZ3ZBQSIsInZlciI6IjEuMCJ9.Q0olXkHqdxEw9vVdlY5VEnB6bcJsIxXS0HDMS0__6I_S6Zu0WZmMy0tGCLxQtKgZqcS18Y2J7rtCPgl3RvlnKbuL6SOpU-4rciaY2Z5kv3QFK8lRy9Ea0zYvrgWPkzxglreLRLrfLe95Jt_fTG5VSd6s_bnkfezCsGMz2oirGzayre0s5t_yor9f1Y8RGtJ7xdn-nJFXRhBOX9f4mOKbH6A3_7TotOU47tJ2GBhwqSWdO8BMo5f3VXXDxTtPTGuXgjUQ7nVqry5Zoa3FInESDB7D6NsnhGMTsNC8vS-HTxDuRoq_somRri34BZuWoHJ1zGfT9go-Gnn2JR2oqb4Hlw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"0efc9684-fb7d-4fb7-b9b9-f33dbac04a28"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 0e055364-c440-49b4-99ec-6e8e0a483b22
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14917'
+      X-Ms-Correlation-Request-Id:
+      - b9cc021d-d726-4c4d-bdb5-ab5edc29d3c7
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180313T090109Z:b9cc021d-d726-4c4d-bdb5-ab5edc29d3c7
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Tue, 13 Mar 2018 09:01:09 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"miqazure-linux-managed-ip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqazure-linux-managed-ip\",\r\n
+        \ \"etag\": \"W/\\\"0efc9684-fb7d-4fb7-b9b9-f33dbac04a28\\\"\",\r\n  \"location\":
         \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"83e7257d-ab94-4229-8eb5-4798f37ef28d\",\r\n    \"publicIPAddressVersion\":
+        \   \"resourceGuid\": \"6a2a9142-26e8-45cd-93bf-7318192f3528\",\r\n    \"publicIPAddressVersion\":
         \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
-        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
+        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944/ipConfigurations/ipconfig1\"\r\n
         \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
         \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:26 GMT
+  recorded_at: Tue, 13 Mar 2018 09:01:09 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_0/orchestration_stack_lb_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_0/orchestration_stack_lb_refresh.yml
@@ -16,7 +16,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcwNjMsIm5iZiI6MTUyMDg0NzA2MywiZXhwIjoxNTIwODUwOTYzLCJhaW8iOiJZMk5nWURnY2RQQks2cFZ5anRmL0pHYWt0ajI5RGdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiaEVobDdDS0hGa1c0RjV2TExiY2lBQSIsInZlciI6IjEuMCJ9.MywLrYlLzZCy4yVEqcN17usz0ujBpvlLeFDVNfTb_5KSOKHpDmqiK14CoLuzvAP-sHS7HM-YvxzM_6fW9VzWLYC6kaUN_zWDYc7OPjKFpEvFtRv7dlfbuGIGem4-VdlO8jAgcG3gvQ7Mv95xKPelZt2BbssFPEsWnDhKrJNa0z5qGFUl9NnAPe0r2z7WoAhM4JDvTl71swAGnsaRCypUraKgO6bfxg4gmgsfc6oTK3VQ1DDaKRpV0n3HNSjEHpPTmm5lxo83iRDzvs3IlYNbf6n056CKD3urJSsykuB5QukEoJfubzXH9Z9UCemSYBIPj30abqb96Y8xNMgkEnmyfg
   response:
     status:
       code: 200
@@ -35,26 +35,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14997'
+      - '14998'
       X-Ms-Request-Id:
-      - cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - 5b4ae167-ac76-4f3f-bdff-015104827e1e
       X-Ms-Correlation-Request-Id:
-      - cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - 5b4ae167-ac76-4f3f-bdff-015104827e1e
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102417Z:cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - WESTEUROPE:20180312T093916Z:5b4ae167-ac76-4f3f-bdff-015104827e1e
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:17 GMT
+      - Mon, 12 Mar 2018 09:39:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID","subscriptionId":"AZURE_SUBSCRIPTION_ID","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:22 GMT
+  recorded_at: Mon, 12 Mar 2018 09:39:20 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers?api-version=2015-01-01
@@ -71,7 +71,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcwNjMsIm5iZiI6MTUyMDg0NzA2MywiZXhwIjoxNTIwODUwOTYzLCJhaW8iOiJZMk5nWURnY2RQQks2cFZ5anRmL0pHYWt0ajI5RGdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiaEVobDdDS0hGa1c0RjV2TExiY2lBQSIsInZlciI6IjEuMCJ9.MywLrYlLzZCy4yVEqcN17usz0ujBpvlLeFDVNfTb_5KSOKHpDmqiK14CoLuzvAP-sHS7HM-YvxzM_6fW9VzWLYC6kaUN_zWDYc7OPjKFpEvFtRv7dlfbuGIGem4-VdlO8jAgcG3gvQ7Mv95xKPelZt2BbssFPEsWnDhKrJNa0z5qGFUl9NnAPe0r2z7WoAhM4JDvTl71swAGnsaRCypUraKgO6bfxg4gmgsfc6oTK3VQ1DDaKRpV0n3HNSjEHpPTmm5lxo83iRDzvs3IlYNbf6n056CKD3urJSsykuB5QukEoJfubzXH9Z9UCemSYBIPj30abqb96Y8xNMgkEnmyfg
   response:
     status:
       code: 200
@@ -88,19 +88,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - '14992'
       X-Ms-Request-Id:
-      - fe3532ca-59a2-474e-9094-8a3697b82bef
+      - 3511711e-eef1-4873-9624-9b1dd6bfc1db
       X-Ms-Correlation-Request-Id:
-      - fe3532ca-59a2-474e-9094-8a3697b82bef
+      - 3511711e-eef1-4873-9624-9b1dd6bfc1db
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102419Z:fe3532ca-59a2-474e-9094-8a3697b82bef
+      - WESTEUROPE:20180312T093917Z:3511711e-eef1-4873-9624-9b1dd6bfc1db
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:18 GMT
+      - Mon, 12 Mar 2018 09:39:16 GMT
       Content-Length:
       - '320853'
     body:
@@ -2322,10 +2322,10 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:23 GMT
+  recorded_at: Mon, 12 Mar 2018 09:39:22 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb?api-version=2018-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2339,7 +2339,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcwNjMsIm5iZiI6MTUyMDg0NzA2MywiZXhwIjoxNTIwODUwOTYzLCJhaW8iOiJZMk5nWURnY2RQQks2cFZ5anRmL0pHYWt0ajI5RGdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiaEVobDdDS0hGa1c0RjV2TExiY2lBQSIsInZlciI6IjEuMCJ9.MywLrYlLzZCy4yVEqcN17usz0ujBpvlLeFDVNfTb_5KSOKHpDmqiK14CoLuzvAP-sHS7HM-YvxzM_6fW9VzWLYC6kaUN_zWDYc7OPjKFpEvFtRv7dlfbuGIGem4-VdlO8jAgcG3gvQ7Mv95xKPelZt2BbssFPEsWnDhKrJNa0z5qGFUl9NnAPe0r2z7WoAhM4JDvTl71swAGnsaRCypUraKgO6bfxg4gmgsfc6oTK3VQ1DDaKRpV0n3HNSjEHpPTmm5lxo83iRDzvs3IlYNbf6n056CKD3urJSsykuB5QukEoJfubzXH9Z9UCemSYBIPj30abqb96Y8xNMgkEnmyfg
   response:
     status:
       code: 200
@@ -2356,87 +2356,96 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67"
+      - W/"92982330-0f29-406e-bba9-ad19198579a5"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - '080de667-081e-4d58-9e94-9e7243d4200e'
+      - 4047b815-7e3b-4aca-a39b-869c1daa79e5
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
+      - '14984'
       X-Ms-Correlation-Request-Id:
-      - '093d49ac-c85f-440e-956b-955b6698dd19'
+      - 6f2ac2e4-8455-443a-85eb-3cfd903738d8
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102419Z:093d49ac-c85f-440e-956b-955b6698dd19
+      - WESTEUROPE:20180312T093918Z:6f2ac2e4-8455-443a-85eb-3cfd903738d8
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:19 GMT
+      - Mon, 12 Mar 2018 09:39:17 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1\",\r\n
-        \ \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n  \"type\":
+      string: "{\r\n  \"name\": \"spec0deply1lb\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb\",\r\n
+        \ \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n  \"type\":
         \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"7ab88756-810f-4083-95db-8b05d50e38f2\",\r\n
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"8cd72f7c-03bd-4584-abc6-d9ce77ae6202\",\r\n
         \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
+        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\"\r\n
+        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip\"\r\n
         \         },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
         \           }\r\n          ],\r\n          \"inboundNatRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\"\r\n
+        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1\"\r\n
         \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
+        [\r\n      {\r\n        \"name\": \"BackendPool1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\",\r\n
+        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"backendIPConfigurations\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\"\r\n
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1\"\r\n
         \           }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
+        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
         \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-rule\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
+        [\r\n      {\r\n        \"name\": \"LBRule\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\",\r\n
+        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
+        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
         \         },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\":
         80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
+        5,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
         false,\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\"\r\n
-        \         },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\"\r\n
+        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\"\r\n
+        \         },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/probes/tcpProbe\"\r\n
         \         }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n
-        \       \"name\": \"rspec-lb-probe\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
+        \       \"name\": \"tcpProbe\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/probes/tcpProbe\",\r\n
+        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
+        \         \"protocol\": \"Tcp\",\r\n          \"port\": 80,\r\n          \"intervalInSeconds\":
+        5,\r\n          \"numberOfProbes\": 2,\r\n          \"loadBalancingRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
         \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-NAT\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
+        [\r\n      {\r\n        \"name\": \"RDP-VM0\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0\",\r\n
+        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 3441,\r\n          \"backendPort\":
+        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
+        \         },\r\n          \"frontendPort\": 50001,\r\n          \"backendPort\":
         3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
         4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
+        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1\"\r\n
+        \         }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"RDP-VM1\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1\",\r\n
+        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
+        \         },\r\n          \"frontendPort\": 50002,\r\n          \"backendPort\":
+        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
+        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
+        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1\"\r\n
         \         }\r\n        }\r\n      }\r\n    ],\r\n    \"outboundNatRules\":
         [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
         \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:24 GMT
+  recorded_at: Mon, 12 Mar 2018 09:39:22 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip?api-version=2018-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2450,7 +2459,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcwNjMsIm5iZiI6MTUyMDg0NzA2MywiZXhwIjoxNTIwODUwOTYzLCJhaW8iOiJZMk5nWURnY2RQQks2cFZ5anRmL0pHYWt0ajI5RGdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiaEVobDdDS0hGa1c0RjV2TExiY2lBQSIsInZlciI6IjEuMCJ9.MywLrYlLzZCy4yVEqcN17usz0ujBpvlLeFDVNfTb_5KSOKHpDmqiK14CoLuzvAP-sHS7HM-YvxzM_6fW9VzWLYC6kaUN_zWDYc7OPjKFpEvFtRv7dlfbuGIGem4-VdlO8jAgcG3gvQ7Mv95xKPelZt2BbssFPEsWnDhKrJNa0z5qGFUl9NnAPe0r2z7WoAhM4JDvTl71swAGnsaRCypUraKgO6bfxg4gmgsfc6oTK3VQ1DDaKRpV0n3HNSjEHpPTmm5lxo83iRDzvs3IlYNbf6n056CKD3urJSsykuB5QukEoJfubzXH9Z9UCemSYBIPj30abqb96Y8xNMgkEnmyfg
   response:
     status:
       code: 200
@@ -2467,11 +2476,11 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"7a8e5fe7-f777-4435-992b-a54f28c2f28c"
+      - W/"2080997a-38a6-420d-ba86-e9582e1331c7"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - bd22ca22-a01f-4ecf-9230-a4558fb66931
+      - e17d64fe-b416-4b8e-92e5-7cc2b6421f72
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
@@ -2480,170 +2489,25 @@ http_interactions:
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
       - '14986'
       X-Ms-Correlation-Request-Id:
-      - 19c674a8-c8da-4b5e-8265-5ebc21926459
+      - cc007e3a-a403-45c5-bc92-3eeb6f300da6
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102420Z:19c674a8-c8da-4b5e-8265-5ebc21926459
+      - WESTEUROPE:20180312T093918Z:cc007e3a-a403-45c5-bc92-3eeb6f300da6
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:19 GMT
+      - Mon, 12 Mar 2018 09:39:18 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb2\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2\",\r\n
-        \ \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"e2e30a77-f81b-43fc-9693-08303e43deed\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/backendAddressPools/rspec-lb2-pool\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\r\n
-        \       }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\": [],\r\n    \"probes\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-probe\",\r\n        \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/probes/rspec-lb2-probe\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\": [],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:25 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"a38434c8-7b23-4092-b7c6-402238eac0dc"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 0fd15240-6a1c-4b39-a4f6-aa53fd8591c2
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Correlation-Request-Id:
-      - 5cc03163-922e-41a1-9601-dba2d7cf2a81
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102421Z:5cc03163-922e-41a1-9601-dba2d7cf2a81
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Mon, 12 Mar 2018 10:24:20 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb1-LoadBalancerFrontEnd\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\",\r\n
-        \ \"etag\": \"W/\\\"a38434c8-7b23-4092-b7c6-402238eac0dc\\\"\",\r\n  \"location\":
+      string: "{\r\n  \"name\": \"spec0deply1ip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip\",\r\n
+        \ \"etag\": \"W/\\\"2080997a-38a6-420d-ba86-e9582e1331c7\\\"\",\r\n  \"location\":
         \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"f28e0f25-b372-4edf-97d9-13a9e3b4ba2d\",\r\n    \"ipAddress\":
-        \"40.71.82.83\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\":
-        \"Static\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipTags\": [],\r\n
-        \   \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
-        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:25 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"cddd97d1-6111-4477-8a00-3dc885237a1d"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 1403e5b6-8fa0-4cd3-89b1-76b6c4fd805b
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
-      X-Ms-Correlation-Request-Id:
-      - e4a5f369-a742-466f-bd8f-42e17eaaf9c9
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102421Z:e4a5f369-a742-466f-bd8f-42e17eaaf9c9
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Mon, 12 Mar 2018 10:24:21 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb2-publicip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\",\r\n
-        \ \"etag\": \"W/\\\"cddd97d1-6111-4477-8a00-3dc885237a1d\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"83e7257d-ab94-4229-8eb5-4798f37ef28d\",\r\n    \"publicIPAddressVersion\":
+        \   \"resourceGuid\": \"a08b891e-e45a-4970-aefc-f6c996989490\",\r\n    \"publicIPAddressVersion\":
         \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
-        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
+        4,\r\n    \"dnsSettings\": {\r\n      \"domainNameLabel\": \"spec0deply1dns\",\r\n
+        \     \"fqdn\": \"spec0deply1dns.eastus.cloudapp.azure.com\"\r\n    },\r\n
+        \   \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
         \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
         \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:26 GMT
+  recorded_at: Mon, 12 Mar 2018 09:39:23 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_0/orchestration_stack_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_0/orchestration_stack_refresh.yml
@@ -37,25 +37,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 6995c376-2e14-4dbc-9c50-f8a929560000
+      - ec654884-8722-4516-b817-9bcb2db72200
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzet5bHylzJ6x-slLkgiMAqtn4gU_KMJEC0SMUVf4sEhRY8Gc5DRolJNmId10OyxY7iHAee4quZ2iHmC8sU1IgPnmDTUHG3HcNF2cczJ0jW4nBfVT6gDte1n_pzRmm96a5tnnzxaVnPnmVcL7F2Fy4odvn6vOkLjEM81fkhngHwLIgAA;
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzH5qCHGqUVpeKJWCGm5bcYBa5Fd_JkKHGOV-uPvq6NVExMCSda59OiRVMmefsTf_4bhNnTVQPEZZ0X55J4ev5t_NZWirdRa5NEFzWmvJbMQXZPVg0qV9M0GTq9wl_u4AgithxNhPKMZzmE5RuZkxvunpJO-w6j8bS65y_kn1v-w8gAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=005; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=002; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Wed, 07 Mar 2018 20:15:38 GMT
+      - Mon, 12 Mar 2018 09:36:03 GMT
       Content-Length:
       - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1520457338","not_before":"1520453438","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MzgsIm5iZiI6MTUyMDQ1MzQzOCwiZXhwIjoxNTIwNDU3MzM4LCJhaW8iOiJZMk5nWUxEbUtXMDk5clB4cU9QdGorL1crV3NlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZHNPVmFSUXV2RTJjVVBpcEtWWUFBQSIsInZlciI6IjEuMCJ9.drT5CKw95WRF7LzC0WuhK-fTLpw3j61XMw_DZdrLOWP8sjjsrbn9kF7xjDSTUM0ooF5_1Y-j3dNjvI9crm_F3PMAyhYXmCsKjTJkc3DIK6URy3hqbKiRBNlrutwvILE777NY-uXK9PH-gcaVuV-mNrjrLuxxClMJ3OPpTU8Ux0fj3Nuyf3KrXC27Oks_M_RDqDaXHOTckrdz2m_LNLpi5x0nKCoxwR9r5C1m5IKZ25FSbvyRNwjwz5dReqnv5LxllQMHVWkpvO7i5438wAnnyaS2x211IBiE6_dnV2god8Sp3ZRinXc4aCimUnJl6tLa5EtT_VSmR2QcBSaq0wS_ZQ"}'
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1520850963","not_before":"1520847063","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcwNjMsIm5iZiI6MTUyMDg0NzA2MywiZXhwIjoxNTIwODUwOTYzLCJhaW8iOiJZMk5nWURnY2RQQks2cFZ5anRmL0pHYWt0ajI5RGdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiaEVobDdDS0hGa1c0RjV2TExiY2lBQSIsInZlciI6IjEuMCJ9.MywLrYlLzZCy4yVEqcN17usz0ujBpvlLeFDVNfTb_5KSOKHpDmqiK14CoLuzvAP-sHS7HM-YvxzM_6fW9VzWLYC6kaUN_zWDYc7OPjKFpEvFtRv7dlfbuGIGem4-VdlO8jAgcG3gvQ7Mv95xKPelZt2BbssFPEsWnDhKrJNa0z5qGFUl9NnAPe0r2z7WoAhM4JDvTl71swAGnsaRCypUraKgO6bfxg4gmgsfc6oTK3VQ1DDaKRpV0n3HNSjEHpPTmm5lxo83iRDzvs3IlYNbf6n056CKD3urJSsykuB5QukEoJfubzXH9Z9UCemSYBIPj30abqb96Y8xNMgkEnmyfg"}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:39 GMT
+  recorded_at: Mon, 12 Mar 2018 09:36:08 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -72,7 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MzgsIm5iZiI6MTUyMDQ1MzQzOCwiZXhwIjoxNTIwNDU3MzM4LCJhaW8iOiJZMk5nWUxEbUtXMDk5clB4cU9QdGorL1crV3NlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZHNPVmFSUXV2RTJjVVBpcEtWWUFBQSIsInZlciI6IjEuMCJ9.drT5CKw95WRF7LzC0WuhK-fTLpw3j61XMw_DZdrLOWP8sjjsrbn9kF7xjDSTUM0ooF5_1Y-j3dNjvI9crm_F3PMAyhYXmCsKjTJkc3DIK6URy3hqbKiRBNlrutwvILE777NY-uXK9PH-gcaVuV-mNrjrLuxxClMJ3OPpTU8Ux0fj3Nuyf3KrXC27Oks_M_RDqDaXHOTckrdz2m_LNLpi5x0nKCoxwR9r5C1m5IKZ25FSbvyRNwjwz5dReqnv5LxllQMHVWkpvO7i5438wAnnyaS2x211IBiE6_dnV2god8Sp3ZRinXc4aCimUnJl6tLa5EtT_VSmR2QcBSaq0wS_ZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcwNjMsIm5iZiI6MTUyMDg0NzA2MywiZXhwIjoxNTIwODUwOTYzLCJhaW8iOiJZMk5nWURnY2RQQks2cFZ5anRmL0pHYWt0ajI5RGdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiaEVobDdDS0hGa1c0RjV2TExiY2lBQSIsInZlciI6IjEuMCJ9.MywLrYlLzZCy4yVEqcN17usz0ujBpvlLeFDVNfTb_5KSOKHpDmqiK14CoLuzvAP-sHS7HM-YvxzM_6fW9VzWLYC6kaUN_zWDYc7OPjKFpEvFtRv7dlfbuGIGem4-VdlO8jAgcG3gvQ7Mv95xKPelZt2BbssFPEsWnDhKrJNa0z5qGFUl9NnAPe0r2z7WoAhM4JDvTl71swAGnsaRCypUraKgO6bfxg4gmgsfc6oTK3VQ1DDaKRpV0n3HNSjEHpPTmm5lxo83iRDzvs3IlYNbf6n056CKD3urJSsykuB5QukEoJfubzXH9Z9UCemSYBIPj30abqb96Y8xNMgkEnmyfg
   response:
     status:
       code: 200
@@ -91,26 +91,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14998'
+      - '14999'
       X-Ms-Request-Id:
-      - 376d2278-1269-40b2-aad0-10993a489a5d
+      - a5be143c-6b82-485d-abec-25f2ff043a0a
       X-Ms-Correlation-Request-Id:
-      - 376d2278-1269-40b2-aad0-10993a489a5d
+      - a5be143c-6b82-485d-abec-25f2ff043a0a
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201540Z:376d2278-1269-40b2-aad0-10993a489a5d
+      - WESTEUROPE:20180312T093604Z:a5be143c-6b82-485d-abec-25f2ff043a0a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:15:39 GMT
+      - Mon, 12 Mar 2018 09:36:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID","subscriptionId":"AZURE_SUBSCRIPTION_ID","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:40 GMT
+  recorded_at: Mon, 12 Mar 2018 09:36:08 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers?api-version=2015-01-01
@@ -127,7 +127,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MzgsIm5iZiI6MTUyMDQ1MzQzOCwiZXhwIjoxNTIwNDU3MzM4LCJhaW8iOiJZMk5nWUxEbUtXMDk5clB4cU9QdGorL1crV3NlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZHNPVmFSUXV2RTJjVVBpcEtWWUFBQSIsInZlciI6IjEuMCJ9.drT5CKw95WRF7LzC0WuhK-fTLpw3j61XMw_DZdrLOWP8sjjsrbn9kF7xjDSTUM0ooF5_1Y-j3dNjvI9crm_F3PMAyhYXmCsKjTJkc3DIK6URy3hqbKiRBNlrutwvILE777NY-uXK9PH-gcaVuV-mNrjrLuxxClMJ3OPpTU8Ux0fj3Nuyf3KrXC27Oks_M_RDqDaXHOTckrdz2m_LNLpi5x0nKCoxwR9r5C1m5IKZ25FSbvyRNwjwz5dReqnv5LxllQMHVWkpvO7i5438wAnnyaS2x211IBiE6_dnV2god8Sp3ZRinXc4aCimUnJl6tLa5EtT_VSmR2QcBSaq0wS_ZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcwNjMsIm5iZiI6MTUyMDg0NzA2MywiZXhwIjoxNTIwODUwOTYzLCJhaW8iOiJZMk5nWURnY2RQQks2cFZ5anRmL0pHYWt0ajI5RGdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiaEVobDdDS0hGa1c0RjV2TExiY2lBQSIsInZlciI6IjEuMCJ9.MywLrYlLzZCy4yVEqcN17usz0ujBpvlLeFDVNfTb_5KSOKHpDmqiK14CoLuzvAP-sHS7HM-YvxzM_6fW9VzWLYC6kaUN_zWDYc7OPjKFpEvFtRv7dlfbuGIGem4-VdlO8jAgcG3gvQ7Mv95xKPelZt2BbssFPEsWnDhKrJNa0z5qGFUl9NnAPe0r2z7WoAhM4JDvTl71swAGnsaRCypUraKgO6bfxg4gmgsfc6oTK3VQ1DDaKRpV0n3HNSjEHpPTmm5lxo83iRDzvs3IlYNbf6n056CKD3urJSsykuB5QukEoJfubzXH9Z9UCemSYBIPj30abqb96Y8xNMgkEnmyfg
   response:
     status:
       code: 200
@@ -144,39 +144,37 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14977'
+      - '14993'
       X-Ms-Request-Id:
-      - 2a5b1aec-57b4-4beb-9868-d8ee336db426
+      - 6154d335-4727-4f39-8d43-3ba230eca0f2
       X-Ms-Correlation-Request-Id:
-      - 2a5b1aec-57b4-4beb-9868-d8ee336db426
+      - 6154d335-4727-4f39-8d43-3ba230eca0f2
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201541Z:2a5b1aec-57b4-4beb-9868-d8ee336db426
+      - WESTEUROPE:20180312T093605Z:6154d335-4727-4f39-8d43-3ba230eca0f2
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:15:41 GMT
+      - Mon, 12 Mar 2018 09:36:05 GMT
       Content-Length:
-      - '310901'
+      - '320853'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"},{"applicationId":"d87dcbc6-a371-462e-88e3-28ad15ec4e64","roleDefinitionId":"861776c5-e0df-4f95-be4f-ac1eec193323"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
+      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"},{"applicationId":"d87dcbc6-a371-462e-88e3-28ad15ec4e64","roleDefinitionId":"861776c5-e0df-4f95-be4f-ac1eec193323"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["East
+        Asia","Southeast Asia","Australia East","Australia Southeast","Japan East","Japan
+        West","Central India","South India","West India","West Europe","North Europe","Canada
+        Central","Canada East","Brazil South","West US","Central US","East US","South
+        Central US","East US 2","West Central US","North Central US","West US 2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
         US","Central US","East US","South Central US","West Europe","North Europe","East
         Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
         Central US","North Central US","Japan East","Japan West","Brazil South","Central
         India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"operations","locations":["West
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["East
+        Asia","Southeast Asia","Australia East","Australia Southeast","Japan East","Japan
+        West","Central India","South India","West India","West Europe","North Europe","Canada
+        Central","Canada East","Brazil South","West US","Central US","East US","South
+        Central US","East US 2","West Central US","North Central US","West US 2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"operations","locations":["West
         US","Central US","East US","South Central US","West Europe","North Europe","East
         Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
         Central US","North Central US","Japan East","Japan West","Brazil South","Central
@@ -232,177 +230,177 @@ http_interactions:
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/internalLoadBalancers","locations":[],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"domainNames/slots/roles/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"domainNames/slots/roles/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"domainNames/capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"domainNames/serviceCertificates","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
         US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
         Central","Canada East","UK South","UK West","West US","Central US","South
         Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
-        East","Australia Southeast","West US 2","West Central US","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        East","Australia Southeast","West US 2","West Central US","France Central","South
+        India","Central India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
         US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
         Central","Canada East","UK South","UK West","West US","Central US","South
         Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
-        East","Australia Southeast","West US 2","West Central US","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metrics","locations":["North
+        East","Australia Southeast","West US 2","West Central US","France Central","South
+        India","Central India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metrics","locations":["North
         Central US","South Central US","East US","East US 2","Canada Central","Canada
         East","West US","West US 2","West Central US","Central US","East Asia","Southeast
         Asia","North Europe","West Europe","UK South","UK West","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"resourceTypes","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"moveSubscriptionResources","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"validateSubscriptionMoveAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operationStatuses","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operatingSystems","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"operatingSystemFamilies","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicNetwork","namespace":"Microsoft.ClassicNetwork","resourceTypes":[{"resourceType":"virtualNetworks","locations":["East
+        India","West India","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"resourceTypes","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"moveSubscriptionResources","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"validateSubscriptionMoveAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operationStatuses","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operatingSystems","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"operatingSystemFamilies","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicNetwork","namespace":"Microsoft.ClassicNetwork","resourceTypes":[{"resourceType":"virtualNetworks","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"virtualNetworks/remoteVirtualNetworkPeeringProxies","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01"]},{"resourceType":"virtualNetworks/remoteVirtualNetworkPeeringProxies","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"reservedIps","locations":["East
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01"]},{"resourceType":"reservedIps","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"gatewaySupportedDevices","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"networkSecurityGroups","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"gatewaySupportedDevices","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"networkSecurityGroups","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicStorage","namespace":"Microsoft.ClassicStorage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"expressRouteCrossConnections","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"expressRouteCrossConnections/peerings","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicStorage","namespace":"Microsoft.ClassicStorage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkStorageAccountAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"storageAccounts/services","locations":["West
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkStorageAccountAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"storageAccounts/services","locations":["West
         US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
         Asia","Australia East","Australia Southeast","South India","Central India","West
         India","West US 2","West Central US","East US","East US 2","North Central
         US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
-        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/diagnosticSettings","locations":["West
+        South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/diagnosticSettings","locations":["West
         US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
         Asia","Australia East","Australia Southeast","South India","Central India","West
         India","West US 2","West Central US","East US","East US 2","North Central
         US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
-        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"disks","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"images","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"vmImages","locations":[],"apiVersions":["2016-11-01"]},{"resourceType":"publicImages","locations":[],"apiVersions":["2016-11-01","2016-04-01"]},{"resourceType":"osImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"osPlatformImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute","namespace":"Microsoft.Compute","authorizations":[{"applicationId":"60e6cd67-9c8c-4951-9b3c-23c25a2169af","roleDefinitionId":"e4770acb-272e-4dc8-87f3-12f44a612224"},{"applicationId":"a303894e-f1d8-4a37-bf10-67aa654a0596","roleDefinitionId":"903ac751-8ad5-4e5a-bfc2-5e49f450a241"},{"applicationId":"a8b6bf88-1d1a-4626-b040-9a729ea93c65","roleDefinitionId":"45c8267c-80ba-4b96-9a43-115b8f49fccd"}],"resourceTypes":[{"resourceType":"availabilitySets","locations":["East
+        South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"disks","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"images","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"vmImages","locations":[],"apiVersions":["2016-11-01"]},{"resourceType":"storageAccounts/vmImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"publicImages","locations":[],"apiVersions":["2016-11-01","2016-04-01"]},{"resourceType":"osImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"osPlatformImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute","namespace":"Microsoft.Compute","authorizations":[{"applicationId":"60e6cd67-9c8c-4951-9b3c-23c25a2169af","roleDefinitionId":"e4770acb-272e-4dc8-87f3-12f44a612224"},{"applicationId":"a303894e-f1d8-4a37-bf10-67aa654a0596","roleDefinitionId":"903ac751-8ad5-4e5a-bfc2-5e49f450a241"},{"applicationId":"a8b6bf88-1d1a-4626-b040-9a729ea93c65","roleDefinitionId":"45c8267c-80ba-4b96-9a43-115b8f49fccd"}],"resourceTypes":[{"resourceType":"availabilitySets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations/usages","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations/usages","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"sharedVMImages","locations":["West
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"sharedVMImages","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"sharedVMImages/versions","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"locations/capsoperations","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"disks","locations":["Southeast
@@ -410,27 +408,27 @@ http_interactions:
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"snapshots","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"snapshots","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"locations/diskoperations","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"locations/diskoperations","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"images","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"images","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"]},{"resourceType":"locations/logAnalytics","locations":["East
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"]},{"resourceType":"locations/logAnalytics","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
         US","East US","South Central US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
@@ -547,7 +545,12 @@ http_interactions:
         US","East Asia","East US","East US 2","Japan East","Japan West","North Central
         US","North Europe","South Central US","South India","Southeast Asia","West
         Central US","West Europe","West India","West US","West US 2","UK West","UK
-        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"},{"applicationId":"f5c26e74-f226-4ae8-85f0-b4af0080ac9e","roleDefinitionId":"529d7ae6-e892-4d43-809d-8547aeb90643"}],"resourceTypes":[{"resourceType":"components","locations":["East
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/consumergroups","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/disasterrecoveryconfigs","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"},{"applicationId":"f5c26e74-f226-4ae8-85f0-b4af0080ac9e","roleDefinitionId":"529d7ae6-e892-4d43-809d-8547aeb90643"}],"resourceTypes":[{"resourceType":"components","locations":["East
         US","South Central US","North Europe","West Europe","Southeast Asia","West
         US 2"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
         US","South Central US","North Europe","West Europe","Southeast Asia","West
@@ -614,32 +617,32 @@ http_interactions:
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/accessPolicies","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"vaults/accessPolicies","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-10-01","2015-06-01","2014-12-19-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"deletedVaults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01","2014-12-19-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"deletedVaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-10-01"]},{"resourceType":"locations/deletedVaults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations/deletedVaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
         Central US","West Europe","Southeast Asia","Japan East","West Central US"],"apiVersions":["2016-04-01"]},{"resourceType":"webServices","locations":["South
         Central US","West Europe","Southeast Asia","Japan East","East US 2","West
         Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"operations","locations":["South
@@ -665,97 +668,97 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"networkWatchers/lenses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"networkWatchers/lenses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","West
         US 2","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
@@ -846,7 +849,7 @@ http_interactions:
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
         West","Korea Central","Korea South"],"apiVersions":["2017-07-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ResourceHealth","namespace":"Microsoft.ResourceHealth","authorizations":[{"applicationId":"8bdebf23-c0fe-4187-a378-717ad86f6a53","roleDefinitionId":"cc026344-c8b1-4561-83ba-59eba84b27cc"}],"resourceTypes":[{"resourceType":"availabilityStatuses","locations":[],"apiVersions":["2017-07-01","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"notifications","locations":["Australia
-        Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Security","namespace":"Microsoft.Security","authorization":{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
+        Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Security","namespace":"Microsoft.Security","authorizations":[{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},{"applicationId":"fc780465-2017-40d4-a0c5-307022471b92"}],"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatuses","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/virtualMachines","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/endpoints","locations":["Central
@@ -898,565 +901,595 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Central India","South
         India"],"apiVersions":["2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Sql","namespace":"Microsoft.Sql","authorizations":[{"applicationId":"e4ab13ed-33cb-41b4-9140-6e264582cf85","roleDefinitionId":"ec3ddc95-44dc-47a2-9926-5e9f5ffd44ec"},{"applicationId":"0130cc9f-7ac5-4026-bd5f-80a08a54e6d9","roleDefinitionId":"45e8abf8-0ec4-44f3-9c37-cff4f7779302"},{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},{"applicationId":"76c7f279-7959-468f-8943-3954880e0d8c","roleDefinitionId":"7f7513a8-73f9-4c5f-97a2-c41f0ea783ef"}],"resourceTypes":[{"resourceType":"operations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/capabilities","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/databaseAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/databaseOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverKeyOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/keys","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/encryptionProtector","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/usages","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01","2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/communicationLinks","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administrators","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administratorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/restorableDroppedDatabases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recoverableDatabases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/geoBackupPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/importExportOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/operationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/backupLongTermRetentionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/automaticTuning","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/automaticTuning","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/databases/transparentDataEncryption","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recommendedElasticPools","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/auditingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/connectionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/connectionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies/rules","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/securityAlertPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/securityAlertPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/auditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/extendedAuditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/elasticpools","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-09-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/jobAgentOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/jobAgentAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/disasterRecoveryConfiguration","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/dnsAliases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/failoverGroups","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/virtualNetworkRules","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/virtualNetworkRulesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/virtualNetworkRulesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/databaseRestoreAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metricDefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/aggregatedDatabaseMetrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metricdefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries/queryText","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPools/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/extensions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPoolEstimates","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditRecords","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentScans","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/vulnerabilityAssessments","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessment","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/syncGroups","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups/syncMembers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/syncAgents","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"managedInstances/administrators","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/databases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metricDefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/administratorAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/administratorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncMemberOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncAgentOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncDatabaseIds","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorizations":[{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},{"applicationId":"e406a681-f3d4-42a8-90b6-c2b029497af1"}],"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/capabilities","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/databaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"locations/databaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverKeyOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/keys","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/encryptionProtector","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01","2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/communicationLinks","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/restorableDroppedDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recoverableDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/geoBackupPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/importExportOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/operationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/backupLongTermRetentionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/databases/transparentDataEncryption","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recommendedElasticPools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies/rules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/extendedAuditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/elasticPoolAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/elasticPoolOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/elasticpools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-09-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/jobAgentOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/jobAgentAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/disasterRecoveryConfiguration","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/dnsAliases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/failoverGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/virtualNetworkRules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/virtualNetworkRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/virtualNetworkRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/databaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/aggregatedDatabaseMetrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metricdefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries/queryText","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPools/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/extensions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPoolEstimates","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditRecords","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentScans","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/vulnerabilityAssessments","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessment","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/syncGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups/syncMembers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/syncAgents","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"managedInstances/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/administratorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncMemberOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncAgentOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncDatabaseIds","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/longTermRetentionPolicyOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionPolicyAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionBackupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionBackupAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorizations":[{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},{"applicationId":"e406a681-f3d4-42a8-90b6-c2b029497af1"}],"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
@@ -1795,12 +1828,12 @@ http_interactions:
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","Canada Central","Canada East","UK South","UK West","West US 2","West
-        Central US","South India","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","South India","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","South India","Canada Central","Canada East","UK South","UK West","West
-        US 2","West Central US","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Capacity","namespace":"Microsoft.Capacity","authorization":{"applicationId":"4d0ad6c7-f6c3-46d8-ab0d-1406d5e6c86b","roleDefinitionId":"FD9C0A9A-4DB9-4F41-8A61-98385DEB6E2D"},"resourceTypes":[{"resourceType":"resources","locations":["South
+        US 2","West Central US","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Capacity","namespace":"Microsoft.Capacity","authorization":{"applicationId":"4d0ad6c7-f6c3-46d8-ab0d-1406d5e6c86b","roleDefinitionId":"FD9C0A9A-4DB9-4F41-8A61-98385DEB6E2D"},"resourceTypes":[{"resourceType":"resources","locations":["South
         Central US"],"apiVersions":["2017-11-01"]},{"resourceType":"reservationOrders","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/reservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/reservations/revisions","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"catalogs","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"appliedReservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"checkOffers","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"checkScopes","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"calculatePrice","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/calculateRefund","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/return","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/split","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/merge","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"validateReservationOrder","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/availableScopes","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Cdn","namespace":"Microsoft.Cdn","resourceTypes":[{"resourceType":"profiles","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
@@ -1876,9 +1909,9 @@ http_interactions:
         2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/updateAccountsCreationSettings","locations":["West
         US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/accountsCreationSettings","locations":["West
         US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2016-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Commerce","namespace":"Microsoft.Commerce","resourceTypes":[{"resourceType":"UsageAggregates","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]},{"resourceType":"RateCard","locations":[],"apiVersions":["2016-08-31-preview","2015-06-01-preview","2015-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Consumption","namespace":"Microsoft.Consumption","resourceTypes":[{"resourceType":"ReservationSummaries","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationTransactions","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Balances","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Marketplaces","locations":[],"apiVersions":["2018-01-31"]},{"resourceType":"Pricesheets","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationDetails","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Budgets","locations":[],"apiVersions":["2018-01-31","2017-12-30-preview"]},{"resourceType":"Terms","locations":[],"apiVersions":["2018-01-31","2017-12-30-preview"]},{"resourceType":"UsageDetails","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview","2017-04-24-preview"]},{"resourceType":"Operations","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview","2017-04-24-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerInstance","namespace":"Microsoft.ContainerInstance","resourceTypes":[{"resourceType":"containerGroups","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/usages","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/operations","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/operations","locations":["West
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
         US"],"apiVersions":["2016-04-08"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.CustomerInsights","namespace":"Microsoft.CustomerInsights","authorization":{"applicationId":"38c77d00-5fcb-4cce-9d93-af4738258e3c","roleDefinitionId":"E006F9C7-F333-477C-8AD6-1F3A9FE87F55"},"resourceTypes":[{"resourceType":"hubs","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/profiles","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/interactions","locations":["East
@@ -1895,7 +1928,9 @@ http_interactions:
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"operations","locations":["East
         US 2"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Databricks","namespace":"Microsoft.Databricks","authorizations":[{"applicationId":"d9327919-6775-4843-9037-3fb0fb0473cb","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},{"applicationId":"2ff814a6-3304-4ab8-85cb-cd0e6f879c1d","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"}],"resourceTypes":[{"resourceType":"workspaces","locations":["West
         US","East US 2","West Europe","East US","North Europe","Southeast Asia","East
-        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]},{"resourceType":"locations","locations":["West
+        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2017-09-01-preview"]},{"resourceType":"workspaces/virtualNetworkPeerings","locations":["West
+        US","East US 2","West Europe","North Europe","East US","Southeast Asia","East
+        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01"]},{"resourceType":"locations","locations":["West
         US","East US 2","West Europe","North Europe","East US","Southeast Asia"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
         US","East US 2","West Europe","East US","North Europe","Southeast Asia","East
         Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataCatalog","namespace":"Microsoft.DataCatalog","resourceTypes":[{"resourceType":"catalogs","locations":["East
@@ -1919,23 +1954,26 @@ http_interactions:
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers/listSasTokens","locations":["East
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataLakeStore","namespace":"Microsoft.DataLakeStore","authorization":{"applicationId":"e9f49c6b-5ce5-44c8-925d-015017e9f7ad","roleDefinitionId":"17eb9cca-f08a-4499-b2d3-852d175f614f"},"resourceTypes":[{"resourceType":"accounts","locations":["East
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/firewallRules","locations":["East
-        US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataMigration","namespace":"Microsoft.DataMigration","authorization":{"applicationId":"a4bad4aa-bf02-4631-9f78-a64ffdba8150","roleDefinitionId":"b831a21d-db98-4760-89cb-bef871952df1","managedByRoleDefinitionId":"6256fb55-9e59-4018-a9e1-76b11c0a4c89"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services/projects","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationStatuses","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
+        US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataMigration","namespace":"Microsoft.DataMigration","authorization":{"applicationId":"a4bad4aa-bf02-4631-9f78-a64ffdba8150","roleDefinitionId":"b831a21d-db98-4760-89cb-bef871952df1","managedByRoleDefinitionId":"6256fb55-9e59-4018-a9e1-76b11c0a4c89"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services/projects","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationStatuses","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
-        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/recoverableServers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
@@ -1959,7 +1997,10 @@ http_interactions:
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
-        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/recoverableServers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
@@ -2015,12 +2056,7 @@ http_interactions:
         US 2","East US","West US","Central US","East US 2","West Central US","West
         Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
         US 2","East US","West US","Central US","East US 2","West Central US","West
-        Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","West
-        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
-        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
-        India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/consumergroups","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/disasterrecoveryconfigs","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
         US 2","South Central US","Central US","Australia Southeast","Central India","West
         Central US","West US 2","Canada East","Canada Central","Brazil South","UK
         South","UK West","East Asia","Australia East","Japan East","Japan West","North
@@ -2131,7 +2167,7 @@ http_interactions:
         West","Japan East","East Asia","Southeast Asia","West Europe","North Europe","East
         US","West US","Australia East","Australia Southeast","Central US","Brazil
         South","Central India","West India","South India","South Central US","Canada
-        Central","Canada East","West Central US","West US 2"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
+        Central","Canada East","West Central US","West US 2"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-05","2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
         Central US","East US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"operations","locations":["West
         Central US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
         Central US","East US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.PolicyInsights","namespace":"Microsoft.PolicyInsights","authorization":{"applicationId":"1d78a85d-813d-46f0-b496-dd72f50a3ec0","roleDefinitionId":"63d2b225-4c34-4641-8768-21a1f7c68ce8"},"resourceTypes":[{"resourceType":"policyEvents","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"policyStates","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
@@ -2163,12 +2199,12 @@ http_interactions:
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
         Central US","South Central US","North Europe","West Europe","East Asia","Southeast
         Asia","West US","East US","Japan West","Japan East","Brazil South","Central
         US","East US 2","Australia East","Australia Southeast","South India","Central
@@ -2208,40 +2244,50 @@ http_interactions:
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/clusterVersions","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"clusters/applications","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operations","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/clusterVersions","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/environments","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operations","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
         Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applianceDefinitions","locations":["West
         Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applications","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
-        Central US"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
+        Central US"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
         US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
         US","Canada Central","Canada East","Central US","East US 2","UK South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups","locations":["West
         US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
@@ -2332,7 +2378,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:41 GMT
+  recorded_at: Mon, 12 Mar 2018 09:36:10 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-deployment-dont-delete?api-version=2017-08-01
@@ -2349,7 +2395,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MzgsIm5iZiI6MTUyMDQ1MzQzOCwiZXhwIjoxNTIwNDU3MzM4LCJhaW8iOiJZMk5nWUxEbUtXMDk5clB4cU9QdGorL1crV3NlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZHNPVmFSUXV2RTJjVVBpcEtWWUFBQSIsInZlciI6IjEuMCJ9.drT5CKw95WRF7LzC0WuhK-fTLpw3j61XMw_DZdrLOWP8sjjsrbn9kF7xjDSTUM0ooF5_1Y-j3dNjvI9crm_F3PMAyhYXmCsKjTJkc3DIK6URy3hqbKiRBNlrutwvILE777NY-uXK9PH-gcaVuV-mNrjrLuxxClMJ3OPpTU8Ux0fj3Nuyf3KrXC27Oks_M_RDqDaXHOTckrdz2m_LNLpi5x0nKCoxwR9r5C1m5IKZ25FSbvyRNwjwz5dReqnv5LxllQMHVWkpvO7i5438wAnnyaS2x211IBiE6_dnV2god8Sp3ZRinXc4aCimUnJl6tLa5EtT_VSmR2QcBSaq0wS_ZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcwNjMsIm5iZiI6MTUyMDg0NzA2MywiZXhwIjoxNTIwODUwOTYzLCJhaW8iOiJZMk5nWURnY2RQQks2cFZ5anRmL0pHYWt0ajI5RGdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiaEVobDdDS0hGa1c0RjV2TExiY2lBQSIsInZlciI6IjEuMCJ9.MywLrYlLzZCy4yVEqcN17usz0ujBpvlLeFDVNfTb_5KSOKHpDmqiK14CoLuzvAP-sHS7HM-YvxzM_6fW9VzWLYC6kaUN_zWDYc7OPjKFpEvFtRv7dlfbuGIGem4-VdlO8jAgcG3gvQ7Mv95xKPelZt2BbssFPEsWnDhKrJNa0z5qGFUl9NnAPe0r2z7WoAhM4JDvTl71swAGnsaRCypUraKgO6bfxg4gmgsfc6oTK3VQ1DDaKRpV0n3HNSjEHpPTmm5lxo83iRDzvs3IlYNbf6n056CKD3urJSsykuB5QukEoJfubzXH9Z9UCemSYBIPj30abqb96Y8xNMgkEnmyfg
   response:
     status:
       code: 200
@@ -2366,19 +2412,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14974'
+      - '14990'
       X-Ms-Request-Id:
-      - 5ce26481-3672-4dd9-a789-3ef9ef7124b0
+      - 6711239d-03f2-4a82-91ab-ccd432b7e428
       X-Ms-Correlation-Request-Id:
-      - 5ce26481-3672-4dd9-a789-3ef9ef7124b0
+      - 6711239d-03f2-4a82-91ab-ccd432b7e428
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201542Z:5ce26481-3672-4dd9-a789-3ef9ef7124b0
+      - WESTEUROPE:20180312T093607Z:6711239d-03f2-4a82-91ab-ccd432b7e428
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:15:42 GMT
+      - Mon, 12 Mar 2018 09:36:06 GMT
       Content-Length:
       - '3083'
     body:
@@ -2386,7 +2432,7 @@ http_interactions:
       string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-deployment-dont-delete","name":"spec-deployment-dont-delete","properties":{"templateLink":{"uri":"https://gist.githubusercontent.com/bzwei/e6ccc4d641d6afab8e26ef55c37c498e/raw/769505e37256e926a9b581a100c90bb657ff45ff/azure-parent-spec.json","contentVersion":"1.0.0.0"},"parameters":{"childDeployName":{"type":"String","value":"spec-nested-deployment-dont-delete"},"storageAccountName":{"type":"String","value":"spec0deply1stor"},"availabilitySetName":{"type":"String","value":"spec0deply1as"},"adminUsername":{"type":"String","value":"deploy1admin"},"adminPassword":{"type":"SecureString"},"dnsNameforLBIP":{"type":"String","value":"spec0deply1dns"},"vmNamePrefix":{"type":"String","value":"spec0deply1vm"},"imagePublisher":{"type":"String","value":"MicrosoftWindowsServer"},"imageOffer":{"type":"String","value":"WindowsServer"},"imageSKU":{"type":"String","value":"2012-R2-Datacenter"},"lbName":{"type":"String","value":"spec0deply1lb"},"nicNamePrefix":{"type":"String","value":"spec0deply1nic"},"publicIPAddressName":{"type":"String","value":"spec0deply1ip"},"vnetName":{"type":"String","value":"spec0deply1vnet"},"vmSize":{"type":"String","value":"Standard_D1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-04-04T23:29:05.0043846Z","duration":"PT24M6.1512983S","correlationId":"3a55e6b5-4a3b-431e-8144-53698bf6f1dc","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[],"outputs":{"siteUri":{"type":"String","value":"hard-coded
         output for test"}},"outputResources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor"}]}}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:42 GMT
+  recorded_at: Mon, 12 Mar 2018 09:36:11 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-deployment-dont-delete/operations?api-version=2017-08-01
@@ -2403,7 +2449,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MzgsIm5iZiI6MTUyMDQ1MzQzOCwiZXhwIjoxNTIwNDU3MzM4LCJhaW8iOiJZMk5nWUxEbUtXMDk5clB4cU9QdGorL1crV3NlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZHNPVmFSUXV2RTJjVVBpcEtWWUFBQSIsInZlciI6IjEuMCJ9.drT5CKw95WRF7LzC0WuhK-fTLpw3j61XMw_DZdrLOWP8sjjsrbn9kF7xjDSTUM0ooF5_1Y-j3dNjvI9crm_F3PMAyhYXmCsKjTJkc3DIK6URy3hqbKiRBNlrutwvILE777NY-uXK9PH-gcaVuV-mNrjrLuxxClMJ3OPpTU8Ux0fj3Nuyf3KrXC27Oks_M_RDqDaXHOTckrdz2m_LNLpi5x0nKCoxwR9r5C1m5IKZ25FSbvyRNwjwz5dReqnv5LxllQMHVWkpvO7i5438wAnnyaS2x211IBiE6_dnV2god8Sp3ZRinXc4aCimUnJl6tLa5EtT_VSmR2QcBSaq0wS_ZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcwNjMsIm5iZiI6MTUyMDg0NzA2MywiZXhwIjoxNTIwODUwOTYzLCJhaW8iOiJZMk5nWURnY2RQQks2cFZ5anRmL0pHYWt0ajI5RGdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiaEVobDdDS0hGa1c0RjV2TExiY2lBQSIsInZlciI6IjEuMCJ9.MywLrYlLzZCy4yVEqcN17usz0ujBpvlLeFDVNfTb_5KSOKHpDmqiK14CoLuzvAP-sHS7HM-YvxzM_6fW9VzWLYC6kaUN_zWDYc7OPjKFpEvFtRv7dlfbuGIGem4-VdlO8jAgcG3gvQ7Mv95xKPelZt2BbssFPEsWnDhKrJNa0z5qGFUl9NnAPe0r2z7WoAhM4JDvTl71swAGnsaRCypUraKgO6bfxg4gmgsfc6oTK3VQ1DDaKRpV0n3HNSjEHpPTmm5lxo83iRDzvs3IlYNbf6n056CKD3urJSsykuB5QukEoJfubzXH9Z9UCemSYBIPj30abqb96Y8xNMgkEnmyfg
   response:
     status:
       code: 200
@@ -2420,80 +2466,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14983'
+      - '14994'
       X-Ms-Request-Id:
-      - 8ea50457-5b10-44ec-a228-bee08c7903ff
+      - 74da7344-4a64-4938-b204-58021c71c204
       X-Ms-Correlation-Request-Id:
-      - 8ea50457-5b10-44ec-a228-bee08c7903ff
+      - 74da7344-4a64-4938-b204-58021c71c204
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201543Z:8ea50457-5b10-44ec-a228-bee08c7903ff
+      - WESTEUROPE:20180312T093608Z:74da7344-4a64-4938-b204-58021c71c204
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:15:43 GMT
+      - Mon, 12 Mar 2018 09:36:08 GMT
       Content-Length:
       - '801'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-deployment-dont-delete/operations/6AF613CA61ABB553","operationId":"6AF613CA61ABB553","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:29:04.6934934Z","duration":"PT24M3.4746371S","trackingId":"a0997dbb-9578-4dd9-bad6-1286c02855c8","serviceRequestId":"08b8faec-0f0f-4cb2-8453-fabbd3448cb9","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete","resourceType":"Microsoft.Resources/deployments","resourceName":"spec-nested-deployment-dont-delete"}}}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:44 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-deployment-dont-delete?api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MzgsIm5iZiI6MTUyMDQ1MzQzOCwiZXhwIjoxNTIwNDU3MzM4LCJhaW8iOiJZMk5nWUxEbUtXMDk5clB4cU9QdGorL1crV3NlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZHNPVmFSUXV2RTJjVVBpcEtWWUFBQSIsInZlciI6IjEuMCJ9.drT5CKw95WRF7LzC0WuhK-fTLpw3j61XMw_DZdrLOWP8sjjsrbn9kF7xjDSTUM0ooF5_1Y-j3dNjvI9crm_F3PMAyhYXmCsKjTJkc3DIK6URy3hqbKiRBNlrutwvILE777NY-uXK9PH-gcaVuV-mNrjrLuxxClMJ3OPpTU8Ux0fj3Nuyf3KrXC27Oks_M_RDqDaXHOTckrdz2m_LNLpi5x0nKCoxwR9r5C1m5IKZ25FSbvyRNwjwz5dReqnv5LxllQMHVWkpvO7i5438wAnnyaS2x211IBiE6_dnV2god8Sp3ZRinXc4aCimUnJl6tLa5EtT_VSmR2QcBSaq0wS_ZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14977'
-      X-Ms-Request-Id:
-      - a6d8bfc9-11ed-4167-baf5-492c2bb6d774
-      X-Ms-Correlation-Request-Id:
-      - a6d8bfc9-11ed-4167-baf5-492c2bb6d774
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201545Z:a6d8bfc9-11ed-4167-baf5-492c2bb6d774
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:15:44 GMT
-      Content-Length:
-      - '3083'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-deployment-dont-delete","name":"spec-deployment-dont-delete","properties":{"templateLink":{"uri":"https://gist.githubusercontent.com/bzwei/e6ccc4d641d6afab8e26ef55c37c498e/raw/769505e37256e926a9b581a100c90bb657ff45ff/azure-parent-spec.json","contentVersion":"1.0.0.0"},"parameters":{"childDeployName":{"type":"String","value":"spec-nested-deployment-dont-delete"},"storageAccountName":{"type":"String","value":"spec0deply1stor"},"availabilitySetName":{"type":"String","value":"spec0deply1as"},"adminUsername":{"type":"String","value":"deploy1admin"},"adminPassword":{"type":"SecureString"},"dnsNameforLBIP":{"type":"String","value":"spec0deply1dns"},"vmNamePrefix":{"type":"String","value":"spec0deply1vm"},"imagePublisher":{"type":"String","value":"MicrosoftWindowsServer"},"imageOffer":{"type":"String","value":"WindowsServer"},"imageSKU":{"type":"String","value":"2012-R2-Datacenter"},"lbName":{"type":"String","value":"spec0deply1lb"},"nicNamePrefix":{"type":"String","value":"spec0deply1nic"},"publicIPAddressName":{"type":"String","value":"spec0deply1ip"},"vnetName":{"type":"String","value":"spec0deply1vnet"},"vmSize":{"type":"String","value":"Standard_D1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-04-04T23:29:05.0043846Z","duration":"PT24M6.1512983S","correlationId":"3a55e6b5-4a3b-431e-8144-53698bf6f1dc","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[],"outputs":{"siteUri":{"type":"String","value":"hard-coded
-        output for test"}},"outputResources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor"}]}}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:45 GMT
+  recorded_at: Mon, 12 Mar 2018 09:36:13 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete?api-version=2017-08-01
@@ -2510,7 +2502,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MzgsIm5iZiI6MTUyMDQ1MzQzOCwiZXhwIjoxNTIwNDU3MzM4LCJhaW8iOiJZMk5nWUxEbUtXMDk5clB4cU9QdGorL1crV3NlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZHNPVmFSUXV2RTJjVVBpcEtWWUFBQSIsInZlciI6IjEuMCJ9.drT5CKw95WRF7LzC0WuhK-fTLpw3j61XMw_DZdrLOWP8sjjsrbn9kF7xjDSTUM0ooF5_1Y-j3dNjvI9crm_F3PMAyhYXmCsKjTJkc3DIK6URy3hqbKiRBNlrutwvILE777NY-uXK9PH-gcaVuV-mNrjrLuxxClMJ3OPpTU8Ux0fj3Nuyf3KrXC27Oks_M_RDqDaXHOTckrdz2m_LNLpi5x0nKCoxwR9r5C1m5IKZ25FSbvyRNwjwz5dReqnv5LxllQMHVWkpvO7i5438wAnnyaS2x211IBiE6_dnV2god8Sp3ZRinXc4aCimUnJl6tLa5EtT_VSmR2QcBSaq0wS_ZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcwNjMsIm5iZiI6MTUyMDg0NzA2MywiZXhwIjoxNTIwODUwOTYzLCJhaW8iOiJZMk5nWURnY2RQQks2cFZ5anRmL0pHYWt0ajI5RGdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiaEVobDdDS0hGa1c0RjV2TExiY2lBQSIsInZlciI6IjEuMCJ9.MywLrYlLzZCy4yVEqcN17usz0ujBpvlLeFDVNfTb_5KSOKHpDmqiK14CoLuzvAP-sHS7HM-YvxzM_6fW9VzWLYC6kaUN_zWDYc7OPjKFpEvFtRv7dlfbuGIGem4-VdlO8jAgcG3gvQ7Mv95xKPelZt2BbssFPEsWnDhKrJNa0z5qGFUl9NnAPe0r2z7WoAhM4JDvTl71swAGnsaRCypUraKgO6bfxg4gmgsfc6oTK3VQ1DDaKRpV0n3HNSjEHpPTmm5lxo83iRDzvs3IlYNbf6n056CKD3urJSsykuB5QukEoJfubzXH9Z9UCemSYBIPj30abqb96Y8xNMgkEnmyfg
   response:
     status:
       code: 200
@@ -2527,26 +2519,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
+      - '14995'
       X-Ms-Request-Id:
-      - c84bb53f-d8a2-4cb5-a46e-ba985646b116
+      - 13599c5b-e59b-4557-ae08-fc6f26c3d6ce
       X-Ms-Correlation-Request-Id:
-      - c84bb53f-d8a2-4cb5-a46e-ba985646b116
+      - 13599c5b-e59b-4557-ae08-fc6f26c3d6ce
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201545Z:c84bb53f-d8a2-4cb5-a46e-ba985646b116
+      - WESTEUROPE:20180312T093613Z:13599c5b-e59b-4557-ae08-fc6f26c3d6ce
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:15:45 GMT
+      - Mon, 12 Mar 2018 09:36:12 GMT
       Content-Length:
       - '7230'
     body:
       encoding: ASCII-8BIT
       string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete","name":"spec-nested-deployment-dont-delete","properties":{"templateLink":{"uri":"https://gist.githubusercontent.com/bzwei/c09f906306399d238762bce711781200/raw/3558b735da03c1c030023d70b78ec3451dab5689/azure-loadbalancer.json","contentVersion":"1.0.0.0"},"parameters":{"storageAccountName":{"type":"String","value":"spec0deply1stor"},"availabilitySetName":{"type":"String","value":"spec0deply1as"},"adminUsername":{"type":"String","value":"deploy1admin"},"adminPassword":{"type":"SecureString"},"dnsNameforLBIP":{"type":"String","value":"spec0deply1dns"},"vmNamePrefix":{"type":"String","value":"spec0deply1vm"},"imagePublisher":{"type":"String","value":"MicrosoftWindowsServer"},"imageOffer":{"type":"String","value":"WindowsServer"},"imageSKU":{"type":"String","value":"2012-R2-Datacenter"},"lbName":{"type":"String","value":"spec0deply1lb"},"nicNamePrefix":{"type":"String","value":"spec0deply1nic"},"publicIPAddressName":{"type":"String","value":"spec0deply1ip"},"vnetName":{"type":"String","value":"spec0deply1vnet"},"vmSize":{"type":"String","value":"Standard_D1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-04-04T23:28:59.2682474Z","duration":"PT23M55.442141S","correlationId":"3a55e6b5-4a3b-431e-8144-53698bf6f1dc","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["eastus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"availabilitySets","locations":["eastus"]},{"resourceType":"virtualMachines","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"publicIPAddresses","locations":["eastus"]},{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"loadBalancers","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"spec0deply1ip"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic0"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic1"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"spec0deply1stor"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"spec0deply1as"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"spec0deply1vm0"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"spec0deply1stor"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"spec0deply1as"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"spec0deply1vm1"}],"outputResources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor"}]}}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:46 GMT
+  recorded_at: Mon, 12 Mar 2018 09:36:18 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations?api-version=2017-08-01
@@ -2563,7 +2555,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MzgsIm5iZiI6MTUyMDQ1MzQzOCwiZXhwIjoxNTIwNDU3MzM4LCJhaW8iOiJZMk5nWUxEbUtXMDk5clB4cU9QdGorL1crV3NlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZHNPVmFSUXV2RTJjVVBpcEtWWUFBQSIsInZlciI6IjEuMCJ9.drT5CKw95WRF7LzC0WuhK-fTLpw3j61XMw_DZdrLOWP8sjjsrbn9kF7xjDSTUM0ooF5_1Y-j3dNjvI9crm_F3PMAyhYXmCsKjTJkc3DIK6URy3hqbKiRBNlrutwvILE777NY-uXK9PH-gcaVuV-mNrjrLuxxClMJ3OPpTU8Ux0fj3Nuyf3KrXC27Oks_M_RDqDaXHOTckrdz2m_LNLpi5x0nKCoxwR9r5C1m5IKZ25FSbvyRNwjwz5dReqnv5LxllQMHVWkpvO7i5438wAnnyaS2x211IBiE6_dnV2god8Sp3ZRinXc4aCimUnJl6tLa5EtT_VSmR2QcBSaq0wS_ZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcwNjMsIm5iZiI6MTUyMDg0NzA2MywiZXhwIjoxNTIwODUwOTYzLCJhaW8iOiJZMk5nWURnY2RQQks2cFZ5anRmL0pHYWt0ajI5RGdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiaEVobDdDS0hGa1c0RjV2TExiY2lBQSIsInZlciI6IjEuMCJ9.MywLrYlLzZCy4yVEqcN17usz0ujBpvlLeFDVNfTb_5KSOKHpDmqiK14CoLuzvAP-sHS7HM-YvxzM_6fW9VzWLYC6kaUN_zWDYc7OPjKFpEvFtRv7dlfbuGIGem4-VdlO8jAgcG3gvQ7Mv95xKPelZt2BbssFPEsWnDhKrJNa0z5qGFUl9NnAPe0r2z7WoAhM4JDvTl71swAGnsaRCypUraKgO6bfxg4gmgsfc6oTK3VQ1DDaKRpV0n3HNSjEHpPTmm5lxo83iRDzvs3IlYNbf6n056CKD3urJSsykuB5QukEoJfubzXH9Z9UCemSYBIPj30abqb96Y8xNMgkEnmyfg
   response:
     status:
       code: 200
@@ -2580,26 +2572,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14976'
+      - '14993'
       X-Ms-Request-Id:
-      - cfda35a0-19b7-4818-a178-3de329ef3e43
+      - 25ad8220-09b6-44e5-9d58-b7b7c0aecbc6
       X-Ms-Correlation-Request-Id:
-      - cfda35a0-19b7-4818-a178-3de329ef3e43
+      - 25ad8220-09b6-44e5-9d58-b7b7c0aecbc6
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201546Z:cfda35a0-19b7-4818-a178-3de329ef3e43
+      - WESTEUROPE:20180312T093615Z:25ad8220-09b6-44e5-9d58-b7b7c0aecbc6
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:15:46 GMT
+      - Mon, 12 Mar 2018 09:36:15 GMT
       Content-Length:
       - '6866'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/2A5D9DB48CB9B87D","operationId":"2A5D9DB48CB9B87D","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:28:58.871396Z","duration":"PT4M5.2351465S","trackingId":"413c1acd-4a86-42aa-8371-2f7fe7760fba","serviceRequestId":"520c4ff7-a725-4e8f-946e-d203617aa3f9","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"spec0deply1vm1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/F59DBCC8F57674DA","operationId":"F59DBCC8F57674DA","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:28:57.3638022Z","duration":"PT4M3.6342685S","trackingId":"a7e62d93-ed67-4f9f-93bc-d7ca4451f6f9","serviceRequestId":"5b58ce6a-8aa5-45a1-b7a3-9c82b6150bd7","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"spec0deply1vm0"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/727DE014666F097A","operationId":"727DE014666F097A","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:28.2942519Z","duration":"PT3.4353223S","trackingId":"dda58292-47ab-4139-8d67-8c99aae9c93c","serviceRequestId":"7b1ba585-6ce8-4e35-83cf-27d7a344ff40","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/8984B6C47B4DBB63","operationId":"8984B6C47B4DBB63","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:26.6945925Z","duration":"PT1.75149S","trackingId":"cf689996-82e8-4740-87f0-8f820b4d153a","serviceRequestId":"831312e5-eaf1-417d-9fdb-5723d493b396","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic0"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/5BB7F6FEF271DCC5","operationId":"5BB7F6FEF271DCC5","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:24.7522379Z","duration":"PT1.8393589S","trackingId":"f42ecee0-2ab0-44d0-9748-44249046b29e","serviceRequestId":"2c6c9788-7fc1-4e6b-928f-241a44e192ea","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/ACBE290D4E246F6C","operationId":"ACBE290D4E246F6C","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:22.8224458Z","duration":"PT16.8373612S","trackingId":"a7759f29-cf9e-4892-bb7b-3e08f64e4ff7","serviceRequestId":"25c16d1d-b611-4fc3-ad7c-eedb21574599","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"spec0deply1ip"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/CDA31B5D53DE7D18","operationId":"CDA31B5D53DE7D18","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:24:53.5717985Z","duration":"PT19M47.4658028S","trackingId":"1ce6f839-7da9-4e40-97d4-2693cfbbc796","serviceRequestId":"3a55e6b5-4a3b-431e-8144-53698bf6f1dc","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"spec0deply1stor"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/07A1436712650187","operationId":"07A1436712650187","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:22.0339723Z","duration":"PT16.0077667S","trackingId":"89200282-9510-4328-ac23-a73df06aea3e","serviceRequestId":"86d89b1a-900e-4719-8d9b-7f18bc963ec7","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"spec0deply1vnet"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/C35E071B1E2FC92A","operationId":"C35E071B1E2FC92A","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:08.170721Z","duration":"PT2.1819157S","trackingId":"a2495990-63ae-4ea3-8904-866b7e01ec18","serviceRequestId":"97334c1c-6e32-4bc5-b96c-25314a5fef57","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"spec0deply1as"}}}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:47 GMT
+  recorded_at: Mon, 12 Mar 2018 09:36:19 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb?api-version=2018-01-01
@@ -2616,7 +2608,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MzgsIm5iZiI6MTUyMDQ1MzQzOCwiZXhwIjoxNTIwNDU3MzM4LCJhaW8iOiJZMk5nWUxEbUtXMDk5clB4cU9QdGorL1crV3NlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZHNPVmFSUXV2RTJjVVBpcEtWWUFBQSIsInZlciI6IjEuMCJ9.drT5CKw95WRF7LzC0WuhK-fTLpw3j61XMw_DZdrLOWP8sjjsrbn9kF7xjDSTUM0ooF5_1Y-j3dNjvI9crm_F3PMAyhYXmCsKjTJkc3DIK6URy3hqbKiRBNlrutwvILE777NY-uXK9PH-gcaVuV-mNrjrLuxxClMJ3OPpTU8Ux0fj3Nuyf3KrXC27Oks_M_RDqDaXHOTckrdz2m_LNLpi5x0nKCoxwR9r5C1m5IKZ25FSbvyRNwjwz5dReqnv5LxllQMHVWkpvO7i5438wAnnyaS2x211IBiE6_dnV2god8Sp3ZRinXc4aCimUnJl6tLa5EtT_VSmR2QcBSaq0wS_ZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcwNjMsIm5iZiI6MTUyMDg0NzA2MywiZXhwIjoxNTIwODUwOTYzLCJhaW8iOiJZMk5nWURnY2RQQks2cFZ5anRmL0pHYWt0ajI5RGdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiaEVobDdDS0hGa1c0RjV2TExiY2lBQSIsInZlciI6IjEuMCJ9.MywLrYlLzZCy4yVEqcN17usz0ujBpvlLeFDVNfTb_5KSOKHpDmqiK14CoLuzvAP-sHS7HM-YvxzM_6fW9VzWLYC6kaUN_zWDYc7OPjKFpEvFtRv7dlfbuGIGem4-VdlO8jAgcG3gvQ7Mv95xKPelZt2BbssFPEsWnDhKrJNa0z5qGFUl9NnAPe0r2z7WoAhM4JDvTl71swAGnsaRCypUraKgO6bfxg4gmgsfc6oTK3VQ1DDaKRpV0n3HNSjEHpPTmm5lxo83iRDzvs3IlYNbf6n056CKD3urJSsykuB5QukEoJfubzXH9Z9UCemSYBIPj30abqb96Y8xNMgkEnmyfg
   response:
     status:
       code: 200
@@ -2637,22 +2629,22 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 13ce1e70-a5e3-41af-b39c-c9c015bd674d
+      - 0ca688c0-429c-4e38-a380-81df37d38745
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14973'
+      - '14996'
       X-Ms-Correlation-Request-Id:
-      - cb6d53b0-8b91-4766-94aa-6d4ad5cfa54f
+      - cc9af1fa-308c-4fb2-ae27-dbee47a9bb0b
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201547Z:cb6d53b0-8b91-4766-94aa-6d4ad5cfa54f
+      - WESTEUROPE:20180312T093616Z:cc9af1fa-308c-4fb2-ae27-dbee47a9bb0b
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:15:47 GMT
+      - Mon, 12 Mar 2018 09:36:15 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"spec0deply1lb\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb\",\r\n
@@ -2719,7 +2711,7 @@ http_interactions:
         [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
         \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:47 GMT
+  recorded_at: Mon, 12 Mar 2018 09:36:20 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1?api-version=2017-12-01
@@ -2736,7 +2728,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MzgsIm5iZiI6MTUyMDQ1MzQzOCwiZXhwIjoxNTIwNDU3MzM4LCJhaW8iOiJZMk5nWUxEbUtXMDk5clB4cU9QdGorL1crV3NlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZHNPVmFSUXV2RTJjVVBpcEtWWUFBQSIsInZlciI6IjEuMCJ9.drT5CKw95WRF7LzC0WuhK-fTLpw3j61XMw_DZdrLOWP8sjjsrbn9kF7xjDSTUM0ooF5_1Y-j3dNjvI9crm_F3PMAyhYXmCsKjTJkc3DIK6URy3hqbKiRBNlrutwvILE777NY-uXK9PH-gcaVuV-mNrjrLuxxClMJ3OPpTU8Ux0fj3Nuyf3KrXC27Oks_M_RDqDaXHOTckrdz2m_LNLpi5x0nKCoxwR9r5C1m5IKZ25FSbvyRNwjwz5dReqnv5LxllQMHVWkpvO7i5438wAnnyaS2x211IBiE6_dnV2god8Sp3ZRinXc4aCimUnJl6tLa5EtT_VSmR2QcBSaq0wS_ZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcwNjMsIm5iZiI6MTUyMDg0NzA2MywiZXhwIjoxNTIwODUwOTYzLCJhaW8iOiJZMk5nWURnY2RQQks2cFZ5anRmL0pHYWt0ajI5RGdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiaEVobDdDS0hGa1c0RjV2TExiY2lBQSIsInZlciI6IjEuMCJ9.MywLrYlLzZCy4yVEqcN17usz0ujBpvlLeFDVNfTb_5KSOKHpDmqiK14CoLuzvAP-sHS7HM-YvxzM_6fW9VzWLYC6kaUN_zWDYc7OPjKFpEvFtRv7dlfbuGIGem4-VdlO8jAgcG3gvQ7Mv95xKPelZt2BbssFPEsWnDhKrJNa0z5qGFUl9NnAPe0r2z7WoAhM4JDvTl71swAGnsaRCypUraKgO6bfxg4gmgsfc6oTK3VQ1DDaKRpV0n3HNSjEHpPTmm5lxo83iRDzvs3IlYNbf6n056CKD3urJSsykuB5QukEoJfubzXH9Z9UCemSYBIPj30abqb96Y8xNMgkEnmyfg
   response:
     status:
       code: 200
@@ -2755,26 +2747,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/LowCostGet3Min;4749,Microsoft.Compute/LowCostGet30Min;37940
+      - Microsoft.Compute/LowCostGet3Min;4757,Microsoft.Compute/LowCostGet30Min;37912
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
       - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
       X-Ms-Request-Id:
-      - f96990ed-5242-481f-abd3-7f66dfa2827f
+      - 3a27962c-9c63-4f92-a107-2b2de3da2e51
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14982'
+      - '14989'
       X-Ms-Correlation-Request-Id:
-      - 1ec82248-157d-4164-871a-58e04a828f71
+      - 8d61b977-b2c0-4130-baa5-1930ee3ec5d4
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201547Z:1ec82248-157d-4164-871a-58e04a828f71
+      - WESTEUROPE:20180312T093621Z:8d61b977-b2c0-4130-baa5-1930ee3ec5d4
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:15:47 GMT
+      - Mon, 12 Mar 2018 09:36:20 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"4d1502d5-351a-42f4-8569-22284f906d68\",\r\n
@@ -2799,7 +2791,7 @@ http_interactions:
         \ \"tags\": {\r\n    \"Shutdown\": \"true\"\r\n  },\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1\",\r\n
         \ \"name\": \"spec0deply1vm1\"\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:48 GMT
+  recorded_at: Mon, 12 Mar 2018 09:36:25 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0?api-version=2017-12-01
@@ -2816,7 +2808,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MzgsIm5iZiI6MTUyMDQ1MzQzOCwiZXhwIjoxNTIwNDU3MzM4LCJhaW8iOiJZMk5nWUxEbUtXMDk5clB4cU9QdGorL1crV3NlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZHNPVmFSUXV2RTJjVVBpcEtWWUFBQSIsInZlciI6IjEuMCJ9.drT5CKw95WRF7LzC0WuhK-fTLpw3j61XMw_DZdrLOWP8sjjsrbn9kF7xjDSTUM0ooF5_1Y-j3dNjvI9crm_F3PMAyhYXmCsKjTJkc3DIK6URy3hqbKiRBNlrutwvILE777NY-uXK9PH-gcaVuV-mNrjrLuxxClMJ3OPpTU8Ux0fj3Nuyf3KrXC27Oks_M_RDqDaXHOTckrdz2m_LNLpi5x0nKCoxwR9r5C1m5IKZ25FSbvyRNwjwz5dReqnv5LxllQMHVWkpvO7i5438wAnnyaS2x211IBiE6_dnV2god8Sp3ZRinXc4aCimUnJl6tLa5EtT_VSmR2QcBSaq0wS_ZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcwNjMsIm5iZiI6MTUyMDg0NzA2MywiZXhwIjoxNTIwODUwOTYzLCJhaW8iOiJZMk5nWURnY2RQQks2cFZ5anRmL0pHYWt0ajI5RGdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiaEVobDdDS0hGa1c0RjV2TExiY2lBQSIsInZlciI6IjEuMCJ9.MywLrYlLzZCy4yVEqcN17usz0ujBpvlLeFDVNfTb_5KSOKHpDmqiK14CoLuzvAP-sHS7HM-YvxzM_6fW9VzWLYC6kaUN_zWDYc7OPjKFpEvFtRv7dlfbuGIGem4-VdlO8jAgcG3gvQ7Mv95xKPelZt2BbssFPEsWnDhKrJNa0z5qGFUl9NnAPe0r2z7WoAhM4JDvTl71swAGnsaRCypUraKgO6bfxg4gmgsfc6oTK3VQ1DDaKRpV0n3HNSjEHpPTmm5lxo83iRDzvs3IlYNbf6n056CKD3urJSsykuB5QukEoJfubzXH9Z9UCemSYBIPj30abqb96Y8xNMgkEnmyfg
   response:
     status:
       code: 200
@@ -2835,26 +2827,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/LowCostGet3Min;4748,Microsoft.Compute/LowCostGet30Min;37939
+      - Microsoft.Compute/LowCostGet3Min;4753,Microsoft.Compute/LowCostGet30Min;37908
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
       - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
       X-Ms-Request-Id:
-      - 9c2cd53b-2f91-4de4-b7a6-31bc96183570
+      - 7aa24364-34b6-4310-92ca-575847127c94
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14783'
+      - '14993'
       X-Ms-Correlation-Request-Id:
-      - 051cbdaa-87e9-43f5-95e2-4a091fd4d536
+      - 98cdc190-7cb7-4dad-b6eb-21d2e029f67b
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201548Z:051cbdaa-87e9-43f5-95e2-4a091fd4d536
+      - WESTEUROPE:20180312T093627Z:98cdc190-7cb7-4dad-b6eb-21d2e029f67b
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:15:48 GMT
+      - Mon, 12 Mar 2018 09:36:26 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"d7022008-f6b1-4f4c-8be8-e2d677ef3261\",\r\n
@@ -2879,7 +2871,7 @@ http_interactions:
         \ \"tags\": {\r\n    \"Shutdown\": \"true\"\r\n  },\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0\",\r\n
         \ \"name\": \"spec0deply1vm0\"\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:48 GMT
+  recorded_at: Mon, 12 Mar 2018 09:36:32 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1?api-version=2018-01-01
@@ -2896,7 +2888,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MzgsIm5iZiI6MTUyMDQ1MzQzOCwiZXhwIjoxNTIwNDU3MzM4LCJhaW8iOiJZMk5nWUxEbUtXMDk5clB4cU9QdGorL1crV3NlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZHNPVmFSUXV2RTJjVVBpcEtWWUFBQSIsInZlciI6IjEuMCJ9.drT5CKw95WRF7LzC0WuhK-fTLpw3j61XMw_DZdrLOWP8sjjsrbn9kF7xjDSTUM0ooF5_1Y-j3dNjvI9crm_F3PMAyhYXmCsKjTJkc3DIK6URy3hqbKiRBNlrutwvILE777NY-uXK9PH-gcaVuV-mNrjrLuxxClMJ3OPpTU8Ux0fj3Nuyf3KrXC27Oks_M_RDqDaXHOTckrdz2m_LNLpi5x0nKCoxwR9r5C1m5IKZ25FSbvyRNwjwz5dReqnv5LxllQMHVWkpvO7i5438wAnnyaS2x211IBiE6_dnV2god8Sp3ZRinXc4aCimUnJl6tLa5EtT_VSmR2QcBSaq0wS_ZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcwNjMsIm5iZiI6MTUyMDg0NzA2MywiZXhwIjoxNTIwODUwOTYzLCJhaW8iOiJZMk5nWURnY2RQQks2cFZ5anRmL0pHYWt0ajI5RGdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiaEVobDdDS0hGa1c0RjV2TExiY2lBQSIsInZlciI6IjEuMCJ9.MywLrYlLzZCy4yVEqcN17usz0ujBpvlLeFDVNfTb_5KSOKHpDmqiK14CoLuzvAP-sHS7HM-YvxzM_6fW9VzWLYC6kaUN_zWDYc7OPjKFpEvFtRv7dlfbuGIGem4-VdlO8jAgcG3gvQ7Mv95xKPelZt2BbssFPEsWnDhKrJNa0z5qGFUl9NnAPe0r2z7WoAhM4JDvTl71swAGnsaRCypUraKgO6bfxg4gmgsfc6oTK3VQ1DDaKRpV0n3HNSjEHpPTmm5lxo83iRDzvs3IlYNbf6n056CKD3urJSsykuB5QukEoJfubzXH9Z9UCemSYBIPj30abqb96Y8xNMgkEnmyfg
   response:
     status:
       code: 200
@@ -2917,22 +2909,22 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - c739bb48-dcbc-4bfa-a4f3-322ae2f1a96f
+      - 666d374c-115d-4ac0-b999-7bfd39931166
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14976'
+      - '14994'
       X-Ms-Correlation-Request-Id:
-      - 1c74b64e-aa8d-438e-a6aa-315cf0070acd
+      - 11f6840b-40de-4629-b88e-b77ca19a7b9f
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201552Z:1c74b64e-aa8d-438e-a6aa-315cf0070acd
+      - WESTEUROPE:20180312T093628Z:11f6840b-40de-4629-b88e-b77ca19a7b9f
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:15:51 GMT
+      - Mon, 12 Mar 2018 09:36:28 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"spec0deply1nic1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1\",\r\n
@@ -2957,7 +2949,7 @@ http_interactions:
         \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
         \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:52 GMT
+  recorded_at: Mon, 12 Mar 2018 09:36:33 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0?api-version=2018-01-01
@@ -2974,7 +2966,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MzgsIm5iZiI6MTUyMDQ1MzQzOCwiZXhwIjoxNTIwNDU3MzM4LCJhaW8iOiJZMk5nWUxEbUtXMDk5clB4cU9QdGorL1crV3NlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZHNPVmFSUXV2RTJjVVBpcEtWWUFBQSIsInZlciI6IjEuMCJ9.drT5CKw95WRF7LzC0WuhK-fTLpw3j61XMw_DZdrLOWP8sjjsrbn9kF7xjDSTUM0ooF5_1Y-j3dNjvI9crm_F3PMAyhYXmCsKjTJkc3DIK6URy3hqbKiRBNlrutwvILE777NY-uXK9PH-gcaVuV-mNrjrLuxxClMJ3OPpTU8Ux0fj3Nuyf3KrXC27Oks_M_RDqDaXHOTckrdz2m_LNLpi5x0nKCoxwR9r5C1m5IKZ25FSbvyRNwjwz5dReqnv5LxllQMHVWkpvO7i5438wAnnyaS2x211IBiE6_dnV2god8Sp3ZRinXc4aCimUnJl6tLa5EtT_VSmR2QcBSaq0wS_ZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcwNjMsIm5iZiI6MTUyMDg0NzA2MywiZXhwIjoxNTIwODUwOTYzLCJhaW8iOiJZMk5nWURnY2RQQks2cFZ5anRmL0pHYWt0ajI5RGdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiaEVobDdDS0hGa1c0RjV2TExiY2lBQSIsInZlciI6IjEuMCJ9.MywLrYlLzZCy4yVEqcN17usz0ujBpvlLeFDVNfTb_5KSOKHpDmqiK14CoLuzvAP-sHS7HM-YvxzM_6fW9VzWLYC6kaUN_zWDYc7OPjKFpEvFtRv7dlfbuGIGem4-VdlO8jAgcG3gvQ7Mv95xKPelZt2BbssFPEsWnDhKrJNa0z5qGFUl9NnAPe0r2z7WoAhM4JDvTl71swAGnsaRCypUraKgO6bfxg4gmgsfc6oTK3VQ1DDaKRpV0n3HNSjEHpPTmm5lxo83iRDzvs3IlYNbf6n056CKD3urJSsykuB5QukEoJfubzXH9Z9UCemSYBIPj30abqb96Y8xNMgkEnmyfg
   response:
     status:
       code: 200
@@ -2995,22 +2987,22 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 5a4c2acb-7c14-482d-a4a9-de87376ecc91
+      - 32b5da08-aa37-4a50-a611-c2ac59b19ed6
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14782'
+      - '14993'
       X-Ms-Correlation-Request-Id:
-      - e6ba53b7-2768-4351-b000-221aeddc164a
+      - 74045a74-b2d1-4cd4-afd7-6812b2b0d059
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201552Z:e6ba53b7-2768-4351-b000-221aeddc164a
+      - WESTEUROPE:20180312T093633Z:74045a74-b2d1-4cd4-afd7-6812b2b0d059
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:15:52 GMT
+      - Mon, 12 Mar 2018 09:36:32 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"spec0deply1nic0\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0\",\r\n
@@ -3035,10 +3027,10 @@ http_interactions:
         \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
         \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:52 GMT
+  recorded_at: Mon, 12 Mar 2018 09:36:37 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups/miq-azure-test1?api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1/instanceView?api-version=2017-12-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3052,60 +3044,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MzgsIm5iZiI6MTUyMDQ1MzQzOCwiZXhwIjoxNTIwNDU3MzM4LCJhaW8iOiJZMk5nWUxEbUtXMDk5clB4cU9QdGorL1crV3NlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZHNPVmFSUXV2RTJjVVBpcEtWWUFBQSIsInZlciI6IjEuMCJ9.drT5CKw95WRF7LzC0WuhK-fTLpw3j61XMw_DZdrLOWP8sjjsrbn9kF7xjDSTUM0ooF5_1Y-j3dNjvI9crm_F3PMAyhYXmCsKjTJkc3DIK6URy3hqbKiRBNlrutwvILE777NY-uXK9PH-gcaVuV-mNrjrLuxxClMJ3OPpTU8Ux0fj3Nuyf3KrXC27Oks_M_RDqDaXHOTckrdz2m_LNLpi5x0nKCoxwR9r5C1m5IKZ25FSbvyRNwjwz5dReqnv5LxllQMHVWkpvO7i5438wAnnyaS2x211IBiE6_dnV2god8Sp3ZRinXc4aCimUnJl6tLa5EtT_VSmR2QcBSaq0wS_ZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14975'
-      X-Ms-Request-Id:
-      - de11e3a1-515a-4216-aad4-10652b22d0eb
-      X-Ms-Correlation-Request-Id:
-      - de11e3a1-515a-4216-aad4-10652b22d0eb
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201553Z:de11e3a1-515a-4216-aad4-10652b22d0eb
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:15:52 GMT
-      Content-Length:
-      - '183'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1","name":"miq-azure-test1","location":"eastus","properties":{"provisioningState":"Succeeded"}}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:53 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute/locations/eastus/vmSizes?api-version=2017-12-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MzgsIm5iZiI6MTUyMDQ1MzQzOCwiZXhwIjoxNTIwNDU3MzM4LCJhaW8iOiJZMk5nWUxEbUtXMDk5clB4cU9QdGorL1crV3NlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZHNPVmFSUXV2RTJjVVBpcEtWWUFBQSIsInZlciI6IjEuMCJ9.drT5CKw95WRF7LzC0WuhK-fTLpw3j61XMw_DZdrLOWP8sjjsrbn9kF7xjDSTUM0ooF5_1Y-j3dNjvI9crm_F3PMAyhYXmCsKjTJkc3DIK6URy3hqbKiRBNlrutwvILE777NY-uXK9PH-gcaVuV-mNrjrLuxxClMJ3OPpTU8Ux0fj3Nuyf3KrXC27Oks_M_RDqDaXHOTckrdz2m_LNLpi5x0nKCoxwR9r5C1m5IKZ25FSbvyRNwjwz5dReqnv5LxllQMHVWkpvO7i5438wAnnyaS2x211IBiE6_dnV2god8Sp3ZRinXc4aCimUnJl6tLa5EtT_VSmR2QcBSaq0wS_ZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcwNjMsIm5iZiI6MTUyMDg0NzA2MywiZXhwIjoxNTIwODUwOTYzLCJhaW8iOiJZMk5nWURnY2RQQks2cFZ5anRmL0pHYWt0ajI5RGdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiaEVobDdDS0hGa1c0RjV2TExiY2lBQSIsInZlciI6IjEuMCJ9.MywLrYlLzZCy4yVEqcN17usz0ujBpvlLeFDVNfTb_5KSOKHpDmqiK14CoLuzvAP-sHS7HM-YvxzM_6fW9VzWLYC6kaUN_zWDYc7OPjKFpEvFtRv7dlfbuGIGem4-VdlO8jAgcG3gvQ7Mv95xKPelZt2BbssFPEsWnDhKrJNa0z5qGFUl9NnAPe0r2z7WoAhM4JDvTl71swAGnsaRCypUraKgO6bfxg4gmgsfc6oTK3VQ1DDaKRpV0n3HNSjEHpPTmm5lxo83iRDzvs3IlYNbf6n056CKD3urJSsykuB5QukEoJfubzXH9Z9UCemSYBIPj30abqb96Y8xNMgkEnmyfg
   response:
     status:
       code: 200
@@ -3124,26 +3063,231 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/LowCostGet3Min;4746,Microsoft.Compute/LowCostGet30Min;37937
+      - Microsoft.Compute/GetInstanceView3Min;4799,Microsoft.Compute/GetInstanceView30Min;23914
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
       - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
       X-Ms-Request-Id:
-      - d9803c20-fb0a-4f4f-8557-b1fd76c98646
+      - 98a0db5d-3632-4e54-a9e9-0a03676e25a0
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
+      - '14995'
       X-Ms-Correlation-Request-Id:
-      - f9fe99d1-a718-46cd-b81c-4db12c853de3
+      - e76e0313-75f9-435c-9bfa-e0b8f4d8fcf3
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201553Z:f9fe99d1-a718-46cd-b81c-4db12c853de3
+      - WESTEUROPE:20180312T093633Z:e76e0313-75f9-435c-9bfa-e0b8f4d8fcf3
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:15:53 GMT
+      - Mon, 12 Mar 2018 09:36:32 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"platformUpdateDomain\": 0,\r\n  \"platformFaultDomain\": 0,\r\n
+        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
+        [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
+        \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
+        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2018-03-12T09:36:33+00:00\"\r\n
+        \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"osdisk\",\r\n
+        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
+        succeeded\",\r\n          \"time\": \"2016-09-03T02:09:09.3853413+00:00\"\r\n
+        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
+        \"https://spec0deply1stor.blob.core.windows.net/bootdiagnostics-spec0depl-4d1502d5-351a-42f4-8569-22284f906d68/spec0deply1vm1.4d1502d5-351a-42f4-8569-22284f906d68.screenshot.bmp\",\r\n
+        \   \"serialConsoleLogBlobUri\": \"https://spec0deply1stor.blob.core.windows.net/bootdiagnostics-spec0depl-4d1502d5-351a-42f4-8569-22284f906d68/spec0deply1vm1.4d1502d5-351a-42f4-8569-22284f906d68.serialconsole.log\"\r\n
+        \ },\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n
+        \     \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n
+        \     \"time\": \"2016-09-03T02:09:09.4478672+00:00\"\r\n    },\r\n    {\r\n
+        \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
+        \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:36:38 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0/instanceView?api-version=2017-12-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcwNjMsIm5iZiI6MTUyMDg0NzA2MywiZXhwIjoxNTIwODUwOTYzLCJhaW8iOiJZMk5nWURnY2RQQks2cFZ5anRmL0pHYWt0ajI5RGdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiaEVobDdDS0hGa1c0RjV2TExiY2lBQSIsInZlciI6IjEuMCJ9.MywLrYlLzZCy4yVEqcN17usz0ujBpvlLeFDVNfTb_5KSOKHpDmqiK14CoLuzvAP-sHS7HM-YvxzM_6fW9VzWLYC6kaUN_zWDYc7OPjKFpEvFtRv7dlfbuGIGem4-VdlO8jAgcG3gvQ7Mv95xKPelZt2BbssFPEsWnDhKrJNa0z5qGFUl9NnAPe0r2z7WoAhM4JDvTl71swAGnsaRCypUraKgO6bfxg4gmgsfc6oTK3VQ1DDaKRpV0n3HNSjEHpPTmm5lxo83iRDzvs3IlYNbf6n056CKD3urJSsykuB5QukEoJfubzXH9Z9UCemSYBIPj30abqb96Y8xNMgkEnmyfg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/GetInstanceView3Min;4798,Microsoft.Compute/GetInstanceView30Min;23913
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      X-Ms-Request-Id:
+      - 39a64fb2-a36d-4ec1-a63e-8903c51afe95
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Correlation-Request-Id:
+      - 779e3771-4677-41f9-a4b2-ad5cc7d8bada
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T093639Z:779e3771-4677-41f9-a4b2-ad5cc7d8bada
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:36:39 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"platformUpdateDomain\": 1,\r\n  \"platformFaultDomain\": 1,\r\n
+        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
+        [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
+        \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
+        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2018-03-12T09:36:34+00:00\"\r\n
+        \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"osdisk\",\r\n
+        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
+        succeeded\",\r\n          \"time\": \"2016-09-03T02:05:35.0977796+00:00\"\r\n
+        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
+        \"https://spec0deply1stor.blob.core.windows.net/bootdiagnostics-spec0depl-d7022008-f6b1-4f4c-8be8-e2d677ef3261/spec0deply1vm0.d7022008-f6b1-4f4c-8be8-e2d677ef3261.screenshot.bmp\",\r\n
+        \   \"serialConsoleLogBlobUri\": \"https://spec0deply1stor.blob.core.windows.net/bootdiagnostics-spec0depl-d7022008-f6b1-4f4c-8be8-e2d677ef3261/spec0deply1vm0.d7022008-f6b1-4f4c-8be8-e2d677ef3261.serialconsole.log\"\r\n
+        \ },\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n
+        \     \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n
+        \     \"time\": \"2016-09-03T02:05:35.1602741+00:00\"\r\n    },\r\n    {\r\n
+        \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
+        \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:36:44 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups/miq-azure-test1?api-version=2017-08-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcwNjMsIm5iZiI6MTUyMDg0NzA2MywiZXhwIjoxNTIwODUwOTYzLCJhaW8iOiJZMk5nWURnY2RQQks2cFZ5anRmL0pHYWt0ajI5RGdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiaEVobDdDS0hGa1c0RjV2TExiY2lBQSIsInZlciI6IjEuMCJ9.MywLrYlLzZCy4yVEqcN17usz0ujBpvlLeFDVNfTb_5KSOKHpDmqiK14CoLuzvAP-sHS7HM-YvxzM_6fW9VzWLYC6kaUN_zWDYc7OPjKFpEvFtRv7dlfbuGIGem4-VdlO8jAgcG3gvQ7Mv95xKPelZt2BbssFPEsWnDhKrJNa0z5qGFUl9NnAPe0r2z7WoAhM4JDvTl71swAGnsaRCypUraKgO6bfxg4gmgsfc6oTK3VQ1DDaKRpV0n3HNSjEHpPTmm5lxo83iRDzvs3IlYNbf6n056CKD3urJSsykuB5QukEoJfubzXH9Z9UCemSYBIPj30abqb96Y8xNMgkEnmyfg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Request-Id:
+      - 6a082534-2585-41b5-a07d-a4eac4f05cc3
+      X-Ms-Correlation-Request-Id:
+      - 6a082534-2585-41b5-a07d-a4eac4f05cc3
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T093641Z:6a082534-2585-41b5-a07d-a4eac4f05cc3
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:36:41 GMT
+      Content-Length:
+      - '183'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1","name":"miq-azure-test1","location":"eastus","properties":{"provisioningState":"Succeeded"}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:36:46 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute/locations/eastus/vmSizes?api-version=2017-12-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcwNjMsIm5iZiI6MTUyMDg0NzA2MywiZXhwIjoxNTIwODUwOTYzLCJhaW8iOiJZMk5nWURnY2RQQks2cFZ5anRmL0pHYWt0ajI5RGdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiaEVobDdDS0hGa1c0RjV2TExiY2lBQSIsInZlciI6IjEuMCJ9.MywLrYlLzZCy4yVEqcN17usz0ujBpvlLeFDVNfTb_5KSOKHpDmqiK14CoLuzvAP-sHS7HM-YvxzM_6fW9VzWLYC6kaUN_zWDYc7OPjKFpEvFtRv7dlfbuGIGem4-VdlO8jAgcG3gvQ7Mv95xKPelZt2BbssFPEsWnDhKrJNa0z5qGFUl9NnAPe0r2z7WoAhM4JDvTl71swAGnsaRCypUraKgO6bfxg4gmgsfc6oTK3VQ1DDaKRpV0n3HNSjEHpPTmm5lxo83iRDzvs3IlYNbf6n056CKD3urJSsykuB5QukEoJfubzXH9Z9UCemSYBIPj30abqb96Y8xNMgkEnmyfg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/LowCostGet3Min;4754,Microsoft.Compute/LowCostGet30Min;37902
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      X-Ms-Request-Id:
+      - 2dc9bafc-38cd-4b37-9664-a84b53ad2487
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14989'
+      X-Ms-Correlation-Request-Id:
+      - 00e2db78-c2ae-4b3d-86bb-7ffded985240
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T093642Z:00e2db78-c2ae-4b3d-86bb-7ffded985240
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:36:41 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"Standard_B1ms\",\r\n
@@ -3620,6 +3764,12 @@ http_interactions:
         \   },\r\n    {\r\n      \"name\": \"Standard_F72s_v2\",\r\n      \"numberOfCores\":
         72,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
         589824,\r\n      \"memoryInMB\": 147456,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_L8s_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1811981,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_L16s_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        3623962,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
         \   },\r\n    {\r\n      \"name\": \"Standard_ND6s\",\r\n      \"numberOfCores\":
         6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
         344064,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 12\r\n
@@ -3646,221 +3796,7 @@ http_interactions:
         391168,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
         \   }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:54 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-deployment-dont-delete?api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MzgsIm5iZiI6MTUyMDQ1MzQzOCwiZXhwIjoxNTIwNDU3MzM4LCJhaW8iOiJZMk5nWUxEbUtXMDk5clB4cU9QdGorL1crV3NlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZHNPVmFSUXV2RTJjVVBpcEtWWUFBQSIsInZlciI6IjEuMCJ9.drT5CKw95WRF7LzC0WuhK-fTLpw3j61XMw_DZdrLOWP8sjjsrbn9kF7xjDSTUM0ooF5_1Y-j3dNjvI9crm_F3PMAyhYXmCsKjTJkc3DIK6URy3hqbKiRBNlrutwvILE777NY-uXK9PH-gcaVuV-mNrjrLuxxClMJ3OPpTU8Ux0fj3Nuyf3KrXC27Oks_M_RDqDaXHOTckrdz2m_LNLpi5x0nKCoxwR9r5C1m5IKZ25FSbvyRNwjwz5dReqnv5LxllQMHVWkpvO7i5438wAnnyaS2x211IBiE6_dnV2god8Sp3ZRinXc4aCimUnJl6tLa5EtT_VSmR2QcBSaq0wS_ZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14976'
-      X-Ms-Request-Id:
-      - 79337a6c-1b50-4ed5-8cc0-5e8a0374cabc
-      X-Ms-Correlation-Request-Id:
-      - 79337a6c-1b50-4ed5-8cc0-5e8a0374cabc
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201554Z:79337a6c-1b50-4ed5-8cc0-5e8a0374cabc
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:15:54 GMT
-      Content-Length:
-      - '3083'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-deployment-dont-delete","name":"spec-deployment-dont-delete","properties":{"templateLink":{"uri":"https://gist.githubusercontent.com/bzwei/e6ccc4d641d6afab8e26ef55c37c498e/raw/769505e37256e926a9b581a100c90bb657ff45ff/azure-parent-spec.json","contentVersion":"1.0.0.0"},"parameters":{"childDeployName":{"type":"String","value":"spec-nested-deployment-dont-delete"},"storageAccountName":{"type":"String","value":"spec0deply1stor"},"availabilitySetName":{"type":"String","value":"spec0deply1as"},"adminUsername":{"type":"String","value":"deploy1admin"},"adminPassword":{"type":"SecureString"},"dnsNameforLBIP":{"type":"String","value":"spec0deply1dns"},"vmNamePrefix":{"type":"String","value":"spec0deply1vm"},"imagePublisher":{"type":"String","value":"MicrosoftWindowsServer"},"imageOffer":{"type":"String","value":"WindowsServer"},"imageSKU":{"type":"String","value":"2012-R2-Datacenter"},"lbName":{"type":"String","value":"spec0deply1lb"},"nicNamePrefix":{"type":"String","value":"spec0deply1nic"},"publicIPAddressName":{"type":"String","value":"spec0deply1ip"},"vnetName":{"type":"String","value":"spec0deply1vnet"},"vmSize":{"type":"String","value":"Standard_D1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-04-04T23:29:05.0043846Z","duration":"PT24M6.1512983S","correlationId":"3a55e6b5-4a3b-431e-8144-53698bf6f1dc","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[],"outputs":{"siteUri":{"type":"String","value":"hard-coded
-        output for test"}},"outputResources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor"}]}}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:54 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete?api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MzgsIm5iZiI6MTUyMDQ1MzQzOCwiZXhwIjoxNTIwNDU3MzM4LCJhaW8iOiJZMk5nWUxEbUtXMDk5clB4cU9QdGorL1crV3NlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZHNPVmFSUXV2RTJjVVBpcEtWWUFBQSIsInZlciI6IjEuMCJ9.drT5CKw95WRF7LzC0WuhK-fTLpw3j61XMw_DZdrLOWP8sjjsrbn9kF7xjDSTUM0ooF5_1Y-j3dNjvI9crm_F3PMAyhYXmCsKjTJkc3DIK6URy3hqbKiRBNlrutwvILE777NY-uXK9PH-gcaVuV-mNrjrLuxxClMJ3OPpTU8Ux0fj3Nuyf3KrXC27Oks_M_RDqDaXHOTckrdz2m_LNLpi5x0nKCoxwR9r5C1m5IKZ25FSbvyRNwjwz5dReqnv5LxllQMHVWkpvO7i5438wAnnyaS2x211IBiE6_dnV2god8Sp3ZRinXc4aCimUnJl6tLa5EtT_VSmR2QcBSaq0wS_ZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14984'
-      X-Ms-Request-Id:
-      - 1583d98d-0b6d-4675-841c-56704e80e954
-      X-Ms-Correlation-Request-Id:
-      - 1583d98d-0b6d-4675-841c-56704e80e954
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201555Z:1583d98d-0b6d-4675-841c-56704e80e954
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:15:54 GMT
-      Content-Length:
-      - '7230'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete","name":"spec-nested-deployment-dont-delete","properties":{"templateLink":{"uri":"https://gist.githubusercontent.com/bzwei/c09f906306399d238762bce711781200/raw/3558b735da03c1c030023d70b78ec3451dab5689/azure-loadbalancer.json","contentVersion":"1.0.0.0"},"parameters":{"storageAccountName":{"type":"String","value":"spec0deply1stor"},"availabilitySetName":{"type":"String","value":"spec0deply1as"},"adminUsername":{"type":"String","value":"deploy1admin"},"adminPassword":{"type":"SecureString"},"dnsNameforLBIP":{"type":"String","value":"spec0deply1dns"},"vmNamePrefix":{"type":"String","value":"spec0deply1vm"},"imagePublisher":{"type":"String","value":"MicrosoftWindowsServer"},"imageOffer":{"type":"String","value":"WindowsServer"},"imageSKU":{"type":"String","value":"2012-R2-Datacenter"},"lbName":{"type":"String","value":"spec0deply1lb"},"nicNamePrefix":{"type":"String","value":"spec0deply1nic"},"publicIPAddressName":{"type":"String","value":"spec0deply1ip"},"vnetName":{"type":"String","value":"spec0deply1vnet"},"vmSize":{"type":"String","value":"Standard_D1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-04-04T23:28:59.2682474Z","duration":"PT23M55.442141S","correlationId":"3a55e6b5-4a3b-431e-8144-53698bf6f1dc","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["eastus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"availabilitySets","locations":["eastus"]},{"resourceType":"virtualMachines","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"publicIPAddresses","locations":["eastus"]},{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"loadBalancers","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"spec0deply1ip"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic0"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic1"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"spec0deply1stor"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"spec0deply1as"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"spec0deply1vm0"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"spec0deply1stor"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"spec0deply1as"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"spec0deply1vm1"}],"outputResources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor"}]}}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:55 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-deployment-dont-delete?api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MzgsIm5iZiI6MTUyMDQ1MzQzOCwiZXhwIjoxNTIwNDU3MzM4LCJhaW8iOiJZMk5nWUxEbUtXMDk5clB4cU9QdGorL1crV3NlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZHNPVmFSUXV2RTJjVVBpcEtWWUFBQSIsInZlciI6IjEuMCJ9.drT5CKw95WRF7LzC0WuhK-fTLpw3j61XMw_DZdrLOWP8sjjsrbn9kF7xjDSTUM0ooF5_1Y-j3dNjvI9crm_F3PMAyhYXmCsKjTJkc3DIK6URy3hqbKiRBNlrutwvILE777NY-uXK9PH-gcaVuV-mNrjrLuxxClMJ3OPpTU8Ux0fj3Nuyf3KrXC27Oks_M_RDqDaXHOTckrdz2m_LNLpi5x0nKCoxwR9r5C1m5IKZ25FSbvyRNwjwz5dReqnv5LxllQMHVWkpvO7i5438wAnnyaS2x211IBiE6_dnV2god8Sp3ZRinXc4aCimUnJl6tLa5EtT_VSmR2QcBSaq0wS_ZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14985'
-      X-Ms-Request-Id:
-      - 4f9fcae6-5c2e-45a6-aa0b-144e8a685fe8
-      X-Ms-Correlation-Request-Id:
-      - 4f9fcae6-5c2e-45a6-aa0b-144e8a685fe8
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201556Z:4f9fcae6-5c2e-45a6-aa0b-144e8a685fe8
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:15:55 GMT
-      Content-Length:
-      - '3083'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-deployment-dont-delete","name":"spec-deployment-dont-delete","properties":{"templateLink":{"uri":"https://gist.githubusercontent.com/bzwei/e6ccc4d641d6afab8e26ef55c37c498e/raw/769505e37256e926a9b581a100c90bb657ff45ff/azure-parent-spec.json","contentVersion":"1.0.0.0"},"parameters":{"childDeployName":{"type":"String","value":"spec-nested-deployment-dont-delete"},"storageAccountName":{"type":"String","value":"spec0deply1stor"},"availabilitySetName":{"type":"String","value":"spec0deply1as"},"adminUsername":{"type":"String","value":"deploy1admin"},"adminPassword":{"type":"SecureString"},"dnsNameforLBIP":{"type":"String","value":"spec0deply1dns"},"vmNamePrefix":{"type":"String","value":"spec0deply1vm"},"imagePublisher":{"type":"String","value":"MicrosoftWindowsServer"},"imageOffer":{"type":"String","value":"WindowsServer"},"imageSKU":{"type":"String","value":"2012-R2-Datacenter"},"lbName":{"type":"String","value":"spec0deply1lb"},"nicNamePrefix":{"type":"String","value":"spec0deply1nic"},"publicIPAddressName":{"type":"String","value":"spec0deply1ip"},"vnetName":{"type":"String","value":"spec0deply1vnet"},"vmSize":{"type":"String","value":"Standard_D1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-04-04T23:29:05.0043846Z","duration":"PT24M6.1512983S","correlationId":"3a55e6b5-4a3b-431e-8144-53698bf6f1dc","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[],"outputs":{"siteUri":{"type":"String","value":"hard-coded
-        output for test"}},"outputResources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor"}]}}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:56 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete?api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MzgsIm5iZiI6MTUyMDQ1MzQzOCwiZXhwIjoxNTIwNDU3MzM4LCJhaW8iOiJZMk5nWUxEbUtXMDk5clB4cU9QdGorL1crV3NlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZHNPVmFSUXV2RTJjVVBpcEtWWUFBQSIsInZlciI6IjEuMCJ9.drT5CKw95WRF7LzC0WuhK-fTLpw3j61XMw_DZdrLOWP8sjjsrbn9kF7xjDSTUM0ooF5_1Y-j3dNjvI9crm_F3PMAyhYXmCsKjTJkc3DIK6URy3hqbKiRBNlrutwvILE777NY-uXK9PH-gcaVuV-mNrjrLuxxClMJ3OPpTU8Ux0fj3Nuyf3KrXC27Oks_M_RDqDaXHOTckrdz2m_LNLpi5x0nKCoxwR9r5C1m5IKZ25FSbvyRNwjwz5dReqnv5LxllQMHVWkpvO7i5438wAnnyaS2x211IBiE6_dnV2god8Sp3ZRinXc4aCimUnJl6tLa5EtT_VSmR2QcBSaq0wS_ZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14983'
-      X-Ms-Request-Id:
-      - 8293b20d-d808-4051-94d9-1a9e79ef410d
-      X-Ms-Correlation-Request-Id:
-      - 8293b20d-d808-4051-94d9-1a9e79ef410d
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201557Z:8293b20d-d808-4051-94d9-1a9e79ef410d
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:15:57 GMT
-      Content-Length:
-      - '7230'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete","name":"spec-nested-deployment-dont-delete","properties":{"templateLink":{"uri":"https://gist.githubusercontent.com/bzwei/c09f906306399d238762bce711781200/raw/3558b735da03c1c030023d70b78ec3451dab5689/azure-loadbalancer.json","contentVersion":"1.0.0.0"},"parameters":{"storageAccountName":{"type":"String","value":"spec0deply1stor"},"availabilitySetName":{"type":"String","value":"spec0deply1as"},"adminUsername":{"type":"String","value":"deploy1admin"},"adminPassword":{"type":"SecureString"},"dnsNameforLBIP":{"type":"String","value":"spec0deply1dns"},"vmNamePrefix":{"type":"String","value":"spec0deply1vm"},"imagePublisher":{"type":"String","value":"MicrosoftWindowsServer"},"imageOffer":{"type":"String","value":"WindowsServer"},"imageSKU":{"type":"String","value":"2012-R2-Datacenter"},"lbName":{"type":"String","value":"spec0deply1lb"},"nicNamePrefix":{"type":"String","value":"spec0deply1nic"},"publicIPAddressName":{"type":"String","value":"spec0deply1ip"},"vnetName":{"type":"String","value":"spec0deply1vnet"},"vmSize":{"type":"String","value":"Standard_D1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-04-04T23:28:59.2682474Z","duration":"PT23M55.442141S","correlationId":"3a55e6b5-4a3b-431e-8144-53698bf6f1dc","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["eastus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"availabilitySets","locations":["eastus"]},{"resourceType":"virtualMachines","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"publicIPAddresses","locations":["eastus"]},{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"loadBalancers","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"spec0deply1ip"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic0"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic1"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"spec0deply1stor"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"spec0deply1as"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"spec0deply1vm0"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"spec0deply1stor"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"spec0deply1as"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"spec0deply1vm1"}],"outputResources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor"}]}}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:57 GMT
+  recorded_at: Mon, 12 Mar 2018 09:36:46 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-deployment-dont-delete/exportTemplate?api-version=2017-08-01
@@ -3877,7 +3813,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MzgsIm5iZiI6MTUyMDQ1MzQzOCwiZXhwIjoxNTIwNDU3MzM4LCJhaW8iOiJZMk5nWUxEbUtXMDk5clB4cU9QdGorL1crV3NlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZHNPVmFSUXV2RTJjVVBpcEtWWUFBQSIsInZlciI6IjEuMCJ9.drT5CKw95WRF7LzC0WuhK-fTLpw3j61XMw_DZdrLOWP8sjjsrbn9kF7xjDSTUM0ooF5_1Y-j3dNjvI9crm_F3PMAyhYXmCsKjTJkc3DIK6URy3hqbKiRBNlrutwvILE777NY-uXK9PH-gcaVuV-mNrjrLuxxClMJ3OPpTU8Ux0fj3Nuyf3KrXC27Oks_M_RDqDaXHOTckrdz2m_LNLpi5x0nKCoxwR9r5C1m5IKZ25FSbvyRNwjwz5dReqnv5LxllQMHVWkpvO7i5438wAnnyaS2x211IBiE6_dnV2god8Sp3ZRinXc4aCimUnJl6tLa5EtT_VSmR2QcBSaq0wS_ZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcwNjMsIm5iZiI6MTUyMDg0NzA2MywiZXhwIjoxNTIwODUwOTYzLCJhaW8iOiJZMk5nWURnY2RQQks2cFZ5anRmL0pHYWt0ajI5RGdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiaEVobDdDS0hGa1c0RjV2TExiY2lBQSIsInZlciI6IjEuMCJ9.MywLrYlLzZCy4yVEqcN17usz0ujBpvlLeFDVNfTb_5KSOKHpDmqiK14CoLuzvAP-sHS7HM-YvxzM_6fW9VzWLYC6kaUN_zWDYc7OPjKFpEvFtRv7dlfbuGIGem4-VdlO8jAgcG3gvQ7Mv95xKPelZt2BbssFPEsWnDhKrJNa0z5qGFUl9NnAPe0r2z7WoAhM4JDvTl71swAGnsaRCypUraKgO6bfxg4gmgsfc6oTK3VQ1DDaKRpV0n3HNSjEHpPTmm5lxo83iRDzvs3IlYNbf6n056CKD3urJSsykuB5QukEoJfubzXH9Z9UCemSYBIPj30abqb96Y8xNMgkEnmyfg
       Content-Length:
       - '0'
   response:
@@ -3900,17 +3836,17 @@ http_interactions:
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
       - '1199'
       X-Ms-Request-Id:
-      - 16871eb6-3797-42d0-9952-76df6cf016ef
+      - acaca279-e4a6-4e99-8e12-f3badee7bc9a
       X-Ms-Correlation-Request-Id:
-      - 16871eb6-3797-42d0-9952-76df6cf016ef
+      - acaca279-e4a6-4e99-8e12-f3badee7bc9a
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201558Z:16871eb6-3797-42d0-9952-76df6cf016ef
+      - WESTEUROPE:20180312T093642Z:acaca279-e4a6-4e99-8e12-f3badee7bc9a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:15:57 GMT
+      - Mon, 12 Mar 2018 09:36:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"template":{"$schema":"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#","contentVersion":"1.0.0.0","parameters":{"childDeployName":{"type":"String"},"storageAccountName":{"type":"String","metadata":{"description":"Name
@@ -3930,7 +3866,7 @@ http_interactions:
         of the VM"}}},"resources":[{"type":"Microsoft.Resources/deployments","name":"[parameters(''childDeployName'')]","apiVersion":"2015-01-01","properties":{"mode":"Incremental","templateLink":{"uri":"https://gist.githubusercontent.com/bzwei/c09f906306399d238762bce711781200/raw/3558b735da03c1c030023d70b78ec3451dab5689/azure-loadbalancer.json","contentVersion":"1.0.0.0"},"parameters":{"storageAccountName":{"value":"[parameters(''storageAccountName'')]"},"availabilitySetName":{"value":"[parameters(''availabilitySetName'')]"},"adminUsername":{"value":"[parameters(''adminUsername'')]"},"adminPassword":{"value":"[parameters(''adminPassword'')]"},"dnsNameforLBIP":{"value":"[parameters(''dnsNameforLBIP'')]"},"vmNamePrefix":{"value":"[parameters(''vmNamePrefix'')]"},"imagePublisher":{"value":"[parameters(''imagePublisher'')]"},"imageOffer":{"value":"[parameters(''imageOffer'')]"},"imageSKU":{"value":"[parameters(''imageSKU'')]"},"lbName":{"value":"[parameters(''lbName'')]"},"nicNamePrefix":{"value":"[parameters(''nicNamePrefix'')]"},"publicIPAddressName":{"value":"[parameters(''publicIPAddressName'')]"},"vnetName":{"value":"[parameters(''vnetName'')]"},"vmSize":{"value":"[parameters(''vmSize'')]"}}}}],"outputs":{"siteUri":{"type":"String","value":"hard-coded
         output for test"}}}}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:58 GMT
+  recorded_at: Mon, 12 Mar 2018 09:36:47 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/exportTemplate?api-version=2017-08-01
@@ -3947,7 +3883,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MzgsIm5iZiI6MTUyMDQ1MzQzOCwiZXhwIjoxNTIwNDU3MzM4LCJhaW8iOiJZMk5nWUxEbUtXMDk5clB4cU9QdGorL1crV3NlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZHNPVmFSUXV2RTJjVVBpcEtWWUFBQSIsInZlciI6IjEuMCJ9.drT5CKw95WRF7LzC0WuhK-fTLpw3j61XMw_DZdrLOWP8sjjsrbn9kF7xjDSTUM0ooF5_1Y-j3dNjvI9crm_F3PMAyhYXmCsKjTJkc3DIK6URy3hqbKiRBNlrutwvILE777NY-uXK9PH-gcaVuV-mNrjrLuxxClMJ3OPpTU8Ux0fj3Nuyf3KrXC27Oks_M_RDqDaXHOTckrdz2m_LNLpi5x0nKCoxwR9r5C1m5IKZ25FSbvyRNwjwz5dReqnv5LxllQMHVWkpvO7i5438wAnnyaS2x211IBiE6_dnV2god8Sp3ZRinXc4aCimUnJl6tLa5EtT_VSmR2QcBSaq0wS_ZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcwNjMsIm5iZiI6MTUyMDg0NzA2MywiZXhwIjoxNTIwODUwOTYzLCJhaW8iOiJZMk5nWURnY2RQQks2cFZ5anRmL0pHYWt0ajI5RGdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiaEVobDdDS0hGa1c0RjV2TExiY2lBQSIsInZlciI6IjEuMCJ9.MywLrYlLzZCy4yVEqcN17usz0ujBpvlLeFDVNfTb_5KSOKHpDmqiK14CoLuzvAP-sHS7HM-YvxzM_6fW9VzWLYC6kaUN_zWDYc7OPjKFpEvFtRv7dlfbuGIGem4-VdlO8jAgcG3gvQ7Mv95xKPelZt2BbssFPEsWnDhKrJNa0z5qGFUl9NnAPe0r2z7WoAhM4JDvTl71swAGnsaRCypUraKgO6bfxg4gmgsfc6oTK3VQ1DDaKRpV0n3HNSjEHpPTmm5lxo83iRDzvs3IlYNbf6n056CKD3urJSsykuB5QukEoJfubzXH9Z9UCemSYBIPj30abqb96Y8xNMgkEnmyfg
       Content-Length:
       - '0'
   response:
@@ -3970,17 +3906,17 @@ http_interactions:
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
       - '1198'
       X-Ms-Request-Id:
-      - e7f6ca51-55c7-4696-b1d1-07ffb128956e
+      - 7c025f93-d386-40c3-a02c-570376b3973a
       X-Ms-Correlation-Request-Id:
-      - e7f6ca51-55c7-4696-b1d1-07ffb128956e
+      - 7c025f93-d386-40c3-a02c-570376b3973a
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201558Z:e7f6ca51-55c7-4696-b1d1-07ffb128956e
+      - WESTEUROPE:20180312T093645Z:7c025f93-d386-40c3-a02c-570376b3973a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:15:58 GMT
+      - Mon, 12 Mar 2018 09:36:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"template":{"$schema":"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json","contentVersion":"1.0.0.0","parameters":{"storageAccountName":{"type":"String","metadata":{"description":"Name
@@ -4012,10 +3948,10 @@ http_interactions:
         parameters(''nicNamePrefix''), copyindex())]","[concat(''Microsoft.Compute/availabilitySets/'',
         parameters(''availabilitySetName''))]"]}]}}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:59 GMT
+  recorded_at: Mon, 12 Mar 2018 09:36:50 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor?api-version=2017-10-01
     body:
       encoding: US-ASCII
       string: ''
@@ -4029,7 +3965,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MzgsIm5iZiI6MTUyMDQ1MzQzOCwiZXhwIjoxNTIwNDU3MzM4LCJhaW8iOiJZMk5nWUxEbUtXMDk5clB4cU9QdGorL1crV3NlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZHNPVmFSUXV2RTJjVVBpcEtWWUFBQSIsInZlciI6IjEuMCJ9.drT5CKw95WRF7LzC0WuhK-fTLpw3j61XMw_DZdrLOWP8sjjsrbn9kF7xjDSTUM0ooF5_1Y-j3dNjvI9crm_F3PMAyhYXmCsKjTJkc3DIK6URy3hqbKiRBNlrutwvILE777NY-uXK9PH-gcaVuV-mNrjrLuxxClMJ3OPpTU8Ux0fj3Nuyf3KrXC27Oks_M_RDqDaXHOTckrdz2m_LNLpi5x0nKCoxwR9r5C1m5IKZ25FSbvyRNwjwz5dReqnv5LxllQMHVWkpvO7i5438wAnnyaS2x211IBiE6_dnV2god8Sp3ZRinXc4aCimUnJl6tLa5EtT_VSmR2QcBSaq0wS_ZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcwNjMsIm5iZiI6MTUyMDg0NzA2MywiZXhwIjoxNTIwODUwOTYzLCJhaW8iOiJZMk5nWURnY2RQQks2cFZ5anRmL0pHYWt0ajI5RGdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiaEVobDdDS0hGa1c0RjV2TExiY2lBQSIsInZlciI6IjEuMCJ9.MywLrYlLzZCy4yVEqcN17usz0ujBpvlLeFDVNfTb_5KSOKHpDmqiK14CoLuzvAP-sHS7HM-YvxzM_6fW9VzWLYC6kaUN_zWDYc7OPjKFpEvFtRv7dlfbuGIGem4-VdlO8jAgcG3gvQ7Mv95xKPelZt2BbssFPEsWnDhKrJNa0z5qGFUl9NnAPe0r2z7WoAhM4JDvTl71swAGnsaRCypUraKgO6bfxg4gmgsfc6oTK3VQ1DDaKRpV0n3HNSjEHpPTmm5lxo83iRDzvs3IlYNbf6n056CKD3urJSsykuB5QukEoJfubzXH9Z9UCemSYBIPj30abqb96Y8xNMgkEnmyfg
   response:
     status:
       code: 200
@@ -4042,315 +3978,32 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Content-Type:
-      - application/json; charset=utf-8
+      - application/json
       Expires:
       - "-1"
       Vary:
       - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/LowCostGet3Min;4743,Microsoft.Compute/LowCostGet30Min;37934
+      X-Ms-Request-Id:
+      - f7d1b015-7ea8-4550-a0c1-2466950dc013
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
-      X-Ms-Request-Id:
-      - ca93c3fa-5b23-4452-9986-bf8949c8522e
       Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - '14992'
       X-Ms-Correlation-Request-Id:
-      - cef055de-d033-4d59-9655-6161b965207a
+      - a9efe9dd-95a3-4bc5-9b76-6c435cc0cfd9
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201559Z:cef055de-d033-4d59-9655-6161b965207a
+      - WESTEUROPE:20180312T093646Z:a9efe9dd-95a3-4bc5-9b76-6c435cc0cfd9
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:15:59 GMT
+      - Mon, 12 Mar 2018 09:36:45 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"4d1502d5-351a-42f4-8569-22284f906d68\",\r\n
-        \   \"availabilitySet\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/SPEC0DEPLY1AS\"\r\n
-        \   },\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_D1\"\r\n
-        \   },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
-        \"MicrosoftWindowsServer\",\r\n        \"offer\": \"WindowsServer\",\r\n        \"sku\":
-        \"2012-R2-Datacenter\",\r\n        \"version\": \"latest\"\r\n      },\r\n
-        \     \"osDisk\": {\r\n        \"osType\": \"Windows\",\r\n        \"name\":
-        \"osdisk\",\r\n        \"createOption\": \"FromImage\",\r\n        \"vhd\":
-        {\r\n          \"uri\": \"http://spec0deply1stor.blob.core.windows.net/vhds/osdisk1.vhd\"\r\n
-        \       },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n      \"dataDisks\":
-        []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"spec0deply1vm1\",\r\n
-        \     \"adminUsername\": \"deploy1admin\",\r\n      \"windowsConfiguration\":
-        {\r\n        \"provisionVMAgent\": true,\r\n        \"enableAutomaticUpdates\":
-        true\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\":
-        {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1\"}]},\r\n
-        \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
-        true,\r\n        \"storageUri\": \"http://spec0deply1stor.blob.core.windows.net\"\r\n
-        \     }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n
-        \ \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"eastus\",\r\n
-        \ \"tags\": {\r\n    \"Shutdown\": \"true\"\r\n  },\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1\",\r\n
-        \ \"name\": \"spec0deply1vm1\"\r\n}"
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","name":"spec0deply1stor","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-04-04T23:05:07.8274794Z","primaryEndpoints":{"blob":"https://spec0deply1stor.blob.core.windows.net/","queue":"https://spec0deply1stor.queue.core.windows.net/","table":"https://spec0deply1stor.table.core.windows.net/","file":"https://spec0deply1stor.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:00 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0?api-version=2017-12-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MzgsIm5iZiI6MTUyMDQ1MzQzOCwiZXhwIjoxNTIwNDU3MzM4LCJhaW8iOiJZMk5nWUxEbUtXMDk5clB4cU9QdGorL1crV3NlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZHNPVmFSUXV2RTJjVVBpcEtWWUFBQSIsInZlciI6IjEuMCJ9.drT5CKw95WRF7LzC0WuhK-fTLpw3j61XMw_DZdrLOWP8sjjsrbn9kF7xjDSTUM0ooF5_1Y-j3dNjvI9crm_F3PMAyhYXmCsKjTJkc3DIK6URy3hqbKiRBNlrutwvILE777NY-uXK9PH-gcaVuV-mNrjrLuxxClMJ3OPpTU8Ux0fj3Nuyf3KrXC27Oks_M_RDqDaXHOTckrdz2m_LNLpi5x0nKCoxwR9r5C1m5IKZ25FSbvyRNwjwz5dReqnv5LxllQMHVWkpvO7i5438wAnnyaS2x211IBiE6_dnV2god8Sp3ZRinXc4aCimUnJl6tLa5EtT_VSmR2QcBSaq0wS_ZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/LowCostGet3Min;4753,Microsoft.Compute/LowCostGet30Min;37933
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
-      X-Ms-Request-Id:
-      - 6d81c27b-bfc2-4c1a-be13-a9fe35399702
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14979'
-      X-Ms-Correlation-Request-Id:
-      - c5f387d7-c3ea-4a60-b7af-054d87eba3b1
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201600Z:c5f387d7-c3ea-4a60-b7af-054d87eba3b1
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:15:59 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"d7022008-f6b1-4f4c-8be8-e2d677ef3261\",\r\n
-        \   \"availabilitySet\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/SPEC0DEPLY1AS\"\r\n
-        \   },\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_D1\"\r\n
-        \   },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
-        \"MicrosoftWindowsServer\",\r\n        \"offer\": \"WindowsServer\",\r\n        \"sku\":
-        \"2012-R2-Datacenter\",\r\n        \"version\": \"latest\"\r\n      },\r\n
-        \     \"osDisk\": {\r\n        \"osType\": \"Windows\",\r\n        \"name\":
-        \"osdisk\",\r\n        \"createOption\": \"FromImage\",\r\n        \"vhd\":
-        {\r\n          \"uri\": \"http://spec0deply1stor.blob.core.windows.net/vhds/osdisk0.vhd\"\r\n
-        \       },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n      \"dataDisks\":
-        []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"spec0deply1vm0\",\r\n
-        \     \"adminUsername\": \"deploy1admin\",\r\n      \"windowsConfiguration\":
-        {\r\n        \"provisionVMAgent\": true,\r\n        \"enableAutomaticUpdates\":
-        true\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\":
-        {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0\"}]},\r\n
-        \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
-        true,\r\n        \"storageUri\": \"http://spec0deply1stor.blob.core.windows.net\"\r\n
-        \     }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n
-        \ \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"eastus\",\r\n
-        \ \"tags\": {\r\n    \"Shutdown\": \"true\"\r\n  },\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0\",\r\n
-        \ \"name\": \"spec0deply1vm0\"\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:00 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1/instanceView?api-version=2017-12-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MzgsIm5iZiI6MTUyMDQ1MzQzOCwiZXhwIjoxNTIwNDU3MzM4LCJhaW8iOiJZMk5nWUxEbUtXMDk5clB4cU9QdGorL1crV3NlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZHNPVmFSUXV2RTJjVVBpcEtWWUFBQSIsInZlciI6IjEuMCJ9.drT5CKw95WRF7LzC0WuhK-fTLpw3j61XMw_DZdrLOWP8sjjsrbn9kF7xjDSTUM0ooF5_1Y-j3dNjvI9crm_F3PMAyhYXmCsKjTJkc3DIK6URy3hqbKiRBNlrutwvILE777NY-uXK9PH-gcaVuV-mNrjrLuxxClMJ3OPpTU8Ux0fj3Nuyf3KrXC27Oks_M_RDqDaXHOTckrdz2m_LNLpi5x0nKCoxwR9r5C1m5IKZ25FSbvyRNwjwz5dReqnv5LxllQMHVWkpvO7i5438wAnnyaS2x211IBiE6_dnV2god8Sp3ZRinXc4aCimUnJl6tLa5EtT_VSmR2QcBSaq0wS_ZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/GetInstanceView3Min;4799,Microsoft.Compute/GetInstanceView30Min;23928
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
-      X-Ms-Request-Id:
-      - 73b8a2e6-807e-4eca-b213-0a2920691e62
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14984'
-      X-Ms-Correlation-Request-Id:
-      - cbeaeb78-4239-4165-b67d-f37b36047abf
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201611Z:cbeaeb78-4239-4165-b67d-f37b36047abf
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:16:11 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"platformUpdateDomain\": 0,\r\n  \"platformFaultDomain\": 0,\r\n
-        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
-        [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
-        \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
-        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2018-03-07T20:16:00+00:00\"\r\n
-        \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"osdisk\",\r\n
-        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
-        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"time\": \"2016-09-03T02:09:09.3853413+00:00\"\r\n
-        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
-        \"https://spec0deply1stor.blob.core.windows.net/bootdiagnostics-spec0depl-4d1502d5-351a-42f4-8569-22284f906d68/spec0deply1vm1.4d1502d5-351a-42f4-8569-22284f906d68.screenshot.bmp\",\r\n
-        \   \"serialConsoleLogBlobUri\": \"https://spec0deply1stor.blob.core.windows.net/bootdiagnostics-spec0depl-4d1502d5-351a-42f4-8569-22284f906d68/spec0deply1vm1.4d1502d5-351a-42f4-8569-22284f906d68.serialconsole.log\"\r\n
-        \ },\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n
-        \     \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n
-        \     \"time\": \"2016-09-03T02:09:09.4478672+00:00\"\r\n    },\r\n    {\r\n
-        \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
-        \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:12 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Network/networkInterfaces?api-version=2017-11-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MzgsIm5iZiI6MTUyMDQ1MzQzOCwiZXhwIjoxNTIwNDU3MzM4LCJhaW8iOiJZMk5nWUxEbUtXMDk5clB4cU9QdGorL1crV3NlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZHNPVmFSUXV2RTJjVVBpcEtWWUFBQSIsInZlciI6IjEuMCJ9.drT5CKw95WRF7LzC0WuhK-fTLpw3j61XMw_DZdrLOWP8sjjsrbn9kF7xjDSTUM0ooF5_1Y-j3dNjvI9crm_F3PMAyhYXmCsKjTJkc3DIK6URy3hqbKiRBNlrutwvILE777NY-uXK9PH-gcaVuV-mNrjrLuxxClMJ3OPpTU8Ux0fj3Nuyf3KrXC27Oks_M_RDqDaXHOTckrdz2m_LNLpi5x0nKCoxwR9r5C1m5IKZ25FSbvyRNwjwz5dReqnv5LxllQMHVWkpvO7i5438wAnnyaS2x211IBiE6_dnV2god8Sp3ZRinXc4aCimUnJl6tLa5EtT_VSmR2QcBSaq0wS_ZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 64fb5267-ad04-4978-bc40-a8a06a4f15ad
-      X-Ms-Correlation-Request-Id:
-      - 64fb5267-ad04-4978-bc40-a8a06a4f15ad
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201614Z:64fb5267-ad04-4978-bc40-a8a06a4f15ad
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:16:13 GMT
-      Content-Length:
-      - '31614'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[{"name":"miqazure-coreos1235","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235","etag":"W/\"4a6546ab-a4c0-4d27-bccd-f6ebf3c405a2\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"fb0a5e60-a6c2-4bb8-a2f5-0c16216a49b0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235/ipConfigurations/ipconfig1","etag":"W/\"4a6546ab-a4c0-4d27-bccd-f6ebf3c405a2\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.20.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/publicIPAddresses/miqazure-coreos1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/virtualNetworks/miq-azure-test3/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"rliadcyr3l1elbnsw4rabxqg1f.dx.internal.cloudapp.net"},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkSecurityGroups/miqazure-coreos1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Compute/virtualMachines/miqazure-coreos1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"dbergerprov1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/dbergerprov1","etag":"W/\"074dd836-918c-4e40-a118-94f0d366e175\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"ecdcd2f0-91bb-4c40-91cd-a3d76fc5e455","ipConfigurations":[{"name":"dbergerprov1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/dbergerprov1/ipConfigurations/dbergerprov1","etag":"W/\"074dd836-918c-4e40-a118-94f0d366e175\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.9","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/dbergerprov1-publicIp"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/virtualMachines/dbergerprov1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-rhel1390","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390","etag":"W/\"f006e6f9-0292-42cd-99fc-f72f194553c1\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"98853f48-2806-4065-be57-cf9159550440","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1","etag":"W/\"f006e6f9-0292-42cd-99fc-f72f194553c1\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"macAddress":"00-0D-3A-10-EB-AB","enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-ubuntu1989","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989","etag":"W/\"64e07488-15a2-4cec-b84a-6fd5ef04323c\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"134a6669-ac4a-4d08-a0db-387bc4c49537","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989/ipConfigurations/ipconfig1","etag":"W/\"64e07488-15a2-4cec-b84a-6fd5ef04323c\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.17.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-ubuntu1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest18687/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-win12610","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610","etag":"W/\"dd925ef5-33d1-402c-a0f4-18c78c2641f4\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"5c2eef2c-0b36-4277-a940-957ed4d13be0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610/ipConfigurations/ipconfig1","etag":"W/\"dd925ef5-33d1-402c-a0f4-18c78c2641f4\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.18.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-win12"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest19881/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-winimg241","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241","etag":"W/\"4a17a745-16a9-42d9-88c9-17a518959525\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"8ed2f3b0-4a4b-49ae-9f1d-ff7890dbd396","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241/ipConfigurations/ipconfig1","etag":"W/\"4a17a745-16a9-42d9-88c9-17a518959525\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.7","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqtestwinimg6202"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-centos1611","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611","etag":"W/\"26031ef6-bb55-4019-8185-2dd1edcb207c\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"f1760e49-9853-4fdc-acfc-4ea232b9ed76","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1","etag":"W/\"26031ef6-bb55-4019-8185-2dd1edcb207c\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.5","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqmismatch1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1","etag":"W/\"3a72d0c3-bfda-4da5-a61b-e8c33e43de79\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"23d804a8-b623-49e7-9c8d-1d64245bef1e","ipConfigurations":[{"name":"miqmismatch1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1/ipConfigurations/miqmismatch1","etag":"W/\"3a72d0c3-bfda-4da5-a61b-e8c33e43de79\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.8","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqmismatch1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqmismatch1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"rspec-lb-a670","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670","etag":"W/\"cf3a0b0d-d596-4f33-bc31-749f92ba4f00\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"46cb8216-786e-408e-9d86-c0855b357349","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1","etag":"W/\"cf3a0b0d-d596-4f33-bc31-749f92ba4f00\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.6","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-a-ip"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"rspec-lb-b843","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843","etag":"W/\"76aabe0c-8678-43f0-81a5-2f15784a4b99\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"3ef6fa01-ac34-43a1-8fd7-67c706b4d8ef","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1","etag":"W/\"76aabe0c-8678-43f0-81a5-2f15784a4b99\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.11","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-b-ip"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"spec0deply1nic0","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","etag":"W/\"b817491c-aab8-4aab-b41d-b07bfffa5639\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"80ad9866-071d-4e3f-91d0-d47954eccee0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1","etag":"W/\"b817491c-aab8-4aab-b41d-b07bfffa5639\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.4","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"spec0deply1nic1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","etag":"W/\"2ec58a0b-4c03-4d0a-b788-9daffd54e7b2\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"57bbf7aa-d6c4-4f56-8f6a-089d15334221","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1","etag":"W/\"2ec58a0b-4c03-4d0a-b788-9daffd54e7b2\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.5","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqmismatch2656","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqmismatch2656","etag":"W/\"fef6a836-2802-4897-90c3-b3d71f133384\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"969dde6c-73c0-4340-877d-2b5fe2060026","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqmismatch2656/ipConfigurations/ipconfig1","etag":"W/\"fef6a836-2802-4897-90c3-b3d71f133384\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"172.23.0.4","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/virtualNetworks/miqazuretest33606/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkSecurityGroups/miqmismatch2-nsg"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Compute/virtualMachines/miqmismatch2"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-linux-manag944","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944","etag":"W/\"b6339880-8ead-4c9e-b5c0-f38c4f8612d5\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"c5e8b90e-5a78-49b0-b224-b70ed3fb45e5","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944/ipConfigurations/ipconfig1","etag":"W/\"b6339880-8ead-4c9e-b5c0-f38c4f8612d5\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"172.25.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqazure-linux-managed-ip"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"jf-metrics-2751","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751","etag":"W/\"c5f6f02a-b17c-4f34-882b-11c7adef0b44\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"207a58d3-f18d-4dab-8168-919877297a52","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751/ipConfigurations/ipconfig1","etag":"W/\"c5f6f02a-b17c-4f34-882b-11c7adef0b44\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.7","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-2"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-2"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/jf-metrics-2"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"jf-metrics-3421","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421","etag":"W/\"0b6f160b-ad10-48f8-9d0c-657193bb823f\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"b8b345e8-a353-4700-992e-be48a717b4e2","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421/ipConfigurations/ipconfig1","etag":"W/\"0b6f160b-ad10-48f8-9d0c-657193bb823f\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.8","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-3"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-3"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/jf-metrics-3"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-oraclelinux310","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310","etag":"W/\"54cd4fe1-3ed5-4a8c-bc8d-527679c7a631\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"6a3fc1d7-4532-4ca0-b5c2-546cc8f7f313","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310/ipConfigurations/ipconfig1","etag":"W/\"54cd4fe1-3ed5-4a8c-bc8d-527679c7a631\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.5","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-oraclelinux993","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993","etag":"W/\"a9432274-7b40-4eb3-a64f-a04267a423ff\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"75d8ed14-e0ae-4d84-99f6-e3f43d073e76","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993/ipConfigurations/ipconfig1","etag":"W/\"a9432274-7b40-4eb3-a64f-a04267a423ff\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.6","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux2"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux2"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"}]}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:14 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Storage/storageAccounts?api-version=2017-10-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MzgsIm5iZiI6MTUyMDQ1MzQzOCwiZXhwIjoxNTIwNDU3MzM4LCJhaW8iOiJZMk5nWUxEbUtXMDk5clB4cU9QdGorL1crV3NlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZHNPVmFSUXV2RTJjVVBpcEtWWUFBQSIsInZlciI6IjEuMCJ9.drT5CKw95WRF7LzC0WuhK-fTLpw3j61XMw_DZdrLOWP8sjjsrbn9kF7xjDSTUM0ooF5_1Y-j3dNjvI9crm_F3PMAyhYXmCsKjTJkc3DIK6URy3hqbKiRBNlrutwvILE777NY-uXK9PH-gcaVuV-mNrjrLuxxClMJ3OPpTU8Ux0fj3Nuyf3KrXC27Oks_M_RDqDaXHOTckrdz2m_LNLpi5x0nKCoxwR9r5C1m5IKZ25FSbvyRNwjwz5dReqnv5LxllQMHVWkpvO7i5438wAnnyaS2x211IBiE6_dnV2god8Sp3ZRinXc4aCimUnJl6tLa5EtT_VSmR2QcBSaq0wS_ZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 53b1b0f1-06da-4b07-b7b1-d344c59f62eb
-      X-Ms-Correlation-Request-Id:
-      - 53b1b0f1-06da-4b07-b7b1-d344c59f62eb
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201616Z:53b1b0f1-06da-4b07-b7b1-d344c59f62eb
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:16:16 GMT
-      Content-Length:
-      - '8649'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","name":"miqazuretest18686","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T17:22:54.7808677Z","primaryEndpoints":{"blob":"https://miqazuretest18686.blob.core.windows.net/","queue":"https://miqazuretest18686.queue.core.windows.net/","table":"https://miqazuretest18686.table.core.windows.net/","file":"https://miqazuretest18686.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","name":"miqazuretest14047","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T17:30:25.7028008Z","primaryEndpoints":{"blob":"https://miqazuretest14047.blob.core.windows.net/","queue":"https://miqazuretest14047.queue.core.windows.net/","table":"https://miqazuretest14047.table.core.windows.net/","file":"https://miqazuretest14047.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Premium_LRS","tier":"Premium"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb","name":"rspeclb","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-09-02T16:29:11.6823797Z","primaryEndpoints":{"blob":"https://rspeclb.blob.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","name":"spec0deply1stor","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-04-04T23:05:07.8274794Z","primaryEndpoints":{"blob":"https://spec0deply1stor.blob.core.windows.net/","queue":"https://spec0deply1stor.queue.core.windows.net/","table":"https://spec0deply1stor.table.core.windows.net/","file":"https://spec0deply1stor.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Storage/storageAccounts/miqazuretest26611","name":"miqazuretest26611","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2211656Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2211656Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-05-02T18:01:29.2743021Z","primaryEndpoints":{"blob":"https://miqazuretest26611.blob.core.windows.net/","queue":"https://miqazuretest26611.queue.core.windows.net/","table":"https://miqazuretest26611.table.core.windows.net/","file":"https://miqazuretest26611.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","name":"miqazuretest16487","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T17:26:55.3231669Z","primaryEndpoints":{"blob":"https://miqazuretest16487.blob.core.windows.net/","queue":"https://miqazuretest16487.queue.core.windows.net/","table":"https://miqazuretest16487.table.core.windows.net/","file":"https://miqazuretest16487.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Storage/storageAccounts/miqazuretest32946","name":"miqazuretest32946","type":"Microsoft.Storage/storageAccounts","location":"westus","tags":{"delete":"false"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.0404359Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.0404359Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T21:18:37.0793411Z","primaryEndpoints":{"blob":"https://miqazuretest32946.blob.core.windows.net/","queue":"https://miqazuretest32946.queue.core.windows.net/","table":"https://miqazuretest32946.table.core.windows.net/","file":"https://miqazuretest32946.file.core.windows.net/"},"primaryLocation":"westus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Storage/storageAccounts/miqazureshared1","name":"miqazureshared1","type":"Microsoft.Storage/storageAccounts","location":"centralus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.1935084Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.1935084Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T20:42:52.498085Z","primaryEndpoints":{"blob":"https://miqazureshared1.blob.core.windows.net/","queue":"https://miqazureshared1.queue.core.windows.net/","table":"https://miqazureshared1.table.core.windows.net/","file":"https://miqazureshared1.file.core.windows.net/"},"primaryLocation":"centralus","statusOfPrimary":"available","secondaryLocation":"eastus2","statusOfSecondary":"available","secondaryEndpoints":{"blob":"https://miqazureshared1-secondary.blob.core.windows.net/","queue":"https://miqazureshared1-secondary.queue.core.windows.net/","table":"https://miqazureshared1-secondary.table.core.windows.net/"}}}]}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:16 GMT
+  recorded_at: Mon, 12 Mar 2018 09:36:50 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor/listKeys?api-version=2017-10-01
@@ -4367,7 +4020,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MzgsIm5iZiI6MTUyMDQ1MzQzOCwiZXhwIjoxNTIwNDU3MzM4LCJhaW8iOiJZMk5nWUxEbUtXMDk5clB4cU9QdGorL1crV3NlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZHNPVmFSUXV2RTJjVVBpcEtWWUFBQSIsInZlciI6IjEuMCJ9.drT5CKw95WRF7LzC0WuhK-fTLpw3j61XMw_DZdrLOWP8sjjsrbn9kF7xjDSTUM0ooF5_1Y-j3dNjvI9crm_F3PMAyhYXmCsKjTJkc3DIK6URy3hqbKiRBNlrutwvILE777NY-uXK9PH-gcaVuV-mNrjrLuxxClMJ3OPpTU8Ux0fj3Nuyf3KrXC27Oks_M_RDqDaXHOTckrdz2m_LNLpi5x0nKCoxwR9r5C1m5IKZ25FSbvyRNwjwz5dReqnv5LxllQMHVWkpvO7i5438wAnnyaS2x211IBiE6_dnV2god8Sp3ZRinXc4aCimUnJl6tLa5EtT_VSmR2QcBSaq0wS_ZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcwNjMsIm5iZiI6MTUyMDg0NzA2MywiZXhwIjoxNTIwODUwOTYzLCJhaW8iOiJZMk5nWURnY2RQQks2cFZ5anRmL0pHYWt0ajI5RGdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiaEVobDdDS0hGa1c0RjV2TExiY2lBQSIsInZlciI6IjEuMCJ9.MywLrYlLzZCy4yVEqcN17usz0ujBpvlLeFDVNfTb_5KSOKHpDmqiK14CoLuzvAP-sHS7HM-YvxzM_6fW9VzWLYC6kaUN_zWDYc7OPjKFpEvFtRv7dlfbuGIGem4-VdlO8jAgcG3gvQ7Mv95xKPelZt2BbssFPEsWnDhKrJNa0z5qGFUl9NnAPe0r2z7WoAhM4JDvTl71swAGnsaRCypUraKgO6bfxg4gmgsfc6oTK3VQ1DDaKRpV0n3HNSjEHpPTmm5lxo83iRDzvs3IlYNbf6n056CKD3urJSsykuB5QukEoJfubzXH9Z9UCemSYBIPj30abqb96Y8xNMgkEnmyfg
       Content-Length:
       - '0'
   response:
@@ -4388,7 +4041,7 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - ba20e9ad-b7ef-4c0d-8d7f-35f4f27ec042
+      - afb2c9aa-aa3c-4247-ac76-3199ce8c5761
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
@@ -4396,18 +4049,18 @@ http_interactions:
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
       - '1199'
       X-Ms-Correlation-Request-Id:
-      - b4719cd9-18ef-4e03-a0f2-8243252a5446
+      - c8b14ac1-4b0a-4750-9735-8879078eefda
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201617Z:b4719cd9-18ef-4e03-a0f2-8243252a5446
+      - WESTEUROPE:20180312T093646Z:c8b14ac1-4b0a-4750-9735-8879078eefda
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:16:16 GMT
+      - Mon, 12 Mar 2018 09:36:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keys":[{"keyName":"key1","value":"68JHlwL/JgyPmvNCqop65JbepxzK0RGKJ4uD6EKszcgv1nRUJKkxO6u4OoyW/6YPT+FMJxvzEBrCGD/bduFGJQ==","permissions":"Full"},{"keyName":"key2","value":"NCT/sPC/+mrVRzXq/V5IwjN2SPaWRF4kY2coPHzJ8f+IkWMUIyfUgYTAN//h4KnxeWuX9OkY1CPyssDhDs91fw==","permissions":"Full"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:17 GMT
+  recorded_at: Mon, 12 Mar 2018 09:36:51 GMT
 - request:
     method: head
     uri: https://spec0deply1stor.blob.core.windows.net/vhds/osdisk1.vhd
@@ -4424,7 +4077,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:16:17 GMT
+      - Mon, 12 Mar 2018 09:36:51 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -4432,7 +4085,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey spec0deply1stor:zwTv8SpgtO5K70g22ZVsQP+b+U3Bo02N7g7TM6f4wwI=
+      - SharedKey spec0deply1stor:YHZVGd0SJQoh74L1zaA5I7SfJNqgQWK8rugqQT+ucxk=
   response:
     status:
       code: 200
@@ -4453,7 +4106,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 5a52e741-001e-0137-6d51-b6cc85000000
+      - b8224921-001e-005d-37e5-b9d67b000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Microsoftazurecompute-Resourcegroupname:
@@ -4489,145 +4142,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:16:17 GMT
+      - Mon, 12 Mar 2018 09:36:46 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:17 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0/instanceView?api-version=2017-12-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MzgsIm5iZiI6MTUyMDQ1MzQzOCwiZXhwIjoxNTIwNDU3MzM4LCJhaW8iOiJZMk5nWUxEbUtXMDk5clB4cU9QdGorL1crV3NlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZHNPVmFSUXV2RTJjVVBpcEtWWUFBQSIsInZlciI6IjEuMCJ9.drT5CKw95WRF7LzC0WuhK-fTLpw3j61XMw_DZdrLOWP8sjjsrbn9kF7xjDSTUM0ooF5_1Y-j3dNjvI9crm_F3PMAyhYXmCsKjTJkc3DIK6URy3hqbKiRBNlrutwvILE777NY-uXK9PH-gcaVuV-mNrjrLuxxClMJ3OPpTU8Ux0fj3Nuyf3KrXC27Oks_M_RDqDaXHOTckrdz2m_LNLpi5x0nKCoxwR9r5C1m5IKZ25FSbvyRNwjwz5dReqnv5LxllQMHVWkpvO7i5438wAnnyaS2x211IBiE6_dnV2god8Sp3ZRinXc4aCimUnJl6tLa5EtT_VSmR2QcBSaq0wS_ZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/GetInstanceView3Min;4798,Microsoft.Compute/GetInstanceView30Min;23927
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
-      X-Ms-Request-Id:
-      - a8d4703b-8a01-46a5-b4af-b61d9a388f79
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
-      X-Ms-Correlation-Request-Id:
-      - bc37f6d4-5b81-4726-846f-df5c6a141678
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201618Z:bc37f6d4-5b81-4726-846f-df5c6a141678
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:16:17 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"platformUpdateDomain\": 1,\r\n  \"platformFaultDomain\": 1,\r\n
-        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
-        [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
-        \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
-        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2018-03-07T20:16:17+00:00\"\r\n
-        \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"osdisk\",\r\n
-        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
-        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"time\": \"2016-09-03T02:05:35.0977796+00:00\"\r\n
-        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
-        \"https://spec0deply1stor.blob.core.windows.net/bootdiagnostics-spec0depl-d7022008-f6b1-4f4c-8be8-e2d677ef3261/spec0deply1vm0.d7022008-f6b1-4f4c-8be8-e2d677ef3261.screenshot.bmp\",\r\n
-        \   \"serialConsoleLogBlobUri\": \"https://spec0deply1stor.blob.core.windows.net/bootdiagnostics-spec0depl-d7022008-f6b1-4f4c-8be8-e2d677ef3261/spec0deply1vm0.d7022008-f6b1-4f4c-8be8-e2d677ef3261.serialconsole.log\"\r\n
-        \ },\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n
-        \     \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n
-        \     \"time\": \"2016-09-03T02:05:35.1602741+00:00\"\r\n    },\r\n    {\r\n
-        \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
-        \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:18 GMT
-- request:
-    method: post
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor/listKeys?api-version=2017-10-01
-    body:
-      encoding: ASCII-8BIT
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MzgsIm5iZiI6MTUyMDQ1MzQzOCwiZXhwIjoxNTIwNDU3MzM4LCJhaW8iOiJZMk5nWUxEbUtXMDk5clB4cU9QdGorL1crV3NlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZHNPVmFSUXV2RTJjVVBpcEtWWUFBQSIsInZlciI6IjEuMCJ9.drT5CKw95WRF7LzC0WuhK-fTLpw3j61XMw_DZdrLOWP8sjjsrbn9kF7xjDSTUM0ooF5_1Y-j3dNjvI9crm_F3PMAyhYXmCsKjTJkc3DIK6URy3hqbKiRBNlrutwvILE777NY-uXK9PH-gcaVuV-mNrjrLuxxClMJ3OPpTU8Ux0fj3Nuyf3KrXC27Oks_M_RDqDaXHOTckrdz2m_LNLpi5x0nKCoxwR9r5C1m5IKZ25FSbvyRNwjwz5dReqnv5LxllQMHVWkpvO7i5438wAnnyaS2x211IBiE6_dnV2god8Sp3ZRinXc4aCimUnJl6tLa5EtT_VSmR2QcBSaq0wS_ZQ
-      Content-Length:
-      - '0'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 9f041ec2-a623-442b-8117-fef10b241153
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1199'
-      X-Ms-Correlation-Request-Id:
-      - c3ec254e-7a56-4dbb-9835-2764feedc93a
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201618Z:c3ec254e-7a56-4dbb-9835-2764feedc93a
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:16:18 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"keys":[{"keyName":"key1","value":"68JHlwL/JgyPmvNCqop65JbepxzK0RGKJ4uD6EKszcgv1nRUJKkxO6u4OoyW/6YPT+FMJxvzEBrCGD/bduFGJQ==","permissions":"Full"},{"keyName":"key2","value":"NCT/sPC/+mrVRzXq/V5IwjN2SPaWRF4kY2coPHzJ8f+IkWMUIyfUgYTAN//h4KnxeWuX9OkY1CPyssDhDs91fw==","permissions":"Full"}]}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:18 GMT
+  recorded_at: Mon, 12 Mar 2018 09:36:51 GMT
 - request:
     method: head
     uri: https://spec0deply1stor.blob.core.windows.net/vhds/osdisk0.vhd
@@ -4644,7 +4164,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:16:18 GMT
+      - Mon, 12 Mar 2018 09:36:51 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -4652,7 +4172,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey spec0deply1stor:EKlPAPToI0QRQ0kZuX+6HNLFAp1I0/W8XQVX/2p6GWs=
+      - SharedKey spec0deply1stor:LvnzgLmmVg5ha4+xhNUpkTPt63VMPr0cyuzI5hMnUUg=
   response:
     status:
       code: 200
@@ -4673,7 +4193,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 1207794c-001e-000b-4d51-b63e0b000000
+      - 6147039f-001e-0089-1be5-b99f5b000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Microsoftazurecompute-Resourcegroupname:
@@ -4709,12 +4229,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:16:18 GMT
+      - Mon, 12 Mar 2018 09:36:47 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:19 GMT
+  recorded_at: Mon, 12 Mar 2018 09:36:52 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet?api-version=2018-01-01
@@ -4731,7 +4251,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MzgsIm5iZiI6MTUyMDQ1MzQzOCwiZXhwIjoxNTIwNDU3MzM4LCJhaW8iOiJZMk5nWUxEbUtXMDk5clB4cU9QdGorL1crV3NlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZHNPVmFSUXV2RTJjVVBpcEtWWUFBQSIsInZlciI6IjEuMCJ9.drT5CKw95WRF7LzC0WuhK-fTLpw3j61XMw_DZdrLOWP8sjjsrbn9kF7xjDSTUM0ooF5_1Y-j3dNjvI9crm_F3PMAyhYXmCsKjTJkc3DIK6URy3hqbKiRBNlrutwvILE777NY-uXK9PH-gcaVuV-mNrjrLuxxClMJ3OPpTU8Ux0fj3Nuyf3KrXC27Oks_M_RDqDaXHOTckrdz2m_LNLpi5x0nKCoxwR9r5C1m5IKZ25FSbvyRNwjwz5dReqnv5LxllQMHVWkpvO7i5438wAnnyaS2x211IBiE6_dnV2god8Sp3ZRinXc4aCimUnJl6tLa5EtT_VSmR2QcBSaq0wS_ZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcwNjMsIm5iZiI6MTUyMDg0NzA2MywiZXhwIjoxNTIwODUwOTYzLCJhaW8iOiJZMk5nWURnY2RQQks2cFZ5anRmL0pHYWt0ajI5RGdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiaEVobDdDS0hGa1c0RjV2TExiY2lBQSIsInZlciI6IjEuMCJ9.MywLrYlLzZCy4yVEqcN17usz0ujBpvlLeFDVNfTb_5KSOKHpDmqiK14CoLuzvAP-sHS7HM-YvxzM_6fW9VzWLYC6kaUN_zWDYc7OPjKFpEvFtRv7dlfbuGIGem4-VdlO8jAgcG3gvQ7Mv95xKPelZt2BbssFPEsWnDhKrJNa0z5qGFUl9NnAPe0r2z7WoAhM4JDvTl71swAGnsaRCypUraKgO6bfxg4gmgsfc6oTK3VQ1DDaKRpV0n3HNSjEHpPTmm5lxo83iRDzvs3IlYNbf6n056CKD3urJSsykuB5QukEoJfubzXH9Z9UCemSYBIPj30abqb96Y8xNMgkEnmyfg
   response:
     status:
       code: 200
@@ -4752,22 +4272,22 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - b3de171b-488c-443e-81ac-8c3715e6bfc8
+      - 91be6246-fa45-46e6-b6e0-658fcf5e26e6
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14978'
+      - '14992'
       X-Ms-Correlation-Request-Id:
-      - 85d07010-884d-42f8-8735-4477ffd8da42
+      - 6d347e17-29db-4fa0-94b5-145eee855cd6
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201619Z:85d07010-884d-42f8-8735-4477ffd8da42
+      - WESTEUROPE:20180312T093651Z:6d347e17-29db-4fa0-94b5-145eee855cd6
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:16:19 GMT
+      - Mon, 12 Mar 2018 09:36:50 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"spec0deply1vnet\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet\",\r\n
@@ -4786,403 +4306,7 @@ http_interactions:
         [],\r\n    \"enableDdosProtection\": false,\r\n    \"enableVmProtection\":
         false\r\n  }\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:19 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MzgsIm5iZiI6MTUyMDQ1MzQzOCwiZXhwIjoxNTIwNDU3MzM4LCJhaW8iOiJZMk5nWUxEbUtXMDk5clB4cU9QdGorL1crV3NlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZHNPVmFSUXV2RTJjVVBpcEtWWUFBQSIsInZlciI6IjEuMCJ9.drT5CKw95WRF7LzC0WuhK-fTLpw3j61XMw_DZdrLOWP8sjjsrbn9kF7xjDSTUM0ooF5_1Y-j3dNjvI9crm_F3PMAyhYXmCsKjTJkc3DIK6URy3hqbKiRBNlrutwvILE777NY-uXK9PH-gcaVuV-mNrjrLuxxClMJ3OPpTU8Ux0fj3Nuyf3KrXC27Oks_M_RDqDaXHOTckrdz2m_LNLpi5x0nKCoxwR9r5C1m5IKZ25FSbvyRNwjwz5dReqnv5LxllQMHVWkpvO7i5438wAnnyaS2x211IBiE6_dnV2god8Sp3ZRinXc4aCimUnJl6tLa5EtT_VSmR2QcBSaq0wS_ZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"2ec58a0b-4c03-4d0a-b788-9daffd54e7b2"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 532bb8fa-a072-453e-9e6c-d01de89ab17f
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14982'
-      X-Ms-Correlation-Request-Id:
-      - a362225d-28ab-409b-af2b-074b178b19ad
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201620Z:a362225d-28ab-409b-af2b-074b178b19ad
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:16:19 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"spec0deply1nic1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1\",\r\n
-        \ \"etag\": \"W/\\\"2ec58a0b-4c03-4d0a-b788-9daffd54e7b2\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"57bbf7aa-d6c4-4f56-8f6a-089d15334221\",\r\n    \"ipConfigurations\":
-        [\r\n      {\r\n        \"name\": \"ipconfig1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1\",\r\n
-        \       \"etag\": \"W/\\\"2ec58a0b-4c03-4d0a-b788-9daffd54e7b2\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAddress\": \"10.0.0.5\",\r\n          \"privateIPAllocationMethod\":
-        \"Dynamic\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1\"\r\n
-        \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
-        \"IPv4\",\r\n          \"loadBalancerBackendAddressPools\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\"\r\n
-        \           }\r\n          ],\r\n          \"loadBalancerInboundNatRules\":
-        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\":
-        {\r\n      \"dnsServers\": [],\r\n      \"appliedDnsServers\": []\r\n    },\r\n
-        \   \"enableAcceleratedNetworking\": false,\r\n    \"enableIPForwarding\":
-        false,\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1\"\r\n
-        \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
-        \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:20 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MzgsIm5iZiI6MTUyMDQ1MzQzOCwiZXhwIjoxNTIwNDU3MzM4LCJhaW8iOiJZMk5nWUxEbUtXMDk5clB4cU9QdGorL1crV3NlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZHNPVmFSUXV2RTJjVVBpcEtWWUFBQSIsInZlciI6IjEuMCJ9.drT5CKw95WRF7LzC0WuhK-fTLpw3j61XMw_DZdrLOWP8sjjsrbn9kF7xjDSTUM0ooF5_1Y-j3dNjvI9crm_F3PMAyhYXmCsKjTJkc3DIK6URy3hqbKiRBNlrutwvILE777NY-uXK9PH-gcaVuV-mNrjrLuxxClMJ3OPpTU8Ux0fj3Nuyf3KrXC27Oks_M_RDqDaXHOTckrdz2m_LNLpi5x0nKCoxwR9r5C1m5IKZ25FSbvyRNwjwz5dReqnv5LxllQMHVWkpvO7i5438wAnnyaS2x211IBiE6_dnV2god8Sp3ZRinXc4aCimUnJl6tLa5EtT_VSmR2QcBSaq0wS_ZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"b817491c-aab8-4aab-b41d-b07bfffa5639"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 9367bf87-d02f-4c72-ae3d-75084dfbb81f
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14983'
-      X-Ms-Correlation-Request-Id:
-      - 8668440c-c9d3-4c98-a1cb-892c47be2d20
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201620Z:8668440c-c9d3-4c98-a1cb-892c47be2d20
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:16:20 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"spec0deply1nic0\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0\",\r\n
-        \ \"etag\": \"W/\\\"b817491c-aab8-4aab-b41d-b07bfffa5639\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"80ad9866-071d-4e3f-91d0-d47954eccee0\",\r\n    \"ipConfigurations\":
-        [\r\n      {\r\n        \"name\": \"ipconfig1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1\",\r\n
-        \       \"etag\": \"W/\\\"b817491c-aab8-4aab-b41d-b07bfffa5639\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAddress\": \"10.0.0.4\",\r\n          \"privateIPAllocationMethod\":
-        \"Dynamic\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1\"\r\n
-        \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
-        \"IPv4\",\r\n          \"loadBalancerBackendAddressPools\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\"\r\n
-        \           }\r\n          ],\r\n          \"loadBalancerInboundNatRules\":
-        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\":
-        {\r\n      \"dnsServers\": [],\r\n      \"appliedDnsServers\": []\r\n    },\r\n
-        \   \"enableAcceleratedNetworking\": false,\r\n    \"enableIPForwarding\":
-        false,\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0\"\r\n
-        \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
-        \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:21 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MzgsIm5iZiI6MTUyMDQ1MzQzOCwiZXhwIjoxNTIwNDU3MzM4LCJhaW8iOiJZMk5nWUxEbUtXMDk5clB4cU9QdGorL1crV3NlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZHNPVmFSUXV2RTJjVVBpcEtWWUFBQSIsInZlciI6IjEuMCJ9.drT5CKw95WRF7LzC0WuhK-fTLpw3j61XMw_DZdrLOWP8sjjsrbn9kF7xjDSTUM0ooF5_1Y-j3dNjvI9crm_F3PMAyhYXmCsKjTJkc3DIK6URy3hqbKiRBNlrutwvILE777NY-uXK9PH-gcaVuV-mNrjrLuxxClMJ3OPpTU8Ux0fj3Nuyf3KrXC27Oks_M_RDqDaXHOTckrdz2m_LNLpi5x0nKCoxwR9r5C1m5IKZ25FSbvyRNwjwz5dReqnv5LxllQMHVWkpvO7i5438wAnnyaS2x211IBiE6_dnV2god8Sp3ZRinXc4aCimUnJl6tLa5EtT_VSmR2QcBSaq0wS_ZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"92982330-0f29-406e-bba9-ad19198579a5"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 1d66cea5-c2db-4a08-9d96-8508c4cd3c7d
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14982'
-      X-Ms-Correlation-Request-Id:
-      - d95e6889-3901-41ea-aed6-7bb336004a20
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201621Z:d95e6889-3901-41ea-aed6-7bb336004a20
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:16:20 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"spec0deply1lb\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb\",\r\n
-        \ \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"8cd72f7c-03bd-4584-abc6-d9ce77ae6202\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip\"\r\n
-        \         },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
-        \           }\r\n          ],\r\n          \"inboundNatRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"BackendPool1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"backendIPConfigurations\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1\"\r\n
-        \           }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\":
-        [\r\n      {\r\n        \"name\": \"LBRule\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\":
-        80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        5,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\"\r\n
-        \         },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/probes/tcpProbe\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n
-        \       \"name\": \"tcpProbe\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/probes/tcpProbe\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Tcp\",\r\n          \"port\": 80,\r\n          \"intervalInSeconds\":
-        5,\r\n          \"numberOfProbes\": 2,\r\n          \"loadBalancingRules\":
-        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\":
-        [\r\n      {\r\n        \"name\": \"RDP-VM0\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 50001,\r\n          \"backendPort\":
-        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1\"\r\n
-        \         }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"RDP-VM1\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 50002,\r\n          \"backendPort\":
-        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:21 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MzgsIm5iZiI6MTUyMDQ1MzQzOCwiZXhwIjoxNTIwNDU3MzM4LCJhaW8iOiJZMk5nWUxEbUtXMDk5clB4cU9QdGorL1crV3NlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZHNPVmFSUXV2RTJjVVBpcEtWWUFBQSIsInZlciI6IjEuMCJ9.drT5CKw95WRF7LzC0WuhK-fTLpw3j61XMw_DZdrLOWP8sjjsrbn9kF7xjDSTUM0ooF5_1Y-j3dNjvI9crm_F3PMAyhYXmCsKjTJkc3DIK6URy3hqbKiRBNlrutwvILE777NY-uXK9PH-gcaVuV-mNrjrLuxxClMJ3OPpTU8Ux0fj3Nuyf3KrXC27Oks_M_RDqDaXHOTckrdz2m_LNLpi5x0nKCoxwR9r5C1m5IKZ25FSbvyRNwjwz5dReqnv5LxllQMHVWkpvO7i5438wAnnyaS2x211IBiE6_dnV2god8Sp3ZRinXc4aCimUnJl6tLa5EtT_VSmR2QcBSaq0wS_ZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"92982330-0f29-406e-bba9-ad19198579a5"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - fb8e2192-6c48-4ee8-a239-683d5257e3e0
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14982'
-      X-Ms-Correlation-Request-Id:
-      - 83d16d7b-2a5b-4b6c-847b-ab4bced581ab
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201621Z:83d16d7b-2a5b-4b6c-847b-ab4bced581ab
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:16:20 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"spec0deply1lb\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb\",\r\n
-        \ \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"8cd72f7c-03bd-4584-abc6-d9ce77ae6202\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip\"\r\n
-        \         },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
-        \           }\r\n          ],\r\n          \"inboundNatRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"BackendPool1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"backendIPConfigurations\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1\"\r\n
-        \           }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\":
-        [\r\n      {\r\n        \"name\": \"LBRule\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\":
-        80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        5,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\"\r\n
-        \         },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/probes/tcpProbe\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n
-        \       \"name\": \"tcpProbe\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/probes/tcpProbe\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Tcp\",\r\n          \"port\": 80,\r\n          \"intervalInSeconds\":
-        5,\r\n          \"numberOfProbes\": 2,\r\n          \"loadBalancingRules\":
-        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\":
-        [\r\n      {\r\n        \"name\": \"RDP-VM0\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 50001,\r\n          \"backendPort\":
-        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1\"\r\n
-        \         }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"RDP-VM1\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 50002,\r\n          \"backendPort\":
-        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:22 GMT
+  recorded_at: Mon, 12 Mar 2018 09:36:55 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip?api-version=2018-01-01
@@ -5199,7 +4323,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MzgsIm5iZiI6MTUyMDQ1MzQzOCwiZXhwIjoxNTIwNDU3MzM4LCJhaW8iOiJZMk5nWUxEbUtXMDk5clB4cU9QdGorL1crV3NlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZHNPVmFSUXV2RTJjVVBpcEtWWUFBQSIsInZlciI6IjEuMCJ9.drT5CKw95WRF7LzC0WuhK-fTLpw3j61XMw_DZdrLOWP8sjjsrbn9kF7xjDSTUM0ooF5_1Y-j3dNjvI9crm_F3PMAyhYXmCsKjTJkc3DIK6URy3hqbKiRBNlrutwvILE777NY-uXK9PH-gcaVuV-mNrjrLuxxClMJ3OPpTU8Ux0fj3Nuyf3KrXC27Oks_M_RDqDaXHOTckrdz2m_LNLpi5x0nKCoxwR9r5C1m5IKZ25FSbvyRNwjwz5dReqnv5LxllQMHVWkpvO7i5438wAnnyaS2x211IBiE6_dnV2god8Sp3ZRinXc4aCimUnJl6tLa5EtT_VSmR2QcBSaq0wS_ZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcwNjMsIm5iZiI6MTUyMDg0NzA2MywiZXhwIjoxNTIwODUwOTYzLCJhaW8iOiJZMk5nWURnY2RQQks2cFZ5anRmL0pHYWt0ajI5RGdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiaEVobDdDS0hGa1c0RjV2TExiY2lBQSIsInZlciI6IjEuMCJ9.MywLrYlLzZCy4yVEqcN17usz0ujBpvlLeFDVNfTb_5KSOKHpDmqiK14CoLuzvAP-sHS7HM-YvxzM_6fW9VzWLYC6kaUN_zWDYc7OPjKFpEvFtRv7dlfbuGIGem4-VdlO8jAgcG3gvQ7Mv95xKPelZt2BbssFPEsWnDhKrJNa0z5qGFUl9NnAPe0r2z7WoAhM4JDvTl71swAGnsaRCypUraKgO6bfxg4gmgsfc6oTK3VQ1DDaKRpV0n3HNSjEHpPTmm5lxo83iRDzvs3IlYNbf6n056CKD3urJSsykuB5QukEoJfubzXH9Z9UCemSYBIPj30abqb96Y8xNMgkEnmyfg
   response:
     status:
       code: 200
@@ -5220,22 +4344,22 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 8237164d-f955-483c-ad8e-f86f41178664
+      - e3d61d97-7684-4fdb-8b76-a3c53fd1eb05
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14984'
+      - '14993'
       X-Ms-Correlation-Request-Id:
-      - 988aed49-1f5a-4c1e-843e-d17360fc661d
+      - 2e5876fc-7386-4fff-8ac8-c16f56d7a8b1
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201622Z:988aed49-1f5a-4c1e-843e-d17360fc661d
+      - WESTEUROPE:20180312T093651Z:2e5876fc-7386-4fff-8ac8-c16f56d7a8b1
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:16:21 GMT
+      - Mon, 12 Mar 2018 09:36:51 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"spec0deply1ip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip\",\r\n
@@ -5249,5 +4373,5 @@ http_interactions:
         \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
         \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:22 GMT
+  recorded_at: Mon, 12 Mar 2018 09:36:56 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_0/orchestration_stack_vm_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_0/orchestration_stack_vm_refresh.yml
@@ -16,7 +16,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcwNjMsIm5iZiI6MTUyMDg0NzA2MywiZXhwIjoxNTIwODUwOTYzLCJhaW8iOiJZMk5nWURnY2RQQks2cFZ5anRmL0pHYWt0ajI5RGdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiaEVobDdDS0hGa1c0RjV2TExiY2lBQSIsInZlciI6IjEuMCJ9.MywLrYlLzZCy4yVEqcN17usz0ujBpvlLeFDVNfTb_5KSOKHpDmqiK14CoLuzvAP-sHS7HM-YvxzM_6fW9VzWLYC6kaUN_zWDYc7OPjKFpEvFtRv7dlfbuGIGem4-VdlO8jAgcG3gvQ7Mv95xKPelZt2BbssFPEsWnDhKrJNa0z5qGFUl9NnAPe0r2z7WoAhM4JDvTl71swAGnsaRCypUraKgO6bfxg4gmgsfc6oTK3VQ1DDaKRpV0n3HNSjEHpPTmm5lxo83iRDzvs3IlYNbf6n056CKD3urJSsykuB5QukEoJfubzXH9Z9UCemSYBIPj30abqb96Y8xNMgkEnmyfg
   response:
     status:
       code: 200
@@ -35,26 +35,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14997'
+      - '14998'
       X-Ms-Request-Id:
-      - cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - c2f53f18-0bbb-47b7-999e-a2a583a26507
       X-Ms-Correlation-Request-Id:
-      - cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - c2f53f18-0bbb-47b7-999e-a2a583a26507
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102417Z:cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - WESTEUROPE:20180312T093729Z:c2f53f18-0bbb-47b7-999e-a2a583a26507
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:17 GMT
+      - Mon, 12 Mar 2018 09:37:29 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID","subscriptionId":"AZURE_SUBSCRIPTION_ID","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:22 GMT
+  recorded_at: Mon, 12 Mar 2018 09:37:34 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers?api-version=2015-01-01
@@ -71,7 +71,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcwNjMsIm5iZiI6MTUyMDg0NzA2MywiZXhwIjoxNTIwODUwOTYzLCJhaW8iOiJZMk5nWURnY2RQQks2cFZ5anRmL0pHYWt0ajI5RGdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiaEVobDdDS0hGa1c0RjV2TExiY2lBQSIsInZlciI6IjEuMCJ9.MywLrYlLzZCy4yVEqcN17usz0ujBpvlLeFDVNfTb_5KSOKHpDmqiK14CoLuzvAP-sHS7HM-YvxzM_6fW9VzWLYC6kaUN_zWDYc7OPjKFpEvFtRv7dlfbuGIGem4-VdlO8jAgcG3gvQ7Mv95xKPelZt2BbssFPEsWnDhKrJNa0z5qGFUl9NnAPe0r2z7WoAhM4JDvTl71swAGnsaRCypUraKgO6bfxg4gmgsfc6oTK3VQ1DDaKRpV0n3HNSjEHpPTmm5lxo83iRDzvs3IlYNbf6n056CKD3urJSsykuB5QukEoJfubzXH9Z9UCemSYBIPj30abqb96Y8xNMgkEnmyfg
   response:
     status:
       code: 200
@@ -88,19 +88,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - '14990'
       X-Ms-Request-Id:
-      - fe3532ca-59a2-474e-9094-8a3697b82bef
+      - e318b396-081c-4382-8555-a54571d8cb44
       X-Ms-Correlation-Request-Id:
-      - fe3532ca-59a2-474e-9094-8a3697b82bef
+      - e318b396-081c-4382-8555-a54571d8cb44
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102419Z:fe3532ca-59a2-474e-9094-8a3697b82bef
+      - WESTEUROPE:20180312T093730Z:e318b396-081c-4382-8555-a54571d8cb44
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:18 GMT
+      - Mon, 12 Mar 2018 09:37:30 GMT
       Content-Length:
       - '320853'
     body:
@@ -2322,10 +2322,10 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:23 GMT
+  recorded_at: Mon, 12 Mar 2018 09:37:34 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0?api-version=2017-12-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2339,7 +2339,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcwNjMsIm5iZiI6MTUyMDg0NzA2MywiZXhwIjoxNTIwODUwOTYzLCJhaW8iOiJZMk5nWURnY2RQQks2cFZ5anRmL0pHYWt0ajI5RGdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiaEVobDdDS0hGa1c0RjV2TExiY2lBQSIsInZlciI6IjEuMCJ9.MywLrYlLzZCy4yVEqcN17usz0ujBpvlLeFDVNfTb_5KSOKHpDmqiK14CoLuzvAP-sHS7HM-YvxzM_6fW9VzWLYC6kaUN_zWDYc7OPjKFpEvFtRv7dlfbuGIGem4-VdlO8jAgcG3gvQ7Mv95xKPelZt2BbssFPEsWnDhKrJNa0z5qGFUl9NnAPe0r2z7WoAhM4JDvTl71swAGnsaRCypUraKgO6bfxg4gmgsfc6oTK3VQ1DDaKRpV0n3HNSjEHpPTmm5lxo83iRDzvs3IlYNbf6n056CKD3urJSsykuB5QukEoJfubzXH9Z9UCemSYBIPj30abqb96Y8xNMgkEnmyfg
   response:
     status:
       code: 200
@@ -2355,88 +2355,57 @@ http_interactions:
       - application/json; charset=utf-8
       Expires:
       - "-1"
-      Etag:
-      - W/"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67"
       Vary:
       - Accept-Encoding
-      X-Ms-Request-Id:
-      - '080de667-081e-4d58-9e94-9e7243d4200e'
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/LowCostGet3Min;4752,Microsoft.Compute/LowCostGet30Min;37885
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      X-Ms-Request-Id:
+      - 07dfecb2-c0a1-4113-8c54-9844bcbedff5
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
+      - '14987'
       X-Ms-Correlation-Request-Id:
-      - '093d49ac-c85f-440e-956b-955b6698dd19'
+      - 27101556-5ef4-4b6e-bf8b-f71b80eec50a
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102419Z:093d49ac-c85f-440e-956b-955b6698dd19
+      - WESTEUROPE:20180312T093731Z:27101556-5ef4-4b6e-bf8b-f71b80eec50a
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:19 GMT
+      - Mon, 12 Mar 2018 09:37:30 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1\",\r\n
-        \ \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"7ab88756-810f-4083-95db-8b05d50e38f2\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ],\r\n          \"inboundNatRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"backendIPConfigurations\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\"\r\n
-        \           }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-rule\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\":
-        80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\"\r\n
-        \         },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n
-        \       \"name\": \"rspec-lb-probe\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-NAT\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 3441,\r\n          \"backendPort\":
-        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
+      string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"d7022008-f6b1-4f4c-8be8-e2d677ef3261\",\r\n
+        \   \"availabilitySet\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/SPEC0DEPLY1AS\"\r\n
+        \   },\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_D1\"\r\n
+        \   },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
+        \"MicrosoftWindowsServer\",\r\n        \"offer\": \"WindowsServer\",\r\n        \"sku\":
+        \"2012-R2-Datacenter\",\r\n        \"version\": \"latest\"\r\n      },\r\n
+        \     \"osDisk\": {\r\n        \"osType\": \"Windows\",\r\n        \"name\":
+        \"osdisk\",\r\n        \"createOption\": \"FromImage\",\r\n        \"vhd\":
+        {\r\n          \"uri\": \"http://spec0deply1stor.blob.core.windows.net/vhds/osdisk0.vhd\"\r\n
+        \       },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n      \"dataDisks\":
+        []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"spec0deply1vm0\",\r\n
+        \     \"adminUsername\": \"deploy1admin\",\r\n      \"windowsConfiguration\":
+        {\r\n        \"provisionVMAgent\": true,\r\n        \"enableAutomaticUpdates\":
+        true\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\":
+        {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0\"}]},\r\n
+        \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
+        true,\r\n        \"storageUri\": \"http://spec0deply1stor.blob.core.windows.net\"\r\n
+        \     }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n
+        \ \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"tags\": {\r\n    \"Shutdown\": \"true\"\r\n  },\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0\",\r\n
+        \ \"name\": \"spec0deply1vm0\"\r\n}"
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:24 GMT
+  recorded_at: Mon, 12 Mar 2018 09:37:35 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0?api-version=2018-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2450,7 +2419,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcwNjMsIm5iZiI6MTUyMDg0NzA2MywiZXhwIjoxNTIwODUwOTYzLCJhaW8iOiJZMk5nWURnY2RQQks2cFZ5anRmL0pHYWt0ajI5RGdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiaEVobDdDS0hGa1c0RjV2TExiY2lBQSIsInZlciI6IjEuMCJ9.MywLrYlLzZCy4yVEqcN17usz0ujBpvlLeFDVNfTb_5KSOKHpDmqiK14CoLuzvAP-sHS7HM-YvxzM_6fW9VzWLYC6kaUN_zWDYc7OPjKFpEvFtRv7dlfbuGIGem4-VdlO8jAgcG3gvQ7Mv95xKPelZt2BbssFPEsWnDhKrJNa0z5qGFUl9NnAPe0r2z7WoAhM4JDvTl71swAGnsaRCypUraKgO6bfxg4gmgsfc6oTK3VQ1DDaKRpV0n3HNSjEHpPTmm5lxo83iRDzvs3IlYNbf6n056CKD3urJSsykuB5QukEoJfubzXH9Z9UCemSYBIPj30abqb96Y8xNMgkEnmyfg
   response:
     status:
       code: 200
@@ -2467,123 +2436,54 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"7a8e5fe7-f777-4435-992b-a54f28c2f28c"
+      - W/"b817491c-aab8-4aab-b41d-b07bfffa5639"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - bd22ca22-a01f-4ecf-9230-a4558fb66931
+      - c5dd7d68-6cc3-4322-bce5-5b9b69df1763
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
+      - '14993'
       X-Ms-Correlation-Request-Id:
-      - 19c674a8-c8da-4b5e-8265-5ebc21926459
+      - 8508f012-9adc-45f5-a205-e58b8cbd1f52
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102420Z:19c674a8-c8da-4b5e-8265-5ebc21926459
+      - WESTEUROPE:20180312T093731Z:8508f012-9adc-45f5-a205-e58b8cbd1f52
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:19 GMT
+      - Mon, 12 Mar 2018 09:37:31 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb2\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2\",\r\n
-        \ \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"e2e30a77-f81b-43fc-9693-08303e43deed\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/backendAddressPools/rspec-lb2-pool\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\r\n
-        \       }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\": [],\r\n    \"probes\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-probe\",\r\n        \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/probes/rspec-lb2-probe\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\": [],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:25 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"a38434c8-7b23-4092-b7c6-402238eac0dc"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 0fd15240-6a1c-4b39-a4f6-aa53fd8591c2
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Correlation-Request-Id:
-      - 5cc03163-922e-41a1-9601-dba2d7cf2a81
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102421Z:5cc03163-922e-41a1-9601-dba2d7cf2a81
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Mon, 12 Mar 2018 10:24:20 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb1-LoadBalancerFrontEnd\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\",\r\n
-        \ \"etag\": \"W/\\\"a38434c8-7b23-4092-b7c6-402238eac0dc\\\"\",\r\n  \"location\":
+      string: "{\r\n  \"name\": \"spec0deply1nic0\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0\",\r\n
+        \ \"etag\": \"W/\\\"b817491c-aab8-4aab-b41d-b07bfffa5639\\\"\",\r\n  \"location\":
         \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"f28e0f25-b372-4edf-97d9-13a9e3b4ba2d\",\r\n    \"ipAddress\":
-        \"40.71.82.83\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\":
-        \"Static\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipTags\": [],\r\n
-        \   \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
-        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
+        \   \"resourceGuid\": \"80ad9866-071d-4e3f-91d0-d47954eccee0\",\r\n    \"ipConfigurations\":
+        [\r\n      {\r\n        \"name\": \"ipconfig1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1\",\r\n
+        \       \"etag\": \"W/\\\"b817491c-aab8-4aab-b41d-b07bfffa5639\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"privateIPAddress\": \"10.0.0.4\",\r\n          \"privateIPAllocationMethod\":
+        \"Dynamic\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1\"\r\n
+        \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
+        \"IPv4\",\r\n          \"loadBalancerBackendAddressPools\": [\r\n            {\r\n
+        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\"\r\n
+        \           }\r\n          ],\r\n          \"loadBalancerInboundNatRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\":
+        {\r\n      \"dnsServers\": [],\r\n      \"appliedDnsServers\": []\r\n    },\r\n
+        \   \"enableAcceleratedNetworking\": false,\r\n    \"enableIPForwarding\":
+        false,\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0\"\r\n
+        \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
+        \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:25 GMT
+  recorded_at: Mon, 12 Mar 2018 09:37:36 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0/instanceView?api-version=2017-12-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2597,7 +2497,1006 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcwNjMsIm5iZiI6MTUyMDg0NzA2MywiZXhwIjoxNTIwODUwOTYzLCJhaW8iOiJZMk5nWURnY2RQQks2cFZ5anRmL0pHYWt0ajI5RGdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiaEVobDdDS0hGa1c0RjV2TExiY2lBQSIsInZlciI6IjEuMCJ9.MywLrYlLzZCy4yVEqcN17usz0ujBpvlLeFDVNfTb_5KSOKHpDmqiK14CoLuzvAP-sHS7HM-YvxzM_6fW9VzWLYC6kaUN_zWDYc7OPjKFpEvFtRv7dlfbuGIGem4-VdlO8jAgcG3gvQ7Mv95xKPelZt2BbssFPEsWnDhKrJNa0z5qGFUl9NnAPe0r2z7WoAhM4JDvTl71swAGnsaRCypUraKgO6bfxg4gmgsfc6oTK3VQ1DDaKRpV0n3HNSjEHpPTmm5lxo83iRDzvs3IlYNbf6n056CKD3urJSsykuB5QukEoJfubzXH9Z9UCemSYBIPj30abqb96Y8xNMgkEnmyfg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/GetInstanceView3Min;4796,Microsoft.Compute/GetInstanceView30Min;23911
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      X-Ms-Request-Id:
+      - 7dc0258b-3bbe-4329-987f-7b0ddca2b707
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Correlation-Request-Id:
+      - 74b2a818-8f08-4868-a038-deae913b9f24
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T093743Z:74b2a818-8f08-4868-a038-deae913b9f24
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:37:42 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"platformUpdateDomain\": 1,\r\n  \"platformFaultDomain\": 1,\r\n
+        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
+        [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
+        \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
+        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2018-03-12T09:37:35+00:00\"\r\n
+        \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"osdisk\",\r\n
+        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
+        succeeded\",\r\n          \"time\": \"2016-09-03T02:05:35.0977796+00:00\"\r\n
+        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
+        \"https://spec0deply1stor.blob.core.windows.net/bootdiagnostics-spec0depl-d7022008-f6b1-4f4c-8be8-e2d677ef3261/spec0deply1vm0.d7022008-f6b1-4f4c-8be8-e2d677ef3261.screenshot.bmp\",\r\n
+        \   \"serialConsoleLogBlobUri\": \"https://spec0deply1stor.blob.core.windows.net/bootdiagnostics-spec0depl-d7022008-f6b1-4f4c-8be8-e2d677ef3261/spec0deply1vm0.d7022008-f6b1-4f4c-8be8-e2d677ef3261.serialconsole.log\"\r\n
+        \ },\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n
+        \     \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n
+        \     \"time\": \"2016-09-03T02:05:35.1602741+00:00\"\r\n    },\r\n    {\r\n
+        \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
+        \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:37:47 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups/miq-azure-test1?api-version=2017-08-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcwNjMsIm5iZiI6MTUyMDg0NzA2MywiZXhwIjoxNTIwODUwOTYzLCJhaW8iOiJZMk5nWURnY2RQQks2cFZ5anRmL0pHYWt0ajI5RGdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiaEVobDdDS0hGa1c0RjV2TExiY2lBQSIsInZlciI6IjEuMCJ9.MywLrYlLzZCy4yVEqcN17usz0ujBpvlLeFDVNfTb_5KSOKHpDmqiK14CoLuzvAP-sHS7HM-YvxzM_6fW9VzWLYC6kaUN_zWDYc7OPjKFpEvFtRv7dlfbuGIGem4-VdlO8jAgcG3gvQ7Mv95xKPelZt2BbssFPEsWnDhKrJNa0z5qGFUl9NnAPe0r2z7WoAhM4JDvTl71swAGnsaRCypUraKgO6bfxg4gmgsfc6oTK3VQ1DDaKRpV0n3HNSjEHpPTmm5lxo83iRDzvs3IlYNbf6n056CKD3urJSsykuB5QukEoJfubzXH9Z9UCemSYBIPj30abqb96Y8xNMgkEnmyfg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Request-Id:
+      - 7fe664b3-543d-4e9a-a0b8-003325094bae
+      X-Ms-Correlation-Request-Id:
+      - 7fe664b3-543d-4e9a-a0b8-003325094bae
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T093743Z:7fe664b3-543d-4e9a-a0b8-003325094bae
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:37:42 GMT
+      Content-Length:
+      - '183'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1","name":"miq-azure-test1","location":"eastus","properties":{"provisioningState":"Succeeded"}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:37:48 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute/locations/eastus/vmSizes?api-version=2017-12-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcwNjMsIm5iZiI6MTUyMDg0NzA2MywiZXhwIjoxNTIwODUwOTYzLCJhaW8iOiJZMk5nWURnY2RQQks2cFZ5anRmL0pHYWt0ajI5RGdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiaEVobDdDS0hGa1c0RjV2TExiY2lBQSIsInZlciI6IjEuMCJ9.MywLrYlLzZCy4yVEqcN17usz0ujBpvlLeFDVNfTb_5KSOKHpDmqiK14CoLuzvAP-sHS7HM-YvxzM_6fW9VzWLYC6kaUN_zWDYc7OPjKFpEvFtRv7dlfbuGIGem4-VdlO8jAgcG3gvQ7Mv95xKPelZt2BbssFPEsWnDhKrJNa0z5qGFUl9NnAPe0r2z7WoAhM4JDvTl71swAGnsaRCypUraKgO6bfxg4gmgsfc6oTK3VQ1DDaKRpV0n3HNSjEHpPTmm5lxo83iRDzvs3IlYNbf6n056CKD3urJSsykuB5QukEoJfubzXH9Z9UCemSYBIPj30abqb96Y8xNMgkEnmyfg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/LowCostGet3Min;4747,Microsoft.Compute/LowCostGet30Min;37880
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      X-Ms-Request-Id:
+      - f006421e-5ed2-4ec5-9061-3fab3471da4e
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14987'
+      X-Ms-Correlation-Request-Id:
+      - bac9f19f-1e7b-49d5-adfa-c424b76342e9
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T093743Z:bac9f19f-1e7b-49d5-adfa-c424b76342e9
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:37:43 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"Standard_B1ms\",\r\n
+        \     \"numberOfCores\": 1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        4096,\r\n      \"memoryInMB\": 2048,\r\n      \"maxDataDiskCount\": 2\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_B1s\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        2048,\r\n      \"memoryInMB\": 1024,\r\n      \"maxDataDiskCount\": 2\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_B2ms\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        16384,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_B2s\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        8192,\r\n      \"memoryInMB\": 4096,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_B4ms\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        32768,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_B8ms\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS1_v2\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        7168,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS2_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        14336,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS3_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS4_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS5_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS11-1_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS11_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS12-1_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS12-2_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS12_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS13-2_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS13-4_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS13_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS14-4_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        229376,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS14-8_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        229376,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS14_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        229376,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS15_v2\",\r\n      \"numberOfCores\":
+        20,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        286720,\r\n      \"memoryInMB\": 143360,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS2_v2_Promo\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        14336,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS3_v2_Promo\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS4_v2_Promo\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS5_v2_Promo\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS11_v2_Promo\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS12_v2_Promo\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS13_v2_Promo\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS14_v2_Promo\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        229376,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F1s\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        4096,\r\n      \"memoryInMB\": 2048,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F2s\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        8192,\r\n      \"memoryInMB\": 4096,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F4s\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        16384,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F8s\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        32768,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F16s\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D2s_v3\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        16384,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D4s_v3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        32768,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D8s_v3\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D16s_v3\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        131072,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D32s_v3\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        262144,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A0\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        20480,\r\n      \"memoryInMB\": 768,\r\n      \"maxDataDiskCount\": 1\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A1\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        71680,\r\n      \"memoryInMB\": 1792,\r\n      \"maxDataDiskCount\": 2\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        138240,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        291840,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A5\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        138240,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A4\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        619520,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A6\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        291840,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A7\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        619520,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Basic_A0\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        20480,\r\n      \"memoryInMB\": 768,\r\n      \"maxDataDiskCount\": 1\r\n
+        \   },\r\n    {\r\n      \"name\": \"Basic_A1\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        40960,\r\n      \"memoryInMB\": 1792,\r\n      \"maxDataDiskCount\": 2\r\n
+        \   },\r\n    {\r\n      \"name\": \"Basic_A2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        61440,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Basic_A3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        122880,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Basic_A4\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        245760,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D1_v2\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        51200,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D2_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D3_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D4_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D5_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D11_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D12_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D13_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D14_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D15_v2\",\r\n      \"numberOfCores\":
+        20,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        286720,\r\n      \"memoryInMB\": 143360,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D2_v2_Promo\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D3_v2_Promo\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D4_v2_Promo\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D5_v2_Promo\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D11_v2_Promo\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D12_v2_Promo\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D13_v2_Promo\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D14_v2_Promo\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F1\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        16384,\r\n      \"memoryInMB\": 2048,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        32768,\r\n      \"memoryInMB\": 4096,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F4\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F8\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        131072,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F16\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        262144,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A1_v2\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        10240,\r\n      \"memoryInMB\": 2048,\r\n      \"maxDataDiskCount\": 2\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A2m_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        20480,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A2_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        20480,\r\n      \"memoryInMB\": 4096,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A4m_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        40960,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A4_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        40960,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A8m_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        81920,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A8_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        81920,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D2_v3\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        51200,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D4_v3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D8_v3\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D16_v3\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 65636,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D32_v3\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_H8\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1024000,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_H16\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        2048000,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_H8m\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1024000,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_H16m\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        2048000,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_H16r\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        2048000,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_H16mr\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        2048000,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D1\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        51200,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D4\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D11\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D12\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D13\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D14\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NV6\",\r\n      \"numberOfCores\":
+        6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        389120,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 24\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NV12\",\r\n      \"numberOfCores\":
+        12,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        696320,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 48\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NV24\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1474560,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC6s_v2\",\r\n      \"numberOfCores\":
+        6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        344064,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 12\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC12s_v2\",\r\n      \"numberOfCores\":
+        12,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        688128,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 24\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC24rs_v2\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1376256,\r\n      \"memoryInMB\": 458752,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC24s_v2\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1376256,\r\n      \"memoryInMB\": 458752,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC6\",\r\n      \"numberOfCores\":
+        6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        389120,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 24\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC12\",\r\n      \"numberOfCores\":
+        12,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        696320,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 48\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC24\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1474560,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC24r\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1474560,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS1\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        7168,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        14336,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS4\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS11\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS12\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS13\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS14\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        229376,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC6s_v3\",\r\n      \"numberOfCores\":
+        6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        344064,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 12\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC12s_v3\",\r\n      \"numberOfCores\":
+        12,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        688128,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 24\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC24rs_v3\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1376256,\r\n      \"memoryInMB\": 458752,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC24s_v3\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1376256,\r\n      \"memoryInMB\": 458752,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D64_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1638400,\r\n      \"memoryInMB\": 262144,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D64s_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        524288,\r\n      \"memoryInMB\": 262144,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E2_v3\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        51200,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E4_v3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E8_v3\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E16_v3\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E32_v3\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 262144,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E64i_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1638400,\r\n      \"memoryInMB\": 442368,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E64_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1638400,\r\n      \"memoryInMB\": 442368,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E2s_v3\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        32768,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E4-2s_v3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E4s_v3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E8-2s_v3\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        131072,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E8-4s_v3\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        131072,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E8s_v3\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        131072,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E16-4s_v3\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        262144,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E16-8s_v3\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        262144,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E16s_v3\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        262144,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E32-8s_v3\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        524288,\r\n      \"memoryInMB\": 262144,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E32-16s_v3\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        524288,\r\n      \"memoryInMB\": 262144,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E32s_v3\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        524288,\r\n      \"memoryInMB\": 262144,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E64-16s_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        884736,\r\n      \"memoryInMB\": 442368,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E64-32s_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        884736,\r\n      \"memoryInMB\": 442368,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E64is_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        884736,\r\n      \"memoryInMB\": 442368,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E64s_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        884736,\r\n      \"memoryInMB\": 442368,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F2s_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        16384,\r\n      \"memoryInMB\": 4096,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F4s_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        32768,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F8s_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F16s_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        131072,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F32s_v2\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        262144,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F64s_v2\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        524288,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F72s_v2\",\r\n      \"numberOfCores\":
+        72,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        589824,\r\n      \"memoryInMB\": 147456,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_L8s_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1811981,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_L16s_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        3623962,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_ND6s\",\r\n      \"numberOfCores\":
+        6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        344064,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 12\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_ND12s\",\r\n      \"numberOfCores\":
+        12,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        688128,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 24\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_ND24rs\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1376256,\r\n      \"memoryInMB\": 458752,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_ND24s\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1376256,\r\n      \"memoryInMB\": 458752,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A8\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        391168,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A9\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        391168,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A10\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        391168,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A11\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        391168,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   }\r\n  ]\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:37:48 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete?api-version=2017-08-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcwNjMsIm5iZiI6MTUyMDg0NzA2MywiZXhwIjoxNTIwODUwOTYzLCJhaW8iOiJZMk5nWURnY2RQQks2cFZ5anRmL0pHYWt0ajI5RGdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiaEVobDdDS0hGa1c0RjV2TExiY2lBQSIsInZlciI6IjEuMCJ9.MywLrYlLzZCy4yVEqcN17usz0ujBpvlLeFDVNfTb_5KSOKHpDmqiK14CoLuzvAP-sHS7HM-YvxzM_6fW9VzWLYC6kaUN_zWDYc7OPjKFpEvFtRv7dlfbuGIGem4-VdlO8jAgcG3gvQ7Mv95xKPelZt2BbssFPEsWnDhKrJNa0z5qGFUl9NnAPe0r2z7WoAhM4JDvTl71swAGnsaRCypUraKgO6bfxg4gmgsfc6oTK3VQ1DDaKRpV0n3HNSjEHpPTmm5lxo83iRDzvs3IlYNbf6n056CKD3urJSsykuB5QukEoJfubzXH9Z9UCemSYBIPj30abqb96Y8xNMgkEnmyfg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14989'
+      X-Ms-Request-Id:
+      - 81661846-9514-42a0-aaaf-a5c5b9f01672
+      X-Ms-Correlation-Request-Id:
+      - 81661846-9514-42a0-aaaf-a5c5b9f01672
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T093744Z:81661846-9514-42a0-aaaf-a5c5b9f01672
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:37:43 GMT
+      Content-Length:
+      - '7230'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete","name":"spec-nested-deployment-dont-delete","properties":{"templateLink":{"uri":"https://gist.githubusercontent.com/bzwei/c09f906306399d238762bce711781200/raw/3558b735da03c1c030023d70b78ec3451dab5689/azure-loadbalancer.json","contentVersion":"1.0.0.0"},"parameters":{"storageAccountName":{"type":"String","value":"spec0deply1stor"},"availabilitySetName":{"type":"String","value":"spec0deply1as"},"adminUsername":{"type":"String","value":"deploy1admin"},"adminPassword":{"type":"SecureString"},"dnsNameforLBIP":{"type":"String","value":"spec0deply1dns"},"vmNamePrefix":{"type":"String","value":"spec0deply1vm"},"imagePublisher":{"type":"String","value":"MicrosoftWindowsServer"},"imageOffer":{"type":"String","value":"WindowsServer"},"imageSKU":{"type":"String","value":"2012-R2-Datacenter"},"lbName":{"type":"String","value":"spec0deply1lb"},"nicNamePrefix":{"type":"String","value":"spec0deply1nic"},"publicIPAddressName":{"type":"String","value":"spec0deply1ip"},"vnetName":{"type":"String","value":"spec0deply1vnet"},"vmSize":{"type":"String","value":"Standard_D1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-04-04T23:28:59.2682474Z","duration":"PT23M55.442141S","correlationId":"3a55e6b5-4a3b-431e-8144-53698bf6f1dc","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["eastus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"availabilitySets","locations":["eastus"]},{"resourceType":"virtualMachines","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"publicIPAddresses","locations":["eastus"]},{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"loadBalancers","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"spec0deply1ip"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic0"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic1"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"spec0deply1stor"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"spec0deply1as"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"spec0deply1vm0"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"spec0deply1stor"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"spec0deply1as"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"spec0deply1vm1"}],"outputResources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor"}]}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:37:49 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-deployment-dont-delete?api-version=2017-08-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcwNjMsIm5iZiI6MTUyMDg0NzA2MywiZXhwIjoxNTIwODUwOTYzLCJhaW8iOiJZMk5nWURnY2RQQks2cFZ5anRmL0pHYWt0ajI5RGdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiaEVobDdDS0hGa1c0RjV2TExiY2lBQSIsInZlciI6IjEuMCJ9.MywLrYlLzZCy4yVEqcN17usz0ujBpvlLeFDVNfTb_5KSOKHpDmqiK14CoLuzvAP-sHS7HM-YvxzM_6fW9VzWLYC6kaUN_zWDYc7OPjKFpEvFtRv7dlfbuGIGem4-VdlO8jAgcG3gvQ7Mv95xKPelZt2BbssFPEsWnDhKrJNa0z5qGFUl9NnAPe0r2z7WoAhM4JDvTl71swAGnsaRCypUraKgO6bfxg4gmgsfc6oTK3VQ1DDaKRpV0n3HNSjEHpPTmm5lxo83iRDzvs3IlYNbf6n056CKD3urJSsykuB5QukEoJfubzXH9Z9UCemSYBIPj30abqb96Y8xNMgkEnmyfg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Request-Id:
+      - 93c708f1-c824-483a-b68f-173977c941ec
+      X-Ms-Correlation-Request-Id:
+      - 93c708f1-c824-483a-b68f-173977c941ec
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T093745Z:93c708f1-c824-483a-b68f-173977c941ec
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:37:45 GMT
+      Content-Length:
+      - '3083'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-deployment-dont-delete","name":"spec-deployment-dont-delete","properties":{"templateLink":{"uri":"https://gist.githubusercontent.com/bzwei/e6ccc4d641d6afab8e26ef55c37c498e/raw/769505e37256e926a9b581a100c90bb657ff45ff/azure-parent-spec.json","contentVersion":"1.0.0.0"},"parameters":{"childDeployName":{"type":"String","value":"spec-nested-deployment-dont-delete"},"storageAccountName":{"type":"String","value":"spec0deply1stor"},"availabilitySetName":{"type":"String","value":"spec0deply1as"},"adminUsername":{"type":"String","value":"deploy1admin"},"adminPassword":{"type":"SecureString"},"dnsNameforLBIP":{"type":"String","value":"spec0deply1dns"},"vmNamePrefix":{"type":"String","value":"spec0deply1vm"},"imagePublisher":{"type":"String","value":"MicrosoftWindowsServer"},"imageOffer":{"type":"String","value":"WindowsServer"},"imageSKU":{"type":"String","value":"2012-R2-Datacenter"},"lbName":{"type":"String","value":"spec0deply1lb"},"nicNamePrefix":{"type":"String","value":"spec0deply1nic"},"publicIPAddressName":{"type":"String","value":"spec0deply1ip"},"vnetName":{"type":"String","value":"spec0deply1vnet"},"vmSize":{"type":"String","value":"Standard_D1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-04-04T23:29:05.0043846Z","duration":"PT24M6.1512983S","correlationId":"3a55e6b5-4a3b-431e-8144-53698bf6f1dc","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[],"outputs":{"siteUri":{"type":"String","value":"hard-coded
+        output for test"}},"outputResources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor"}]}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:37:50 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor?api-version=2017-10-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcwNjMsIm5iZiI6MTUyMDg0NzA2MywiZXhwIjoxNTIwODUwOTYzLCJhaW8iOiJZMk5nWURnY2RQQks2cFZ5anRmL0pHYWt0ajI5RGdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiaEVobDdDS0hGa1c0RjV2TExiY2lBQSIsInZlciI6IjEuMCJ9.MywLrYlLzZCy4yVEqcN17usz0ujBpvlLeFDVNfTb_5KSOKHpDmqiK14CoLuzvAP-sHS7HM-YvxzM_6fW9VzWLYC6kaUN_zWDYc7OPjKFpEvFtRv7dlfbuGIGem4-VdlO8jAgcG3gvQ7Mv95xKPelZt2BbssFPEsWnDhKrJNa0z5qGFUl9NnAPe0r2z7WoAhM4JDvTl71swAGnsaRCypUraKgO6bfxg4gmgsfc6oTK3VQ1DDaKRpV0n3HNSjEHpPTmm5lxo83iRDzvs3IlYNbf6n056CKD3urJSsykuB5QukEoJfubzXH9Z9UCemSYBIPj30abqb96Y8xNMgkEnmyfg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 94382ea4-eb35-4f7a-9690-a47b31d1736f
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Correlation-Request-Id:
+      - 10bb2d3c-e18b-4490-bc10-442be640be9d
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T093746Z:10bb2d3c-e18b-4490-bc10-442be640be9d
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:37:45 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","name":"spec0deply1stor","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-04-04T23:05:07.8274794Z","primaryEndpoints":{"blob":"https://spec0deply1stor.blob.core.windows.net/","queue":"https://spec0deply1stor.queue.core.windows.net/","table":"https://spec0deply1stor.table.core.windows.net/","file":"https://spec0deply1stor.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:37:50 GMT
+- request:
+    method: post
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor/listKeys?api-version=2017-10-01
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcwNjMsIm5iZiI6MTUyMDg0NzA2MywiZXhwIjoxNTIwODUwOTYzLCJhaW8iOiJZMk5nWURnY2RQQks2cFZ5anRmL0pHYWt0ajI5RGdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiaEVobDdDS0hGa1c0RjV2TExiY2lBQSIsInZlciI6IjEuMCJ9.MywLrYlLzZCy4yVEqcN17usz0ujBpvlLeFDVNfTb_5KSOKHpDmqiK14CoLuzvAP-sHS7HM-YvxzM_6fW9VzWLYC6kaUN_zWDYc7OPjKFpEvFtRv7dlfbuGIGem4-VdlO8jAgcG3gvQ7Mv95xKPelZt2BbssFPEsWnDhKrJNa0z5qGFUl9NnAPe0r2z7WoAhM4JDvTl71swAGnsaRCypUraKgO6bfxg4gmgsfc6oTK3VQ1DDaKRpV0n3HNSjEHpPTmm5lxo83iRDzvs3IlYNbf6n056CKD3urJSsykuB5QukEoJfubzXH9Z9UCemSYBIPj30abqb96Y8xNMgkEnmyfg
+      Content-Length:
+      - '0'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 6bd80497-b6f9-46ca-9867-7b680e2ec49b
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Writes:
+      - '1199'
+      X-Ms-Correlation-Request-Id:
+      - 3cc00e7f-90a3-4a9f-a365-0764086101b8
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T093746Z:3cc00e7f-90a3-4a9f-a365-0764086101b8
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:37:45 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"keys":[{"keyName":"key1","value":"68JHlwL/JgyPmvNCqop65JbepxzK0RGKJ4uD6EKszcgv1nRUJKkxO6u4OoyW/6YPT+FMJxvzEBrCGD/bduFGJQ==","permissions":"Full"},{"keyName":"key2","value":"NCT/sPC/+mrVRzXq/V5IwjN2SPaWRF4kY2coPHzJ8f+IkWMUIyfUgYTAN//h4KnxeWuX9OkY1CPyssDhDs91fw==","permissions":"Full"}]}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:37:51 GMT
+- request:
+    method: head
+    uri: https://spec0deply1stor.blob.core.windows.net/vhds/osdisk0.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:37:51 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey spec0deply1stor:t/Y/obMhEBJ4FbNaMxZmH5lxyukAZcM2C2/Td4BQbXM=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - VbYhW9/6NOXzQVK/vQkdvg==
+      Last-Modified:
+      - Sat, 03 Sep 2016 02:04:38 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D3D39EA8F71715"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - b6366f0f-001e-0039-5de5-b966db000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Meta-Microsoftazurecompute-Resourcegroupname:
+      - miq-azure-test1
+      X-Ms-Meta-Microsoftazurecompute-Vmname:
+      - spec0deply1vm0
+      X-Ms-Meta-Microsoftazurecompute-Diskid:
+      - b059fe2a-4ccb-4a50-a235-ea3b7b089730
+      X-Ms-Meta-Microsoftazurecompute-Diskname:
+      - osdisk
+      X-Ms-Meta-Microsoftazurecompute-Disktype:
+      - OSDisk
+      X-Ms-Lease-Status:
+      - locked
+      X-Ms-Lease-State:
+      - leased
+      X-Ms-Lease-Duration:
+      - infinite
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '43'
+      X-Ms-Copy-Id:
+      - 27fb6a34-f422-4f0a-afcb-528942d6012f
+      X-Ms-Copy-Source:
+      - https://ardfepirv2bl5prdstr06.blob.core.windows.net/a699494373c04fc0bc8f2bb1389d6106/Windows-Server-2012-R2-20160229-en.us-127GB.vhd?sv=2014-02-14&sr=b&si=PirCacheAccountPublisherContainerPolicy&sig=ipib%2Bgp2Sh4hS%2BBx5OUKgXSymDC0Tu0Ge60PGFuy5uk%3D
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Mon, 04 Apr 2016 23:24:57 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Mon, 12 Mar 2018 09:37:46 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:37:51 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcwNjMsIm5iZiI6MTUyMDg0NzA2MywiZXhwIjoxNTIwODUwOTYzLCJhaW8iOiJZMk5nWURnY2RQQks2cFZ5anRmL0pHYWt0ajI5RGdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiaEVobDdDS0hGa1c0RjV2TExiY2lBQSIsInZlciI6IjEuMCJ9.MywLrYlLzZCy4yVEqcN17usz0ujBpvlLeFDVNfTb_5KSOKHpDmqiK14CoLuzvAP-sHS7HM-YvxzM_6fW9VzWLYC6kaUN_zWDYc7OPjKFpEvFtRv7dlfbuGIGem4-VdlO8jAgcG3gvQ7Mv95xKPelZt2BbssFPEsWnDhKrJNa0z5qGFUl9NnAPe0r2z7WoAhM4JDvTl71swAGnsaRCypUraKgO6bfxg4gmgsfc6oTK3VQ1DDaKRpV0n3HNSjEHpPTmm5lxo83iRDzvs3IlYNbf6n056CKD3urJSsykuB5QukEoJfubzXH9Z9UCemSYBIPj30abqb96Y8xNMgkEnmyfg
   response:
     status:
       code: 200
@@ -2614,36 +3513,43 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"cddd97d1-6111-4477-8a00-3dc885237a1d"
+      - W/"be3510b0-35c7-48ea-874b-49ac343ba8c9"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 1403e5b6-8fa0-4cd3-89b1-76b6c4fd805b
+      - b1d1fcef-28cc-4421-9ec6-1cec97b8c709
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - '14989'
       X-Ms-Correlation-Request-Id:
-      - e4a5f369-a742-466f-bd8f-42e17eaaf9c9
+      - 6374e3f6-0d78-4a69-a060-214f18a415d5
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102421Z:e4a5f369-a742-466f-bd8f-42e17eaaf9c9
+      - WESTEUROPE:20180312T093747Z:6374e3f6-0d78-4a69-a060-214f18a415d5
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:21 GMT
+      - Mon, 12 Mar 2018 09:37:46 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb2-publicip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\",\r\n
-        \ \"etag\": \"W/\\\"cddd97d1-6111-4477-8a00-3dc885237a1d\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"83e7257d-ab94-4229-8eb5-4798f37ef28d\",\r\n    \"publicIPAddressVersion\":
-        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
-        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
-        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
+      string: "{\r\n  \"name\": \"spec0deply1vnet\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet\",\r\n
+        \ \"etag\": \"W/\\\"be3510b0-35c7-48ea-874b-49ac343ba8c9\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
+        \"0bb1f005-1af2-4d4b-966a-89aaf6daefca\",\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\":
+        [\r\n        \"10.0.0.0/16\"\r\n      ]\r\n    },\r\n    \"subnets\": [\r\n
+        \     {\r\n        \"name\": \"Subnet-1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1\",\r\n
+        \       \"etag\": \"W/\\\"be3510b0-35c7-48ea-874b-49ac343ba8c9\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"addressPrefix\": \"10.0.0.0/24\",\r\n          \"ipConfigurations\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"virtualNetworkPeerings\":
+        [],\r\n    \"enableDdosProtection\": false,\r\n    \"enableVmProtection\":
+        false\r\n  }\r\n}"
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:26 GMT
+  recorded_at: Mon, 12 Mar 2018 09:37:52 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_0/powered_off_vm_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_0/powered_off_vm_refresh.yml
@@ -1,6 +1,62 @@
 ---
 http_interactions:
 - request:
+    method: post
+    uri: https://login.microsoftonline.com/AZURE_TENANT_ID/oauth2/token
+    body:
+      encoding: UTF-8
+      string: grant_type=client_credentials&client_id=AZURE_CLIENT_ID&client_secret=AZURE_CLIENT_SECRET&resource=https%3A%2F%2Fmanagement.azure.com%2F
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Server:
+      - Microsoft-IIS/10.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Request-Id:
+      - 64b19192-13e1-4454-a15a-6d0ccb702400
+      P3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Set-Cookie:
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzAdNCAG7HzbFOOa0_RRtaLhLp2I6yyQV_3J-FfO10YJAxHWJQCDwsMZbKGvBGPjXICoP_yOLPid9w3DPGo70lH99YmjefR849g1LVjz3VPHGhl-N01PYPM-V-VIsWTAkvz2RH_NGQsM9178N1M85bhZA3Ui3vpqbh16R4QHZRlH8gAA;
+        domain=.login.microsoftonline.com; path=/; secure; HttpOnly
+      - stsservicecookie=ests; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=006; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 12 Mar 2018 09:36:53 GMT
+      Content-Length:
+      - '1505'
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1520851014","not_before":"1520847114","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcxMTQsIm5iZiI6MTUyMDg0NzExNCwiZXhwIjoxNTIwODUxMDE0LCJhaW8iOiJZMk5nWUxoelZHeHh5QXV4UnU1T3VhaS9iNDVlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoia3BHeFpPRVRWRVNoV20wTXkzQWtBQSIsInZlciI6IjEuMCJ9.gZ-aTEd7yCP2UXqhskazoA2kO9FrY_DtYmqE-ky310zLXRX7T4l3bBrgdGyoriwQVrDcfF9jjUnEkopIy-eaKw_TCT_t1YkBEN3DHuA5Xs3zSHdBY2ojCJbINCdpWV0uqYwds7bimcWPy2FVnLUjU47xrup_eOFDuQm8YDmKrslsI1DIGi8mYUZQ7mN5A4oxqidl42HjzFYxd_Kk8BOLlFNQMhLg3GO6S5Q3YMAECl150dctnndInKOU4J0Iz-RyAE9bkgr7ZbQiFHxBH3FWzcXjyS_QvL7rvdTXVZusiDlziBTRESHq-o99dQSc3M_fpoK0yn887C7dXDNOL-fxlw"}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:36:58 GMT
+- request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
     body:
@@ -16,7 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcxMTQsIm5iZiI6MTUyMDg0NzExNCwiZXhwIjoxNTIwODUxMDE0LCJhaW8iOiJZMk5nWUxoelZHeHh5QXV4UnU1T3VhaS9iNDVlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoia3BHeFpPRVRWRVNoV20wTXkzQWtBQSIsInZlciI6IjEuMCJ9.gZ-aTEd7yCP2UXqhskazoA2kO9FrY_DtYmqE-ky310zLXRX7T4l3bBrgdGyoriwQVrDcfF9jjUnEkopIy-eaKw_TCT_t1YkBEN3DHuA5Xs3zSHdBY2ojCJbINCdpWV0uqYwds7bimcWPy2FVnLUjU47xrup_eOFDuQm8YDmKrslsI1DIGi8mYUZQ7mN5A4oxqidl42HjzFYxd_Kk8BOLlFNQMhLg3GO6S5Q3YMAECl150dctnndInKOU4J0Iz-RyAE9bkgr7ZbQiFHxBH3FWzcXjyS_QvL7rvdTXVZusiDlziBTRESHq-o99dQSc3M_fpoK0yn887C7dXDNOL-fxlw
   response:
     status:
       code: 200
@@ -35,26 +91,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14997'
+      - '14999'
       X-Ms-Request-Id:
-      - cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - 8a8129da-579f-461c-b3ab-2e5df965bd8d
       X-Ms-Correlation-Request-Id:
-      - cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - 8a8129da-579f-461c-b3ab-2e5df965bd8d
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102417Z:cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - WESTEUROPE:20180312T093654Z:8a8129da-579f-461c-b3ab-2e5df965bd8d
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:17 GMT
+      - Mon, 12 Mar 2018 09:36:54 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID","subscriptionId":"AZURE_SUBSCRIPTION_ID","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:22 GMT
+  recorded_at: Mon, 12 Mar 2018 09:36:59 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers?api-version=2015-01-01
@@ -71,7 +127,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcxMTQsIm5iZiI6MTUyMDg0NzExNCwiZXhwIjoxNTIwODUxMDE0LCJhaW8iOiJZMk5nWUxoelZHeHh5QXV4UnU1T3VhaS9iNDVlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoia3BHeFpPRVRWRVNoV20wTXkzQWtBQSIsInZlciI6IjEuMCJ9.gZ-aTEd7yCP2UXqhskazoA2kO9FrY_DtYmqE-ky310zLXRX7T4l3bBrgdGyoriwQVrDcfF9jjUnEkopIy-eaKw_TCT_t1YkBEN3DHuA5Xs3zSHdBY2ojCJbINCdpWV0uqYwds7bimcWPy2FVnLUjU47xrup_eOFDuQm8YDmKrslsI1DIGi8mYUZQ7mN5A4oxqidl42HjzFYxd_Kk8BOLlFNQMhLg3GO6S5Q3YMAECl150dctnndInKOU4J0Iz-RyAE9bkgr7ZbQiFHxBH3FWzcXjyS_QvL7rvdTXVZusiDlziBTRESHq-o99dQSc3M_fpoK0yn887C7dXDNOL-fxlw
   response:
     status:
       code: 200
@@ -88,19 +144,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - '14990'
       X-Ms-Request-Id:
-      - fe3532ca-59a2-474e-9094-8a3697b82bef
+      - a75827f7-f94d-48c5-8932-b21c16c6d3b8
       X-Ms-Correlation-Request-Id:
-      - fe3532ca-59a2-474e-9094-8a3697b82bef
+      - a75827f7-f94d-48c5-8932-b21c16c6d3b8
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102419Z:fe3532ca-59a2-474e-9094-8a3697b82bef
+      - WESTEUROPE:20180312T093655Z:a75827f7-f94d-48c5-8932-b21c16c6d3b8
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:18 GMT
+      - Mon, 12 Mar 2018 09:36:55 GMT
       Content-Length:
       - '320853'
     body:
@@ -2322,10 +2378,10 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:23 GMT
+  recorded_at: Mon, 12 Mar 2018 09:37:00 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1?api-version=2017-12-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2339,7 +2395,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcxMTQsIm5iZiI6MTUyMDg0NzExNCwiZXhwIjoxNTIwODUxMDE0LCJhaW8iOiJZMk5nWUxoelZHeHh5QXV4UnU1T3VhaS9iNDVlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoia3BHeFpPRVRWRVNoV20wTXkzQWtBQSIsInZlciI6IjEuMCJ9.gZ-aTEd7yCP2UXqhskazoA2kO9FrY_DtYmqE-ky310zLXRX7T4l3bBrgdGyoriwQVrDcfF9jjUnEkopIy-eaKw_TCT_t1YkBEN3DHuA5Xs3zSHdBY2ojCJbINCdpWV0uqYwds7bimcWPy2FVnLUjU47xrup_eOFDuQm8YDmKrslsI1DIGi8mYUZQ7mN5A4oxqidl42HjzFYxd_Kk8BOLlFNQMhLg3GO6S5Q3YMAECl150dctnndInKOU4J0Iz-RyAE9bkgr7ZbQiFHxBH3FWzcXjyS_QvL7rvdTXVZusiDlziBTRESHq-o99dQSc3M_fpoK0yn887C7dXDNOL-fxlw
   response:
     status:
       code: 200
@@ -2355,88 +2411,64 @@ http_interactions:
       - application/json; charset=utf-8
       Expires:
       - "-1"
-      Etag:
-      - W/"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67"
       Vary:
       - Accept-Encoding
-      X-Ms-Request-Id:
-      - '080de667-081e-4d58-9e94-9e7243d4200e'
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/LowCostGet3Min;4750,Microsoft.Compute/LowCostGet30Min;37898
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      X-Ms-Request-Id:
+      - 6df11f4c-a982-4f9b-bd6c-e7b60ff29cfe
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
+      - '14991'
       X-Ms-Correlation-Request-Id:
-      - '093d49ac-c85f-440e-956b-955b6698dd19'
+      - 3ccc12bb-72ff-450b-b86d-07ac065530d4
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102419Z:093d49ac-c85f-440e-956b-955b6698dd19
+      - WESTEUROPE:20180312T093656Z:3ccc12bb-72ff-450b-b86d-07ac065530d4
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:19 GMT
+      - Mon, 12 Mar 2018 09:36:55 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1\",\r\n
-        \ \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"7ab88756-810f-4083-95db-8b05d50e38f2\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ],\r\n          \"inboundNatRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"backendIPConfigurations\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\"\r\n
-        \           }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-rule\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\":
-        80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\"\r\n
-        \         },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n
-        \       \"name\": \"rspec-lb-probe\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-NAT\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 3441,\r\n          \"backendPort\":
-        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
+      string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"796c5bcc-338a-448d-b61c-165279a7fb3e\",\r\n
+        \   \"availabilitySet\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/MIQAZURE-AVAILSET-EAST\"\r\n
+        \   },\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Basic_A0\"\r\n
+        \   },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
+        \"OpenLogic\",\r\n        \"offer\": \"CentOS\",\r\n        \"sku\": \"7.1\",\r\n
+        \       \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
+        \"Linux\",\r\n        \"name\": \"miqazure-centos1\",\r\n        \"createOption\":
+        \"FromImage\",\r\n        \"vhd\": {\r\n          \"uri\": \"https://miqazuretest14047.blob.core.windows.net/vhds/miqazure-centos12016221104946.vhd\"\r\n
+        \       },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n      \"dataDisks\":
+        []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"miqazure-centos1\",\r\n
+        \     \"adminUsername\": \"dberger\",\r\n      \"linuxConfiguration\": {\r\n
+        \       \"disablePasswordAuthentication\": false\r\n      },\r\n      \"secrets\":
+        []\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611\"}]},\r\n
+        \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
+        true,\r\n        \"storageUri\": \"https://miqazuretest14047.blob.core.windows.net/\"\r\n
+        \     }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n
+        \ \"resources\": [\r\n    {\r\n      \"properties\": {\r\n        \"publisher\":
+        \"Microsoft.OSTCExtensions\",\r\n        \"type\": \"LinuxDiagnostic\",\r\n
+        \       \"typeHandlerVersion\": \"2.0\",\r\n        \"autoUpgradeMinorVersion\":
+        true,\r\n        \"settings\": {\"xmlCfg\":\"PFdhZENmZz48RGlhZ25vc3RpY01vbml0b3JDb25maWd1cmF0aW9uIG92ZXJhbGxRdW90YUluTUI9IjQwOTYiPjxEaWFnbm9zdGljSW5mcmFzdHJ1Y3R1cmVMb2dzIHNjaGVkdWxlZFRyYW5zZmVyUGVyaW9kPSJQVDFNIiBzY2hlZHVsZWRUcmFuc2ZlckxvZ0xldmVsRmlsdGVyPSJXYXJuaW5nIi8+PFBlcmZvcm1hbmNlQ291bnRlcnMgc2NoZWR1bGVkVHJhbnNmZXJQZXJpb2Q9IlBUMU0iPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlTWVtb3J5IiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQnl0ZXMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcUGVyY2VudEF2YWlsYWJsZU1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iTWVtb3J5IHVzZWQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50VXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgcGVyY2VudGFnZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkQnlDYWNoZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHVzZWQgYnkgY2FjaGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1BlclNlYyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50UGVyU2Vjb25kIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFnZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1JlYWRQZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2UgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1dyaXR0ZW5QZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2Ugd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iU3dhcCBhdmFpbGFibGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50QXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZFN3YXAiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlN3YXAgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRJZGxlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgaWRsZSB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFVzZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iUGVyY2VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkNQVSB1c2VyIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50TmljZVRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIG5pY2UgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRQcml2aWxlZ2VkVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgcHJpdmlsZWdlZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudEludGVycnVwdFRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIGludGVycnVwdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudERQQ1RpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIERQQyB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFByb2Nlc3NvclRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIHBlcmNlbnRhZ2UgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50SU9XYWl0VGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgSU8gd2FpdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xSZWFkQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCBndWVzdCBPUyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXFdyaXRlQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGUgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xUcmFuc2ZlcnNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXJzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcUmVhZHNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xXcml0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVJlYWRUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVdyaXRlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlNlY29uZHMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJEaXNrIHdyaXRlIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xBdmVyYWdlVHJhbnNmZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXIgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXEF2ZXJhZ2VEaXNrUXVldWVMZW5ndGgiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcXVldWUgbGVuZ3RoIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVHJhbnNtaXR0ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgb3V0IGd1ZXN0IE9TIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzUmVjZWl2ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgaW4gZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1RyYW5zbWl0dGVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHNlbnQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1JlY2VpdmVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHJlY2VpdmVkIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVG90YWwiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxSeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyByZWNlaXZlZCBlcnJvcnMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxUeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyBzZW50IGVycm9ycyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTmV0d29ya0ludGVyZmFjZVxUb3RhbENvbGxpc2lvbnMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgY29sbGlzaW9ucyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48L1BlcmZvcm1hbmNlQ291bnRlcnM+PE1ldHJpY3MgcmVzb3VyY2VJZD0iL3N1YnNjcmlwdGlvbnMvMjU4NmM2NGItMzhiNC00NTI3LWExNDAtMDEyZDQ5ZGZjMDJjL3Jlc291cmNlR3JvdXBzL21pcS1henVyZS10ZXN0MS9wcm92aWRlcnMvTWljcm9zb2Z0LkNvbXB1dGUvdmlydHVhbE1hY2hpbmVzL21pcWF6dXJlLWNlbnRvczEiPjxNZXRyaWNBZ2dyZWdhdGlvbiBzY2hlZHVsZWRUcmFuc2ZlclBlcmlvZD0iUFQxSCIvPjxNZXRyaWNBZ2dyZWdhdGlvbiBzY2hlZHVsZWRUcmFuc2ZlclBlcmlvZD0iUFQxTSIvPjwvTWV0cmljcz48L0RpYWdub3N0aWNNb25pdG9yQ29uZmlndXJhdGlvbj48L1dhZENmZz4=\",\"StorageAccount\":\"miqazuretest14047\"},\r\n
+        \       \"provisioningState\": \"Succeeded\"\r\n      },\r\n      \"type\":
+        \"Microsoft.Compute/virtualMachines/extensions\",\r\n      \"location\": \"eastus\",\r\n
+        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1/extensions/Microsoft.Insights.VMDiagnosticsSettings\",\r\n
+        \     \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n    }\r\n
+        \ ],\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\":
+        \"eastus\",\r\n  \"tags\": {\r\n    \"Shutdown\": \"true\"\r\n  },\r\n  \"id\":
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1\",\r\n
+        \ \"name\": \"miqazure-centos1\"\r\n}"
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:24 GMT
+  recorded_at: Mon, 12 Mar 2018 09:37:01 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611?api-version=2018-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2450,7 +2482,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcxMTQsIm5iZiI6MTUyMDg0NzExNCwiZXhwIjoxNTIwODUxMDE0LCJhaW8iOiJZMk5nWUxoelZHeHh5QXV4UnU1T3VhaS9iNDVlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoia3BHeFpPRVRWRVNoV20wTXkzQWtBQSIsInZlciI6IjEuMCJ9.gZ-aTEd7yCP2UXqhskazoA2kO9FrY_DtYmqE-ky310zLXRX7T4l3bBrgdGyoriwQVrDcfF9jjUnEkopIy-eaKw_TCT_t1YkBEN3DHuA5Xs3zSHdBY2ojCJbINCdpWV0uqYwds7bimcWPy2FVnLUjU47xrup_eOFDuQm8YDmKrslsI1DIGi8mYUZQ7mN5A4oxqidl42HjzFYxd_Kk8BOLlFNQMhLg3GO6S5Q3YMAECl150dctnndInKOU4J0Iz-RyAE9bkgr7ZbQiFHxBH3FWzcXjyS_QvL7rvdTXVZusiDlziBTRESHq-o99dQSc3M_fpoK0yn887C7dXDNOL-fxlw
   response:
     status:
       code: 200
@@ -2467,158 +2499,11 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"7a8e5fe7-f777-4435-992b-a54f28c2f28c"
+      - W/"26031ef6-bb55-4019-8185-2dd1edcb207c"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - bd22ca22-a01f-4ecf-9230-a4558fb66931
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Correlation-Request-Id:
-      - 19c674a8-c8da-4b5e-8265-5ebc21926459
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102420Z:19c674a8-c8da-4b5e-8265-5ebc21926459
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Mon, 12 Mar 2018 10:24:19 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb2\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2\",\r\n
-        \ \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"e2e30a77-f81b-43fc-9693-08303e43deed\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/backendAddressPools/rspec-lb2-pool\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\r\n
-        \       }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\": [],\r\n    \"probes\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-probe\",\r\n        \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/probes/rspec-lb2-probe\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\": [],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:25 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"a38434c8-7b23-4092-b7c6-402238eac0dc"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 0fd15240-6a1c-4b39-a4f6-aa53fd8591c2
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Correlation-Request-Id:
-      - 5cc03163-922e-41a1-9601-dba2d7cf2a81
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102421Z:5cc03163-922e-41a1-9601-dba2d7cf2a81
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Mon, 12 Mar 2018 10:24:20 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb1-LoadBalancerFrontEnd\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\",\r\n
-        \ \"etag\": \"W/\\\"a38434c8-7b23-4092-b7c6-402238eac0dc\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"f28e0f25-b372-4edf-97d9-13a9e3b4ba2d\",\r\n    \"ipAddress\":
-        \"40.71.82.83\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\":
-        \"Static\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipTags\": [],\r\n
-        \   \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
-        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:25 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"cddd97d1-6111-4477-8a00-3dc885237a1d"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 1403e5b6-8fa0-4cd3-89b1-76b6c4fd805b
+      - 6b46273a-092c-4933-9b4a-89c6b79c9085
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
@@ -2627,23 +2512,1207 @@ http_interactions:
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
       - '14988'
       X-Ms-Correlation-Request-Id:
-      - e4a5f369-a742-466f-bd8f-42e17eaaf9c9
+      - 51f4f1be-0a58-42dc-851a-1767f768f6f9
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102421Z:e4a5f369-a742-466f-bd8f-42e17eaaf9c9
+      - WESTEUROPE:20180312T093701Z:51f4f1be-0a58-42dc-851a-1767f768f6f9
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:21 GMT
+      - Mon, 12 Mar 2018 09:37:00 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb2-publicip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\",\r\n
-        \ \"etag\": \"W/\\\"cddd97d1-6111-4477-8a00-3dc885237a1d\\\"\",\r\n  \"location\":
+      string: "{\r\n  \"name\": \"miqazure-centos1611\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611\",\r\n
+        \ \"etag\": \"W/\\\"26031ef6-bb55-4019-8185-2dd1edcb207c\\\"\",\r\n  \"location\":
         \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"83e7257d-ab94-4229-8eb5-4798f37ef28d\",\r\n    \"publicIPAddressVersion\":
+        \   \"resourceGuid\": \"f1760e49-9853-4fdc-acfc-4ea232b9ed76\",\r\n    \"ipConfigurations\":
+        [\r\n      {\r\n        \"name\": \"ipconfig1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1\",\r\n
+        \       \"etag\": \"W/\\\"26031ef6-bb55-4019-8185-2dd1edcb207c\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"privateIPAddress\": \"10.16.0.5\",\r\n          \"privateIPAllocationMethod\":
+        \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1\"\r\n
+        \         },\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\"\r\n
+        \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
+        \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\":
+        [],\r\n      \"appliedDnsServers\": []\r\n    },\r\n    \"enableAcceleratedNetworking\":
+        false,\r\n    \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\":
+        {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1\"\r\n
+        \   },\r\n    \"virtualMachine\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1\"\r\n
+        \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
+        \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:37:05 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1/instanceView?api-version=2017-12-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcxMTQsIm5iZiI6MTUyMDg0NzExNCwiZXhwIjoxNTIwODUxMDE0LCJhaW8iOiJZMk5nWUxoelZHeHh5QXV4UnU1T3VhaS9iNDVlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoia3BHeFpPRVRWRVNoV20wTXkzQWtBQSIsInZlciI6IjEuMCJ9.gZ-aTEd7yCP2UXqhskazoA2kO9FrY_DtYmqE-ky310zLXRX7T4l3bBrgdGyoriwQVrDcfF9jjUnEkopIy-eaKw_TCT_t1YkBEN3DHuA5Xs3zSHdBY2ojCJbINCdpWV0uqYwds7bimcWPy2FVnLUjU47xrup_eOFDuQm8YDmKrslsI1DIGi8mYUZQ7mN5A4oxqidl42HjzFYxd_Kk8BOLlFNQMhLg3GO6S5Q3YMAECl150dctnndInKOU4J0Iz-RyAE9bkgr7ZbQiFHxBH3FWzcXjyS_QvL7rvdTXVZusiDlziBTRESHq-o99dQSc3M_fpoK0yn887C7dXDNOL-fxlw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/GetInstanceView3Min;4797,Microsoft.Compute/GetInstanceView30Min;23912
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      X-Ms-Request-Id:
+      - ae9e07cd-7802-4c64-a1d1-eea9a773e386
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Correlation-Request-Id:
+      - 5eeba20c-48b5-44cf-90b3-2868141cced8
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T093710Z:5eeba20c-48b5-44cf-90b3-2868141cced8
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:37:09 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"platformUpdateDomain\": 0,\r\n  \"platformFaultDomain\": 0,\r\n
+        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
+        [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
+        \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
+        \"Failed to fetch the VM status.\",\r\n        \"time\": \"2018-03-12T09:37:01+00:00\"\r\n
+        \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"miqazure-centos1\",\r\n
+        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
+        succeeded\",\r\n          \"time\": \"2016-06-22T21:18:47.2011229+00:00\"\r\n
+        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
+        \"https://miqazuretest14047.blob.core.windows.net/bootdiagnostics-miqazurec-796c5bcc-338a-448d-b61c-165279a7fb3e/miqazure-centos1.796c5bcc-338a-448d-b61c-165279a7fb3e.screenshot.bmp\",\r\n
+        \   \"serialConsoleLogBlobUri\": \"https://miqazuretest14047.blob.core.windows.net/bootdiagnostics-miqazurec-796c5bcc-338a-448d-b61c-165279a7fb3e/miqazure-centos1.796c5bcc-338a-448d-b61c-165279a7fb3e.serialconsole.log\"\r\n
+        \ },\r\n  \"extensions\": [\r\n    {\r\n      \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n
+        \   }\r\n  ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n
+        \     \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n
+        \     \"time\": \"2016-06-22T21:18:47.2636196+00:00\"\r\n    },\r\n    {\r\n
+        \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
+        \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:37:14 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups/miq-azure-test1?api-version=2017-08-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcxMTQsIm5iZiI6MTUyMDg0NzExNCwiZXhwIjoxNTIwODUxMDE0LCJhaW8iOiJZMk5nWUxoelZHeHh5QXV4UnU1T3VhaS9iNDVlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoia3BHeFpPRVRWRVNoV20wTXkzQWtBQSIsInZlciI6IjEuMCJ9.gZ-aTEd7yCP2UXqhskazoA2kO9FrY_DtYmqE-ky310zLXRX7T4l3bBrgdGyoriwQVrDcfF9jjUnEkopIy-eaKw_TCT_t1YkBEN3DHuA5Xs3zSHdBY2ojCJbINCdpWV0uqYwds7bimcWPy2FVnLUjU47xrup_eOFDuQm8YDmKrslsI1DIGi8mYUZQ7mN5A4oxqidl42HjzFYxd_Kk8BOLlFNQMhLg3GO6S5Q3YMAECl150dctnndInKOU4J0Iz-RyAE9bkgr7ZbQiFHxBH3FWzcXjyS_QvL7rvdTXVZusiDlziBTRESHq-o99dQSc3M_fpoK0yn887C7dXDNOL-fxlw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Request-Id:
+      - d2653667-0a6f-4918-97ff-7145e7f88e2a
+      X-Ms-Correlation-Request-Id:
+      - d2653667-0a6f-4918-97ff-7145e7f88e2a
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T093713Z:d2653667-0a6f-4918-97ff-7145e7f88e2a
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:37:13 GMT
+      Content-Length:
+      - '183'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1","name":"miq-azure-test1","location":"eastus","properties":{"provisioningState":"Succeeded"}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:37:17 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute/locations/eastus/vmSizes?api-version=2017-12-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcxMTQsIm5iZiI6MTUyMDg0NzExNCwiZXhwIjoxNTIwODUxMDE0LCJhaW8iOiJZMk5nWUxoelZHeHh5QXV4UnU1T3VhaS9iNDVlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoia3BHeFpPRVRWRVNoV20wTXkzQWtBQSIsInZlciI6IjEuMCJ9.gZ-aTEd7yCP2UXqhskazoA2kO9FrY_DtYmqE-ky310zLXRX7T4l3bBrgdGyoriwQVrDcfF9jjUnEkopIy-eaKw_TCT_t1YkBEN3DHuA5Xs3zSHdBY2ojCJbINCdpWV0uqYwds7bimcWPy2FVnLUjU47xrup_eOFDuQm8YDmKrslsI1DIGi8mYUZQ7mN5A4oxqidl42HjzFYxd_Kk8BOLlFNQMhLg3GO6S5Q3YMAECl150dctnndInKOU4J0Iz-RyAE9bkgr7ZbQiFHxBH3FWzcXjyS_QvL7rvdTXVZusiDlziBTRESHq-o99dQSc3M_fpoK0yn887C7dXDNOL-fxlw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/LowCostGet3Min;4753,Microsoft.Compute/LowCostGet30Min;37893
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      X-Ms-Request-Id:
+      - ab93a2c9-6590-4a0e-be0b-5f112763097c
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Correlation-Request-Id:
+      - e60da17f-b47c-46ea-b977-6b73869d7467
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T093713Z:e60da17f-b47c-46ea-b977-6b73869d7467
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:37:13 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"Standard_B1ms\",\r\n
+        \     \"numberOfCores\": 1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        4096,\r\n      \"memoryInMB\": 2048,\r\n      \"maxDataDiskCount\": 2\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_B1s\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        2048,\r\n      \"memoryInMB\": 1024,\r\n      \"maxDataDiskCount\": 2\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_B2ms\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        16384,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_B2s\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        8192,\r\n      \"memoryInMB\": 4096,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_B4ms\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        32768,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_B8ms\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS1_v2\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        7168,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS2_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        14336,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS3_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS4_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS5_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS11-1_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS11_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS12-1_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS12-2_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS12_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS13-2_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS13-4_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS13_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS14-4_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        229376,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS14-8_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        229376,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS14_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        229376,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS15_v2\",\r\n      \"numberOfCores\":
+        20,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        286720,\r\n      \"memoryInMB\": 143360,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS2_v2_Promo\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        14336,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS3_v2_Promo\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS4_v2_Promo\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS5_v2_Promo\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS11_v2_Promo\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS12_v2_Promo\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS13_v2_Promo\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS14_v2_Promo\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        229376,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F1s\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        4096,\r\n      \"memoryInMB\": 2048,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F2s\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        8192,\r\n      \"memoryInMB\": 4096,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F4s\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        16384,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F8s\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        32768,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F16s\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D2s_v3\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        16384,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D4s_v3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        32768,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D8s_v3\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D16s_v3\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        131072,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D32s_v3\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        262144,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A0\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        20480,\r\n      \"memoryInMB\": 768,\r\n      \"maxDataDiskCount\": 1\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A1\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        71680,\r\n      \"memoryInMB\": 1792,\r\n      \"maxDataDiskCount\": 2\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        138240,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        291840,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A5\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        138240,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A4\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        619520,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A6\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        291840,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A7\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        619520,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Basic_A0\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        20480,\r\n      \"memoryInMB\": 768,\r\n      \"maxDataDiskCount\": 1\r\n
+        \   },\r\n    {\r\n      \"name\": \"Basic_A1\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        40960,\r\n      \"memoryInMB\": 1792,\r\n      \"maxDataDiskCount\": 2\r\n
+        \   },\r\n    {\r\n      \"name\": \"Basic_A2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        61440,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Basic_A3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        122880,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Basic_A4\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        245760,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D1_v2\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        51200,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D2_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D3_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D4_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D5_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D11_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D12_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D13_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D14_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D15_v2\",\r\n      \"numberOfCores\":
+        20,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        286720,\r\n      \"memoryInMB\": 143360,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D2_v2_Promo\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D3_v2_Promo\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D4_v2_Promo\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D5_v2_Promo\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D11_v2_Promo\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D12_v2_Promo\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D13_v2_Promo\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D14_v2_Promo\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F1\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        16384,\r\n      \"memoryInMB\": 2048,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        32768,\r\n      \"memoryInMB\": 4096,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F4\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F8\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        131072,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F16\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        262144,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A1_v2\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        10240,\r\n      \"memoryInMB\": 2048,\r\n      \"maxDataDiskCount\": 2\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A2m_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        20480,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A2_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        20480,\r\n      \"memoryInMB\": 4096,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A4m_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        40960,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A4_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        40960,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A8m_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        81920,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A8_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        81920,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D2_v3\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        51200,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D4_v3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D8_v3\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D16_v3\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 65636,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D32_v3\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_H8\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1024000,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_H16\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        2048000,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_H8m\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1024000,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_H16m\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        2048000,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_H16r\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        2048000,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_H16mr\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        2048000,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D1\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        51200,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D4\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D11\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D12\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D13\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D14\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NV6\",\r\n      \"numberOfCores\":
+        6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        389120,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 24\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NV12\",\r\n      \"numberOfCores\":
+        12,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        696320,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 48\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NV24\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1474560,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC6s_v2\",\r\n      \"numberOfCores\":
+        6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        344064,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 12\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC12s_v2\",\r\n      \"numberOfCores\":
+        12,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        688128,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 24\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC24rs_v2\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1376256,\r\n      \"memoryInMB\": 458752,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC24s_v2\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1376256,\r\n      \"memoryInMB\": 458752,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC6\",\r\n      \"numberOfCores\":
+        6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        389120,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 24\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC12\",\r\n      \"numberOfCores\":
+        12,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        696320,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 48\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC24\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1474560,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC24r\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1474560,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS1\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        7168,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        14336,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS4\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS11\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS12\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS13\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS14\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        229376,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC6s_v3\",\r\n      \"numberOfCores\":
+        6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        344064,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 12\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC12s_v3\",\r\n      \"numberOfCores\":
+        12,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        688128,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 24\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC24rs_v3\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1376256,\r\n      \"memoryInMB\": 458752,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC24s_v3\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1376256,\r\n      \"memoryInMB\": 458752,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D64_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1638400,\r\n      \"memoryInMB\": 262144,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D64s_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        524288,\r\n      \"memoryInMB\": 262144,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E2_v3\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        51200,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E4_v3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E8_v3\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E16_v3\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E32_v3\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 262144,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E64i_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1638400,\r\n      \"memoryInMB\": 442368,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E64_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1638400,\r\n      \"memoryInMB\": 442368,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E2s_v3\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        32768,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E4-2s_v3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E4s_v3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E8-2s_v3\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        131072,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E8-4s_v3\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        131072,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E8s_v3\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        131072,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E16-4s_v3\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        262144,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E16-8s_v3\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        262144,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E16s_v3\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        262144,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E32-8s_v3\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        524288,\r\n      \"memoryInMB\": 262144,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E32-16s_v3\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        524288,\r\n      \"memoryInMB\": 262144,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E32s_v3\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        524288,\r\n      \"memoryInMB\": 262144,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E64-16s_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        884736,\r\n      \"memoryInMB\": 442368,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E64-32s_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        884736,\r\n      \"memoryInMB\": 442368,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E64is_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        884736,\r\n      \"memoryInMB\": 442368,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E64s_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        884736,\r\n      \"memoryInMB\": 442368,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F2s_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        16384,\r\n      \"memoryInMB\": 4096,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F4s_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        32768,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F8s_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F16s_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        131072,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F32s_v2\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        262144,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F64s_v2\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        524288,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F72s_v2\",\r\n      \"numberOfCores\":
+        72,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        589824,\r\n      \"memoryInMB\": 147456,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_L8s_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1811981,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_L16s_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        3623962,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_ND6s\",\r\n      \"numberOfCores\":
+        6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        344064,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 12\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_ND12s\",\r\n      \"numberOfCores\":
+        12,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        688128,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 24\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_ND24rs\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1376256,\r\n      \"memoryInMB\": 458752,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_ND24s\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1376256,\r\n      \"memoryInMB\": 458752,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A8\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        391168,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A9\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        391168,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A10\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        391168,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A11\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        391168,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   }\r\n  ]\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:37:18 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcxMTQsIm5iZiI6MTUyMDg0NzExNCwiZXhwIjoxNTIwODUxMDE0LCJhaW8iOiJZMk5nWUxoelZHeHh5QXV4UnU1T3VhaS9iNDVlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoia3BHeFpPRVRWRVNoV20wTXkzQWtBQSIsInZlciI6IjEuMCJ9.gZ-aTEd7yCP2UXqhskazoA2kO9FrY_DtYmqE-ky310zLXRX7T4l3bBrgdGyoriwQVrDcfF9jjUnEkopIy-eaKw_TCT_t1YkBEN3DHuA5Xs3zSHdBY2ojCJbINCdpWV0uqYwds7bimcWPy2FVnLUjU47xrup_eOFDuQm8YDmKrslsI1DIGi8mYUZQ7mN5A4oxqidl42HjzFYxd_Kk8BOLlFNQMhLg3GO6S5Q3YMAECl150dctnndInKOU4J0Iz-RyAE9bkgr7ZbQiFHxBH3FWzcXjyS_QvL7rvdTXVZusiDlziBTRESHq-o99dQSc3M_fpoK0yn887C7dXDNOL-fxlw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"734a3944-a880-444c-8c92-cace6e28e303"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 7fb7631f-6334-423e-a21e-645e975389bf
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Correlation-Request-Id:
+      - 71d1fbe1-46c1-40f6-a793-676234294d48
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T093714Z:71d1fbe1-46c1-40f6-a793-676234294d48
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:37:14 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"miqazure-centos1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1\",\r\n
+        \ \"etag\": \"W/\\\"734a3944-a880-444c-8c92-cace6e28e303\\\"\",\r\n  \"location\":
+        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"475a66f0-9e89-4226-a9f0-9baaaf31d619\",\r\n    \"publicIPAddressVersion\":
         \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
-        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
+        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1\"\r\n
         \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
         \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:26 GMT
+  recorded_at: Mon, 12 Mar 2018 09:37:19 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047?api-version=2017-10-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcxMTQsIm5iZiI6MTUyMDg0NzExNCwiZXhwIjoxNTIwODUxMDE0LCJhaW8iOiJZMk5nWUxoelZHeHh5QXV4UnU1T3VhaS9iNDVlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoia3BHeFpPRVRWRVNoV20wTXkzQWtBQSIsInZlciI6IjEuMCJ9.gZ-aTEd7yCP2UXqhskazoA2kO9FrY_DtYmqE-ky310zLXRX7T4l3bBrgdGyoriwQVrDcfF9jjUnEkopIy-eaKw_TCT_t1YkBEN3DHuA5Xs3zSHdBY2ojCJbINCdpWV0uqYwds7bimcWPy2FVnLUjU47xrup_eOFDuQm8YDmKrslsI1DIGi8mYUZQ7mN5A4oxqidl42HjzFYxd_Kk8BOLlFNQMhLg3GO6S5Q3YMAECl150dctnndInKOU4J0Iz-RyAE9bkgr7ZbQiFHxBH3FWzcXjyS_QvL7rvdTXVZusiDlziBTRESHq-o99dQSc3M_fpoK0yn887C7dXDNOL-fxlw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 96f2f9c5-adeb-49e3-86fe-39c6ab17fada
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14988'
+      X-Ms-Correlation-Request-Id:
+      - ee83b669-07e9-4731-990e-6b4e4eeac49a
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T093720Z:ee83b669-07e9-4731-990e-6b4e4eeac49a
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:37:20 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","name":"miqazuretest14047","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T17:30:25.7028008Z","primaryEndpoints":{"blob":"https://miqazuretest14047.blob.core.windows.net/","queue":"https://miqazuretest14047.queue.core.windows.net/","table":"https://miqazuretest14047.table.core.windows.net/","file":"https://miqazuretest14047.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:37:25 GMT
+- request:
+    method: post
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047/listKeys?api-version=2017-10-01
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcxMTQsIm5iZiI6MTUyMDg0NzExNCwiZXhwIjoxNTIwODUxMDE0LCJhaW8iOiJZMk5nWUxoelZHeHh5QXV4UnU1T3VhaS9iNDVlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoia3BHeFpPRVRWRVNoV20wTXkzQWtBQSIsInZlciI6IjEuMCJ9.gZ-aTEd7yCP2UXqhskazoA2kO9FrY_DtYmqE-ky310zLXRX7T4l3bBrgdGyoriwQVrDcfF9jjUnEkopIy-eaKw_TCT_t1YkBEN3DHuA5Xs3zSHdBY2ojCJbINCdpWV0uqYwds7bimcWPy2FVnLUjU47xrup_eOFDuQm8YDmKrslsI1DIGi8mYUZQ7mN5A4oxqidl42HjzFYxd_Kk8BOLlFNQMhLg3GO6S5Q3YMAECl150dctnndInKOU4J0Iz-RyAE9bkgr7ZbQiFHxBH3FWzcXjyS_QvL7rvdTXVZusiDlziBTRESHq-o99dQSc3M_fpoK0yn887C7dXDNOL-fxlw
+      Content-Length:
+      - '0'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 2951bbb6-c3a8-4d3e-b751-5b8e3e812bbf
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Writes:
+      - '1199'
+      X-Ms-Correlation-Request-Id:
+      - 03cf3e37-db5e-4103-8fbb-42a926052e3a
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T093721Z:03cf3e37-db5e-4103-8fbb-42a926052e3a
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:37:21 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"keys":[{"keyName":"key1","value":"9hGLwV9mjvAc1ARzeGwpsS9oZPLqOBzHCCHjeixyt1wpPYVn32cXmm3Gs9ogFPXZhDH61PAXxud0Dg/qwOnJ1w==","permissions":"Full"},{"keyName":"key2","value":"FfW8btVjJE2LkKHvN8Prr3FDX71BrS4SnMkONq2fLVPPm6x7vqqjeDSWDh17aI4CBLYf3Y1pc6njkbz53HdMYg==","permissions":"Full"}]}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:37:26 GMT
+- request:
+    method: head
+    uri: https://miqazuretest14047.blob.core.windows.net/vhds/miqazure-centos12016221104946.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:37:26 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey miqazuretest14047:q/PXadVhXfJNT3h8rOJnBVGNeGRoAHsaBgw6eB4KO3s=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '32212255232'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - bLK7rgT7IgMNX2YxL9BCyg==
+      Last-Modified:
+      - Fri, 22 Apr 2016 19:05:58 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D36AE123954B35"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 1a977db9-001e-008f-0fe5-b96823000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Meta-Microsoftazurecompute-Resourcegroupname:
+      - miq-azure-test1
+      X-Ms-Meta-Microsoftazurecompute-Vmname:
+      - miqazure-centos1
+      X-Ms-Meta-Microsoftazurecompute-Diskid:
+      - 66656abf-e460-45ac-a6f0-851d0a50b23a
+      X-Ms-Meta-Microsoftazurecompute-Diskname:
+      - miqazure-centos1
+      X-Ms-Meta-Microsoftazurecompute-Disktype:
+      - OSDisk
+      X-Ms-Lease-Status:
+      - locked
+      X-Ms-Lease-State:
+      - leased
+      X-Ms-Lease-Duration:
+      - infinite
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '1'
+      X-Ms-Copy-Id:
+      - 549dd428-4055-4337-a425-05293b903858
+      X-Ms-Copy-Source:
+      - https://ardfepirv2bl5prdstr06.blob.core.windows.net/5112500ae3b842c8b9c604889f8753c3/OpenLogic-CentOS-71-20160308?sv=2014-02-14&sr=b&si=PirCacheAccountPublisherContainerPolicy&sig=fxe20jiCl%2Foys9OSvljXlookVPi76KM8FYlTr%2BSY4IQ%3D
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 32212255232/32212255232
+      X-Ms-Copy-Completion-Time:
+      - Mon, 21 Mar 2016 16:50:14 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Mon, 12 Mar 2018 09:37:22 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:37:26 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcxMTQsIm5iZiI6MTUyMDg0NzExNCwiZXhwIjoxNTIwODUxMDE0LCJhaW8iOiJZMk5nWUxoelZHeHh5QXV4UnU1T3VhaS9iNDVlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoia3BHeFpPRVRWRVNoV20wTXkzQWtBQSIsInZlciI6IjEuMCJ9.gZ-aTEd7yCP2UXqhskazoA2kO9FrY_DtYmqE-ky310zLXRX7T4l3bBrgdGyoriwQVrDcfF9jjUnEkopIy-eaKw_TCT_t1YkBEN3DHuA5Xs3zSHdBY2ojCJbINCdpWV0uqYwds7bimcWPy2FVnLUjU47xrup_eOFDuQm8YDmKrslsI1DIGi8mYUZQ7mN5A4oxqidl42HjzFYxd_Kk8BOLlFNQMhLg3GO6S5Q3YMAECl150dctnndInKOU4J0Iz-RyAE9bkgr7ZbQiFHxBH3FWzcXjyS_QvL7rvdTXVZusiDlziBTRESHq-o99dQSc3M_fpoK0yn887C7dXDNOL-fxlw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"f1907e14-fcad-4f75-8faa-ab325bf879d9"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 6fd60d7a-fea7-4cad-a34d-a638356e1ef7
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Correlation-Request-Id:
+      - 3bbf549e-5533-46e1-a72f-be4b2530b320
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T093722Z:3bbf549e-5533-46e1-a72f-be4b2530b320
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:37:22 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"miqazure-centos1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1\",\r\n
+        \ \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/networkSecurityGroups\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
+        \"9ca49a93-6f7d-464c-b23d-e61e847ce2d6\",\r\n    \"securityRules\": [\r\n
+        \     {\r\n        \"name\": \"default-allow-ssh\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/securityRules/default-allow-ssh\",\r\n
+        \       \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"protocol\": \"Tcp\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"22\",\r\n          \"sourceAddressPrefix\":
+        \"*\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n          \"access\":
+        \"Allow\",\r\n          \"priority\": 1000,\r\n          \"direction\": \"Inbound\",\r\n
+        \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      }\r\n    ],\r\n    \"defaultSecurityRules\": [\r\n
+        \     {\r\n        \"name\": \"AllowVnetInBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/defaultSecurityRules/AllowVnetInBound\",\r\n
+        \       \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow inbound traffic from all VMs in VNET\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"VirtualNetwork\",\r\n          \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n          \"direction\":
+        \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowAzureLoadBalancerInBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/defaultSecurityRules/AllowAzureLoadBalancerInBound\",\r\n
+        \       \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow inbound traffic from azure load balancer\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"AzureLoadBalancer\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65001,\r\n          \"direction\":
+        \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllInBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/defaultSecurityRules/DenyAllInBound\",\r\n
+        \       \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Deny all inbound traffic\",\r\n          \"protocol\":
+        \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\":
+        \"*\",\r\n          \"sourceAddressPrefix\": \"*\",\r\n          \"destinationAddressPrefix\":
+        \"*\",\r\n          \"access\": \"Deny\",\r\n          \"priority\": 65500,\r\n
+        \         \"direction\": \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n
+        \         \"destinationPortRanges\": [],\r\n          \"sourceAddressPrefixes\":
+        [],\r\n          \"destinationAddressPrefixes\": []\r\n        }\r\n      },\r\n
+        \     {\r\n        \"name\": \"AllowVnetOutBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/defaultSecurityRules/AllowVnetOutBound\",\r\n
+        \       \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow outbound traffic from all VMs to all VMs
+        in VNET\",\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\":
+        \"*\",\r\n          \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"VirtualNetwork\",\r\n          \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n          \"direction\":
+        \"Outbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowInternetOutBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/defaultSecurityRules/AllowInternetOutBound\",\r\n
+        \       \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow outbound traffic from all VMs to Internet\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"*\",\r\n          \"destinationAddressPrefix\": \"Internet\",\r\n          \"access\":
+        \"Allow\",\r\n          \"priority\": 65001,\r\n          \"direction\": \"Outbound\",\r\n
+        \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllOutBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/defaultSecurityRules/DenyAllOutBound\",\r\n
+        \       \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Deny all outbound traffic\",\r\n          \"protocol\":
+        \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\":
+        \"*\",\r\n          \"sourceAddressPrefix\": \"*\",\r\n          \"destinationAddressPrefix\":
+        \"*\",\r\n          \"access\": \"Deny\",\r\n          \"priority\": 65500,\r\n
+        \         \"direction\": \"Outbound\",\r\n          \"sourcePortRanges\":
+        [],\r\n          \"destinationPortRanges\": [],\r\n          \"sourceAddressPrefixes\":
+        [],\r\n          \"destinationAddressPrefixes\": []\r\n        }\r\n      }\r\n
+        \   ],\r\n    \"networkInterfaces\": [\r\n      {\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611\"\r\n
+        \     }\r\n    ]\r\n  }\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:37:27 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcxMTQsIm5iZiI6MTUyMDg0NzExNCwiZXhwIjoxNTIwODUxMDE0LCJhaW8iOiJZMk5nWUxoelZHeHh5QXV4UnU1T3VhaS9iNDVlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoia3BHeFpPRVRWRVNoV20wTXkzQWtBQSIsInZlciI6IjEuMCJ9.gZ-aTEd7yCP2UXqhskazoA2kO9FrY_DtYmqE-ky310zLXRX7T4l3bBrgdGyoriwQVrDcfF9jjUnEkopIy-eaKw_TCT_t1YkBEN3DHuA5Xs3zSHdBY2ojCJbINCdpWV0uqYwds7bimcWPy2FVnLUjU47xrup_eOFDuQm8YDmKrslsI1DIGi8mYUZQ7mN5A4oxqidl42HjzFYxd_Kk8BOLlFNQMhLg3GO6S5Q3YMAECl150dctnndInKOU4J0Iz-RyAE9bkgr7ZbQiFHxBH3FWzcXjyS_QvL7rvdTXVZusiDlziBTRESHq-o99dQSc3M_fpoK0yn887C7dXDNOL-fxlw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"a8b09238-30fc-4b36-a58d-e3cc69e267c5"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 0dbf4c68-d4e2-4677-b1a0-559faff4a3f4
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Correlation-Request-Id:
+      - 5305db91-6d46-46b8-8423-ceb48cf244cb
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T093723Z:5305db91-6d46-46b8-8423-ceb48cf244cb
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:37:22 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"miq-azure-test1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1\",\r\n
+        \ \"etag\": \"W/\\\"a8b09238-30fc-4b36-a58d-e3cc69e267c5\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
+        \"d74c1e5f-50e4-4c8a-a7fe-78eaddc6b915\",\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\":
+        [\r\n        \"10.16.0.0/16\"\r\n      ]\r\n    },\r\n    \"subnets\": [\r\n
+        \     {\r\n        \"name\": \"default\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\",\r\n
+        \       \"etag\": \"W/\\\"a8b09238-30fc-4b36-a58d-e3cc69e267c5\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"addressPrefix\": \"10.16.0.0/24\",\r\n          \"ipConfigurations\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241/ipConfigurations/ipconfig1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1/ipConfigurations/miqmismatch1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/dbergerprov1/ipConfigurations/dbergerprov1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/ladas_test_1/ipConfigurations/ladas_test_1\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"virtualNetworkPeerings\":
+        [],\r\n    \"enableDdosProtection\": false,\r\n    \"enableVmProtection\":
+        false\r\n  }\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:37:28 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_0/powered_on_vm_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_0/powered_on_vm_refresh.yml
@@ -37,25 +37,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 52c1de08-b128-42fc-9561-aa8613610000
+      - f5698636-f5d0-45d3-8ef6-5a12023e2300
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzii4xxCETCGlz2oJJw8byc9rlPe_ZoPzPQhJhsV7d4OdDMabBk_1LM-mbgfaLP7OkszU_76w2liuGlZ3bHsUYoME2HrufC6N5uUj8rT_J6SoNhAoPozcQB-6PN_BREoC96NuliBR37y7vTwySXLCtfiGxuyw72PrueFKeTj6gAeQgAA;
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzKn73qX9YOwCAOrIdWGtQvlYKqyJkR5kacucA77wrS_04ZjT4azguEyd9ZHYqV3kcWWg5WReKaa40fbIL5K4D9S4PssU1HXBk2rT7hULwo6ob2xFj-c1jpgY4EgQ020v2u-25DihR1bpTU6yxPdp8DsWWU5wm7eoqN6hd8THUNNQgAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=004; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=003; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Wed, 07 Mar 2018 20:16:35 GMT
+      - Mon, 12 Mar 2018 09:26:00 GMT
       Content-Length:
       - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1520457395","not_before":"1520453495","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0OTUsIm5iZiI6MTUyMDQ1MzQ5NSwiZXhwIjoxNTIwNDU3Mzk1LCJhaW8iOiJZMk5nWUVndU5CSXl1MXFVeEdEM2ZsSFpieWtHQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ043QlVpaXhfRUtWWWFxR0UyRUFBQSIsInZlciI6IjEuMCJ9.Aj1ctOMBOwBnIeeKdPOaEyzKn5BJN38vjYfTjEdBR3O28GkzKMNrI9osuXXUl-MZJJjHUa5YF9Q23kHoF_2jX6dg692lNdMVrlwFPt61fGgAaiwbz2z05M2vMgtGCRUwh29B9F0SQYNYPIfKFQiPxwTNasGnKv5UVCcyoGkRikbbnqf97GkqW96sykNL5uBWq6Hfs55GNa0vU8-aWsNxc3ErY-w8Ae4dQnYJDNkbBZxWg2qdWcYYyYQt-Rg86PUd8Akishqc7_yKDkqMgLE6g_9GLPvBAQFR1tmoclkHfLbQUD-hjqoXQnNLmwn6TOg54jBmYjHdu2OLrPt0M8pMcA"}'
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1520850360","not_before":"1520846460","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDY0NjAsIm5iZiI6MTUyMDg0NjQ2MCwiZXhwIjoxNTIwODUwMzYwLCJhaW8iOiJZMk5nWUdBTzluZzJLY25wRWNmV20xS1NCOXJmQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTm9acDlkRDEwMFdPOWxvU0FqNGpBQSIsInZlciI6IjEuMCJ9.RT1lqldgy3xYclH7HEXx7zoes4517ZvTUJjlw0mHn9Dpn0GXG9OP28f2qqRR5NfcfCG9097_OHuFrg9Gs7R6J2MZ2CwLwPnVjxEwlc2wNxlSwlNGoRK20-73mpDZSYlRTty10TnjMgiIeQyKhlRGORoz4exaj0vCpMLsGm8dOp0IGVMQNG52VzYouCB2dRYpzXZs4qIkR090uJDCNBiqg2V0qlvSH-aJbhTgZ6meOh7S03o81RLuEnBOXjyYImq2dFuv1jWtAo1t45ePcE-LRcyTgjPDR9cNx0s_7gqd8aqAKqKxq98hRQdK5Kx8aM1jVMJQhWy1AJIwhmRhLNrsHA"}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:35 GMT
+  recorded_at: Mon, 12 Mar 2018 09:26:05 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -72,7 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0OTUsIm5iZiI6MTUyMDQ1MzQ5NSwiZXhwIjoxNTIwNDU3Mzk1LCJhaW8iOiJZMk5nWUVndU5CSXl1MXFVeEdEM2ZsSFpieWtHQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ043QlVpaXhfRUtWWWFxR0UyRUFBQSIsInZlciI6IjEuMCJ9.Aj1ctOMBOwBnIeeKdPOaEyzKn5BJN38vjYfTjEdBR3O28GkzKMNrI9osuXXUl-MZJJjHUa5YF9Q23kHoF_2jX6dg692lNdMVrlwFPt61fGgAaiwbz2z05M2vMgtGCRUwh29B9F0SQYNYPIfKFQiPxwTNasGnKv5UVCcyoGkRikbbnqf97GkqW96sykNL5uBWq6Hfs55GNa0vU8-aWsNxc3ErY-w8Ae4dQnYJDNkbBZxWg2qdWcYYyYQt-Rg86PUd8Akishqc7_yKDkqMgLE6g_9GLPvBAQFR1tmoclkHfLbQUD-hjqoXQnNLmwn6TOg54jBmYjHdu2OLrPt0M8pMcA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDY0NjAsIm5iZiI6MTUyMDg0NjQ2MCwiZXhwIjoxNTIwODUwMzYwLCJhaW8iOiJZMk5nWUdBTzluZzJLY25wRWNmV20xS1NCOXJmQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTm9acDlkRDEwMFdPOWxvU0FqNGpBQSIsInZlciI6IjEuMCJ9.RT1lqldgy3xYclH7HEXx7zoes4517ZvTUJjlw0mHn9Dpn0GXG9OP28f2qqRR5NfcfCG9097_OHuFrg9Gs7R6J2MZ2CwLwPnVjxEwlc2wNxlSwlNGoRK20-73mpDZSYlRTty10TnjMgiIeQyKhlRGORoz4exaj0vCpMLsGm8dOp0IGVMQNG52VzYouCB2dRYpzXZs4qIkR090uJDCNBiqg2V0qlvSH-aJbhTgZ6meOh7S03o81RLuEnBOXjyYImq2dFuv1jWtAo1t45ePcE-LRcyTgjPDR9cNx0s_7gqd8aqAKqKxq98hRQdK5Kx8aM1jVMJQhWy1AJIwhmRhLNrsHA
   response:
     status:
       code: 200
@@ -91,26 +91,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14998'
+      - '14999'
       X-Ms-Request-Id:
-      - d50f0f14-c359-446a-ace7-28a5d3356a52
+      - 0277b192-73d2-4b2e-8212-f48f5d5b7596
       X-Ms-Correlation-Request-Id:
-      - d50f0f14-c359-446a-ace7-28a5d3356a52
+      - 0277b192-73d2-4b2e-8212-f48f5d5b7596
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201635Z:d50f0f14-c359-446a-ace7-28a5d3356a52
+      - WESTEUROPE:20180312T092601Z:0277b192-73d2-4b2e-8212-f48f5d5b7596
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:16:34 GMT
+      - Mon, 12 Mar 2018 09:26:01 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID","subscriptionId":"AZURE_SUBSCRIPTION_ID","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:35 GMT
+  recorded_at: Mon, 12 Mar 2018 09:26:06 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers?api-version=2015-01-01
@@ -127,7 +127,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0OTUsIm5iZiI6MTUyMDQ1MzQ5NSwiZXhwIjoxNTIwNDU3Mzk1LCJhaW8iOiJZMk5nWUVndU5CSXl1MXFVeEdEM2ZsSFpieWtHQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ043QlVpaXhfRUtWWWFxR0UyRUFBQSIsInZlciI6IjEuMCJ9.Aj1ctOMBOwBnIeeKdPOaEyzKn5BJN38vjYfTjEdBR3O28GkzKMNrI9osuXXUl-MZJJjHUa5YF9Q23kHoF_2jX6dg692lNdMVrlwFPt61fGgAaiwbz2z05M2vMgtGCRUwh29B9F0SQYNYPIfKFQiPxwTNasGnKv5UVCcyoGkRikbbnqf97GkqW96sykNL5uBWq6Hfs55GNa0vU8-aWsNxc3ErY-w8Ae4dQnYJDNkbBZxWg2qdWcYYyYQt-Rg86PUd8Akishqc7_yKDkqMgLE6g_9GLPvBAQFR1tmoclkHfLbQUD-hjqoXQnNLmwn6TOg54jBmYjHdu2OLrPt0M8pMcA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDY0NjAsIm5iZiI6MTUyMDg0NjQ2MCwiZXhwIjoxNTIwODUwMzYwLCJhaW8iOiJZMk5nWUdBTzluZzJLY25wRWNmV20xS1NCOXJmQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTm9acDlkRDEwMFdPOWxvU0FqNGpBQSIsInZlciI6IjEuMCJ9.RT1lqldgy3xYclH7HEXx7zoes4517ZvTUJjlw0mHn9Dpn0GXG9OP28f2qqRR5NfcfCG9097_OHuFrg9Gs7R6J2MZ2CwLwPnVjxEwlc2wNxlSwlNGoRK20-73mpDZSYlRTty10TnjMgiIeQyKhlRGORoz4exaj0vCpMLsGm8dOp0IGVMQNG52VzYouCB2dRYpzXZs4qIkR090uJDCNBiqg2V0qlvSH-aJbhTgZ6meOh7S03o81RLuEnBOXjyYImq2dFuv1jWtAo1t45ePcE-LRcyTgjPDR9cNx0s_7gqd8aqAKqKxq98hRQdK5Kx8aM1jVMJQhWy1AJIwhmRhLNrsHA
   response:
     status:
       code: 200
@@ -144,39 +144,37 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14981'
+      - '14996'
       X-Ms-Request-Id:
-      - e83699ba-2a2a-486e-a875-461c1ed9a6a9
+      - 71c754b0-01bf-4031-ba4b-0d5efb23811e
       X-Ms-Correlation-Request-Id:
-      - e83699ba-2a2a-486e-a875-461c1ed9a6a9
+      - 71c754b0-01bf-4031-ba4b-0d5efb23811e
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201638Z:e83699ba-2a2a-486e-a875-461c1ed9a6a9
+      - WESTEUROPE:20180312T092603Z:71c754b0-01bf-4031-ba4b-0d5efb23811e
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:16:37 GMT
+      - Mon, 12 Mar 2018 09:26:03 GMT
       Content-Length:
-      - '310901'
+      - '320853'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"},{"applicationId":"d87dcbc6-a371-462e-88e3-28ad15ec4e64","roleDefinitionId":"861776c5-e0df-4f95-be4f-ac1eec193323"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
+      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"},{"applicationId":"d87dcbc6-a371-462e-88e3-28ad15ec4e64","roleDefinitionId":"861776c5-e0df-4f95-be4f-ac1eec193323"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["East
+        Asia","Southeast Asia","Australia East","Australia Southeast","Japan East","Japan
+        West","Central India","South India","West India","West Europe","North Europe","Canada
+        Central","Canada East","Brazil South","West US","Central US","East US","South
+        Central US","East US 2","West Central US","North Central US","West US 2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
         US","Central US","East US","South Central US","West Europe","North Europe","East
         Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
         Central US","North Central US","Japan East","Japan West","Brazil South","Central
         India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"operations","locations":["West
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["East
+        Asia","Southeast Asia","Australia East","Australia Southeast","Japan East","Japan
+        West","Central India","South India","West India","West Europe","North Europe","Canada
+        Central","Canada East","Brazil South","West US","Central US","East US","South
+        Central US","East US 2","West Central US","North Central US","West US 2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"operations","locations":["West
         US","Central US","East US","South Central US","West Europe","North Europe","East
         Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
         Central US","North Central US","Japan East","Japan West","Brazil South","Central
@@ -232,177 +230,177 @@ http_interactions:
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/internalLoadBalancers","locations":[],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"domainNames/slots/roles/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"domainNames/slots/roles/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"domainNames/capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"domainNames/serviceCertificates","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
         US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
         Central","Canada East","UK South","UK West","West US","Central US","South
         Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
-        East","Australia Southeast","West US 2","West Central US","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        East","Australia Southeast","West US 2","West Central US","France Central","South
+        India","Central India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
         US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
         Central","Canada East","UK South","UK West","West US","Central US","South
         Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
-        East","Australia Southeast","West US 2","West Central US","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metrics","locations":["North
+        East","Australia Southeast","West US 2","West Central US","France Central","South
+        India","Central India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metrics","locations":["North
         Central US","South Central US","East US","East US 2","Canada Central","Canada
         East","West US","West US 2","West Central US","Central US","East Asia","Southeast
         Asia","North Europe","West Europe","UK South","UK West","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"resourceTypes","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"moveSubscriptionResources","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"validateSubscriptionMoveAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operationStatuses","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operatingSystems","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"operatingSystemFamilies","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicNetwork","namespace":"Microsoft.ClassicNetwork","resourceTypes":[{"resourceType":"virtualNetworks","locations":["East
+        India","West India","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"resourceTypes","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"moveSubscriptionResources","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"validateSubscriptionMoveAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operationStatuses","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operatingSystems","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"operatingSystemFamilies","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicNetwork","namespace":"Microsoft.ClassicNetwork","resourceTypes":[{"resourceType":"virtualNetworks","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"virtualNetworks/remoteVirtualNetworkPeeringProxies","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01"]},{"resourceType":"virtualNetworks/remoteVirtualNetworkPeeringProxies","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"reservedIps","locations":["East
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01"]},{"resourceType":"reservedIps","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"gatewaySupportedDevices","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"networkSecurityGroups","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"gatewaySupportedDevices","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"networkSecurityGroups","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicStorage","namespace":"Microsoft.ClassicStorage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"expressRouteCrossConnections","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"expressRouteCrossConnections/peerings","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicStorage","namespace":"Microsoft.ClassicStorage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkStorageAccountAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"storageAccounts/services","locations":["West
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkStorageAccountAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"storageAccounts/services","locations":["West
         US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
         Asia","Australia East","Australia Southeast","South India","Central India","West
         India","West US 2","West Central US","East US","East US 2","North Central
         US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
-        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/diagnosticSettings","locations":["West
+        South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/diagnosticSettings","locations":["West
         US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
         Asia","Australia East","Australia Southeast","South India","Central India","West
         India","West US 2","West Central US","East US","East US 2","North Central
         US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
-        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"disks","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"images","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"vmImages","locations":[],"apiVersions":["2016-11-01"]},{"resourceType":"publicImages","locations":[],"apiVersions":["2016-11-01","2016-04-01"]},{"resourceType":"osImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"osPlatformImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute","namespace":"Microsoft.Compute","authorizations":[{"applicationId":"60e6cd67-9c8c-4951-9b3c-23c25a2169af","roleDefinitionId":"e4770acb-272e-4dc8-87f3-12f44a612224"},{"applicationId":"a303894e-f1d8-4a37-bf10-67aa654a0596","roleDefinitionId":"903ac751-8ad5-4e5a-bfc2-5e49f450a241"},{"applicationId":"a8b6bf88-1d1a-4626-b040-9a729ea93c65","roleDefinitionId":"45c8267c-80ba-4b96-9a43-115b8f49fccd"}],"resourceTypes":[{"resourceType":"availabilitySets","locations":["East
+        South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"disks","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"images","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"vmImages","locations":[],"apiVersions":["2016-11-01"]},{"resourceType":"storageAccounts/vmImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"publicImages","locations":[],"apiVersions":["2016-11-01","2016-04-01"]},{"resourceType":"osImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"osPlatformImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute","namespace":"Microsoft.Compute","authorizations":[{"applicationId":"60e6cd67-9c8c-4951-9b3c-23c25a2169af","roleDefinitionId":"e4770acb-272e-4dc8-87f3-12f44a612224"},{"applicationId":"a303894e-f1d8-4a37-bf10-67aa654a0596","roleDefinitionId":"903ac751-8ad5-4e5a-bfc2-5e49f450a241"},{"applicationId":"a8b6bf88-1d1a-4626-b040-9a729ea93c65","roleDefinitionId":"45c8267c-80ba-4b96-9a43-115b8f49fccd"}],"resourceTypes":[{"resourceType":"availabilitySets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations/usages","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations/usages","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"sharedVMImages","locations":["West
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"sharedVMImages","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"sharedVMImages/versions","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"locations/capsoperations","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"disks","locations":["Southeast
@@ -410,27 +408,27 @@ http_interactions:
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"snapshots","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"snapshots","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"locations/diskoperations","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"locations/diskoperations","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"images","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"images","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"]},{"resourceType":"locations/logAnalytics","locations":["East
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"]},{"resourceType":"locations/logAnalytics","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
         US","East US","South Central US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
@@ -547,7 +545,12 @@ http_interactions:
         US","East Asia","East US","East US 2","Japan East","Japan West","North Central
         US","North Europe","South Central US","South India","Southeast Asia","West
         Central US","West Europe","West India","West US","West US 2","UK West","UK
-        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"},{"applicationId":"f5c26e74-f226-4ae8-85f0-b4af0080ac9e","roleDefinitionId":"529d7ae6-e892-4d43-809d-8547aeb90643"}],"resourceTypes":[{"resourceType":"components","locations":["East
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/consumergroups","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/disasterrecoveryconfigs","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"},{"applicationId":"f5c26e74-f226-4ae8-85f0-b4af0080ac9e","roleDefinitionId":"529d7ae6-e892-4d43-809d-8547aeb90643"}],"resourceTypes":[{"resourceType":"components","locations":["East
         US","South Central US","North Europe","West Europe","Southeast Asia","West
         US 2"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
         US","South Central US","North Europe","West Europe","Southeast Asia","West
@@ -614,32 +617,32 @@ http_interactions:
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/accessPolicies","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"vaults/accessPolicies","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-10-01","2015-06-01","2014-12-19-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"deletedVaults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01","2014-12-19-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"deletedVaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-10-01"]},{"resourceType":"locations/deletedVaults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations/deletedVaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
         Central US","West Europe","Southeast Asia","Japan East","West Central US"],"apiVersions":["2016-04-01"]},{"resourceType":"webServices","locations":["South
         Central US","West Europe","Southeast Asia","Japan East","East US 2","West
         Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"operations","locations":["South
@@ -665,97 +668,97 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"networkWatchers/lenses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"networkWatchers/lenses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","West
         US 2","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
@@ -846,7 +849,7 @@ http_interactions:
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
         West","Korea Central","Korea South"],"apiVersions":["2017-07-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ResourceHealth","namespace":"Microsoft.ResourceHealth","authorizations":[{"applicationId":"8bdebf23-c0fe-4187-a378-717ad86f6a53","roleDefinitionId":"cc026344-c8b1-4561-83ba-59eba84b27cc"}],"resourceTypes":[{"resourceType":"availabilityStatuses","locations":[],"apiVersions":["2017-07-01","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"notifications","locations":["Australia
-        Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Security","namespace":"Microsoft.Security","authorization":{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
+        Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Security","namespace":"Microsoft.Security","authorizations":[{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},{"applicationId":"fc780465-2017-40d4-a0c5-307022471b92"}],"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatuses","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/virtualMachines","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/endpoints","locations":["Central
@@ -898,565 +901,595 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Central India","South
         India"],"apiVersions":["2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Sql","namespace":"Microsoft.Sql","authorizations":[{"applicationId":"e4ab13ed-33cb-41b4-9140-6e264582cf85","roleDefinitionId":"ec3ddc95-44dc-47a2-9926-5e9f5ffd44ec"},{"applicationId":"0130cc9f-7ac5-4026-bd5f-80a08a54e6d9","roleDefinitionId":"45e8abf8-0ec4-44f3-9c37-cff4f7779302"},{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},{"applicationId":"76c7f279-7959-468f-8943-3954880e0d8c","roleDefinitionId":"7f7513a8-73f9-4c5f-97a2-c41f0ea783ef"}],"resourceTypes":[{"resourceType":"operations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/capabilities","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/databaseAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/databaseOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverKeyOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/keys","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/encryptionProtector","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/usages","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01","2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/communicationLinks","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administrators","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administratorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/restorableDroppedDatabases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recoverableDatabases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/geoBackupPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/importExportOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/operationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/backupLongTermRetentionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/automaticTuning","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/automaticTuning","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/databases/transparentDataEncryption","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recommendedElasticPools","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/auditingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/connectionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/connectionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies/rules","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/securityAlertPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/securityAlertPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/auditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/extendedAuditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/elasticpools","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-09-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/jobAgentOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/jobAgentAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/disasterRecoveryConfiguration","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/dnsAliases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/failoverGroups","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/virtualNetworkRules","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/virtualNetworkRulesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/virtualNetworkRulesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/databaseRestoreAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metricDefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/aggregatedDatabaseMetrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metricdefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries/queryText","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPools/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/extensions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPoolEstimates","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditRecords","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentScans","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/vulnerabilityAssessments","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessment","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/syncGroups","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups/syncMembers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/syncAgents","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"managedInstances/administrators","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/databases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metricDefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/administratorAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/administratorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncMemberOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncAgentOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncDatabaseIds","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorizations":[{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},{"applicationId":"e406a681-f3d4-42a8-90b6-c2b029497af1"}],"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/capabilities","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/databaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"locations/databaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverKeyOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/keys","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/encryptionProtector","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01","2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/communicationLinks","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/restorableDroppedDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recoverableDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/geoBackupPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/importExportOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/operationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/backupLongTermRetentionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/databases/transparentDataEncryption","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recommendedElasticPools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies/rules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/extendedAuditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/elasticPoolAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/elasticPoolOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/elasticpools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-09-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/jobAgentOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/jobAgentAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/disasterRecoveryConfiguration","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/dnsAliases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/failoverGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/virtualNetworkRules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/virtualNetworkRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/virtualNetworkRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/databaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/aggregatedDatabaseMetrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metricdefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries/queryText","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPools/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/extensions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPoolEstimates","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditRecords","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentScans","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/vulnerabilityAssessments","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessment","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/syncGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups/syncMembers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/syncAgents","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"managedInstances/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/administratorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncMemberOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncAgentOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncDatabaseIds","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/longTermRetentionPolicyOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionPolicyAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionBackupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionBackupAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorizations":[{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},{"applicationId":"e406a681-f3d4-42a8-90b6-c2b029497af1"}],"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
@@ -1795,12 +1828,12 @@ http_interactions:
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","Canada Central","Canada East","UK South","UK West","West US 2","West
-        Central US","South India","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","South India","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","South India","Canada Central","Canada East","UK South","UK West","West
-        US 2","West Central US","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Capacity","namespace":"Microsoft.Capacity","authorization":{"applicationId":"4d0ad6c7-f6c3-46d8-ab0d-1406d5e6c86b","roleDefinitionId":"FD9C0A9A-4DB9-4F41-8A61-98385DEB6E2D"},"resourceTypes":[{"resourceType":"resources","locations":["South
+        US 2","West Central US","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Capacity","namespace":"Microsoft.Capacity","authorization":{"applicationId":"4d0ad6c7-f6c3-46d8-ab0d-1406d5e6c86b","roleDefinitionId":"FD9C0A9A-4DB9-4F41-8A61-98385DEB6E2D"},"resourceTypes":[{"resourceType":"resources","locations":["South
         Central US"],"apiVersions":["2017-11-01"]},{"resourceType":"reservationOrders","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/reservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/reservations/revisions","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"catalogs","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"appliedReservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"checkOffers","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"checkScopes","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"calculatePrice","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/calculateRefund","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/return","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/split","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/merge","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"validateReservationOrder","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/availableScopes","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Cdn","namespace":"Microsoft.Cdn","resourceTypes":[{"resourceType":"profiles","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
@@ -1876,9 +1909,9 @@ http_interactions:
         2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/updateAccountsCreationSettings","locations":["West
         US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/accountsCreationSettings","locations":["West
         US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2016-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Commerce","namespace":"Microsoft.Commerce","resourceTypes":[{"resourceType":"UsageAggregates","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]},{"resourceType":"RateCard","locations":[],"apiVersions":["2016-08-31-preview","2015-06-01-preview","2015-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Consumption","namespace":"Microsoft.Consumption","resourceTypes":[{"resourceType":"ReservationSummaries","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationTransactions","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Balances","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Marketplaces","locations":[],"apiVersions":["2018-01-31"]},{"resourceType":"Pricesheets","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationDetails","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Budgets","locations":[],"apiVersions":["2018-01-31","2017-12-30-preview"]},{"resourceType":"Terms","locations":[],"apiVersions":["2018-01-31","2017-12-30-preview"]},{"resourceType":"UsageDetails","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview","2017-04-24-preview"]},{"resourceType":"Operations","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview","2017-04-24-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerInstance","namespace":"Microsoft.ContainerInstance","resourceTypes":[{"resourceType":"containerGroups","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/usages","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/operations","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/operations","locations":["West
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
         US"],"apiVersions":["2016-04-08"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.CustomerInsights","namespace":"Microsoft.CustomerInsights","authorization":{"applicationId":"38c77d00-5fcb-4cce-9d93-af4738258e3c","roleDefinitionId":"E006F9C7-F333-477C-8AD6-1F3A9FE87F55"},"resourceTypes":[{"resourceType":"hubs","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/profiles","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/interactions","locations":["East
@@ -1895,7 +1928,9 @@ http_interactions:
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"operations","locations":["East
         US 2"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Databricks","namespace":"Microsoft.Databricks","authorizations":[{"applicationId":"d9327919-6775-4843-9037-3fb0fb0473cb","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},{"applicationId":"2ff814a6-3304-4ab8-85cb-cd0e6f879c1d","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"}],"resourceTypes":[{"resourceType":"workspaces","locations":["West
         US","East US 2","West Europe","East US","North Europe","Southeast Asia","East
-        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]},{"resourceType":"locations","locations":["West
+        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2017-09-01-preview"]},{"resourceType":"workspaces/virtualNetworkPeerings","locations":["West
+        US","East US 2","West Europe","North Europe","East US","Southeast Asia","East
+        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01"]},{"resourceType":"locations","locations":["West
         US","East US 2","West Europe","North Europe","East US","Southeast Asia"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
         US","East US 2","West Europe","East US","North Europe","Southeast Asia","East
         Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataCatalog","namespace":"Microsoft.DataCatalog","resourceTypes":[{"resourceType":"catalogs","locations":["East
@@ -1919,23 +1954,26 @@ http_interactions:
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers/listSasTokens","locations":["East
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataLakeStore","namespace":"Microsoft.DataLakeStore","authorization":{"applicationId":"e9f49c6b-5ce5-44c8-925d-015017e9f7ad","roleDefinitionId":"17eb9cca-f08a-4499-b2d3-852d175f614f"},"resourceTypes":[{"resourceType":"accounts","locations":["East
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/firewallRules","locations":["East
-        US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataMigration","namespace":"Microsoft.DataMigration","authorization":{"applicationId":"a4bad4aa-bf02-4631-9f78-a64ffdba8150","roleDefinitionId":"b831a21d-db98-4760-89cb-bef871952df1","managedByRoleDefinitionId":"6256fb55-9e59-4018-a9e1-76b11c0a4c89"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services/projects","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationStatuses","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
+        US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataMigration","namespace":"Microsoft.DataMigration","authorization":{"applicationId":"a4bad4aa-bf02-4631-9f78-a64ffdba8150","roleDefinitionId":"b831a21d-db98-4760-89cb-bef871952df1","managedByRoleDefinitionId":"6256fb55-9e59-4018-a9e1-76b11c0a4c89"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services/projects","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationStatuses","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
-        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/recoverableServers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
@@ -1959,7 +1997,10 @@ http_interactions:
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
-        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/recoverableServers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
@@ -2015,12 +2056,7 @@ http_interactions:
         US 2","East US","West US","Central US","East US 2","West Central US","West
         Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
         US 2","East US","West US","Central US","East US 2","West Central US","West
-        Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","West
-        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
-        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
-        India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/consumergroups","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/disasterrecoveryconfigs","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
         US 2","South Central US","Central US","Australia Southeast","Central India","West
         Central US","West US 2","Canada East","Canada Central","Brazil South","UK
         South","UK West","East Asia","Australia East","Japan East","Japan West","North
@@ -2131,7 +2167,7 @@ http_interactions:
         West","Japan East","East Asia","Southeast Asia","West Europe","North Europe","East
         US","West US","Australia East","Australia Southeast","Central US","Brazil
         South","Central India","West India","South India","South Central US","Canada
-        Central","Canada East","West Central US","West US 2"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
+        Central","Canada East","West Central US","West US 2"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-05","2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
         Central US","East US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"operations","locations":["West
         Central US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
         Central US","East US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.PolicyInsights","namespace":"Microsoft.PolicyInsights","authorization":{"applicationId":"1d78a85d-813d-46f0-b496-dd72f50a3ec0","roleDefinitionId":"63d2b225-4c34-4641-8768-21a1f7c68ce8"},"resourceTypes":[{"resourceType":"policyEvents","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"policyStates","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
@@ -2163,12 +2199,12 @@ http_interactions:
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
         Central US","South Central US","North Europe","West Europe","East Asia","Southeast
         Asia","West US","East US","Japan West","Japan East","Brazil South","Central
         US","East US 2","Australia East","Australia Southeast","South India","Central
@@ -2208,40 +2244,50 @@ http_interactions:
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/clusterVersions","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"clusters/applications","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operations","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/clusterVersions","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/environments","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operations","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
         Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applianceDefinitions","locations":["West
         Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applications","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
-        Central US"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
+        Central US"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
         US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
         US","Canada Central","Canada East","Central US","East US 2","UK South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups","locations":["West
         US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
@@ -2332,10 +2378,10 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:38 GMT
+  recorded_at: Mon, 12 Mar 2018 09:26:08 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1?api-version=2017-12-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2349,7 +2395,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0OTUsIm5iZiI6MTUyMDQ1MzQ5NSwiZXhwIjoxNTIwNDU3Mzk1LCJhaW8iOiJZMk5nWUVndU5CSXl1MXFVeEdEM2ZsSFpieWtHQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ043QlVpaXhfRUtWWWFxR0UyRUFBQSIsInZlciI6IjEuMCJ9.Aj1ctOMBOwBnIeeKdPOaEyzKn5BJN38vjYfTjEdBR3O28GkzKMNrI9osuXXUl-MZJJjHUa5YF9Q23kHoF_2jX6dg692lNdMVrlwFPt61fGgAaiwbz2z05M2vMgtGCRUwh29B9F0SQYNYPIfKFQiPxwTNasGnKv5UVCcyoGkRikbbnqf97GkqW96sykNL5uBWq6Hfs55GNa0vU8-aWsNxc3ErY-w8Ae4dQnYJDNkbBZxWg2qdWcYYyYQt-Rg86PUd8Akishqc7_yKDkqMgLE6g_9GLPvBAQFR1tmoclkHfLbQUD-hjqoXQnNLmwn6TOg54jBmYjHdu2OLrPt0M8pMcA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDY0NjAsIm5iZiI6MTUyMDg0NjQ2MCwiZXhwIjoxNTIwODUwMzYwLCJhaW8iOiJZMk5nWUdBTzluZzJLY25wRWNmV20xS1NCOXJmQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTm9acDlkRDEwMFdPOWxvU0FqNGpBQSIsInZlciI6IjEuMCJ9.RT1lqldgy3xYclH7HEXx7zoes4517ZvTUJjlw0mHn9Dpn0GXG9OP28f2qqRR5NfcfCG9097_OHuFrg9Gs7R6J2MZ2CwLwPnVjxEwlc2wNxlSwlNGoRK20-73mpDZSYlRTty10TnjMgiIeQyKhlRGORoz4exaj0vCpMLsGm8dOp0IGVMQNG52VzYouCB2dRYpzXZs4qIkR090uJDCNBiqg2V0qlvSH-aJbhTgZ6meOh7S03o81RLuEnBOXjyYImq2dFuv1jWtAo1t45ePcE-LRcyTgjPDR9cNx0s_7gqd8aqAKqKxq98hRQdK5Kx8aM1jVMJQhWy1AJIwhmRhLNrsHA
   response:
     status:
       code: 200
@@ -2368,61 +2414,60 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/LowCostGet3Min;4741,Microsoft.Compute/LowCostGet30Min;37913
+      - Microsoft.Compute/LowCostGet3Min;4746,Microsoft.Compute/LowCostGet30Min;37914
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
       - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
       X-Ms-Request-Id:
-      - fe705c04-e2bb-4d54-a198-926ec733daa0
+      - 682e526d-2233-418b-865f-4d85e999212b
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14980'
+      - '14992'
       X-Ms-Correlation-Request-Id:
-      - 983f9e71-e2b2-4908-9cf1-7c02b6ec7fab
+      - 566ee69d-3a50-420b-8abd-8933e2fbfef5
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201642Z:983f9e71-e2b2-4908-9cf1-7c02b6ec7fab
+      - WESTEUROPE:20180312T092604Z:566ee69d-3a50-420b-8abd-8933e2fbfef5
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:16:42 GMT
+      - Mon, 12 Mar 2018 09:26:04 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"796c5bcc-338a-448d-b61c-165279a7fb3e\",\r\n
-        \   \"availabilitySet\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/MIQAZURE-AVAILSET-EAST\"\r\n
-        \   },\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Basic_A0\"\r\n
-        \   },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
-        \"OpenLogic\",\r\n        \"offer\": \"CentOS\",\r\n        \"sku\": \"7.1\",\r\n
+      string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"03e8467b-baab-4867-9cc4-157336b7e2e4\",\r\n
+        \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Basic_A0\"\r\n    },\r\n
+        \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
+        \"RedHat\",\r\n        \"offer\": \"RHEL\",\r\n        \"sku\": \"7.2\",\r\n
         \       \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
-        \"Linux\",\r\n        \"name\": \"miqazure-centos1\",\r\n        \"createOption\":
-        \"FromImage\",\r\n        \"vhd\": {\r\n          \"uri\": \"https://miqazuretest14047.blob.core.windows.net/vhds/miqazure-centos12016221104946.vhd\"\r\n
+        \"Linux\",\r\n        \"name\": \"miq-test-rhel1\",\r\n        \"createOption\":
+        \"FromImage\",\r\n        \"vhd\": {\r\n          \"uri\": \"https://miqazuretest18686.blob.core.windows.net/vhds/miq-test-rhel12016218112243.vhd\"\r\n
         \       },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n      \"dataDisks\":
-        []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"miqazure-centos1\",\r\n
+        []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"miq-test-rhel1\",\r\n
         \     \"adminUsername\": \"dberger\",\r\n      \"linuxConfiguration\": {\r\n
         \       \"disablePasswordAuthentication\": false\r\n      },\r\n      \"secrets\":
-        []\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611\"}]},\r\n
+        []\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390\"}]},\r\n
         \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
-        true,\r\n        \"storageUri\": \"https://miqazuretest14047.blob.core.windows.net/\"\r\n
+        true,\r\n        \"storageUri\": \"https://miqazuretest18686.blob.core.windows.net/\"\r\n
         \     }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n
         \ \"resources\": [\r\n    {\r\n      \"properties\": {\r\n        \"publisher\":
         \"Microsoft.OSTCExtensions\",\r\n        \"type\": \"LinuxDiagnostic\",\r\n
         \       \"typeHandlerVersion\": \"2.0\",\r\n        \"autoUpgradeMinorVersion\":
-        true,\r\n        \"settings\": {\"xmlCfg\":\"PFdhZENmZz48RGlhZ25vc3RpY01vbml0b3JDb25maWd1cmF0aW9uIG92ZXJhbGxRdW90YUluTUI9IjQwOTYiPjxEaWFnbm9zdGljSW5mcmFzdHJ1Y3R1cmVMb2dzIHNjaGVkdWxlZFRyYW5zZmVyUGVyaW9kPSJQVDFNIiBzY2hlZHVsZWRUcmFuc2ZlckxvZ0xldmVsRmlsdGVyPSJXYXJuaW5nIi8+PFBlcmZvcm1hbmNlQ291bnRlcnMgc2NoZWR1bGVkVHJhbnNmZXJQZXJpb2Q9IlBUMU0iPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlTWVtb3J5IiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQnl0ZXMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcUGVyY2VudEF2YWlsYWJsZU1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iTWVtb3J5IHVzZWQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50VXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgcGVyY2VudGFnZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkQnlDYWNoZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHVzZWQgYnkgY2FjaGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1BlclNlYyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50UGVyU2Vjb25kIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFnZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1JlYWRQZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2UgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1dyaXR0ZW5QZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2Ugd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iU3dhcCBhdmFpbGFibGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50QXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZFN3YXAiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlN3YXAgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRJZGxlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgaWRsZSB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFVzZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iUGVyY2VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkNQVSB1c2VyIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50TmljZVRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIG5pY2UgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRQcml2aWxlZ2VkVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgcHJpdmlsZWdlZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudEludGVycnVwdFRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIGludGVycnVwdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudERQQ1RpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIERQQyB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFByb2Nlc3NvclRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIHBlcmNlbnRhZ2UgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50SU9XYWl0VGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgSU8gd2FpdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xSZWFkQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCBndWVzdCBPUyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXFdyaXRlQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGUgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xUcmFuc2ZlcnNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXJzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcUmVhZHNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xXcml0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVJlYWRUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVdyaXRlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlNlY29uZHMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJEaXNrIHdyaXRlIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xBdmVyYWdlVHJhbnNmZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXIgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXEF2ZXJhZ2VEaXNrUXVldWVMZW5ndGgiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcXVldWUgbGVuZ3RoIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVHJhbnNtaXR0ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgb3V0IGd1ZXN0IE9TIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzUmVjZWl2ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgaW4gZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1RyYW5zbWl0dGVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHNlbnQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1JlY2VpdmVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHJlY2VpdmVkIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVG90YWwiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxSeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyByZWNlaXZlZCBlcnJvcnMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxUeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyBzZW50IGVycm9ycyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTmV0d29ya0ludGVyZmFjZVxUb3RhbENvbGxpc2lvbnMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgY29sbGlzaW9ucyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48L1BlcmZvcm1hbmNlQ291bnRlcnM+PE1ldHJpY3MgcmVzb3VyY2VJZD0iL3N1YnNjcmlwdGlvbnMvMjU4NmM2NGItMzhiNC00NTI3LWExNDAtMDEyZDQ5ZGZjMDJjL3Jlc291cmNlR3JvdXBzL21pcS1henVyZS10ZXN0MS9wcm92aWRlcnMvTWljcm9zb2Z0LkNvbXB1dGUvdmlydHVhbE1hY2hpbmVzL21pcWF6dXJlLWNlbnRvczEiPjxNZXRyaWNBZ2dyZWdhdGlvbiBzY2hlZHVsZWRUcmFuc2ZlclBlcmlvZD0iUFQxSCIvPjxNZXRyaWNBZ2dyZWdhdGlvbiBzY2hlZHVsZWRUcmFuc2ZlclBlcmlvZD0iUFQxTSIvPjwvTWV0cmljcz48L0RpYWdub3N0aWNNb25pdG9yQ29uZmlndXJhdGlvbj48L1dhZENmZz4=\",\"StorageAccount\":\"miqazuretest14047\"},\r\n
+        true,\r\n        \"settings\": {\"xmlCfg\":\"PFdhZENmZz48RGlhZ25vc3RpY01vbml0b3JDb25maWd1cmF0aW9uIG92ZXJhbGxRdW90YUluTUI9IjQwOTYiPjxEaWFnbm9zdGljSW5mcmFzdHJ1Y3R1cmVMb2dzIHNjaGVkdWxlZFRyYW5zZmVyUGVyaW9kPSJQVDFNIiBzY2hlZHVsZWRUcmFuc2ZlckxvZ0xldmVsRmlsdGVyPSJXYXJuaW5nIi8+PFBlcmZvcm1hbmNlQ291bnRlcnMgc2NoZWR1bGVkVHJhbnNmZXJQZXJpb2Q9IlBUMU0iPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlTWVtb3J5IiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQnl0ZXMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcUGVyY2VudEF2YWlsYWJsZU1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iTWVtb3J5IHVzZWQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50VXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgcGVyY2VudGFnZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkQnlDYWNoZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHVzZWQgYnkgY2FjaGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1BlclNlYyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50UGVyU2Vjb25kIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFnZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1JlYWRQZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2UgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1dyaXR0ZW5QZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2Ugd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iU3dhcCBhdmFpbGFibGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50QXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZFN3YXAiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlN3YXAgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRJZGxlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgaWRsZSB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFVzZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iUGVyY2VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkNQVSB1c2VyIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50TmljZVRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIG5pY2UgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRQcml2aWxlZ2VkVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgcHJpdmlsZWdlZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudEludGVycnVwdFRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIGludGVycnVwdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudERQQ1RpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIERQQyB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFByb2Nlc3NvclRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIHBlcmNlbnRhZ2UgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50SU9XYWl0VGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgSU8gd2FpdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xSZWFkQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCBndWVzdCBPUyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXFdyaXRlQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGUgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xUcmFuc2ZlcnNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXJzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcUmVhZHNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xXcml0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVJlYWRUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVdyaXRlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlNlY29uZHMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJEaXNrIHdyaXRlIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xBdmVyYWdlVHJhbnNmZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXIgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXEF2ZXJhZ2VEaXNrUXVldWVMZW5ndGgiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcXVldWUgbGVuZ3RoIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVHJhbnNtaXR0ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgb3V0IGd1ZXN0IE9TIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzUmVjZWl2ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgaW4gZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1RyYW5zbWl0dGVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHNlbnQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1JlY2VpdmVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHJlY2VpdmVkIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVG90YWwiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxSeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyByZWNlaXZlZCBlcnJvcnMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxUeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyBzZW50IGVycm9ycyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTmV0d29ya0ludGVyZmFjZVxUb3RhbENvbGxpc2lvbnMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgY29sbGlzaW9ucyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48L1BlcmZvcm1hbmNlQ291bnRlcnM+PE1ldHJpY3MgcmVzb3VyY2VJZD0iL3N1YnNjcmlwdGlvbnMvMjU4NmM2NGItMzhiNC00NTI3LWExNDAtMDEyZDQ5ZGZjMDJjL3Jlc291cmNlR3JvdXBzL21pcS1henVyZS10ZXN0MS9wcm92aWRlcnMvTWljcm9zb2Z0LkNvbXB1dGUvdmlydHVhbE1hY2hpbmVzL21pcS10ZXN0LXJoZWwxIj48TWV0cmljQWdncmVnYXRpb24gc2NoZWR1bGVkVHJhbnNmZXJQZXJpb2Q9IlBUMUgiLz48TWV0cmljQWdncmVnYXRpb24gc2NoZWR1bGVkVHJhbnNmZXJQZXJpb2Q9IlBUMU0iLz48L01ldHJpY3M+PC9EaWFnbm9zdGljTW9uaXRvckNvbmZpZ3VyYXRpb24+PC9XYWRDZmc+\",\"StorageAccount\":\"miqazuretest18686\"},\r\n
         \       \"provisioningState\": \"Succeeded\"\r\n      },\r\n      \"type\":
         \"Microsoft.Compute/virtualMachines/extensions\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1/extensions/Microsoft.Insights.VMDiagnosticsSettings\",\r\n
+        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/extensions/Microsoft.Insights.VMDiagnosticsSettings\",\r\n
         \     \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n    }\r\n
         \ ],\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\":
         \"eastus\",\r\n  \"tags\": {\r\n    \"Shutdown\": \"true\"\r\n  },\r\n  \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1\",\r\n
-        \ \"name\": \"miqazure-centos1\"\r\n}"
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1\",\r\n
+        \ \"name\": \"miq-test-rhel1\"\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:43 GMT
+  recorded_at: Mon, 12 Mar 2018 09:26:09 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390?api-version=2018-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2436,7 +2481,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0OTUsIm5iZiI6MTUyMDQ1MzQ5NSwiZXhwIjoxNTIwNDU3Mzk1LCJhaW8iOiJZMk5nWUVndU5CSXl1MXFVeEdEM2ZsSFpieWtHQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ043QlVpaXhfRUtWWWFxR0UyRUFBQSIsInZlciI6IjEuMCJ9.Aj1ctOMBOwBnIeeKdPOaEyzKn5BJN38vjYfTjEdBR3O28GkzKMNrI9osuXXUl-MZJJjHUa5YF9Q23kHoF_2jX6dg692lNdMVrlwFPt61fGgAaiwbz2z05M2vMgtGCRUwh29B9F0SQYNYPIfKFQiPxwTNasGnKv5UVCcyoGkRikbbnqf97GkqW96sykNL5uBWq6Hfs55GNa0vU8-aWsNxc3ErY-w8Ae4dQnYJDNkbBZxWg2qdWcYYyYQt-Rg86PUd8Akishqc7_yKDkqMgLE6g_9GLPvBAQFR1tmoclkHfLbQUD-hjqoXQnNLmwn6TOg54jBmYjHdu2OLrPt0M8pMcA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDY0NjAsIm5iZiI6MTUyMDg0NjQ2MCwiZXhwIjoxNTIwODUwMzYwLCJhaW8iOiJZMk5nWUdBTzluZzJLY25wRWNmV20xS1NCOXJmQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTm9acDlkRDEwMFdPOWxvU0FqNGpBQSIsInZlciI6IjEuMCJ9.RT1lqldgy3xYclH7HEXx7zoes4517ZvTUJjlw0mHn9Dpn0GXG9OP28f2qqRR5NfcfCG9097_OHuFrg9Gs7R6J2MZ2CwLwPnVjxEwlc2wNxlSwlNGoRK20-73mpDZSYlRTty10TnjMgiIeQyKhlRGORoz4exaj0vCpMLsGm8dOp0IGVMQNG52VzYouCB2dRYpzXZs4qIkR090uJDCNBiqg2V0qlvSH-aJbhTgZ6meOh7S03o81RLuEnBOXjyYImq2dFuv1jWtAo1t45ePcE-LRcyTgjPDR9cNx0s_7gqd8aqAKqKxq98hRQdK5Kx8aM1jVMJQhWy1AJIwhmRhLNrsHA
   response:
     status:
       code: 200
@@ -2453,51 +2498,54 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"26031ef6-bb55-4019-8185-2dd1edcb207c"
+      - W/"f006e6f9-0292-42cd-99fc-f72f194553c1"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 503b3c9c-b721-4837-9f82-f21c830f3a44
+      - 260bb3cb-00de-441b-9cc2-48aec3220bc4
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14982'
+      - '14994'
       X-Ms-Correlation-Request-Id:
-      - 7f3080f2-7b25-45db-86f3-b04c2ebf34da
+      - '0239d53b-4a0f-4f45-a921-72390265d9f2'
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201645Z:7f3080f2-7b25-45db-86f3-b04c2ebf34da
+      - WESTEUROPE:20180312T092605Z:0239d53b-4a0f-4f45-a921-72390265d9f2
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:16:44 GMT
+      - Mon, 12 Mar 2018 09:26:05 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"miqazure-centos1611\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611\",\r\n
-        \ \"etag\": \"W/\\\"26031ef6-bb55-4019-8185-2dd1edcb207c\\\"\",\r\n  \"location\":
+      string: "{\r\n  \"name\": \"miq-test-rhel1390\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390\",\r\n
+        \ \"etag\": \"W/\\\"f006e6f9-0292-42cd-99fc-f72f194553c1\\\"\",\r\n  \"location\":
         \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"f1760e49-9853-4fdc-acfc-4ea232b9ed76\",\r\n    \"ipConfigurations\":
-        [\r\n      {\r\n        \"name\": \"ipconfig1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1\",\r\n
-        \       \"etag\": \"W/\\\"26031ef6-bb55-4019-8185-2dd1edcb207c\\\"\",\r\n
+        \   \"resourceGuid\": \"98853f48-2806-4065-be57-cf9159550440\",\r\n    \"ipConfigurations\":
+        [\r\n      {\r\n        \"name\": \"ipconfig1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1\",\r\n
+        \       \"etag\": \"W/\\\"f006e6f9-0292-42cd-99fc-f72f194553c1\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAddress\": \"10.16.0.5\",\r\n          \"privateIPAllocationMethod\":
-        \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1\"\r\n
+        \         \"privateIPAddress\": \"10.16.0.4\",\r\n          \"privateIPAllocationMethod\":
+        \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1\"\r\n
         \         },\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\"\r\n
         \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
         \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\":
-        [],\r\n      \"appliedDnsServers\": []\r\n    },\r\n    \"enableAcceleratedNetworking\":
-        false,\r\n    \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\":
-        {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1\"\r\n
-        \   },\r\n    \"virtualMachine\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1\"\r\n
+        [],\r\n      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\":
+        \"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net\"\r\n    },\r\n    \"macAddress\":
+        \"00-0D-3A-10-EB-AB\",\r\n    \"enableAcceleratedNetworking\": false,\r\n
+        \   \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\": {\r\n
+        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1\"\r\n
+        \   },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1\"\r\n
         \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
         \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:45 GMT
+  recorded_at: Mon, 12 Mar 2018 09:26:10 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups/miq-azure-test1?api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/instanceView?api-version=2017-12-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2511,60 +2559,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0OTUsIm5iZiI6MTUyMDQ1MzQ5NSwiZXhwIjoxNTIwNDU3Mzk1LCJhaW8iOiJZMk5nWUVndU5CSXl1MXFVeEdEM2ZsSFpieWtHQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ043QlVpaXhfRUtWWWFxR0UyRUFBQSIsInZlciI6IjEuMCJ9.Aj1ctOMBOwBnIeeKdPOaEyzKn5BJN38vjYfTjEdBR3O28GkzKMNrI9osuXXUl-MZJJjHUa5YF9Q23kHoF_2jX6dg692lNdMVrlwFPt61fGgAaiwbz2z05M2vMgtGCRUwh29B9F0SQYNYPIfKFQiPxwTNasGnKv5UVCcyoGkRikbbnqf97GkqW96sykNL5uBWq6Hfs55GNa0vU8-aWsNxc3ErY-w8Ae4dQnYJDNkbBZxWg2qdWcYYyYQt-Rg86PUd8Akishqc7_yKDkqMgLE6g_9GLPvBAQFR1tmoclkHfLbQUD-hjqoXQnNLmwn6TOg54jBmYjHdu2OLrPt0M8pMcA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14985'
-      X-Ms-Request-Id:
-      - 914762f5-5284-49ff-b221-08baa3899904
-      X-Ms-Correlation-Request-Id:
-      - 914762f5-5284-49ff-b221-08baa3899904
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201645Z:914762f5-5284-49ff-b221-08baa3899904
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:16:45 GMT
-      Content-Length:
-      - '183'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1","name":"miq-azure-test1","location":"eastus","properties":{"provisioningState":"Succeeded"}}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:46 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute/locations/eastus/vmSizes?api-version=2017-12-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0OTUsIm5iZiI6MTUyMDQ1MzQ5NSwiZXhwIjoxNTIwNDU3Mzk1LCJhaW8iOiJZMk5nWUVndU5CSXl1MXFVeEdEM2ZsSFpieWtHQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ043QlVpaXhfRUtWWWFxR0UyRUFBQSIsInZlciI6IjEuMCJ9.Aj1ctOMBOwBnIeeKdPOaEyzKn5BJN38vjYfTjEdBR3O28GkzKMNrI9osuXXUl-MZJJjHUa5YF9Q23kHoF_2jX6dg692lNdMVrlwFPt61fGgAaiwbz2z05M2vMgtGCRUwh29B9F0SQYNYPIfKFQiPxwTNasGnKv5UVCcyoGkRikbbnqf97GkqW96sykNL5uBWq6Hfs55GNa0vU8-aWsNxc3ErY-w8Ae4dQnYJDNkbBZxWg2qdWcYYyYQt-Rg86PUd8Akishqc7_yKDkqMgLE6g_9GLPvBAQFR1tmoclkHfLbQUD-hjqoXQnNLmwn6TOg54jBmYjHdu2OLrPt0M8pMcA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDY0NjAsIm5iZiI6MTUyMDg0NjQ2MCwiZXhwIjoxNTIwODUwMzYwLCJhaW8iOiJZMk5nWUdBTzluZzJLY25wRWNmV20xS1NCOXJmQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTm9acDlkRDEwMFdPOWxvU0FqNGpBQSIsInZlciI6IjEuMCJ9.RT1lqldgy3xYclH7HEXx7zoes4517ZvTUJjlw0mHn9Dpn0GXG9OP28f2qqRR5NfcfCG9097_OHuFrg9Gs7R6J2MZ2CwLwPnVjxEwlc2wNxlSwlNGoRK20-73mpDZSYlRTty10TnjMgiIeQyKhlRGORoz4exaj0vCpMLsGm8dOp0IGVMQNG52VzYouCB2dRYpzXZs4qIkR090uJDCNBiqg2V0qlvSH-aJbhTgZ6meOh7S03o81RLuEnBOXjyYImq2dFuv1jWtAo1t45ePcE-LRcyTgjPDR9cNx0s_7gqd8aqAKqKxq98hRQdK5Kx8aM1jVMJQhWy1AJIwhmRhLNrsHA
   response:
     status:
       code: 200
@@ -2583,26 +2578,164 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/LowCostGet3Min;4738,Microsoft.Compute/LowCostGet30Min;37910
+      - Microsoft.Compute/GetInstanceView3Min;4798,Microsoft.Compute/GetInstanceView30Min;23920
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
       - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
       X-Ms-Request-Id:
-      - 20556843-5442-43a5-bab3-4e9977cf91eb
+      - bde29df7-20a8-4e83-b5b9-536b1fcf8090
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14987'
+      - '14992'
       X-Ms-Correlation-Request-Id:
-      - a1a584d2-b984-44f9-a402-4eb1ce30ea1f
+      - 80e1d0bb-dd29-4153-8de7-7ded807e75bb
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201646Z:a1a584d2-b984-44f9-a402-4eb1ce30ea1f
+      - WESTEUROPE:20180312T092616Z:80e1d0bb-dd29-4153-8de7-7ded807e75bb
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:16:45 GMT
+      - Mon, 12 Mar 2018 09:26:16 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"vmAgent\": {\r\n    \"vmAgentVersion\": \"WALinuxAgent-2.0.16\",\r\n
+        \   \"statuses\": [\r\n      {\r\n        \"code\": \"ProvisioningState/succeeded\",\r\n
+        \       \"level\": \"Info\",\r\n        \"displayStatus\": \"Ready\",\r\n
+        \       \"message\": \"GuestAgent is running and accepting new configurations.\",\r\n
+        \       \"time\": \"2018-03-12T09:25:59+00:00\"\r\n      }\r\n    ],\r\n    \"extensionHandlers\":
+        [\r\n      {\r\n        \"type\": \"Microsoft.OSTCExtensions.LinuxDiagnostic\",\r\n
+        \       \"typeHandlerVersion\": \"2.3.9027\",\r\n        \"status\": {\r\n
+        \         \"code\": \"ProvisioningState/succeeded\",\r\n          \"level\":
+        \"Info\",\r\n          \"displayStatus\": \"Ready\"\r\n        }\r\n      }\r\n
+        \   ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"miq-test-rhel1\",\r\n
+        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
+        succeeded\",\r\n          \"time\": \"2018-01-17T18:00:29.9011002+00:00\"\r\n
+        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
+        \"https://miqazuretest18686.blob.core.windows.net/bootdiagnostics-miqtestrh-03e8467b-baab-4867-9cc4-157336b7e2e4/miq-test-rhel1.03e8467b-baab-4867-9cc4-157336b7e2e4.screenshot.bmp\",\r\n
+        \   \"serialConsoleLogBlobUri\": \"https://miqazuretest18686.blob.core.windows.net/bootdiagnostics-miqtestrh-03e8467b-baab-4867-9cc4-157336b7e2e4/miq-test-rhel1.03e8467b-baab-4867-9cc4-157336b7e2e4.serialconsole.log\"\r\n
+        \ },\r\n  \"extensions\": [\r\n    {\r\n      \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\",\r\n
+        \     \"type\": \"Microsoft.OSTCExtensions.LinuxDiagnostic\",\r\n      \"typeHandlerVersion\":
+        \"2.3.9027\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\":
+        \"ProvisioningState/succeeded\",\r\n          \"level\": \"Info\",\r\n          \"displayStatus\":
+        \"Provisioning succeeded\",\r\n          \"message\": \"Enable succeeded\"\r\n
+        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\":
+        \"ProvisioningState/succeeded\",\r\n      \"level\": \"Info\",\r\n      \"displayStatus\":
+        \"Provisioning succeeded\",\r\n      \"time\": \"2018-01-17T18:02:26.9167163+00:00\"\r\n
+        \   },\r\n    {\r\n      \"code\": \"PowerState/running\",\r\n      \"level\":
+        \"Info\",\r\n      \"displayStatus\": \"VM running\"\r\n    }\r\n  ]\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:26:21 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups/miq-azure-test1?api-version=2017-08-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDY0NjAsIm5iZiI6MTUyMDg0NjQ2MCwiZXhwIjoxNTIwODUwMzYwLCJhaW8iOiJZMk5nWUdBTzluZzJLY25wRWNmV20xS1NCOXJmQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTm9acDlkRDEwMFdPOWxvU0FqNGpBQSIsInZlciI6IjEuMCJ9.RT1lqldgy3xYclH7HEXx7zoes4517ZvTUJjlw0mHn9Dpn0GXG9OP28f2qqRR5NfcfCG9097_OHuFrg9Gs7R6J2MZ2CwLwPnVjxEwlc2wNxlSwlNGoRK20-73mpDZSYlRTty10TnjMgiIeQyKhlRGORoz4exaj0vCpMLsGm8dOp0IGVMQNG52VzYouCB2dRYpzXZs4qIkR090uJDCNBiqg2V0qlvSH-aJbhTgZ6meOh7S03o81RLuEnBOXjyYImq2dFuv1jWtAo1t45ePcE-LRcyTgjPDR9cNx0s_7gqd8aqAKqKxq98hRQdK5Kx8aM1jVMJQhWy1AJIwhmRhLNrsHA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Request-Id:
+      - d9c03167-da6a-4797-b10d-d1468ee3f33c
+      X-Ms-Correlation-Request-Id:
+      - d9c03167-da6a-4797-b10d-d1468ee3f33c
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T092617Z:d9c03167-da6a-4797-b10d-d1468ee3f33c
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:26:16 GMT
+      Content-Length:
+      - '183'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1","name":"miq-azure-test1","location":"eastus","properties":{"provisioningState":"Succeeded"}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:26:21 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute/locations/eastus/vmSizes?api-version=2017-12-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDY0NjAsIm5iZiI6MTUyMDg0NjQ2MCwiZXhwIjoxNTIwODUwMzYwLCJhaW8iOiJZMk5nWUdBTzluZzJLY25wRWNmV20xS1NCOXJmQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTm9acDlkRDEwMFdPOWxvU0FqNGpBQSIsInZlciI6IjEuMCJ9.RT1lqldgy3xYclH7HEXx7zoes4517ZvTUJjlw0mHn9Dpn0GXG9OP28f2qqRR5NfcfCG9097_OHuFrg9Gs7R6J2MZ2CwLwPnVjxEwlc2wNxlSwlNGoRK20-73mpDZSYlRTty10TnjMgiIeQyKhlRGORoz4exaj0vCpMLsGm8dOp0IGVMQNG52VzYouCB2dRYpzXZs4qIkR090uJDCNBiqg2V0qlvSH-aJbhTgZ6meOh7S03o81RLuEnBOXjyYImq2dFuv1jWtAo1t45ePcE-LRcyTgjPDR9cNx0s_7gqd8aqAKqKxq98hRQdK5Kx8aM1jVMJQhWy1AJIwhmRhLNrsHA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/LowCostGet3Min;4742,Microsoft.Compute/LowCostGet30Min;37910
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      X-Ms-Request-Id:
+      - aa16ae9a-6511-4505-957c-8e9dd89bb7c9
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14998'
+      X-Ms-Correlation-Request-Id:
+      - 8ced4f96-af90-44f2-abc7-d3b7f446c310
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T092617Z:8ced4f96-af90-44f2-abc7-d3b7f446c310
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:26:17 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"Standard_B1ms\",\r\n
@@ -3079,6 +3212,12 @@ http_interactions:
         \   },\r\n    {\r\n      \"name\": \"Standard_F72s_v2\",\r\n      \"numberOfCores\":
         72,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
         589824,\r\n      \"memoryInMB\": 147456,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_L8s_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1811981,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_L16s_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        3623962,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
         \   },\r\n    {\r\n      \"name\": \"Standard_ND6s\",\r\n      \"numberOfCores\":
         6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
         344064,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 12\r\n
@@ -3105,10 +3244,10 @@ http_interactions:
         391168,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
         \   }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:46 GMT
+  recorded_at: Mon, 12 Mar 2018 09:26:22 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1?api-version=2018-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3122,7 +3261,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0OTUsIm5iZiI6MTUyMDQ1MzQ5NSwiZXhwIjoxNTIwNDU3Mzk1LCJhaW8iOiJZMk5nWUVndU5CSXl1MXFVeEdEM2ZsSFpieWtHQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ043QlVpaXhfRUtWWWFxR0UyRUFBQSIsInZlciI6IjEuMCJ9.Aj1ctOMBOwBnIeeKdPOaEyzKn5BJN38vjYfTjEdBR3O28GkzKMNrI9osuXXUl-MZJJjHUa5YF9Q23kHoF_2jX6dg692lNdMVrlwFPt61fGgAaiwbz2z05M2vMgtGCRUwh29B9F0SQYNYPIfKFQiPxwTNasGnKv5UVCcyoGkRikbbnqf97GkqW96sykNL5uBWq6Hfs55GNa0vU8-aWsNxc3ErY-w8Ae4dQnYJDNkbBZxWg2qdWcYYyYQt-Rg86PUd8Akishqc7_yKDkqMgLE6g_9GLPvBAQFR1tmoclkHfLbQUD-hjqoXQnNLmwn6TOg54jBmYjHdu2OLrPt0M8pMcA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDY0NjAsIm5iZiI6MTUyMDg0NjQ2MCwiZXhwIjoxNTIwODUwMzYwLCJhaW8iOiJZMk5nWUdBTzluZzJLY25wRWNmV20xS1NCOXJmQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTm9acDlkRDEwMFdPOWxvU0FqNGpBQSIsInZlciI6IjEuMCJ9.RT1lqldgy3xYclH7HEXx7zoes4517ZvTUJjlw0mHn9Dpn0GXG9OP28f2qqRR5NfcfCG9097_OHuFrg9Gs7R6J2MZ2CwLwPnVjxEwlc2wNxlSwlNGoRK20-73mpDZSYlRTty10TnjMgiIeQyKhlRGORoz4exaj0vCpMLsGm8dOp0IGVMQNG52VzYouCB2dRYpzXZs4qIkR090uJDCNBiqg2V0qlvSH-aJbhTgZ6meOh7S03o81RLuEnBOXjyYImq2dFuv1jWtAo1t45ePcE-LRcyTgjPDR9cNx0s_7gqd8aqAKqKxq98hRQdK5Kx8aM1jVMJQhWy1AJIwhmRhLNrsHA
   response:
     status:
       code: 200
@@ -3138,64 +3277,43 @@ http_interactions:
       - application/json; charset=utf-8
       Expires:
       - "-1"
+      Etag:
+      - W/"054052bb-11ff-4f6e-ac1a-3427c2fd17aa"
       Vary:
       - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/LowCostGet3Min;4737,Microsoft.Compute/LowCostGet30Min;37909
+      X-Ms-Request-Id:
+      - c9437c81-aebf-4178-a210-56786076c1ef
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
-      X-Ms-Request-Id:
-      - ba5b1a44-1b85-4fd3-9af7-0484c5f67d04
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14980'
+      - '14990'
       X-Ms-Correlation-Request-Id:
-      - 53750ac6-a805-4b7e-968a-856cd49943bc
+      - b80e99ac-1d05-488f-a29c-1d96cd73f257
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201654Z:53750ac6-a805-4b7e-968a-856cd49943bc
+      - WESTEUROPE:20180312T092618Z:b80e99ac-1d05-488f-a29c-1d96cd73f257
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:16:54 GMT
+      - Mon, 12 Mar 2018 09:26:17 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"796c5bcc-338a-448d-b61c-165279a7fb3e\",\r\n
-        \   \"availabilitySet\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/MIQAZURE-AVAILSET-EAST\"\r\n
-        \   },\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Basic_A0\"\r\n
-        \   },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
-        \"OpenLogic\",\r\n        \"offer\": \"CentOS\",\r\n        \"sku\": \"7.1\",\r\n
-        \       \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
-        \"Linux\",\r\n        \"name\": \"miqazure-centos1\",\r\n        \"createOption\":
-        \"FromImage\",\r\n        \"vhd\": {\r\n          \"uri\": \"https://miqazuretest14047.blob.core.windows.net/vhds/miqazure-centos12016221104946.vhd\"\r\n
-        \       },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n      \"dataDisks\":
-        []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"miqazure-centos1\",\r\n
-        \     \"adminUsername\": \"dberger\",\r\n      \"linuxConfiguration\": {\r\n
-        \       \"disablePasswordAuthentication\": false\r\n      },\r\n      \"secrets\":
-        []\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611\"}]},\r\n
-        \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
-        true,\r\n        \"storageUri\": \"https://miqazuretest14047.blob.core.windows.net/\"\r\n
-        \     }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n
-        \ \"resources\": [\r\n    {\r\n      \"properties\": {\r\n        \"publisher\":
-        \"Microsoft.OSTCExtensions\",\r\n        \"type\": \"LinuxDiagnostic\",\r\n
-        \       \"typeHandlerVersion\": \"2.0\",\r\n        \"autoUpgradeMinorVersion\":
-        true,\r\n        \"settings\": {\"xmlCfg\":\"PFdhZENmZz48RGlhZ25vc3RpY01vbml0b3JDb25maWd1cmF0aW9uIG92ZXJhbGxRdW90YUluTUI9IjQwOTYiPjxEaWFnbm9zdGljSW5mcmFzdHJ1Y3R1cmVMb2dzIHNjaGVkdWxlZFRyYW5zZmVyUGVyaW9kPSJQVDFNIiBzY2hlZHVsZWRUcmFuc2ZlckxvZ0xldmVsRmlsdGVyPSJXYXJuaW5nIi8+PFBlcmZvcm1hbmNlQ291bnRlcnMgc2NoZWR1bGVkVHJhbnNmZXJQZXJpb2Q9IlBUMU0iPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlTWVtb3J5IiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQnl0ZXMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcUGVyY2VudEF2YWlsYWJsZU1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iTWVtb3J5IHVzZWQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50VXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgcGVyY2VudGFnZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkQnlDYWNoZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHVzZWQgYnkgY2FjaGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1BlclNlYyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50UGVyU2Vjb25kIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFnZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1JlYWRQZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2UgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1dyaXR0ZW5QZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2Ugd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iU3dhcCBhdmFpbGFibGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50QXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZFN3YXAiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlN3YXAgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRJZGxlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgaWRsZSB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFVzZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iUGVyY2VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkNQVSB1c2VyIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50TmljZVRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIG5pY2UgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRQcml2aWxlZ2VkVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgcHJpdmlsZWdlZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudEludGVycnVwdFRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIGludGVycnVwdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudERQQ1RpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIERQQyB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFByb2Nlc3NvclRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIHBlcmNlbnRhZ2UgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50SU9XYWl0VGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgSU8gd2FpdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xSZWFkQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCBndWVzdCBPUyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXFdyaXRlQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGUgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xUcmFuc2ZlcnNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXJzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcUmVhZHNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xXcml0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVJlYWRUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVdyaXRlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlNlY29uZHMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJEaXNrIHdyaXRlIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xBdmVyYWdlVHJhbnNmZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXIgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXEF2ZXJhZ2VEaXNrUXVldWVMZW5ndGgiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcXVldWUgbGVuZ3RoIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVHJhbnNtaXR0ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgb3V0IGd1ZXN0IE9TIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzUmVjZWl2ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgaW4gZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1RyYW5zbWl0dGVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHNlbnQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1JlY2VpdmVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHJlY2VpdmVkIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVG90YWwiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxSeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyByZWNlaXZlZCBlcnJvcnMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxUeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyBzZW50IGVycm9ycyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTmV0d29ya0ludGVyZmFjZVxUb3RhbENvbGxpc2lvbnMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgY29sbGlzaW9ucyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48L1BlcmZvcm1hbmNlQ291bnRlcnM+PE1ldHJpY3MgcmVzb3VyY2VJZD0iL3N1YnNjcmlwdGlvbnMvMjU4NmM2NGItMzhiNC00NTI3LWExNDAtMDEyZDQ5ZGZjMDJjL3Jlc291cmNlR3JvdXBzL21pcS1henVyZS10ZXN0MS9wcm92aWRlcnMvTWljcm9zb2Z0LkNvbXB1dGUvdmlydHVhbE1hY2hpbmVzL21pcWF6dXJlLWNlbnRvczEiPjxNZXRyaWNBZ2dyZWdhdGlvbiBzY2hlZHVsZWRUcmFuc2ZlclBlcmlvZD0iUFQxSCIvPjxNZXRyaWNBZ2dyZWdhdGlvbiBzY2hlZHVsZWRUcmFuc2ZlclBlcmlvZD0iUFQxTSIvPjwvTWV0cmljcz48L0RpYWdub3N0aWNNb25pdG9yQ29uZmlndXJhdGlvbj48L1dhZENmZz4=\",\"StorageAccount\":\"miqazuretest14047\"},\r\n
-        \       \"provisioningState\": \"Succeeded\"\r\n      },\r\n      \"type\":
-        \"Microsoft.Compute/virtualMachines/extensions\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1/extensions/Microsoft.Insights.VMDiagnosticsSettings\",\r\n
-        \     \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n    }\r\n
-        \ ],\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\":
-        \"eastus\",\r\n  \"tags\": {\r\n    \"Shutdown\": \"true\"\r\n  },\r\n  \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1\",\r\n
-        \ \"name\": \"miqazure-centos1\"\r\n}"
+      string: "{\r\n  \"name\": \"miq-test-rhel1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1\",\r\n
+        \ \"etag\": \"W/\\\"054052bb-11ff-4f6e-ac1a-3427c2fd17aa\\\"\",\r\n  \"location\":
+        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"f6cfc635-411e-48ce-a627-39a2fc0d3168\",\r\n    \"ipAddress\":
+        \"52.224.165.15\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\":
+        \"Dynamic\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipTags\": [],\r\n
+        \   \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1\"\r\n
+        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
+        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:55 GMT
+  recorded_at: Mon, 12 Mar 2018 09:26:23 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1/instanceView?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686?api-version=2017-10-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3209,7 +3327,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0OTUsIm5iZiI6MTUyMDQ1MzQ5NSwiZXhwIjoxNTIwNDU3Mzk1LCJhaW8iOiJZMk5nWUVndU5CSXl1MXFVeEdEM2ZsSFpieWtHQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ043QlVpaXhfRUtWWWFxR0UyRUFBQSIsInZlciI6IjEuMCJ9.Aj1ctOMBOwBnIeeKdPOaEyzKn5BJN38vjYfTjEdBR3O28GkzKMNrI9osuXXUl-MZJJjHUa5YF9Q23kHoF_2jX6dg692lNdMVrlwFPt61fGgAaiwbz2z05M2vMgtGCRUwh29B9F0SQYNYPIfKFQiPxwTNasGnKv5UVCcyoGkRikbbnqf97GkqW96sykNL5uBWq6Hfs55GNa0vU8-aWsNxc3ErY-w8Ae4dQnYJDNkbBZxWg2qdWcYYyYQt-Rg86PUd8Akishqc7_yKDkqMgLE6g_9GLPvBAQFR1tmoclkHfLbQUD-hjqoXQnNLmwn6TOg54jBmYjHdu2OLrPt0M8pMcA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDY0NjAsIm5iZiI6MTUyMDg0NjQ2MCwiZXhwIjoxNTIwODUwMzYwLCJhaW8iOiJZMk5nWUdBTzluZzJLY25wRWNmV20xS1NCOXJmQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTm9acDlkRDEwMFdPOWxvU0FqNGpBQSIsInZlciI6IjEuMCJ9.RT1lqldgy3xYclH7HEXx7zoes4517ZvTUJjlw0mHn9Dpn0GXG9OP28f2qqRR5NfcfCG9097_OHuFrg9Gs7R6J2MZ2CwLwPnVjxEwlc2wNxlSwlNGoRK20-73mpDZSYlRTty10TnjMgiIeQyKhlRGORoz4exaj0vCpMLsGm8dOp0IGVMQNG52VzYouCB2dRYpzXZs4qIkR090uJDCNBiqg2V0qlvSH-aJbhTgZ6meOh7S03o81RLuEnBOXjyYImq2dFuv1jWtAo1t45ePcE-LRcyTgjPDR9cNx0s_7gqd8aqAKqKxq98hRQdK5Kx8aM1jVMJQhWy1AJIwhmRhLNrsHA
   response:
     status:
       code: 200
@@ -3222,210 +3340,35 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Content-Type:
-      - application/json; charset=utf-8
+      - application/json
       Expires:
       - "-1"
       Vary:
       - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/GetInstanceView3Min;4795,Microsoft.Compute/GetInstanceView30Min;23924
+      X-Ms-Request-Id:
+      - 77b1eeef-c9e5-40e1-9b3a-76850a58ff49
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
-      X-Ms-Request-Id:
-      - 7f936144-5281-4975-b585-61f92d11407c
       Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14979'
+      - '14986'
       X-Ms-Correlation-Request-Id:
-      - b01d4a66-2283-4f8f-8f9e-426f3825eec1
+      - 1947f123-8fe8-4ce6-bb73-9efc8fe32128
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201706Z:b01d4a66-2283-4f8f-8f9e-426f3825eec1
+      - WESTEUROPE:20180312T092622Z:1947f123-8fe8-4ce6-bb73-9efc8fe32128
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:17:06 GMT
+      - Mon, 12 Mar 2018 09:26:21 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"platformUpdateDomain\": 0,\r\n  \"platformFaultDomain\": 0,\r\n
-        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
-        [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
-        \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
-        \"Failed to fetch the VM status.\",\r\n        \"time\": \"2018-03-07T20:16:55+00:00\"\r\n
-        \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"miqazure-centos1\",\r\n
-        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
-        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"time\": \"2016-06-22T21:18:47.2011229+00:00\"\r\n
-        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
-        \"https://miqazuretest14047.blob.core.windows.net/bootdiagnostics-miqazurec-796c5bcc-338a-448d-b61c-165279a7fb3e/miqazure-centos1.796c5bcc-338a-448d-b61c-165279a7fb3e.screenshot.bmp\",\r\n
-        \   \"serialConsoleLogBlobUri\": \"https://miqazuretest14047.blob.core.windows.net/bootdiagnostics-miqazurec-796c5bcc-338a-448d-b61c-165279a7fb3e/miqazure-centos1.796c5bcc-338a-448d-b61c-165279a7fb3e.serialconsole.log\"\r\n
-        \ },\r\n  \"extensions\": [\r\n    {\r\n      \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n
-        \   }\r\n  ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n
-        \     \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n
-        \     \"time\": \"2016-06-22T21:18:47.2636196+00:00\"\r\n    },\r\n    {\r\n
-        \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
-        \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","name":"miqazuretest18686","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T17:22:54.7808677Z","primaryEndpoints":{"blob":"https://miqazuretest18686.blob.core.windows.net/","queue":"https://miqazuretest18686.queue.core.windows.net/","table":"https://miqazuretest18686.table.core.windows.net/","file":"https://miqazuretest18686.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:17:07 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Network/networkInterfaces?api-version=2017-11-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0OTUsIm5iZiI6MTUyMDQ1MzQ5NSwiZXhwIjoxNTIwNDU3Mzk1LCJhaW8iOiJZMk5nWUVndU5CSXl1MXFVeEdEM2ZsSFpieWtHQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ043QlVpaXhfRUtWWWFxR0UyRUFBQSIsInZlciI6IjEuMCJ9.Aj1ctOMBOwBnIeeKdPOaEyzKn5BJN38vjYfTjEdBR3O28GkzKMNrI9osuXXUl-MZJJjHUa5YF9Q23kHoF_2jX6dg692lNdMVrlwFPt61fGgAaiwbz2z05M2vMgtGCRUwh29B9F0SQYNYPIfKFQiPxwTNasGnKv5UVCcyoGkRikbbnqf97GkqW96sykNL5uBWq6Hfs55GNa0vU8-aWsNxc3ErY-w8Ae4dQnYJDNkbBZxWg2qdWcYYyYQt-Rg86PUd8Akishqc7_yKDkqMgLE6g_9GLPvBAQFR1tmoclkHfLbQUD-hjqoXQnNLmwn6TOg54jBmYjHdu2OLrPt0M8pMcA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - c79a874e-c732-4c65-86d5-57fe3938759d
-      X-Ms-Correlation-Request-Id:
-      - c79a874e-c732-4c65-86d5-57fe3938759d
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201710Z:c79a874e-c732-4c65-86d5-57fe3938759d
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:17:09 GMT
-      Content-Length:
-      - '31614'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[{"name":"miqazure-coreos1235","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235","etag":"W/\"4a6546ab-a4c0-4d27-bccd-f6ebf3c405a2\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"fb0a5e60-a6c2-4bb8-a2f5-0c16216a49b0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235/ipConfigurations/ipconfig1","etag":"W/\"4a6546ab-a4c0-4d27-bccd-f6ebf3c405a2\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.20.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/publicIPAddresses/miqazure-coreos1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/virtualNetworks/miq-azure-test3/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"rliadcyr3l1elbnsw4rabxqg1f.dx.internal.cloudapp.net"},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkSecurityGroups/miqazure-coreos1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Compute/virtualMachines/miqazure-coreos1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"dbergerprov1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/dbergerprov1","etag":"W/\"074dd836-918c-4e40-a118-94f0d366e175\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"ecdcd2f0-91bb-4c40-91cd-a3d76fc5e455","ipConfigurations":[{"name":"dbergerprov1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/dbergerprov1/ipConfigurations/dbergerprov1","etag":"W/\"074dd836-918c-4e40-a118-94f0d366e175\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.9","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/dbergerprov1-publicIp"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/virtualMachines/dbergerprov1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-rhel1390","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390","etag":"W/\"f006e6f9-0292-42cd-99fc-f72f194553c1\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"98853f48-2806-4065-be57-cf9159550440","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1","etag":"W/\"f006e6f9-0292-42cd-99fc-f72f194553c1\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"macAddress":"00-0D-3A-10-EB-AB","enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-ubuntu1989","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989","etag":"W/\"64e07488-15a2-4cec-b84a-6fd5ef04323c\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"134a6669-ac4a-4d08-a0db-387bc4c49537","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989/ipConfigurations/ipconfig1","etag":"W/\"64e07488-15a2-4cec-b84a-6fd5ef04323c\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.17.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-ubuntu1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest18687/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-win12610","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610","etag":"W/\"dd925ef5-33d1-402c-a0f4-18c78c2641f4\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"5c2eef2c-0b36-4277-a940-957ed4d13be0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610/ipConfigurations/ipconfig1","etag":"W/\"dd925ef5-33d1-402c-a0f4-18c78c2641f4\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.18.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-win12"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest19881/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-winimg241","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241","etag":"W/\"4a17a745-16a9-42d9-88c9-17a518959525\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"8ed2f3b0-4a4b-49ae-9f1d-ff7890dbd396","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241/ipConfigurations/ipconfig1","etag":"W/\"4a17a745-16a9-42d9-88c9-17a518959525\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.7","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqtestwinimg6202"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-centos1611","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611","etag":"W/\"26031ef6-bb55-4019-8185-2dd1edcb207c\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"f1760e49-9853-4fdc-acfc-4ea232b9ed76","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1","etag":"W/\"26031ef6-bb55-4019-8185-2dd1edcb207c\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.5","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqmismatch1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1","etag":"W/\"3a72d0c3-bfda-4da5-a61b-e8c33e43de79\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"23d804a8-b623-49e7-9c8d-1d64245bef1e","ipConfigurations":[{"name":"miqmismatch1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1/ipConfigurations/miqmismatch1","etag":"W/\"3a72d0c3-bfda-4da5-a61b-e8c33e43de79\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.8","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqmismatch1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqmismatch1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"rspec-lb-a670","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670","etag":"W/\"cf3a0b0d-d596-4f33-bc31-749f92ba4f00\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"46cb8216-786e-408e-9d86-c0855b357349","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1","etag":"W/\"cf3a0b0d-d596-4f33-bc31-749f92ba4f00\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.6","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-a-ip"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"rspec-lb-b843","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843","etag":"W/\"76aabe0c-8678-43f0-81a5-2f15784a4b99\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"3ef6fa01-ac34-43a1-8fd7-67c706b4d8ef","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1","etag":"W/\"76aabe0c-8678-43f0-81a5-2f15784a4b99\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.11","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-b-ip"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"spec0deply1nic0","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","etag":"W/\"b817491c-aab8-4aab-b41d-b07bfffa5639\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"80ad9866-071d-4e3f-91d0-d47954eccee0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1","etag":"W/\"b817491c-aab8-4aab-b41d-b07bfffa5639\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.4","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"spec0deply1nic1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","etag":"W/\"2ec58a0b-4c03-4d0a-b788-9daffd54e7b2\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"57bbf7aa-d6c4-4f56-8f6a-089d15334221","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1","etag":"W/\"2ec58a0b-4c03-4d0a-b788-9daffd54e7b2\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.5","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqmismatch2656","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqmismatch2656","etag":"W/\"fef6a836-2802-4897-90c3-b3d71f133384\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"969dde6c-73c0-4340-877d-2b5fe2060026","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqmismatch2656/ipConfigurations/ipconfig1","etag":"W/\"fef6a836-2802-4897-90c3-b3d71f133384\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"172.23.0.4","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/virtualNetworks/miqazuretest33606/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkSecurityGroups/miqmismatch2-nsg"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Compute/virtualMachines/miqmismatch2"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-linux-manag944","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944","etag":"W/\"b6339880-8ead-4c9e-b5c0-f38c4f8612d5\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"c5e8b90e-5a78-49b0-b224-b70ed3fb45e5","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944/ipConfigurations/ipconfig1","etag":"W/\"b6339880-8ead-4c9e-b5c0-f38c4f8612d5\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"172.25.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqazure-linux-managed-ip"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"jf-metrics-2751","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751","etag":"W/\"c5f6f02a-b17c-4f34-882b-11c7adef0b44\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"207a58d3-f18d-4dab-8168-919877297a52","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751/ipConfigurations/ipconfig1","etag":"W/\"c5f6f02a-b17c-4f34-882b-11c7adef0b44\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.7","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-2"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-2"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/jf-metrics-2"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"jf-metrics-3421","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421","etag":"W/\"0b6f160b-ad10-48f8-9d0c-657193bb823f\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"b8b345e8-a353-4700-992e-be48a717b4e2","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421/ipConfigurations/ipconfig1","etag":"W/\"0b6f160b-ad10-48f8-9d0c-657193bb823f\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.8","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-3"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-3"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/jf-metrics-3"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-oraclelinux310","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310","etag":"W/\"54cd4fe1-3ed5-4a8c-bc8d-527679c7a631\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"6a3fc1d7-4532-4ca0-b5c2-546cc8f7f313","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310/ipConfigurations/ipconfig1","etag":"W/\"54cd4fe1-3ed5-4a8c-bc8d-527679c7a631\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.5","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-oraclelinux993","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993","etag":"W/\"a9432274-7b40-4eb3-a64f-a04267a423ff\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"75d8ed14-e0ae-4d84-99f6-e3f43d073e76","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993/ipConfigurations/ipconfig1","etag":"W/\"a9432274-7b40-4eb3-a64f-a04267a423ff\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.6","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux2"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux2"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"}]}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:17:10 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Network/publicIPAddresses?api-version=2017-11-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0OTUsIm5iZiI6MTUyMDQ1MzQ5NSwiZXhwIjoxNTIwNDU3Mzk1LCJhaW8iOiJZMk5nWUVndU5CSXl1MXFVeEdEM2ZsSFpieWtHQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ043QlVpaXhfRUtWWWFxR0UyRUFBQSIsInZlciI6IjEuMCJ9.Aj1ctOMBOwBnIeeKdPOaEyzKn5BJN38vjYfTjEdBR3O28GkzKMNrI9osuXXUl-MZJJjHUa5YF9Q23kHoF_2jX6dg692lNdMVrlwFPt61fGgAaiwbz2z05M2vMgtGCRUwh29B9F0SQYNYPIfKFQiPxwTNasGnKv5UVCcyoGkRikbbnqf97GkqW96sykNL5uBWq6Hfs55GNa0vU8-aWsNxc3ErY-w8Ae4dQnYJDNkbBZxWg2qdWcYYyYQt-Rg86PUd8Akishqc7_yKDkqMgLE6g_9GLPvBAQFR1tmoclkHfLbQUD-hjqoXQnNLmwn6TOg54jBmYjHdu2OLrPt0M8pMcA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 45bde6f6-b49c-4596-a2aa-575f67ed4e2e
-      X-Ms-Correlation-Request-Id:
-      - 45bde6f6-b49c-4596-a2aa-575f67ed4e2e
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201712Z:45bde6f6-b49c-4596-a2aa-575f67ed4e2e
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:17:12 GMT
-      Content-Length:
-      - '13978'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[{"name":"miqazure-coreos1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/publicIPAddresses/miqazure-coreos1","etag":"W/\"da64b64b-a755-4389-a2f3-5cba32f18c06\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"28617ed1-0270-4b39-873a-c3b48b3deef1","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"dbergerprov1-publicIp","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/dbergerprov1-publicIp","etag":"W/\"3d984c69-3f35-41ce-bdfc-8d207053a6a9\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"eb0e8804-e169-44ac-bb47-0929370977d2","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/dbergerprov1/ipConfigurations/dbergerprov1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"ladas_test","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/ladas_test","etag":"W/\"32e21623-9a1b-4c40-80f4-6a350aa237a7\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"3daa5f66-5a01-4242-b95b-c4e0ee8f0c36","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[]},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miq-test-rhel1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1","etag":"W/\"054052bb-11ff-4f6e-ac1a-3427c2fd17aa\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"f6cfc635-411e-48ce-a627-39a2fc0d3168","ipAddress":"52.224.165.15","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miq-test-ubuntu1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-ubuntu1","etag":"W/\"bcae50c5-146f-4fcb-a461-7c1030ba7b74\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"e272bd74-f661-484f-b223-88dd128a4049","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miq-test-win12","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-win12","etag":"W/\"56ce00f4-50d7-4682-9ee8-6836bf5c0ea6\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"b9200977-8147-40a5-83c2-d5892d5ddedc","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miqazure-centos1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1","etag":"W/\"734a3944-a880-444c-8c92-cace6e28e303\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"475a66f0-9e89-4226-a9f0-9baaaf31d619","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miqtestwinimg6202","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqtestwinimg6202","etag":"W/\"b656279a-26ff-4021-94bb-263420cf494e\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"fb942169-855b-44f8-b12f-fd63e961b140","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"rspec-lb-a-ip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-a-ip","etag":"W/\"3ba30997-7d2f-470c-96f6-301158e93b7c\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"3c605f75-23c0-46ab-ba2b-6fd4430140fd","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"rspec-lb-b-ip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-b-ip","etag":"W/\"cf6012c7-3d47-438f-84d7-332ad1ef4500\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"5d1a2425-a351-4c0f-bc87-37e6500bff22","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"rspec-lb1-LoadBalancerFrontEnd","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd","etag":"W/\"a38434c8-7b23-4092-b7c6-402238eac0dc\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"f28e0f25-b372-4edf-97d9-13a9e3b4ba2d","ipAddress":"40.71.82.83","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"rspec-lb2-publicip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip","etag":"W/\"cddd97d1-6111-4477-8a00-3dc885237a1d\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"83e7257d-ab94-4229-8eb5-4798f37ef28d","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"spec0deply1ip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip","etag":"W/\"2080997a-38a6-420d-ba86-e9582e1331c7\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"a08b891e-e45a-4970-aefc-f6c996989490","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"spec0deply1dns","fqdn":"spec0deply1dns.eastus.cloudapp.azure.com"},"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miqazure-linux-managed-ip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqazure-linux-managed-ip","etag":"W/\"0efc9684-fb7d-4fb7-b9b9-f33dbac04a28\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"6a2a9142-26e8-45cd-93bf-7318192f3528","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miqmismatch1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqmismatch1","etag":"W/\"9b8b1729-21c4-4c53-94f2-15715315ad73\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"a97c71d0-6b78-4ffe-8e5c-0be1ee653f8c","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"miqmismatch1","fqdn":"miqmismatch1.eastus.cloudapp.azure.com"},"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1/ipConfigurations/miqmismatch1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"jf-metrics-2","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-2","etag":"W/\"b43ebe01-574c-4454-87eb-3401fbcf36f2\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"e446f3e4-9410-4d7f-bb04-2652096359de","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"jf-metrics-3","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-3","etag":"W/\"a6ee7100-6202-4ae2-a2db-f828abec8af9\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"de5995a4-15c1-40ba-ad78-67e70a92654b","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miqazure-oraclelinux1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux1","etag":"W/\"98bee7b4-2fcc-471d-b5ce-92850e6c3d6b\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"f2ac7c18-520b-4b42-94e7-da264a842f41","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miqazure-oraclelinux2","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux2","etag":"W/\"0865cebc-95b9-49d2-9f10-21dbafb23cac\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"2f4e1091-46f0-474c-a697-8dbcea6ba2a6","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}}]}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:17:12 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Storage/storageAccounts?api-version=2017-10-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0OTUsIm5iZiI6MTUyMDQ1MzQ5NSwiZXhwIjoxNTIwNDU3Mzk1LCJhaW8iOiJZMk5nWUVndU5CSXl1MXFVeEdEM2ZsSFpieWtHQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ043QlVpaXhfRUtWWWFxR0UyRUFBQSIsInZlciI6IjEuMCJ9.Aj1ctOMBOwBnIeeKdPOaEyzKn5BJN38vjYfTjEdBR3O28GkzKMNrI9osuXXUl-MZJJjHUa5YF9Q23kHoF_2jX6dg692lNdMVrlwFPt61fGgAaiwbz2z05M2vMgtGCRUwh29B9F0SQYNYPIfKFQiPxwTNasGnKv5UVCcyoGkRikbbnqf97GkqW96sykNL5uBWq6Hfs55GNa0vU8-aWsNxc3ErY-w8Ae4dQnYJDNkbBZxWg2qdWcYYyYQt-Rg86PUd8Akishqc7_yKDkqMgLE6g_9GLPvBAQFR1tmoclkHfLbQUD-hjqoXQnNLmwn6TOg54jBmYjHdu2OLrPt0M8pMcA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 933ce20d-9afc-42b7-aa89-cf91e942f28f
-      X-Ms-Correlation-Request-Id:
-      - 933ce20d-9afc-42b7-aa89-cf91e942f28f
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201716Z:933ce20d-9afc-42b7-aa89-cf91e942f28f
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:17:15 GMT
-      Content-Length:
-      - '8649'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","name":"miqazuretest18686","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T17:22:54.7808677Z","primaryEndpoints":{"blob":"https://miqazuretest18686.blob.core.windows.net/","queue":"https://miqazuretest18686.queue.core.windows.net/","table":"https://miqazuretest18686.table.core.windows.net/","file":"https://miqazuretest18686.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","name":"miqazuretest14047","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T17:30:25.7028008Z","primaryEndpoints":{"blob":"https://miqazuretest14047.blob.core.windows.net/","queue":"https://miqazuretest14047.queue.core.windows.net/","table":"https://miqazuretest14047.table.core.windows.net/","file":"https://miqazuretest14047.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Premium_LRS","tier":"Premium"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb","name":"rspeclb","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-09-02T16:29:11.6823797Z","primaryEndpoints":{"blob":"https://rspeclb.blob.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","name":"spec0deply1stor","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-04-04T23:05:07.8274794Z","primaryEndpoints":{"blob":"https://spec0deply1stor.blob.core.windows.net/","queue":"https://spec0deply1stor.queue.core.windows.net/","table":"https://spec0deply1stor.table.core.windows.net/","file":"https://spec0deply1stor.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Storage/storageAccounts/miqazuretest26611","name":"miqazuretest26611","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2211656Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2211656Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-05-02T18:01:29.2743021Z","primaryEndpoints":{"blob":"https://miqazuretest26611.blob.core.windows.net/","queue":"https://miqazuretest26611.queue.core.windows.net/","table":"https://miqazuretest26611.table.core.windows.net/","file":"https://miqazuretest26611.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","name":"miqazuretest16487","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T17:26:55.3231669Z","primaryEndpoints":{"blob":"https://miqazuretest16487.blob.core.windows.net/","queue":"https://miqazuretest16487.queue.core.windows.net/","table":"https://miqazuretest16487.table.core.windows.net/","file":"https://miqazuretest16487.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Storage/storageAccounts/miqazuretest32946","name":"miqazuretest32946","type":"Microsoft.Storage/storageAccounts","location":"westus","tags":{"delete":"false"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.0404359Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.0404359Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T21:18:37.0793411Z","primaryEndpoints":{"blob":"https://miqazuretest32946.blob.core.windows.net/","queue":"https://miqazuretest32946.queue.core.windows.net/","table":"https://miqazuretest32946.table.core.windows.net/","file":"https://miqazuretest32946.file.core.windows.net/"},"primaryLocation":"westus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Storage/storageAccounts/miqazureshared1","name":"miqazureshared1","type":"Microsoft.Storage/storageAccounts","location":"centralus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.1935084Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.1935084Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T20:42:52.498085Z","primaryEndpoints":{"blob":"https://miqazureshared1.blob.core.windows.net/","queue":"https://miqazureshared1.queue.core.windows.net/","table":"https://miqazureshared1.table.core.windows.net/","file":"https://miqazureshared1.file.core.windows.net/"},"primaryLocation":"centralus","statusOfPrimary":"available","secondaryLocation":"eastus2","statusOfSecondary":"available","secondaryEndpoints":{"blob":"https://miqazureshared1-secondary.blob.core.windows.net/","queue":"https://miqazureshared1-secondary.queue.core.windows.net/","table":"https://miqazureshared1-secondary.table.core.windows.net/"}}}]}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:17:16 GMT
+  recorded_at: Mon, 12 Mar 2018 09:26:26 GMT
 - request:
     method: post
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047/listKeys?api-version=2017-10-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686/listKeys?api-version=2017-10-01
     body:
       encoding: ASCII-8BIT
       string: ''
@@ -3439,7 +3382,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0OTUsIm5iZiI6MTUyMDQ1MzQ5NSwiZXhwIjoxNTIwNDU3Mzk1LCJhaW8iOiJZMk5nWUVndU5CSXl1MXFVeEdEM2ZsSFpieWtHQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ043QlVpaXhfRUtWWWFxR0UyRUFBQSIsInZlciI6IjEuMCJ9.Aj1ctOMBOwBnIeeKdPOaEyzKn5BJN38vjYfTjEdBR3O28GkzKMNrI9osuXXUl-MZJJjHUa5YF9Q23kHoF_2jX6dg692lNdMVrlwFPt61fGgAaiwbz2z05M2vMgtGCRUwh29B9F0SQYNYPIfKFQiPxwTNasGnKv5UVCcyoGkRikbbnqf97GkqW96sykNL5uBWq6Hfs55GNa0vU8-aWsNxc3ErY-w8Ae4dQnYJDNkbBZxWg2qdWcYYyYQt-Rg86PUd8Akishqc7_yKDkqMgLE6g_9GLPvBAQFR1tmoclkHfLbQUD-hjqoXQnNLmwn6TOg54jBmYjHdu2OLrPt0M8pMcA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDY0NjAsIm5iZiI6MTUyMDg0NjQ2MCwiZXhwIjoxNTIwODUwMzYwLCJhaW8iOiJZMk5nWUdBTzluZzJLY25wRWNmV20xS1NCOXJmQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTm9acDlkRDEwMFdPOWxvU0FqNGpBQSIsInZlciI6IjEuMCJ9.RT1lqldgy3xYclH7HEXx7zoes4517ZvTUJjlw0mHn9Dpn0GXG9OP28f2qqRR5NfcfCG9097_OHuFrg9Gs7R6J2MZ2CwLwPnVjxEwlc2wNxlSwlNGoRK20-73mpDZSYlRTty10TnjMgiIeQyKhlRGORoz4exaj0vCpMLsGm8dOp0IGVMQNG52VzYouCB2dRYpzXZs4qIkR090uJDCNBiqg2V0qlvSH-aJbhTgZ6meOh7S03o81RLuEnBOXjyYImq2dFuv1jWtAo1t45ePcE-LRcyTgjPDR9cNx0s_7gqd8aqAKqKxq98hRQdK5Kx8aM1jVMJQhWy1AJIwhmRhLNrsHA
       Content-Length:
       - '0'
   response:
@@ -3460,29 +3403,29 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - bddde359-f4fe-492f-8ec1-afb8182c4b74
+      - 8d3fb82c-8bce-4dfb-842d-e22e0bff3cc6
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1197'
+      - '1199'
       X-Ms-Correlation-Request-Id:
-      - c1fa5a94-5673-4194-855f-bf8a1035ecf7
+      - 6ea28971-7a0e-4465-afd8-56290f07cba4
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201717Z:c1fa5a94-5673-4194-855f-bf8a1035ecf7
+      - WESTEUROPE:20180312T092623Z:6ea28971-7a0e-4465-afd8-56290f07cba4
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:17:17 GMT
+      - Mon, 12 Mar 2018 09:26:22 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"keys":[{"keyName":"key1","value":"9hGLwV9mjvAc1ARzeGwpsS9oZPLqOBzHCCHjeixyt1wpPYVn32cXmm3Gs9ogFPXZhDH61PAXxud0Dg/qwOnJ1w==","permissions":"Full"},{"keyName":"key2","value":"FfW8btVjJE2LkKHvN8Prr3FDX71BrS4SnMkONq2fLVPPm6x7vqqjeDSWDh17aI4CBLYf3Y1pc6njkbz53HdMYg==","permissions":"Full"}]}'
+      string: '{"keys":[{"keyName":"key1","value":"32PV5jeBt8nw1XvFbZokY26SXchbD6H2tw/YrteEYVE0kpMLKrZ74VrwaIjDyucdi/RxDaAlf7dJIilLS7muNw==","permissions":"Full"},{"keyName":"key2","value":"Eo5x9CQJL1/wl6Tkj5N7M5eEdw6Hym6AeyTt3xjcDl30sV8Iadro6ywZzOHQwNDlmrDaBF6x2a9ZFL7zswxQ7w==","permissions":"Full"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:17:17 GMT
+  recorded_at: Mon, 12 Mar 2018 09:26:27 GMT
 - request:
     method: head
-    uri: https://miqazuretest14047.blob.core.windows.net/vhds/miqazure-centos12016221104946.vhd
+    uri: https://miqazuretest18686.blob.core.windows.net/vhds/miq-test-rhel12016218112243.vhd
     body:
       encoding: US-ASCII
       string: ''
@@ -3496,7 +3439,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:17:17 GMT
+      - Mon, 12 Mar 2018 09:28:50 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -3504,7 +3447,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:d3evVLz83BEJoVizuPMNool/DPDizbOzsPdlwbKTw6w=
+      - SharedKey miqazuretest18686:mz/3Zqfpx2cIWYHVwq6wKGEI+d3Wj/WvQasA0q/vm3E=
   response:
     status:
       code: 200
@@ -3515,27 +3458,27 @@ http_interactions:
       Content-Type:
       - application/octet-stream
       Content-Md5:
-      - bLK7rgT7IgMNX2YxL9BCyg==
+      - dQL+XHjFNPdoMEweI63fwQ==
       Last-Modified:
-      - Fri, 22 Apr 2016 19:05:58 GMT
+      - Mon, 12 Mar 2018 09:28:43 GMT
       Accept-Ranges:
       - bytes
       Etag:
-      - '"0x8D36AE123954B35"'
+      - '"0x8D587FBA5ECC304"'
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 0c7c9e00-001e-00ae-5851-b60512000000
+      - 28275459-001e-00aa-64e4-b9f090000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Microsoftazurecompute-Resourcegroupname:
       - miq-azure-test1
       X-Ms-Meta-Microsoftazurecompute-Vmname:
-      - miqazure-centos1
+      - miq-test-rhel1
       X-Ms-Meta-Microsoftazurecompute-Diskid:
-      - 66656abf-e460-45ac-a6f0-851d0a50b23a
+      - 0ea91415-9058-46c6-9792-3afcb4da976f
       X-Ms-Meta-Microsoftazurecompute-Diskname:
-      - miqazure-centos1
+      - miq-test-rhel1
       X-Ms-Meta-Microsoftazurecompute-Disktype:
       - OSDisk
       X-Ms-Lease-Status:
@@ -3547,29 +3490,29 @@ http_interactions:
       X-Ms-Blob-Type:
       - PageBlob
       X-Ms-Blob-Sequence-Number:
-      - '1'
+      - '372'
       X-Ms-Copy-Id:
-      - 549dd428-4055-4337-a425-05293b903858
+      - b967ea05-82a2-405a-8df9-4615d59df4eb
       X-Ms-Copy-Source:
-      - https://ardfepirv2bl5prdstr06.blob.core.windows.net/5112500ae3b842c8b9c604889f8753c3/OpenLogic-CentOS-71-20160308?sv=2014-02-14&sr=b&si=PirCacheAccountPublisherContainerPolicy&sig=fxe20jiCl%2Foys9OSvljXlookVPi76KM8FYlTr%2BSY4IQ%3D
+      - https://ardfepirv2bl5prdstr06.blob.core.windows.net/a879bbefc56a43abb0ce65052aac09f3/rhel-72-20160302?sv=2014-02-14&sr=b&si=PirCacheAccountPublisherContainerPolicy&sig=2TQ3SKHqVnqe4jVKB4qMCBOphv2nYelKworI7pfckrs%3D
       X-Ms-Copy-Status:
       - success
       X-Ms-Copy-Progress:
       - 32212255232/32212255232
       X-Ms-Copy-Completion-Time:
-      - Mon, 21 Mar 2016 16:50:14 GMT
+      - Fri, 18 Mar 2016 17:23:28 GMT
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:17:17 GMT
+      - Mon, 12 Mar 2018 09:28:46 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:17:18 GMT
+  recorded_at: Mon, 12 Mar 2018 09:28:51 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1?api-version=2018-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3583,7 +3526,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0OTUsIm5iZiI6MTUyMDQ1MzQ5NSwiZXhwIjoxNTIwNDU3Mzk1LCJhaW8iOiJZMk5nWUVndU5CSXl1MXFVeEdEM2ZsSFpieWtHQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ043QlVpaXhfRUtWWWFxR0UyRUFBQSIsInZlciI6IjEuMCJ9.Aj1ctOMBOwBnIeeKdPOaEyzKn5BJN38vjYfTjEdBR3O28GkzKMNrI9osuXXUl-MZJJjHUa5YF9Q23kHoF_2jX6dg692lNdMVrlwFPt61fGgAaiwbz2z05M2vMgtGCRUwh29B9F0SQYNYPIfKFQiPxwTNasGnKv5UVCcyoGkRikbbnqf97GkqW96sykNL5uBWq6Hfs55GNa0vU8-aWsNxc3ErY-w8Ae4dQnYJDNkbBZxWg2qdWcYYyYQt-Rg86PUd8Akishqc7_yKDkqMgLE6g_9GLPvBAQFR1tmoclkHfLbQUD-hjqoXQnNLmwn6TOg54jBmYjHdu2OLrPt0M8pMcA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDY0NjAsIm5iZiI6MTUyMDg0NjQ2MCwiZXhwIjoxNTIwODUwMzYwLCJhaW8iOiJZMk5nWUdBTzluZzJLY25wRWNmV20xS1NCOXJmQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTm9acDlkRDEwMFdPOWxvU0FqNGpBQSIsInZlciI6IjEuMCJ9.RT1lqldgy3xYclH7HEXx7zoes4517ZvTUJjlw0mHn9Dpn0GXG9OP28f2qqRR5NfcfCG9097_OHuFrg9Gs7R6J2MZ2CwLwPnVjxEwlc2wNxlSwlNGoRK20-73mpDZSYlRTty10TnjMgiIeQyKhlRGORoz4exaj0vCpMLsGm8dOp0IGVMQNG52VzYouCB2dRYpzXZs4qIkR090uJDCNBiqg2V0qlvSH-aJbhTgZ6meOh7S03o81RLuEnBOXjyYImq2dFuv1jWtAo1t45ePcE-LRcyTgjPDR9cNx0s_7gqd8aqAKqKxq98hRQdK5Kx8aM1jVMJQhWy1AJIwhmRhLNrsHA
   response:
     status:
       code: 200
@@ -3600,35 +3543,36 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"f1907e14-fcad-4f75-8faa-ab325bf879d9"
+      - W/"5ad0e691-263e-42ca-8a93-833bd4dbf13f"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 1305e8b0-ed58-4c14-af3f-8c070d279f71
+      - d3d58a68-f21e-4117-9744-3cf87b9ef9f6
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14977'
+      - '14994'
       X-Ms-Correlation-Request-Id:
-      - f2347db5-248c-4df1-822a-36c22c840c24
+      - 286fa284-125b-471d-99ae-64e514f01619
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201718Z:f2347db5-248c-4df1-822a-36c22c840c24
+      - WESTEUROPE:20180312T092846Z:286fa284-125b-471d-99ae-64e514f01619
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:17:18 GMT
+      - Mon, 12 Mar 2018 09:28:46 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"miqazure-centos1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1\",\r\n
-        \ \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n  \"type\":
+      string: "{\r\n  \"name\": \"miq-test-rhel1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1\",\r\n
+        \ \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n  \"type\":
         \"Microsoft.Network/networkSecurityGroups\",\r\n  \"location\": \"eastus\",\r\n
-        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
-        \"9ca49a93-6f7d-464c-b23d-e61e847ce2d6\",\r\n    \"securityRules\": [\r\n
-        \     {\r\n        \"name\": \"default-allow-ssh\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/securityRules/default-allow-ssh\",\r\n
-        \       \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"f4a4a6a5-e2e8-47bd-b46f-00592f8fce53\",\r\n    \"securityRules\":
+        [\r\n      {\r\n        \"name\": \"default-allow-ssh\",\r\n        \"id\":
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/securityRules/default-allow-ssh\",\r\n
+        \       \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"protocol\": \"Tcp\",\r\n          \"sourcePortRange\": \"*\",\r\n
         \         \"destinationPortRange\": \"22\",\r\n          \"sourceAddressPrefix\":
@@ -3636,9 +3580,29 @@ http_interactions:
         \"Allow\",\r\n          \"priority\": 1000,\r\n          \"direction\": \"Inbound\",\r\n
         \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
         [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"rhel1-inbound1\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/securityRules/rhel1-inbound1\",\r\n
+        \       \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"protocol\": \"Tcp\",\r\n          \"sourcePortRange\": \"80\",\r\n
+        \         \"destinationPortRange\": \"80\",\r\n          \"sourceAddressPrefix\":
+        \"*\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n          \"access\":
+        \"Allow\",\r\n          \"priority\": 100,\r\n          \"direction\": \"Inbound\",\r\n
+        \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"rhel1-inbound2\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/securityRules/rhel1-inbound2\",\r\n
+        \       \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"protocol\": \"Tcp\",\r\n          \"sourcePortRange\": \"443\",\r\n
+        \         \"destinationPortRange\": \"443\",\r\n          \"sourceAddressPrefix\":
+        \"*\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n          \"access\":
+        \"Allow\",\r\n          \"priority\": 200,\r\n          \"direction\": \"Inbound\",\r\n
+        \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
         []\r\n        }\r\n      }\r\n    ],\r\n    \"defaultSecurityRules\": [\r\n
-        \     {\r\n        \"name\": \"AllowVnetInBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/defaultSecurityRules/AllowVnetInBound\",\r\n
-        \       \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n
+        \     {\r\n        \"name\": \"AllowVnetInBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/defaultSecurityRules/AllowVnetInBound\",\r\n
+        \       \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"description\": \"Allow inbound traffic from all VMs in VNET\",\r\n
         \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
@@ -3648,8 +3612,8 @@ http_interactions:
         \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
         [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
         []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowAzureLoadBalancerInBound\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/defaultSecurityRules/AllowAzureLoadBalancerInBound\",\r\n
-        \       \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/defaultSecurityRules/AllowAzureLoadBalancerInBound\",\r\n
+        \       \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"description\": \"Allow inbound traffic from azure load balancer\",\r\n
         \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
@@ -3659,8 +3623,8 @@ http_interactions:
         \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
         [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
         []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllInBound\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/defaultSecurityRules/DenyAllInBound\",\r\n
-        \       \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/defaultSecurityRules/DenyAllInBound\",\r\n
+        \       \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"description\": \"Deny all inbound traffic\",\r\n          \"protocol\":
         \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\":
@@ -3669,8 +3633,8 @@ http_interactions:
         \         \"direction\": \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n
         \         \"destinationPortRanges\": [],\r\n          \"sourceAddressPrefixes\":
         [],\r\n          \"destinationAddressPrefixes\": []\r\n        }\r\n      },\r\n
-        \     {\r\n        \"name\": \"AllowVnetOutBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/defaultSecurityRules/AllowVnetOutBound\",\r\n
-        \       \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n
+        \     {\r\n        \"name\": \"AllowVnetOutBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/defaultSecurityRules/AllowVnetOutBound\",\r\n
+        \       \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"description\": \"Allow outbound traffic from all VMs to all VMs
         in VNET\",\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\":
@@ -3680,8 +3644,8 @@ http_interactions:
         \"Outbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
         [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
         []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowInternetOutBound\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/defaultSecurityRules/AllowInternetOutBound\",\r\n
-        \       \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/defaultSecurityRules/AllowInternetOutBound\",\r\n
+        \       \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"description\": \"Allow outbound traffic from all VMs to Internet\",\r\n
         \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
@@ -3691,8 +3655,8 @@ http_interactions:
         \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
         [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
         []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllOutBound\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/defaultSecurityRules/DenyAllOutBound\",\r\n
-        \       \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/defaultSecurityRules/DenyAllOutBound\",\r\n
+        \       \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"description\": \"Deny all outbound traffic\",\r\n          \"protocol\":
         \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\":
@@ -3701,10 +3665,10 @@ http_interactions:
         \         \"direction\": \"Outbound\",\r\n          \"sourcePortRanges\":
         [],\r\n          \"destinationPortRanges\": [],\r\n          \"sourceAddressPrefixes\":
         [],\r\n          \"destinationAddressPrefixes\": []\r\n        }\r\n      }\r\n
-        \   ],\r\n    \"networkInterfaces\": [\r\n      {\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611\"\r\n
+        \   ],\r\n    \"networkInterfaces\": [\r\n      {\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390\"\r\n
         \     }\r\n    ]\r\n  }\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:17:19 GMT
+  recorded_at: Mon, 12 Mar 2018 09:28:51 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1?api-version=2018-01-01
@@ -3721,7 +3685,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0OTUsIm5iZiI6MTUyMDQ1MzQ5NSwiZXhwIjoxNTIwNDU3Mzk1LCJhaW8iOiJZMk5nWUVndU5CSXl1MXFVeEdEM2ZsSFpieWtHQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ043QlVpaXhfRUtWWWFxR0UyRUFBQSIsInZlciI6IjEuMCJ9.Aj1ctOMBOwBnIeeKdPOaEyzKn5BJN38vjYfTjEdBR3O28GkzKMNrI9osuXXUl-MZJJjHUa5YF9Q23kHoF_2jX6dg692lNdMVrlwFPt61fGgAaiwbz2z05M2vMgtGCRUwh29B9F0SQYNYPIfKFQiPxwTNasGnKv5UVCcyoGkRikbbnqf97GkqW96sykNL5uBWq6Hfs55GNa0vU8-aWsNxc3ErY-w8Ae4dQnYJDNkbBZxWg2qdWcYYyYQt-Rg86PUd8Akishqc7_yKDkqMgLE6g_9GLPvBAQFR1tmoclkHfLbQUD-hjqoXQnNLmwn6TOg54jBmYjHdu2OLrPt0M8pMcA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDY0NjAsIm5iZiI6MTUyMDg0NjQ2MCwiZXhwIjoxNTIwODUwMzYwLCJhaW8iOiJZMk5nWUdBTzluZzJLY25wRWNmV20xS1NCOXJmQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTm9acDlkRDEwMFdPOWxvU0FqNGpBQSIsInZlciI6IjEuMCJ9.RT1lqldgy3xYclH7HEXx7zoes4517ZvTUJjlw0mHn9Dpn0GXG9OP28f2qqRR5NfcfCG9097_OHuFrg9Gs7R6J2MZ2CwLwPnVjxEwlc2wNxlSwlNGoRK20-73mpDZSYlRTty10TnjMgiIeQyKhlRGORoz4exaj0vCpMLsGm8dOp0IGVMQNG52VzYouCB2dRYpzXZs4qIkR090uJDCNBiqg2V0qlvSH-aJbhTgZ6meOh7S03o81RLuEnBOXjyYImq2dFuv1jWtAo1t45ePcE-LRcyTgjPDR9cNx0s_7gqd8aqAKqKxq98hRQdK5Kx8aM1jVMJQhWy1AJIwhmRhLNrsHA
   response:
     status:
       code: 200
@@ -3738,36 +3702,36 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"fceae1ac-4620-482a-bc6d-79c867179ae5"
+      - W/"a8b09238-30fc-4b36-a58d-e3cc69e267c5"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - f004fac7-5b92-44bc-b512-39ce2605ba94
+      - ae76d31e-8f3e-4a00-b38a-3cbead5606a9
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14977'
+      - '14997'
       X-Ms-Correlation-Request-Id:
-      - 4022dd45-9eaa-4ed8-b9ed-e9c0bd155436
+      - 64b61583-8171-41c2-8d2a-810966983e32
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201719Z:4022dd45-9eaa-4ed8-b9ed-e9c0bd155436
+      - WESTEUROPE:20180312T092847Z:64b61583-8171-41c2-8d2a-810966983e32
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:17:18 GMT
+      - Mon, 12 Mar 2018 09:28:47 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"miq-azure-test1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1\",\r\n
-        \ \"etag\": \"W/\\\"fceae1ac-4620-482a-bc6d-79c867179ae5\\\"\",\r\n  \"type\":
+        \ \"etag\": \"W/\\\"a8b09238-30fc-4b36-a58d-e3cc69e267c5\\\"\",\r\n  \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
         \"d74c1e5f-50e4-4c8a-a7fe-78eaddc6b915\",\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\":
         [\r\n        \"10.16.0.0/16\"\r\n      ]\r\n    },\r\n    \"subnets\": [\r\n
         \     {\r\n        \"name\": \"default\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\",\r\n
-        \       \"etag\": \"W/\\\"fceae1ac-4620-482a-bc6d-79c867179ae5\\\"\",\r\n
+        \       \"etag\": \"W/\\\"a8b09238-30fc-4b36-a58d-e3cc69e267c5\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"addressPrefix\": \"10.16.0.0/24\",\r\n          \"ipConfigurations\":
         [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1\"\r\n
@@ -3777,149 +3741,10 @@ http_interactions:
         \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/dbergerprov1/ipConfigurations/dbergerprov1\"\r\n
         \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
         \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/ladas_test_1/ipConfigurations/ladas_test_1\"\r\n
         \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"virtualNetworkPeerings\":
         [],\r\n    \"enableDdosProtection\": false,\r\n    \"enableVmProtection\":
         false\r\n  }\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:17:19 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0OTUsIm5iZiI6MTUyMDQ1MzQ5NSwiZXhwIjoxNTIwNDU3Mzk1LCJhaW8iOiJZMk5nWUVndU5CSXl1MXFVeEdEM2ZsSFpieWtHQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ043QlVpaXhfRUtWWWFxR0UyRUFBQSIsInZlciI6IjEuMCJ9.Aj1ctOMBOwBnIeeKdPOaEyzKn5BJN38vjYfTjEdBR3O28GkzKMNrI9osuXXUl-MZJJjHUa5YF9Q23kHoF_2jX6dg692lNdMVrlwFPt61fGgAaiwbz2z05M2vMgtGCRUwh29B9F0SQYNYPIfKFQiPxwTNasGnKv5UVCcyoGkRikbbnqf97GkqW96sykNL5uBWq6Hfs55GNa0vU8-aWsNxc3ErY-w8Ae4dQnYJDNkbBZxWg2qdWcYYyYQt-Rg86PUd8Akishqc7_yKDkqMgLE6g_9GLPvBAQFR1tmoclkHfLbQUD-hjqoXQnNLmwn6TOg54jBmYjHdu2OLrPt0M8pMcA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"26031ef6-bb55-4019-8185-2dd1edcb207c"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 31c83062-4322-462f-a2fe-fd2543190793
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14979'
-      X-Ms-Correlation-Request-Id:
-      - 371ca5c9-0966-40d5-8650-cfd45f08f06d
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201719Z:371ca5c9-0966-40d5-8650-cfd45f08f06d
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:17:19 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"miqazure-centos1611\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611\",\r\n
-        \ \"etag\": \"W/\\\"26031ef6-bb55-4019-8185-2dd1edcb207c\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"f1760e49-9853-4fdc-acfc-4ea232b9ed76\",\r\n    \"ipConfigurations\":
-        [\r\n      {\r\n        \"name\": \"ipconfig1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1\",\r\n
-        \       \"etag\": \"W/\\\"26031ef6-bb55-4019-8185-2dd1edcb207c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAddress\": \"10.16.0.5\",\r\n          \"privateIPAllocationMethod\":
-        \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1\"\r\n
-        \         },\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\"\r\n
-        \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
-        \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\":
-        [],\r\n      \"appliedDnsServers\": []\r\n    },\r\n    \"enableAcceleratedNetworking\":
-        false,\r\n    \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\":
-        {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1\"\r\n
-        \   },\r\n    \"virtualMachine\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1\"\r\n
-        \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
-        \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:17:20 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0OTUsIm5iZiI6MTUyMDQ1MzQ5NSwiZXhwIjoxNTIwNDU3Mzk1LCJhaW8iOiJZMk5nWUVndU5CSXl1MXFVeEdEM2ZsSFpieWtHQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQ043QlVpaXhfRUtWWWFxR0UyRUFBQSIsInZlciI6IjEuMCJ9.Aj1ctOMBOwBnIeeKdPOaEyzKn5BJN38vjYfTjEdBR3O28GkzKMNrI9osuXXUl-MZJJjHUa5YF9Q23kHoF_2jX6dg692lNdMVrlwFPt61fGgAaiwbz2z05M2vMgtGCRUwh29B9F0SQYNYPIfKFQiPxwTNasGnKv5UVCcyoGkRikbbnqf97GkqW96sykNL5uBWq6Hfs55GNa0vU8-aWsNxc3ErY-w8Ae4dQnYJDNkbBZxWg2qdWcYYyYQt-Rg86PUd8Akishqc7_yKDkqMgLE6g_9GLPvBAQFR1tmoclkHfLbQUD-hjqoXQnNLmwn6TOg54jBmYjHdu2OLrPt0M8pMcA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"734a3944-a880-444c-8c92-cace6e28e303"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - '08d2db2b-288a-4afd-ad04-8980e7b454cf'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14985'
-      X-Ms-Correlation-Request-Id:
-      - c4e756ab-84fa-47f5-8c67-c7e6b7383e99
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201720Z:c4e756ab-84fa-47f5-8c67-c7e6b7383e99
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:17:19 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"miqazure-centos1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1\",\r\n
-        \ \"etag\": \"W/\\\"734a3944-a880-444c-8c92-cace6e28e303\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"475a66f0-9e89-4226-a9f0-9baaaf31d619\",\r\n    \"publicIPAddressVersion\":
-        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
-        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1\"\r\n
-        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
-        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:17:20 GMT
+  recorded_at: Mon, 12 Mar 2018 09:28:52 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_0/resource_group_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_0/resource_group_refresh.yml
@@ -1,6 +1,62 @@
 ---
 http_interactions:
 - request:
+    method: post
+    uri: https://login.microsoftonline.com/AZURE_TENANT_ID/oauth2/token
+    body:
+      encoding: UTF-8
+      string: grant_type=client_credentials&client_id=AZURE_CLIENT_ID&client_secret=AZURE_CLIENT_SECRET&resource=https%3A%2F%2Fmanagement.azure.com%2F
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Server:
+      - Microsoft-IIS/10.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Request-Id:
+      - 9be00bf2-62af-47d0-97f7-59e1825d3400
+      P3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Set-Cookie:
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzdYp9AL3sF1A042J7HG8qmj1N7B_zb546QwqAoa-jvSnaJ4fidcU-4Dxu1wT6DJFaFZ8qgNz4Zkdti7nd0z484-HIgQs1YnmKIMlIV0HWqPAdVPQxkpUtynkS3DA3k3agDlK_khGF47P3x5cMQqbBc9dnHpWVNQnuhuF5T4Ih2RkgAA;
+        domain=.login.microsoftonline.com; path=/; secure; HttpOnly
+      - stsservicecookie=ests; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=005; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Tue, 13 Mar 2018 08:59:10 GMT
+      Content-Length:
+      - '1505'
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"Bearer","expires_in":"3600","ext_expires_in":"0","expires_on":"1520935150","not_before":"1520931250","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA5MzEyNTAsIm5iZiI6MTUyMDkzMTI1MCwiZXhwIjoxNTIwOTM1MTUwLCJhaW8iOiJZMk5nWU9Ed2VIdjVXWGNjenpZTGx1VXpYUjk1QWdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiOGd2Z202OWkwRWVYOTFuaGdsMDBBQSIsInZlciI6IjEuMCJ9.EoJydfyQm_QGo1CvSbp0FUx6qDPD9LQfk5tmJwmq8ndDFNKojZBUUxIvsEtJBEe0XD2rqkIXB8WZEKytznPQPgLixozTJwwHCc6tVcdQALyCgO6rznQUzfMDUApNK6jrAGOJ31nqtcUZZN_TiwZXVpzYH2kd_DtvuYkKoCSR9zQfQ4a-MT659-FRHLqltg11MWLvn_Ovd722uHEWFVKuanLWquRcPxbxn3EJCJBlUkibEek0ZwfoEMaVUH6Aih1r2PVkCzzPX_vf4pRbnk1LF9AFl2U9Bb4UGHTEb5dy31OiXG4PiHkzniSn_R9Q7f-9XVhXAC_FaxC_aO_ZjAiPXg"}'
+    http_version: 
+  recorded_at: Tue, 13 Mar 2018 08:59:11 GMT
+- request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
     body:
@@ -16,7 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA5MzEyNTAsIm5iZiI6MTUyMDkzMTI1MCwiZXhwIjoxNTIwOTM1MTUwLCJhaW8iOiJZMk5nWU9Ed2VIdjVXWGNjenpZTGx1VXpYUjk1QWdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiOGd2Z202OWkwRWVYOTFuaGdsMDBBQSIsInZlciI6IjEuMCJ9.EoJydfyQm_QGo1CvSbp0FUx6qDPD9LQfk5tmJwmq8ndDFNKojZBUUxIvsEtJBEe0XD2rqkIXB8WZEKytznPQPgLixozTJwwHCc6tVcdQALyCgO6rznQUzfMDUApNK6jrAGOJ31nqtcUZZN_TiwZXVpzYH2kd_DtvuYkKoCSR9zQfQ4a-MT659-FRHLqltg11MWLvn_Ovd722uHEWFVKuanLWquRcPxbxn3EJCJBlUkibEek0ZwfoEMaVUH6Aih1r2PVkCzzPX_vf4pRbnk1LF9AFl2U9Bb4UGHTEb5dy31OiXG4PiHkzniSn_R9Q7f-9XVhXAC_FaxC_aO_ZjAiPXg
   response:
     status:
       code: 200
@@ -35,26 +91,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14997'
+      - '14999'
       X-Ms-Request-Id:
-      - cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - 77b81cc3-376e-40c3-8edb-dad781126cd4
       X-Ms-Correlation-Request-Id:
-      - cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - 77b81cc3-376e-40c3-8edb-dad781126cd4
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102417Z:cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - WESTEUROPE:20180313T085911Z:77b81cc3-376e-40c3-8edb-dad781126cd4
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:17 GMT
+      - Tue, 13 Mar 2018 08:59:11 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID","subscriptionId":"AZURE_SUBSCRIPTION_ID","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:22 GMT
+  recorded_at: Tue, 13 Mar 2018 08:59:11 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers?api-version=2015-01-01
@@ -71,7 +127,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA5MzEyNTAsIm5iZiI6MTUyMDkzMTI1MCwiZXhwIjoxNTIwOTM1MTUwLCJhaW8iOiJZMk5nWU9Ed2VIdjVXWGNjenpZTGx1VXpYUjk1QWdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiOGd2Z202OWkwRWVYOTFuaGdsMDBBQSIsInZlciI6IjEuMCJ9.EoJydfyQm_QGo1CvSbp0FUx6qDPD9LQfk5tmJwmq8ndDFNKojZBUUxIvsEtJBEe0XD2rqkIXB8WZEKytznPQPgLixozTJwwHCc6tVcdQALyCgO6rznQUzfMDUApNK6jrAGOJ31nqtcUZZN_TiwZXVpzYH2kd_DtvuYkKoCSR9zQfQ4a-MT659-FRHLqltg11MWLvn_Ovd722uHEWFVKuanLWquRcPxbxn3EJCJBlUkibEek0ZwfoEMaVUH6Aih1r2PVkCzzPX_vf4pRbnk1LF9AFl2U9Bb4UGHTEb5dy31OiXG4PiHkzniSn_R9Q7f-9XVhXAC_FaxC_aO_ZjAiPXg
   response:
     status:
       code: 200
@@ -88,21 +144,21 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - '14929'
       X-Ms-Request-Id:
-      - fe3532ca-59a2-474e-9094-8a3697b82bef
+      - 3f87883f-3265-487d-b99d-0991be7a987d
       X-Ms-Correlation-Request-Id:
-      - fe3532ca-59a2-474e-9094-8a3697b82bef
+      - 3f87883f-3265-487d-b99d-0991be7a987d
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102419Z:fe3532ca-59a2-474e-9094-8a3697b82bef
+      - WESTEUROPE:20180313T085917Z:3f87883f-3265-487d-b99d-0991be7a987d
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:18 GMT
+      - Tue, 13 Mar 2018 08:59:16 GMT
       Content-Length:
-      - '320853'
+      - '322992'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"},{"applicationId":"d87dcbc6-a371-462e-88e3-28ad15ec4e64","roleDefinitionId":"861776c5-e0df-4f95-be4f-ac1eec193323"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["East
@@ -442,7 +498,10 @@ http_interactions:
         Central US","West Europe","North Europe","East US","UK West","UK South","West
         Central US","West US 2","South India","Central India","West India","Canada
         East","Canada Central","Korea South","Korea Central"],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"managedClusters","locations":["East
-        US","West Europe","Central US","Canada Central","Canada East"],"apiVersions":["2017-08-31"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
+        US","West Europe","Central US","Canada Central","Canada East"],"apiVersions":["2017-08-31"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operationresults","locations":["East
+        US","West Europe","Central US","UK West","UK South","West Central US","West
+        US 2","South India","Central India","West India","Canada East","Canada Central","Korea
+        South","Korea Central"],"apiVersions":["2017-08-31","2016-03-30"]},{"resourceType":"locations/operations","locations":["Japan
         East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
@@ -510,7 +569,7 @@ http_interactions:
         US","South Central US","North Europe","West Europe","Southeast Asia","West
         US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"listMigrationdate","locations":["East
         US","South Central US","North Europe","West Europe","Southeast Asia","West
-        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2018-03-01","2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
@@ -612,47 +671,47 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"networkWatchers/lenses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"networkWatchers/lenses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -662,47 +721,52 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2018-02-01","2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"ddosProtectionPlans","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","West
         US 2","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
@@ -1438,57 +1502,57 @@ http_interactions:
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/asyncoperations","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/asyncoperations","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/listAccountSas","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/listAccountSas","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/listServiceSas","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/listServiceSas","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/blobServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/blobServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/tableServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/tableServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/queueServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/queueServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/fileServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/fileServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01","2016-01-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01","2016-01-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
         US","West US","West Europe","North Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":["East
         US","West US","West Europe","North Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.visualstudio","namespace":"microsoft.visualstudio","authorization":{"applicationId":"499b84ac-1321-427f-aa17-267ca6975798","roleDefinitionId":"6a18f445-86f0-4e2e-b8a9-6b9b5677e3d8"},"resourceTypes":[{"resourceType":"account","locations":["North
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.visualstudio","namespace":"microsoft.visualstudio","authorization":{"applicationId":"499b84ac-1321-427f-aa17-267ca6975798","roleDefinitionId":"6a18f445-86f0-4e2e-b8a9-6b9b5677e3d8"},"resourceTypes":[{"resourceType":"account","locations":["North
         Central US","South Central US","East US","West US","Central US","North Europe","West
         Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
         East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/project","locations":["North
@@ -2173,7 +2237,8 @@ http_interactions:
         US","West US 2","East US","East US 2","North Europe","West Europe","Southeast
         Asia","East Asia","North Central US","South Central US","Japan West","Australia
         East","Brazil South","Central India","West Central US","Canada Central","UK
-        South"],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ServiceBus","namespace":"Microsoft.ServiceBus","authorization":{"applicationId":"80a10ef9-8168-493d-abf9-3297c4ef6e3c","roleDefinitionId":"2b7763f7-bbe2-4e19-befe-28c79f1cf7f7"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        South"],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.SecurityGraph","namespace":"Microsoft.SecurityGraph","resourceTypes":[{"resourceType":"operations","locations":["West
+        US"],"apiVersions":["2017-04-01-preview"]},{"resourceType":"diagnosticSettings","locations":[],"apiVersions":["2017-04-01-preview"]},{"resourceType":"diagnosticSettingsCategories","locations":[],"apiVersions":["2017-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ServiceBus","namespace":"Microsoft.ServiceBus","authorization":{"applicationId":"80a10ef9-8168-493d-abf9-3297c4ef6e3c","roleDefinitionId":"2b7763f7-bbe2-4e19-befe-28c79f1cf7f7"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US 2","West
         US","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
@@ -2322,10 +2387,10 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:23 GMT
+  recorded_at: Tue, 13 Mar 2018 08:59:17 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups/miq-azure-test4?api-version=2017-08-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2339,7 +2404,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA5MzEyNTAsIm5iZiI6MTUyMDkzMTI1MCwiZXhwIjoxNTIwOTM1MTUwLCJhaW8iOiJZMk5nWU9Ed2VIdjVXWGNjenpZTGx1VXpYUjk1QWdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiOGd2Z202OWkwRWVYOTFuaGdsMDBBQSIsInZlciI6IjEuMCJ9.EoJydfyQm_QGo1CvSbp0FUx6qDPD9LQfk5tmJwmq8ndDFNKojZBUUxIvsEtJBEe0XD2rqkIXB8WZEKytznPQPgLixozTJwwHCc6tVcdQALyCgO6rznQUzfMDUApNK6jrAGOJ31nqtcUZZN_TiwZXVpzYH2kd_DtvuYkKoCSR9zQfQ4a-MT659-FRHLqltg11MWLvn_Ovd722uHEWFVKuanLWquRcPxbxn3EJCJBlUkibEek0ZwfoEMaVUH6Aih1r2PVkCzzPX_vf4pRbnk1LF9AFl2U9Bb4UGHTEb5dy31OiXG4PiHkzniSn_R9Q7f-9XVhXAC_FaxC_aO_ZjAiPXg
   response:
     status:
       code: 200
@@ -2349,301 +2414,31 @@ http_interactions:
       - no-cache
       Pragma:
       - no-cache
-      Transfer-Encoding:
-      - chunked
       Content-Type:
       - application/json; charset=utf-8
       Expires:
       - "-1"
-      Etag:
-      - W/"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67"
       Vary:
       - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14912'
       X-Ms-Request-Id:
-      - '080de667-081e-4d58-9e94-9e7243d4200e'
+      - df67a3b1-9919-4b3a-bb7e-be92402288f6
+      X-Ms-Correlation-Request-Id:
+      - df67a3b1-9919-4b3a-bb7e-be92402288f6
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180313T085918Z:df67a3b1-9919-4b3a-bb7e-be92402288f6
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Correlation-Request-Id:
-      - '093d49ac-c85f-440e-956b-955b6698dd19'
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102419Z:093d49ac-c85f-440e-956b-955b6698dd19
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:19 GMT
+      - Tue, 13 Mar 2018 08:59:17 GMT
+      Content-Length:
+      - '183'
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1\",\r\n
-        \ \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"7ab88756-810f-4083-95db-8b05d50e38f2\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ],\r\n          \"inboundNatRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"backendIPConfigurations\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\"\r\n
-        \           }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-rule\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\":
-        80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\"\r\n
-        \         },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n
-        \       \"name\": \"rspec-lb-probe\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-NAT\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 3441,\r\n          \"backendPort\":
-        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
+      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4","name":"miq-azure-test4","location":"eastus","properties":{"provisioningState":"Succeeded"}}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:24 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"7a8e5fe7-f777-4435-992b-a54f28c2f28c"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - bd22ca22-a01f-4ecf-9230-a4558fb66931
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Correlation-Request-Id:
-      - 19c674a8-c8da-4b5e-8265-5ebc21926459
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102420Z:19c674a8-c8da-4b5e-8265-5ebc21926459
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Mon, 12 Mar 2018 10:24:19 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb2\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2\",\r\n
-        \ \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"e2e30a77-f81b-43fc-9693-08303e43deed\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/backendAddressPools/rspec-lb2-pool\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\r\n
-        \       }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\": [],\r\n    \"probes\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-probe\",\r\n        \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/probes/rspec-lb2-probe\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\": [],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:25 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"a38434c8-7b23-4092-b7c6-402238eac0dc"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 0fd15240-6a1c-4b39-a4f6-aa53fd8591c2
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Correlation-Request-Id:
-      - 5cc03163-922e-41a1-9601-dba2d7cf2a81
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102421Z:5cc03163-922e-41a1-9601-dba2d7cf2a81
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Mon, 12 Mar 2018 10:24:20 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb1-LoadBalancerFrontEnd\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\",\r\n
-        \ \"etag\": \"W/\\\"a38434c8-7b23-4092-b7c6-402238eac0dc\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"f28e0f25-b372-4edf-97d9-13a9e3b4ba2d\",\r\n    \"ipAddress\":
-        \"40.71.82.83\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\":
-        \"Static\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipTags\": [],\r\n
-        \   \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
-        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:25 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"cddd97d1-6111-4477-8a00-3dc885237a1d"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 1403e5b6-8fa0-4cd3-89b1-76b6c4fd805b
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
-      X-Ms-Correlation-Request-Id:
-      - e4a5f369-a742-466f-bd8f-42e17eaaf9c9
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102421Z:e4a5f369-a742-466f-bd8f-42e17eaaf9c9
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Mon, 12 Mar 2018 10:24:21 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb2-publicip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\",\r\n
-        \ \"etag\": \"W/\\\"cddd97d1-6111-4477-8a00-3dc885237a1d\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"83e7257d-ab94-4229-8eb5-4798f37ef28d\",\r\n    \"publicIPAddressVersion\":
-        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
-        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
-        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:26 GMT
+  recorded_at: Tue, 13 Mar 2018 08:59:18 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_0/security_group_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_0/security_group_refresh.yml
@@ -1,6 +1,62 @@
 ---
 http_interactions:
 - request:
+    method: post
+    uri: https://login.microsoftonline.com/AZURE_TENANT_ID/oauth2/token
+    body:
+      encoding: UTF-8
+      string: grant_type=client_credentials&client_id=AZURE_CLIENT_ID&client_secret=AZURE_CLIENT_SECRET&resource=https%3A%2F%2Fmanagement.azure.com%2F
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Server:
+      - Microsoft-IIS/10.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Request-Id:
+      - 42e55447-82a6-4ce2-a0eb-84dfd6fa3200
+      P3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Set-Cookie:
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzLqtGk-dg9StXSZJdbhzvPYpRx-f-7iznqQUm_PqsTmtKHkCZaQcscMeK5sNGPe9KewcuB6XwLO0yeyF1_utMEDKJg-JUUq1VTLiBx8nKteKE7F1D8njSPViM1N4__NYtbs5LT00Uu94fLufs63pbXUYmaDQrmdYWc86e1GGJf1cgAA;
+        domain=.login.microsoftonline.com; path=/; secure; HttpOnly
+      - stsservicecookie=ests; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=005; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Tue, 13 Mar 2018 09:00:18 GMT
+      Content-Length:
+      - '1505'
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1520935219","not_before":"1520931319","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA5MzEzMTksIm5iZiI6MTUyMDkzMTMxOSwiZXhwIjoxNTIwOTM1MjE5LCJhaW8iOiJZMk5nWUpodFB0a2k2MFo1cHgyTHlWdHU5NzI3QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUjFUbFFxYUM0a3lnNjRUZjF2b3lBQSIsInZlciI6IjEuMCJ9.AKbQhUni5j6QpaWJvyd_t-6ro97Ik18Qgnp59mlinCws0rfOh56ll3MF-9aeXg1_k7JiprpQb3hpiXtDuApZKhiL-A7Gu85zQK2KPDaRx1ad43IeSS_aaji8FLESbfyo-sREcee5a_SSkVkK2YfDbT9T8ZcI59tGZYSAusy0taEwpE-ov8qphX-IFKPLbceY-BvobYN9JBjhJF2ePEbXPpMo51moY0EFectQ-n9emvw159TiFbUxV3q9EO4tzkEqVuCchfuMOpKecZJPNY4YSwWpyoERESTg2dEFRiJV5MXShTyqBV7-CDZEcZltcxGnTXmrpQ9_oXaNEJ2DZ1huEA"}'
+    http_version: 
+  recorded_at: Tue, 13 Mar 2018 09:00:19 GMT
+- request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
     body:
@@ -16,7 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA5MzEzMTksIm5iZiI6MTUyMDkzMTMxOSwiZXhwIjoxNTIwOTM1MjE5LCJhaW8iOiJZMk5nWUpodFB0a2k2MFo1cHgyTHlWdHU5NzI3QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUjFUbFFxYUM0a3lnNjRUZjF2b3lBQSIsInZlciI6IjEuMCJ9.AKbQhUni5j6QpaWJvyd_t-6ro97Ik18Qgnp59mlinCws0rfOh56ll3MF-9aeXg1_k7JiprpQb3hpiXtDuApZKhiL-A7Gu85zQK2KPDaRx1ad43IeSS_aaji8FLESbfyo-sREcee5a_SSkVkK2YfDbT9T8ZcI59tGZYSAusy0taEwpE-ov8qphX-IFKPLbceY-BvobYN9JBjhJF2ePEbXPpMo51moY0EFectQ-n9emvw159TiFbUxV3q9EO4tzkEqVuCchfuMOpKecZJPNY4YSwWpyoERESTg2dEFRiJV5MXShTyqBV7-CDZEcZltcxGnTXmrpQ9_oXaNEJ2DZ1huEA
   response:
     status:
       code: 200
@@ -35,26 +91,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14997'
+      - '14999'
       X-Ms-Request-Id:
-      - cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - 86b7e50c-b87c-4861-afae-e948ea5de134
       X-Ms-Correlation-Request-Id:
-      - cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - 86b7e50c-b87c-4861-afae-e948ea5de134
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102417Z:cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - WESTEUROPE:20180313T090019Z:86b7e50c-b87c-4861-afae-e948ea5de134
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:17 GMT
+      - Tue, 13 Mar 2018 09:00:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID","subscriptionId":"AZURE_SUBSCRIPTION_ID","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:22 GMT
+  recorded_at: Tue, 13 Mar 2018 09:00:19 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers?api-version=2015-01-01
@@ -71,7 +127,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA5MzEzMTksIm5iZiI6MTUyMDkzMTMxOSwiZXhwIjoxNTIwOTM1MjE5LCJhaW8iOiJZMk5nWUpodFB0a2k2MFo1cHgyTHlWdHU5NzI3QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUjFUbFFxYUM0a3lnNjRUZjF2b3lBQSIsInZlciI6IjEuMCJ9.AKbQhUni5j6QpaWJvyd_t-6ro97Ik18Qgnp59mlinCws0rfOh56ll3MF-9aeXg1_k7JiprpQb3hpiXtDuApZKhiL-A7Gu85zQK2KPDaRx1ad43IeSS_aaji8FLESbfyo-sREcee5a_SSkVkK2YfDbT9T8ZcI59tGZYSAusy0taEwpE-ov8qphX-IFKPLbceY-BvobYN9JBjhJF2ePEbXPpMo51moY0EFectQ-n9emvw159TiFbUxV3q9EO4tzkEqVuCchfuMOpKecZJPNY4YSwWpyoERESTg2dEFRiJV5MXShTyqBV7-CDZEcZltcxGnTXmrpQ9_oXaNEJ2DZ1huEA
   response:
     status:
       code: 200
@@ -88,21 +144,21 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - '14928'
       X-Ms-Request-Id:
-      - fe3532ca-59a2-474e-9094-8a3697b82bef
+      - de9ed417-3b0f-4775-af46-3e92e6357d39
       X-Ms-Correlation-Request-Id:
-      - fe3532ca-59a2-474e-9094-8a3697b82bef
+      - de9ed417-3b0f-4775-af46-3e92e6357d39
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102419Z:fe3532ca-59a2-474e-9094-8a3697b82bef
+      - WESTEUROPE:20180313T090020Z:de9ed417-3b0f-4775-af46-3e92e6357d39
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:18 GMT
+      - Tue, 13 Mar 2018 09:00:20 GMT
       Content-Length:
-      - '320853'
+      - '322992'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"},{"applicationId":"d87dcbc6-a371-462e-88e3-28ad15ec4e64","roleDefinitionId":"861776c5-e0df-4f95-be4f-ac1eec193323"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["East
@@ -442,7 +498,10 @@ http_interactions:
         Central US","West Europe","North Europe","East US","UK West","UK South","West
         Central US","West US 2","South India","Central India","West India","Canada
         East","Canada Central","Korea South","Korea Central"],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"managedClusters","locations":["East
-        US","West Europe","Central US","Canada Central","Canada East"],"apiVersions":["2017-08-31"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
+        US","West Europe","Central US","Canada Central","Canada East"],"apiVersions":["2017-08-31"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operationresults","locations":["East
+        US","West Europe","Central US","UK West","UK South","West Central US","West
+        US 2","South India","Central India","West India","Canada East","Canada Central","Korea
+        South","Korea Central"],"apiVersions":["2017-08-31","2016-03-30"]},{"resourceType":"locations/operations","locations":["Japan
         East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
@@ -510,7 +569,7 @@ http_interactions:
         US","South Central US","North Europe","West Europe","Southeast Asia","West
         US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"listMigrationdate","locations":["East
         US","South Central US","North Europe","West Europe","Southeast Asia","West
-        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2018-03-01","2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
@@ -612,47 +671,47 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"networkWatchers/lenses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"networkWatchers/lenses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -662,47 +721,52 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2018-02-01","2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"ddosProtectionPlans","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","West
         US 2","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
@@ -1438,57 +1502,57 @@ http_interactions:
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/asyncoperations","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/asyncoperations","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/listAccountSas","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/listAccountSas","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/listServiceSas","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/listServiceSas","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/blobServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/blobServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/tableServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/tableServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/queueServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/queueServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/fileServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/fileServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01","2016-01-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01","2016-01-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
         US","West US","West Europe","North Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":["East
         US","West US","West Europe","North Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.visualstudio","namespace":"microsoft.visualstudio","authorization":{"applicationId":"499b84ac-1321-427f-aa17-267ca6975798","roleDefinitionId":"6a18f445-86f0-4e2e-b8a9-6b9b5677e3d8"},"resourceTypes":[{"resourceType":"account","locations":["North
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.visualstudio","namespace":"microsoft.visualstudio","authorization":{"applicationId":"499b84ac-1321-427f-aa17-267ca6975798","roleDefinitionId":"6a18f445-86f0-4e2e-b8a9-6b9b5677e3d8"},"resourceTypes":[{"resourceType":"account","locations":["North
         Central US","South Central US","East US","West US","Central US","North Europe","West
         Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
         East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/project","locations":["North
@@ -2173,7 +2237,8 @@ http_interactions:
         US","West US 2","East US","East US 2","North Europe","West Europe","Southeast
         Asia","East Asia","North Central US","South Central US","Japan West","Australia
         East","Brazil South","Central India","West Central US","Canada Central","UK
-        South"],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ServiceBus","namespace":"Microsoft.ServiceBus","authorization":{"applicationId":"80a10ef9-8168-493d-abf9-3297c4ef6e3c","roleDefinitionId":"2b7763f7-bbe2-4e19-befe-28c79f1cf7f7"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        South"],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.SecurityGraph","namespace":"Microsoft.SecurityGraph","resourceTypes":[{"resourceType":"operations","locations":["West
+        US"],"apiVersions":["2017-04-01-preview"]},{"resourceType":"diagnosticSettings","locations":[],"apiVersions":["2017-04-01-preview"]},{"resourceType":"diagnosticSettingsCategories","locations":[],"apiVersions":["2017-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ServiceBus","namespace":"Microsoft.ServiceBus","authorization":{"applicationId":"80a10ef9-8168-493d-abf9-3297c4ef6e3c","roleDefinitionId":"2b7763f7-bbe2-4e19-befe-28c79f1cf7f7"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US 2","West
         US","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
@@ -2322,10 +2387,10 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:23 GMT
+  recorded_at: Tue, 13 Mar 2018 09:00:21 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg?api-version=2018-03-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2339,7 +2404,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA5MzEzMTksIm5iZiI6MTUyMDkzMTMxOSwiZXhwIjoxNTIwOTM1MjE5LCJhaW8iOiJZMk5nWUpodFB0a2k2MFo1cHgyTHlWdHU5NzI3QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUjFUbFFxYUM0a3lnNjRUZjF2b3lBQSIsInZlciI6IjEuMCJ9.AKbQhUni5j6QpaWJvyd_t-6ro97Ik18Qgnp59mlinCws0rfOh56ll3MF-9aeXg1_k7JiprpQb3hpiXtDuApZKhiL-A7Gu85zQK2KPDaRx1ad43IeSS_aaji8FLESbfyo-sREcee5a_SSkVkK2YfDbT9T8ZcI59tGZYSAusy0taEwpE-ov8qphX-IFKPLbceY-BvobYN9JBjhJF2ePEbXPpMo51moY0EFectQ-n9emvw159TiFbUxV3q9EO4tzkEqVuCchfuMOpKecZJPNY4YSwWpyoERESTg2dEFRiJV5MXShTyqBV7-CDZEcZltcxGnTXmrpQ9_oXaNEJ2DZ1huEA
   response:
     status:
       code: 200
@@ -2356,294 +2421,109 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67"
+      - W/"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - '080de667-081e-4d58-9e94-9e7243d4200e'
+      - 44e3328f-7aa5-4297-bcb5-02d5b66252d6
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
+      - '14933'
       X-Ms-Correlation-Request-Id:
-      - '093d49ac-c85f-440e-956b-955b6698dd19'
+      - ce8b926f-a379-4f01-a940-a7bca6e1cd77
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102419Z:093d49ac-c85f-440e-956b-955b6698dd19
+      - WESTEUROPE:20180313T090024Z:ce8b926f-a379-4f01-a940-a7bca6e1cd77
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:19 GMT
+      - Tue, 13 Mar 2018 09:00:23 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1\",\r\n
-        \ \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"7ab88756-810f-4083-95db-8b05d50e38f2\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
+      string: "{\r\n  \"name\": \"miqazure-linux-managed-nsg\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg\",\r\n
+        \ \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/networkSecurityGroups\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
+        \"b4611f96-94a8-4486-94c5-16bb6c7a5c84\",\r\n    \"securityRules\": [\r\n
+        \     {\r\n        \"name\": \"default-allow-ssh\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/securityRules/default-allow-ssh\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ],\r\n          \"inboundNatRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
+        \         \"protocol\": \"TCP\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"22\",\r\n          \"sourceAddressPrefix\":
+        \"*\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n          \"access\":
+        \"Allow\",\r\n          \"priority\": 1000,\r\n          \"direction\": \"Inbound\",\r\n
+        \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      }\r\n    ],\r\n    \"defaultSecurityRules\": [\r\n
+        \     {\r\n        \"name\": \"AllowVnetInBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/AllowVnetInBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"backendIPConfigurations\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\"\r\n
-        \           }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-rule\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
+        \         \"description\": \"Allow inbound traffic from all VMs in VNET\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"VirtualNetwork\",\r\n          \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n          \"direction\":
+        \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowAzureLoadBalancerInBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/AllowAzureLoadBalancerInBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\":
-        80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\"\r\n
-        \         },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n
-        \       \"name\": \"rspec-lb-probe\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
+        \         \"description\": \"Allow inbound traffic from azure load balancer\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"AzureLoadBalancer\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65001,\r\n          \"direction\":
+        \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllInBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/DenyAllInBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-NAT\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
+        \         \"description\": \"Deny all inbound traffic\",\r\n          \"protocol\":
+        \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\":
+        \"*\",\r\n          \"sourceAddressPrefix\": \"*\",\r\n          \"destinationAddressPrefix\":
+        \"*\",\r\n          \"access\": \"Deny\",\r\n          \"priority\": 65500,\r\n
+        \         \"direction\": \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n
+        \         \"destinationPortRanges\": [],\r\n          \"sourceAddressPrefixes\":
+        [],\r\n          \"destinationAddressPrefixes\": []\r\n        }\r\n      },\r\n
+        \     {\r\n        \"name\": \"AllowVnetOutBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/AllowVnetOutBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 3441,\r\n          \"backendPort\":
-        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
+        \         \"description\": \"Allow outbound traffic from all VMs to all VMs
+        in VNET\",\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\":
+        \"*\",\r\n          \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"VirtualNetwork\",\r\n          \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n          \"direction\":
+        \"Outbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowInternetOutBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/AllowInternetOutBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow outbound traffic from all VMs to Internet\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"*\",\r\n          \"destinationAddressPrefix\": \"Internet\",\r\n          \"access\":
+        \"Allow\",\r\n          \"priority\": 65001,\r\n          \"direction\": \"Outbound\",\r\n
+        \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllOutBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/DenyAllOutBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Deny all outbound traffic\",\r\n          \"protocol\":
+        \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\":
+        \"*\",\r\n          \"sourceAddressPrefix\": \"*\",\r\n          \"destinationAddressPrefix\":
+        \"*\",\r\n          \"access\": \"Deny\",\r\n          \"priority\": 65500,\r\n
+        \         \"direction\": \"Outbound\",\r\n          \"sourcePortRanges\":
+        [],\r\n          \"destinationPortRanges\": [],\r\n          \"sourceAddressPrefixes\":
+        [],\r\n          \"destinationAddressPrefixes\": []\r\n        }\r\n      }\r\n
+        \   ],\r\n    \"networkInterfaces\": [\r\n      {\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944\"\r\n
+        \     }\r\n    ]\r\n  }\r\n}"
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:24 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"7a8e5fe7-f777-4435-992b-a54f28c2f28c"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - bd22ca22-a01f-4ecf-9230-a4558fb66931
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Correlation-Request-Id:
-      - 19c674a8-c8da-4b5e-8265-5ebc21926459
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102420Z:19c674a8-c8da-4b5e-8265-5ebc21926459
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Mon, 12 Mar 2018 10:24:19 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb2\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2\",\r\n
-        \ \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"e2e30a77-f81b-43fc-9693-08303e43deed\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/backendAddressPools/rspec-lb2-pool\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\r\n
-        \       }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\": [],\r\n    \"probes\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-probe\",\r\n        \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/probes/rspec-lb2-probe\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\": [],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:25 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"a38434c8-7b23-4092-b7c6-402238eac0dc"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 0fd15240-6a1c-4b39-a4f6-aa53fd8591c2
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Correlation-Request-Id:
-      - 5cc03163-922e-41a1-9601-dba2d7cf2a81
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102421Z:5cc03163-922e-41a1-9601-dba2d7cf2a81
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Mon, 12 Mar 2018 10:24:20 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb1-LoadBalancerFrontEnd\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\",\r\n
-        \ \"etag\": \"W/\\\"a38434c8-7b23-4092-b7c6-402238eac0dc\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"f28e0f25-b372-4edf-97d9-13a9e3b4ba2d\",\r\n    \"ipAddress\":
-        \"40.71.82.83\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\":
-        \"Static\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipTags\": [],\r\n
-        \   \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
-        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:25 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"cddd97d1-6111-4477-8a00-3dc885237a1d"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 1403e5b6-8fa0-4cd3-89b1-76b6c4fd805b
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
-      X-Ms-Correlation-Request-Id:
-      - e4a5f369-a742-466f-bd8f-42e17eaaf9c9
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102421Z:e4a5f369-a742-466f-bd8f-42e17eaaf9c9
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Mon, 12 Mar 2018 10:24:21 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb2-publicip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\",\r\n
-        \ \"etag\": \"W/\\\"cddd97d1-6111-4477-8a00-3dc885237a1d\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"83e7257d-ab94-4229-8eb5-4798f37ef28d\",\r\n    \"publicIPAddressVersion\":
-        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
-        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
-        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:26 GMT
+  recorded_at: Tue, 13 Mar 2018 09:00:24 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_0/template_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_0/template_refresh.yml
@@ -37,25 +37,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 7e4a49a7-ad76-4534-af92-e65592600000
+      - 5c520f8d-f94a-471c-81fc-6ac266692300
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzl0HMMbgnQR0UsA_bGz5aK9e9IZTQsXwJ_n_USsp46xEB7dg35kHXrAgogLUAR3hEXcmM9xYdEpfD4fBrcBdScCIXJHDLd4tGfePBKOnT-38v-rR5ofL5J_c3mAYQgA1bysGYviQI2HWICzAud3AxSJdRVf5Ms9h_NdtAsCjKgoggAA;
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzy9Wle3Z3emoK1Q1HComk4vvDdkvl2Km4v9tDF0iqdBMADaCcgssIgmms5tNGzdT10IpCKnXg9X0XyLlJrMGSDN5u9TfHHpaWu4C32EgJpz0zGLVP2yBpIGBGKBIlX_KQtrqq-BWcyjSde4ltMMDPhZ0jPTudx5-agbbd3aOTuwkgAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=008; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=003; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Wed, 07 Mar 2018 20:21:24 GMT
+      - Mon, 12 Mar 2018 09:35:13 GMT
       Content-Length:
       - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1520457684","not_before":"1520453784","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3ODQsIm5iZiI6MTUyMDQ1Mzc4NCwiZXhwIjoxNTIwNDU3Njg0LCJhaW8iOiJZMk5nWUpnU2xxeG4vSTJOMTBmYWNkZHltZXE3QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoicDBsS2ZuYXRORVd2a3VaVmttQUFBQSIsInZlciI6IjEuMCJ9.iC1HIh7EJhSg4gWNwK-4-iAm1Y57QbVEKhbqmrgwOPUjVEl83aDkQcFgk_LTJlYJxuWt32jXyPTVllnJyz8dQlAV3NbzVr2Ob3u7Tma1NOOnxZkLpH9EE8B1SgQypHRbWQa5OXi98OEU429EDLTLzRPhb0ePBhu9oz0AtzI8jHVr46i_X7jxoTKLQsx83mOyBS68htVskAiZtMVcl38z5OHFZ15jBJJfCsbMEVL632TFBKiKwwwKKgMvTbgR9lRqXNgLsCl4sYWtuXD1i5vKr9GHvFE4byo7KUAmecWPb9ZdogYjVVEpoXXh5IkbAY-T7K_JTEBJL7lWK1t640tBjw"}'
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1520850913","not_before":"1520847013","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcwMTMsIm5iZiI6MTUyMDg0NzAxMywiZXhwIjoxNTIwODUwOTEzLCJhaW8iOiJZMk5nWUhCMFludmpjNGN6aE5NNTh0M0t5a1FYQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoialE5U1hFcjVIRWVCX0dyQ1pta2pBQSIsInZlciI6IjEuMCJ9.CNps7ehQ4gjIipFpeHtH1uayoFrjNQmz9DNt8X_pu3FJIMidCRl8zafvhLybkMt3jBTg3ilWiyWZfJ-LaCVtgzQqXRZh4TitdGaw6BtQXx5BndCxbJdfQQWyDDtaXijWD6EjF5OpGZJ0nBglCx-KPAAPhSZXRIvjPNXgsDseRlJxWTSzxYkOUfGY5gn9E9CT6Qe54gFtFsID7PIhBmFOLFrgEjl9dEidPDaLO9f7lba8LHWTjDFozQ_FgyhD_PqDzJYySpX8wTabcb1A1tynX-1rd5v9e4pPrxjRLEvJ_VLaP9RN8XVqo2YoZadQ9FlTwiv4l7aY36nqd2QffgkYsg"}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:25 GMT
+  recorded_at: Mon, 12 Mar 2018 09:35:18 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -72,7 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3ODQsIm5iZiI6MTUyMDQ1Mzc4NCwiZXhwIjoxNTIwNDU3Njg0LCJhaW8iOiJZMk5nWUpnU2xxeG4vSTJOMTBmYWNkZHltZXE3QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoicDBsS2ZuYXRORVd2a3VaVmttQUFBQSIsInZlciI6IjEuMCJ9.iC1HIh7EJhSg4gWNwK-4-iAm1Y57QbVEKhbqmrgwOPUjVEl83aDkQcFgk_LTJlYJxuWt32jXyPTVllnJyz8dQlAV3NbzVr2Ob3u7Tma1NOOnxZkLpH9EE8B1SgQypHRbWQa5OXi98OEU429EDLTLzRPhb0ePBhu9oz0AtzI8jHVr46i_X7jxoTKLQsx83mOyBS68htVskAiZtMVcl38z5OHFZ15jBJJfCsbMEVL632TFBKiKwwwKKgMvTbgR9lRqXNgLsCl4sYWtuXD1i5vKr9GHvFE4byo7KUAmecWPb9ZdogYjVVEpoXXh5IkbAY-T7K_JTEBJL7lWK1t640tBjw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcwMTMsIm5iZiI6MTUyMDg0NzAxMywiZXhwIjoxNTIwODUwOTEzLCJhaW8iOiJZMk5nWUhCMFludmpjNGN6aE5NNTh0M0t5a1FYQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoialE5U1hFcjVIRWVCX0dyQ1pta2pBQSIsInZlciI6IjEuMCJ9.CNps7ehQ4gjIipFpeHtH1uayoFrjNQmz9DNt8X_pu3FJIMidCRl8zafvhLybkMt3jBTg3ilWiyWZfJ-LaCVtgzQqXRZh4TitdGaw6BtQXx5BndCxbJdfQQWyDDtaXijWD6EjF5OpGZJ0nBglCx-KPAAPhSZXRIvjPNXgsDseRlJxWTSzxYkOUfGY5gn9E9CT6Qe54gFtFsID7PIhBmFOLFrgEjl9dEidPDaLO9f7lba8LHWTjDFozQ_FgyhD_PqDzJYySpX8wTabcb1A1tynX-1rd5v9e4pPrxjRLEvJ_VLaP9RN8XVqo2YoZadQ9FlTwiv4l7aY36nqd2QffgkYsg
   response:
     status:
       code: 200
@@ -93,24 +93,24 @@ http_interactions:
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
       - '14999'
       X-Ms-Request-Id:
-      - 95c47f78-4b5b-4dba-b163-7d316982ba18
+      - 54503bf4-460d-45d9-9b65-c369378ff573
       X-Ms-Correlation-Request-Id:
-      - 95c47f78-4b5b-4dba-b163-7d316982ba18
+      - 54503bf4-460d-45d9-9b65-c369378ff573
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202125Z:95c47f78-4b5b-4dba-b163-7d316982ba18
+      - WESTEUROPE:20180312T093514Z:54503bf4-460d-45d9-9b65-c369378ff573
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:21:25 GMT
+      - Mon, 12 Mar 2018 09:35:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID","subscriptionId":"AZURE_SUBSCRIPTION_ID","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:25 GMT
+  recorded_at: Mon, 12 Mar 2018 09:35:18 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers?api-version=2015-01-01
@@ -127,7 +127,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3ODQsIm5iZiI6MTUyMDQ1Mzc4NCwiZXhwIjoxNTIwNDU3Njg0LCJhaW8iOiJZMk5nWUpnU2xxeG4vSTJOMTBmYWNkZHltZXE3QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoicDBsS2ZuYXRORVd2a3VaVmttQUFBQSIsInZlciI6IjEuMCJ9.iC1HIh7EJhSg4gWNwK-4-iAm1Y57QbVEKhbqmrgwOPUjVEl83aDkQcFgk_LTJlYJxuWt32jXyPTVllnJyz8dQlAV3NbzVr2Ob3u7Tma1NOOnxZkLpH9EE8B1SgQypHRbWQa5OXi98OEU429EDLTLzRPhb0ePBhu9oz0AtzI8jHVr46i_X7jxoTKLQsx83mOyBS68htVskAiZtMVcl38z5OHFZ15jBJJfCsbMEVL632TFBKiKwwwKKgMvTbgR9lRqXNgLsCl4sYWtuXD1i5vKr9GHvFE4byo7KUAmecWPb9ZdogYjVVEpoXXh5IkbAY-T7K_JTEBJL7lWK1t640tBjw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcwMTMsIm5iZiI6MTUyMDg0NzAxMywiZXhwIjoxNTIwODUwOTEzLCJhaW8iOiJZMk5nWUhCMFludmpjNGN6aE5NNTh0M0t5a1FYQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoialE5U1hFcjVIRWVCX0dyQ1pta2pBQSIsInZlciI6IjEuMCJ9.CNps7ehQ4gjIipFpeHtH1uayoFrjNQmz9DNt8X_pu3FJIMidCRl8zafvhLybkMt3jBTg3ilWiyWZfJ-LaCVtgzQqXRZh4TitdGaw6BtQXx5BndCxbJdfQQWyDDtaXijWD6EjF5OpGZJ0nBglCx-KPAAPhSZXRIvjPNXgsDseRlJxWTSzxYkOUfGY5gn9E9CT6Qe54gFtFsID7PIhBmFOLFrgEjl9dEidPDaLO9f7lba8LHWTjDFozQ_FgyhD_PqDzJYySpX8wTabcb1A1tynX-1rd5v9e4pPrxjRLEvJ_VLaP9RN8XVqo2YoZadQ9FlTwiv4l7aY36nqd2QffgkYsg
   response:
     status:
       code: 200
@@ -144,39 +144,37 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14969'
+      - '14991'
       X-Ms-Request-Id:
-      - 6fdad5bd-5d2c-458f-ac24-b220438bcd13
+      - f9056d30-4830-4b41-9869-c49dedb68142
       X-Ms-Correlation-Request-Id:
-      - 6fdad5bd-5d2c-458f-ac24-b220438bcd13
+      - f9056d30-4830-4b41-9869-c49dedb68142
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202126Z:6fdad5bd-5d2c-458f-ac24-b220438bcd13
+      - WESTEUROPE:20180312T093515Z:f9056d30-4830-4b41-9869-c49dedb68142
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:21:26 GMT
+      - Mon, 12 Mar 2018 09:35:14 GMT
       Content-Length:
-      - '310901'
+      - '320853'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"},{"applicationId":"d87dcbc6-a371-462e-88e3-28ad15ec4e64","roleDefinitionId":"861776c5-e0df-4f95-be4f-ac1eec193323"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
+      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"},{"applicationId":"d87dcbc6-a371-462e-88e3-28ad15ec4e64","roleDefinitionId":"861776c5-e0df-4f95-be4f-ac1eec193323"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["East
+        Asia","Southeast Asia","Australia East","Australia Southeast","Japan East","Japan
+        West","Central India","South India","West India","West Europe","North Europe","Canada
+        Central","Canada East","Brazil South","West US","Central US","East US","South
+        Central US","East US 2","West Central US","North Central US","West US 2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
         US","Central US","East US","South Central US","West Europe","North Europe","East
         Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
         Central US","North Central US","Japan East","Japan West","Brazil South","Central
         India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"operations","locations":["West
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["East
+        Asia","Southeast Asia","Australia East","Australia Southeast","Japan East","Japan
+        West","Central India","South India","West India","West Europe","North Europe","Canada
+        Central","Canada East","Brazil South","West US","Central US","East US","South
+        Central US","East US 2","West Central US","North Central US","West US 2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"operations","locations":["West
         US","Central US","East US","South Central US","West Europe","North Europe","East
         Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
         Central US","North Central US","Japan East","Japan West","Brazil South","Central
@@ -232,177 +230,177 @@ http_interactions:
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/internalLoadBalancers","locations":[],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"domainNames/slots/roles/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"domainNames/slots/roles/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"domainNames/capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"domainNames/serviceCertificates","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
         US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
         Central","Canada East","UK South","UK West","West US","Central US","South
         Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
-        East","Australia Southeast","West US 2","West Central US","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        East","Australia Southeast","West US 2","West Central US","France Central","South
+        India","Central India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
         US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
         Central","Canada East","UK South","UK West","West US","Central US","South
         Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
-        East","Australia Southeast","West US 2","West Central US","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metrics","locations":["North
+        East","Australia Southeast","West US 2","West Central US","France Central","South
+        India","Central India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metrics","locations":["North
         Central US","South Central US","East US","East US 2","Canada Central","Canada
         East","West US","West US 2","West Central US","Central US","East Asia","Southeast
         Asia","North Europe","West Europe","UK South","UK West","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"resourceTypes","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"moveSubscriptionResources","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"validateSubscriptionMoveAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operationStatuses","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operatingSystems","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"operatingSystemFamilies","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicNetwork","namespace":"Microsoft.ClassicNetwork","resourceTypes":[{"resourceType":"virtualNetworks","locations":["East
+        India","West India","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"resourceTypes","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"moveSubscriptionResources","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"validateSubscriptionMoveAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operationStatuses","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operatingSystems","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"operatingSystemFamilies","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicNetwork","namespace":"Microsoft.ClassicNetwork","resourceTypes":[{"resourceType":"virtualNetworks","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"virtualNetworks/remoteVirtualNetworkPeeringProxies","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01"]},{"resourceType":"virtualNetworks/remoteVirtualNetworkPeeringProxies","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"reservedIps","locations":["East
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01"]},{"resourceType":"reservedIps","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"gatewaySupportedDevices","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"networkSecurityGroups","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"gatewaySupportedDevices","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"networkSecurityGroups","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicStorage","namespace":"Microsoft.ClassicStorage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"expressRouteCrossConnections","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"expressRouteCrossConnections/peerings","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicStorage","namespace":"Microsoft.ClassicStorage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkStorageAccountAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"storageAccounts/services","locations":["West
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkStorageAccountAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"storageAccounts/services","locations":["West
         US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
         Asia","Australia East","Australia Southeast","South India","Central India","West
         India","West US 2","West Central US","East US","East US 2","North Central
         US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
-        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/diagnosticSettings","locations":["West
+        South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/diagnosticSettings","locations":["West
         US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
         Asia","Australia East","Australia Southeast","South India","Central India","West
         India","West US 2","West Central US","East US","East US 2","North Central
         US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
-        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"disks","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"images","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"vmImages","locations":[],"apiVersions":["2016-11-01"]},{"resourceType":"publicImages","locations":[],"apiVersions":["2016-11-01","2016-04-01"]},{"resourceType":"osImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"osPlatformImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute","namespace":"Microsoft.Compute","authorizations":[{"applicationId":"60e6cd67-9c8c-4951-9b3c-23c25a2169af","roleDefinitionId":"e4770acb-272e-4dc8-87f3-12f44a612224"},{"applicationId":"a303894e-f1d8-4a37-bf10-67aa654a0596","roleDefinitionId":"903ac751-8ad5-4e5a-bfc2-5e49f450a241"},{"applicationId":"a8b6bf88-1d1a-4626-b040-9a729ea93c65","roleDefinitionId":"45c8267c-80ba-4b96-9a43-115b8f49fccd"}],"resourceTypes":[{"resourceType":"availabilitySets","locations":["East
+        South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"disks","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"images","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"vmImages","locations":[],"apiVersions":["2016-11-01"]},{"resourceType":"storageAccounts/vmImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"publicImages","locations":[],"apiVersions":["2016-11-01","2016-04-01"]},{"resourceType":"osImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"osPlatformImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute","namespace":"Microsoft.Compute","authorizations":[{"applicationId":"60e6cd67-9c8c-4951-9b3c-23c25a2169af","roleDefinitionId":"e4770acb-272e-4dc8-87f3-12f44a612224"},{"applicationId":"a303894e-f1d8-4a37-bf10-67aa654a0596","roleDefinitionId":"903ac751-8ad5-4e5a-bfc2-5e49f450a241"},{"applicationId":"a8b6bf88-1d1a-4626-b040-9a729ea93c65","roleDefinitionId":"45c8267c-80ba-4b96-9a43-115b8f49fccd"}],"resourceTypes":[{"resourceType":"availabilitySets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations/usages","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations/usages","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"sharedVMImages","locations":["West
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"sharedVMImages","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"sharedVMImages/versions","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"locations/capsoperations","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"disks","locations":["Southeast
@@ -410,27 +408,27 @@ http_interactions:
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"snapshots","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"snapshots","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"locations/diskoperations","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"locations/diskoperations","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"images","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"images","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"]},{"resourceType":"locations/logAnalytics","locations":["East
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"]},{"resourceType":"locations/logAnalytics","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
         US","East US","South Central US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
@@ -547,7 +545,12 @@ http_interactions:
         US","East Asia","East US","East US 2","Japan East","Japan West","North Central
         US","North Europe","South Central US","South India","Southeast Asia","West
         Central US","West Europe","West India","West US","West US 2","UK West","UK
-        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"},{"applicationId":"f5c26e74-f226-4ae8-85f0-b4af0080ac9e","roleDefinitionId":"529d7ae6-e892-4d43-809d-8547aeb90643"}],"resourceTypes":[{"resourceType":"components","locations":["East
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/consumergroups","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/disasterrecoveryconfigs","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"},{"applicationId":"f5c26e74-f226-4ae8-85f0-b4af0080ac9e","roleDefinitionId":"529d7ae6-e892-4d43-809d-8547aeb90643"}],"resourceTypes":[{"resourceType":"components","locations":["East
         US","South Central US","North Europe","West Europe","Southeast Asia","West
         US 2"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
         US","South Central US","North Europe","West Europe","Southeast Asia","West
@@ -614,32 +617,32 @@ http_interactions:
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/accessPolicies","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"vaults/accessPolicies","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-10-01","2015-06-01","2014-12-19-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"deletedVaults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01","2014-12-19-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"deletedVaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-10-01"]},{"resourceType":"locations/deletedVaults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations/deletedVaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
         Central US","West Europe","Southeast Asia","Japan East","West Central US"],"apiVersions":["2016-04-01"]},{"resourceType":"webServices","locations":["South
         Central US","West Europe","Southeast Asia","Japan East","East US 2","West
         Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"operations","locations":["South
@@ -665,97 +668,97 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"networkWatchers/lenses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"networkWatchers/lenses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","West
         US 2","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
@@ -846,7 +849,7 @@ http_interactions:
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
         West","Korea Central","Korea South"],"apiVersions":["2017-07-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ResourceHealth","namespace":"Microsoft.ResourceHealth","authorizations":[{"applicationId":"8bdebf23-c0fe-4187-a378-717ad86f6a53","roleDefinitionId":"cc026344-c8b1-4561-83ba-59eba84b27cc"}],"resourceTypes":[{"resourceType":"availabilityStatuses","locations":[],"apiVersions":["2017-07-01","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"notifications","locations":["Australia
-        Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Security","namespace":"Microsoft.Security","authorization":{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
+        Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Security","namespace":"Microsoft.Security","authorizations":[{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},{"applicationId":"fc780465-2017-40d4-a0c5-307022471b92"}],"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatuses","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/virtualMachines","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/endpoints","locations":["Central
@@ -898,565 +901,595 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Central India","South
         India"],"apiVersions":["2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Sql","namespace":"Microsoft.Sql","authorizations":[{"applicationId":"e4ab13ed-33cb-41b4-9140-6e264582cf85","roleDefinitionId":"ec3ddc95-44dc-47a2-9926-5e9f5ffd44ec"},{"applicationId":"0130cc9f-7ac5-4026-bd5f-80a08a54e6d9","roleDefinitionId":"45e8abf8-0ec4-44f3-9c37-cff4f7779302"},{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},{"applicationId":"76c7f279-7959-468f-8943-3954880e0d8c","roleDefinitionId":"7f7513a8-73f9-4c5f-97a2-c41f0ea783ef"}],"resourceTypes":[{"resourceType":"operations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/capabilities","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/databaseAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/databaseOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverKeyOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/keys","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/encryptionProtector","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/usages","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01","2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/communicationLinks","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administrators","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administratorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/restorableDroppedDatabases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recoverableDatabases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/geoBackupPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/importExportOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/operationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/backupLongTermRetentionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/automaticTuning","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/automaticTuning","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/databases/transparentDataEncryption","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recommendedElasticPools","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/auditingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/connectionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/connectionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies/rules","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/securityAlertPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/securityAlertPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/auditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/extendedAuditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/elasticpools","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-09-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/jobAgentOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/jobAgentAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/disasterRecoveryConfiguration","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/dnsAliases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/failoverGroups","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/virtualNetworkRules","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/virtualNetworkRulesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/virtualNetworkRulesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/databaseRestoreAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metricDefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/aggregatedDatabaseMetrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metricdefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries/queryText","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPools/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/extensions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPoolEstimates","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditRecords","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentScans","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/vulnerabilityAssessments","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessment","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/syncGroups","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups/syncMembers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/syncAgents","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"managedInstances/administrators","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/databases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metricDefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/administratorAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/administratorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncMemberOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncAgentOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncDatabaseIds","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorizations":[{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},{"applicationId":"e406a681-f3d4-42a8-90b6-c2b029497af1"}],"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/capabilities","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/databaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"locations/databaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverKeyOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/keys","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/encryptionProtector","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01","2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/communicationLinks","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/restorableDroppedDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recoverableDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/geoBackupPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/importExportOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/operationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/backupLongTermRetentionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/databases/transparentDataEncryption","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recommendedElasticPools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies/rules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/extendedAuditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/elasticPoolAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/elasticPoolOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/elasticpools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-09-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/jobAgentOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/jobAgentAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/disasterRecoveryConfiguration","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/dnsAliases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/failoverGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/virtualNetworkRules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/virtualNetworkRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/virtualNetworkRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/databaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/aggregatedDatabaseMetrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metricdefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries/queryText","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPools/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/extensions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPoolEstimates","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditRecords","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentScans","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/vulnerabilityAssessments","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessment","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/syncGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups/syncMembers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/syncAgents","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"managedInstances/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/administratorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncMemberOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncAgentOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncDatabaseIds","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/longTermRetentionPolicyOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionPolicyAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionBackupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionBackupAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorizations":[{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},{"applicationId":"e406a681-f3d4-42a8-90b6-c2b029497af1"}],"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
@@ -1795,12 +1828,12 @@ http_interactions:
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","Canada Central","Canada East","UK South","UK West","West US 2","West
-        Central US","South India","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","South India","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","South India","Canada Central","Canada East","UK South","UK West","West
-        US 2","West Central US","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Capacity","namespace":"Microsoft.Capacity","authorization":{"applicationId":"4d0ad6c7-f6c3-46d8-ab0d-1406d5e6c86b","roleDefinitionId":"FD9C0A9A-4DB9-4F41-8A61-98385DEB6E2D"},"resourceTypes":[{"resourceType":"resources","locations":["South
+        US 2","West Central US","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Capacity","namespace":"Microsoft.Capacity","authorization":{"applicationId":"4d0ad6c7-f6c3-46d8-ab0d-1406d5e6c86b","roleDefinitionId":"FD9C0A9A-4DB9-4F41-8A61-98385DEB6E2D"},"resourceTypes":[{"resourceType":"resources","locations":["South
         Central US"],"apiVersions":["2017-11-01"]},{"resourceType":"reservationOrders","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/reservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/reservations/revisions","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"catalogs","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"appliedReservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"checkOffers","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"checkScopes","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"calculatePrice","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/calculateRefund","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/return","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/split","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/merge","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"validateReservationOrder","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/availableScopes","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Cdn","namespace":"Microsoft.Cdn","resourceTypes":[{"resourceType":"profiles","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
@@ -1876,9 +1909,9 @@ http_interactions:
         2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/updateAccountsCreationSettings","locations":["West
         US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/accountsCreationSettings","locations":["West
         US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2016-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Commerce","namespace":"Microsoft.Commerce","resourceTypes":[{"resourceType":"UsageAggregates","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]},{"resourceType":"RateCard","locations":[],"apiVersions":["2016-08-31-preview","2015-06-01-preview","2015-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Consumption","namespace":"Microsoft.Consumption","resourceTypes":[{"resourceType":"ReservationSummaries","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationTransactions","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Balances","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Marketplaces","locations":[],"apiVersions":["2018-01-31"]},{"resourceType":"Pricesheets","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationDetails","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Budgets","locations":[],"apiVersions":["2018-01-31","2017-12-30-preview"]},{"resourceType":"Terms","locations":[],"apiVersions":["2018-01-31","2017-12-30-preview"]},{"resourceType":"UsageDetails","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview","2017-04-24-preview"]},{"resourceType":"Operations","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview","2017-04-24-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerInstance","namespace":"Microsoft.ContainerInstance","resourceTypes":[{"resourceType":"containerGroups","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/usages","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/operations","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/operations","locations":["West
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
         US"],"apiVersions":["2016-04-08"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.CustomerInsights","namespace":"Microsoft.CustomerInsights","authorization":{"applicationId":"38c77d00-5fcb-4cce-9d93-af4738258e3c","roleDefinitionId":"E006F9C7-F333-477C-8AD6-1F3A9FE87F55"},"resourceTypes":[{"resourceType":"hubs","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/profiles","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/interactions","locations":["East
@@ -1895,7 +1928,9 @@ http_interactions:
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"operations","locations":["East
         US 2"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Databricks","namespace":"Microsoft.Databricks","authorizations":[{"applicationId":"d9327919-6775-4843-9037-3fb0fb0473cb","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},{"applicationId":"2ff814a6-3304-4ab8-85cb-cd0e6f879c1d","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"}],"resourceTypes":[{"resourceType":"workspaces","locations":["West
         US","East US 2","West Europe","East US","North Europe","Southeast Asia","East
-        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]},{"resourceType":"locations","locations":["West
+        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2017-09-01-preview"]},{"resourceType":"workspaces/virtualNetworkPeerings","locations":["West
+        US","East US 2","West Europe","North Europe","East US","Southeast Asia","East
+        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01"]},{"resourceType":"locations","locations":["West
         US","East US 2","West Europe","North Europe","East US","Southeast Asia"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
         US","East US 2","West Europe","East US","North Europe","Southeast Asia","East
         Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataCatalog","namespace":"Microsoft.DataCatalog","resourceTypes":[{"resourceType":"catalogs","locations":["East
@@ -1919,23 +1954,26 @@ http_interactions:
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers/listSasTokens","locations":["East
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataLakeStore","namespace":"Microsoft.DataLakeStore","authorization":{"applicationId":"e9f49c6b-5ce5-44c8-925d-015017e9f7ad","roleDefinitionId":"17eb9cca-f08a-4499-b2d3-852d175f614f"},"resourceTypes":[{"resourceType":"accounts","locations":["East
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/firewallRules","locations":["East
-        US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataMigration","namespace":"Microsoft.DataMigration","authorization":{"applicationId":"a4bad4aa-bf02-4631-9f78-a64ffdba8150","roleDefinitionId":"b831a21d-db98-4760-89cb-bef871952df1","managedByRoleDefinitionId":"6256fb55-9e59-4018-a9e1-76b11c0a4c89"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services/projects","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationStatuses","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
+        US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataMigration","namespace":"Microsoft.DataMigration","authorization":{"applicationId":"a4bad4aa-bf02-4631-9f78-a64ffdba8150","roleDefinitionId":"b831a21d-db98-4760-89cb-bef871952df1","managedByRoleDefinitionId":"6256fb55-9e59-4018-a9e1-76b11c0a4c89"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services/projects","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationStatuses","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
-        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/recoverableServers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
@@ -1959,7 +1997,10 @@ http_interactions:
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
-        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/recoverableServers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
@@ -2015,12 +2056,7 @@ http_interactions:
         US 2","East US","West US","Central US","East US 2","West Central US","West
         Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
         US 2","East US","West US","Central US","East US 2","West Central US","West
-        Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","West
-        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
-        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
-        India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/consumergroups","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/disasterrecoveryconfigs","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
         US 2","South Central US","Central US","Australia Southeast","Central India","West
         Central US","West US 2","Canada East","Canada Central","Brazil South","UK
         South","UK West","East Asia","Australia East","Japan East","Japan West","North
@@ -2131,7 +2167,7 @@ http_interactions:
         West","Japan East","East Asia","Southeast Asia","West Europe","North Europe","East
         US","West US","Australia East","Australia Southeast","Central US","Brazil
         South","Central India","West India","South India","South Central US","Canada
-        Central","Canada East","West Central US","West US 2"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
+        Central","Canada East","West Central US","West US 2"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-05","2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
         Central US","East US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"operations","locations":["West
         Central US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
         Central US","East US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.PolicyInsights","namespace":"Microsoft.PolicyInsights","authorization":{"applicationId":"1d78a85d-813d-46f0-b496-dd72f50a3ec0","roleDefinitionId":"63d2b225-4c34-4641-8768-21a1f7c68ce8"},"resourceTypes":[{"resourceType":"policyEvents","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"policyStates","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
@@ -2163,12 +2199,12 @@ http_interactions:
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
         Central US","South Central US","North Europe","West Europe","East Asia","Southeast
         Asia","West US","East US","Japan West","Japan East","Brazil South","Central
         US","East US 2","Australia East","Australia Southeast","South India","Central
@@ -2208,40 +2244,50 @@ http_interactions:
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/clusterVersions","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"clusters/applications","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operations","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/clusterVersions","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/environments","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operations","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
         Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applianceDefinitions","locations":["West
         Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applications","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
-        Central US"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
+        Central US"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
         US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
         US","Canada Central","Canada East","Central US","East US 2","UK South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups","locations":["West
         US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
@@ -2332,7 +2378,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:27 GMT
+  recorded_at: Mon, 12 Mar 2018 09:35:20 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Storage/storageAccounts?api-version=2017-10-01
@@ -2349,7 +2395,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3ODQsIm5iZiI6MTUyMDQ1Mzc4NCwiZXhwIjoxNTIwNDU3Njg0LCJhaW8iOiJZMk5nWUpnU2xxeG4vSTJOMTBmYWNkZHltZXE3QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoicDBsS2ZuYXRORVd2a3VaVmttQUFBQSIsInZlciI6IjEuMCJ9.iC1HIh7EJhSg4gWNwK-4-iAm1Y57QbVEKhbqmrgwOPUjVEl83aDkQcFgk_LTJlYJxuWt32jXyPTVllnJyz8dQlAV3NbzVr2Ob3u7Tma1NOOnxZkLpH9EE8B1SgQypHRbWQa5OXi98OEU429EDLTLzRPhb0ePBhu9oz0AtzI8jHVr46i_X7jxoTKLQsx83mOyBS68htVskAiZtMVcl38z5OHFZ15jBJJfCsbMEVL632TFBKiKwwwKKgMvTbgR9lRqXNgLsCl4sYWtuXD1i5vKr9GHvFE4byo7KUAmecWPb9ZdogYjVVEpoXXh5IkbAY-T7K_JTEBJL7lWK1t640tBjw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcwMTMsIm5iZiI6MTUyMDg0NzAxMywiZXhwIjoxNTIwODUwOTEzLCJhaW8iOiJZMk5nWUhCMFludmpjNGN6aE5NNTh0M0t5a1FYQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoialE5U1hFcjVIRWVCX0dyQ1pta2pBQSIsInZlciI6IjEuMCJ9.CNps7ehQ4gjIipFpeHtH1uayoFrjNQmz9DNt8X_pu3FJIMidCRl8zafvhLybkMt3jBTg3ilWiyWZfJ-LaCVtgzQqXRZh4TitdGaw6BtQXx5BndCxbJdfQQWyDDtaXijWD6EjF5OpGZJ0nBglCx-KPAAPhSZXRIvjPNXgsDseRlJxWTSzxYkOUfGY5gn9E9CT6Qe54gFtFsID7PIhBmFOLFrgEjl9dEidPDaLO9f7lba8LHWTjDFozQ_FgyhD_PqDzJYySpX8wTabcb1A1tynX-1rd5v9e4pPrxjRLEvJ_VLaP9RN8XVqo2YoZadQ9FlTwiv4l7aY36nqd2QffgkYsg
   response:
     status:
       code: 200
@@ -2366,24 +2412,24 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 6d38c1fc-6c7c-4a9b-b5b7-a34703ee469c
+      - 61266e2a-3d79-40c2-ab04-60ce2731af3e
       X-Ms-Correlation-Request-Id:
-      - 6d38c1fc-6c7c-4a9b-b5b7-a34703ee469c
+      - 61266e2a-3d79-40c2-ab04-60ce2731af3e
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202131Z:6d38c1fc-6c7c-4a9b-b5b7-a34703ee469c
+      - WESTEUROPE:20180312T093518Z:61266e2a-3d79-40c2-ab04-60ce2731af3e
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:21:31 GMT
+      - Mon, 12 Mar 2018 09:35:17 GMT
       Content-Length:
       - '8649'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","name":"miqazuretest18686","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T17:22:54.7808677Z","primaryEndpoints":{"blob":"https://miqazuretest18686.blob.core.windows.net/","queue":"https://miqazuretest18686.queue.core.windows.net/","table":"https://miqazuretest18686.table.core.windows.net/","file":"https://miqazuretest18686.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","name":"miqazuretest14047","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T17:30:25.7028008Z","primaryEndpoints":{"blob":"https://miqazuretest14047.blob.core.windows.net/","queue":"https://miqazuretest14047.queue.core.windows.net/","table":"https://miqazuretest14047.table.core.windows.net/","file":"https://miqazuretest14047.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Premium_LRS","tier":"Premium"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb","name":"rspeclb","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-09-02T16:29:11.6823797Z","primaryEndpoints":{"blob":"https://rspeclb.blob.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","name":"spec0deply1stor","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-04-04T23:05:07.8274794Z","primaryEndpoints":{"blob":"https://spec0deply1stor.blob.core.windows.net/","queue":"https://spec0deply1stor.queue.core.windows.net/","table":"https://spec0deply1stor.table.core.windows.net/","file":"https://spec0deply1stor.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Storage/storageAccounts/miqazuretest26611","name":"miqazuretest26611","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2211656Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2211656Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-05-02T18:01:29.2743021Z","primaryEndpoints":{"blob":"https://miqazuretest26611.blob.core.windows.net/","queue":"https://miqazuretest26611.queue.core.windows.net/","table":"https://miqazuretest26611.table.core.windows.net/","file":"https://miqazuretest26611.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","name":"miqazuretest16487","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T17:26:55.3231669Z","primaryEndpoints":{"blob":"https://miqazuretest16487.blob.core.windows.net/","queue":"https://miqazuretest16487.queue.core.windows.net/","table":"https://miqazuretest16487.table.core.windows.net/","file":"https://miqazuretest16487.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Storage/storageAccounts/miqazuretest32946","name":"miqazuretest32946","type":"Microsoft.Storage/storageAccounts","location":"westus","tags":{"delete":"false"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.0404359Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.0404359Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T21:18:37.0793411Z","primaryEndpoints":{"blob":"https://miqazuretest32946.blob.core.windows.net/","queue":"https://miqazuretest32946.queue.core.windows.net/","table":"https://miqazuretest32946.table.core.windows.net/","file":"https://miqazuretest32946.file.core.windows.net/"},"primaryLocation":"westus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Storage/storageAccounts/miqazureshared1","name":"miqazureshared1","type":"Microsoft.Storage/storageAccounts","location":"centralus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.1935084Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.1935084Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T20:42:52.498085Z","primaryEndpoints":{"blob":"https://miqazureshared1.blob.core.windows.net/","queue":"https://miqazureshared1.queue.core.windows.net/","table":"https://miqazureshared1.table.core.windows.net/","file":"https://miqazureshared1.file.core.windows.net/"},"primaryLocation":"centralus","statusOfPrimary":"available","secondaryLocation":"eastus2","statusOfSecondary":"available","secondaryEndpoints":{"blob":"https://miqazureshared1-secondary.blob.core.windows.net/","queue":"https://miqazureshared1-secondary.queue.core.windows.net/","table":"https://miqazureshared1-secondary.table.core.windows.net/"}}}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:31 GMT
+  recorded_at: Mon, 12 Mar 2018 09:35:22 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686/listKeys?api-version=2017-10-01
@@ -2400,7 +2446,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3ODQsIm5iZiI6MTUyMDQ1Mzc4NCwiZXhwIjoxNTIwNDU3Njg0LCJhaW8iOiJZMk5nWUpnU2xxeG4vSTJOMTBmYWNkZHltZXE3QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoicDBsS2ZuYXRORVd2a3VaVmttQUFBQSIsInZlciI6IjEuMCJ9.iC1HIh7EJhSg4gWNwK-4-iAm1Y57QbVEKhbqmrgwOPUjVEl83aDkQcFgk_LTJlYJxuWt32jXyPTVllnJyz8dQlAV3NbzVr2Ob3u7Tma1NOOnxZkLpH9EE8B1SgQypHRbWQa5OXi98OEU429EDLTLzRPhb0ePBhu9oz0AtzI8jHVr46i_X7jxoTKLQsx83mOyBS68htVskAiZtMVcl38z5OHFZ15jBJJfCsbMEVL632TFBKiKwwwKKgMvTbgR9lRqXNgLsCl4sYWtuXD1i5vKr9GHvFE4byo7KUAmecWPb9ZdogYjVVEpoXXh5IkbAY-T7K_JTEBJL7lWK1t640tBjw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcwMTMsIm5iZiI6MTUyMDg0NzAxMywiZXhwIjoxNTIwODUwOTEzLCJhaW8iOiJZMk5nWUhCMFludmpjNGN6aE5NNTh0M0t5a1FYQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoialE5U1hFcjVIRWVCX0dyQ1pta2pBQSIsInZlciI6IjEuMCJ9.CNps7ehQ4gjIipFpeHtH1uayoFrjNQmz9DNt8X_pu3FJIMidCRl8zafvhLybkMt3jBTg3ilWiyWZfJ-LaCVtgzQqXRZh4TitdGaw6BtQXx5BndCxbJdfQQWyDDtaXijWD6EjF5OpGZJ0nBglCx-KPAAPhSZXRIvjPNXgsDseRlJxWTSzxYkOUfGY5gn9E9CT6Qe54gFtFsID7PIhBmFOLFrgEjl9dEidPDaLO9f7lba8LHWTjDFozQ_FgyhD_PqDzJYySpX8wTabcb1A1tynX-1rd5v9e4pPrxjRLEvJ_VLaP9RN8XVqo2YoZadQ9FlTwiv4l7aY36nqd2QffgkYsg
       Content-Length:
       - '0'
   response:
@@ -2421,26 +2467,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 31e6d8a6-c1dc-4d3e-b639-c1d0192c13e7
+      - c9c78e82-7098-4237-bf56-d3ab9d07a3ce
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1197'
+      - '1199'
       X-Ms-Correlation-Request-Id:
-      - d20596cf-513b-41a8-939f-1d04e91103ab
+      - 44463c3c-5fde-4ffe-bd45-f90880e61e97
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202132Z:d20596cf-513b-41a8-939f-1d04e91103ab
+      - WESTEUROPE:20180312T093519Z:44463c3c-5fde-4ffe-bd45-f90880e61e97
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:21:31 GMT
+      - Mon, 12 Mar 2018 09:35:18 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keys":[{"keyName":"key1","value":"32PV5jeBt8nw1XvFbZokY26SXchbD6H2tw/YrteEYVE0kpMLKrZ74VrwaIjDyucdi/RxDaAlf7dJIilLS7muNw==","permissions":"Full"},{"keyName":"key2","value":"Eo5x9CQJL1/wl6Tkj5N7M5eEdw6Hym6AeyTt3xjcDl30sV8Iadro6ywZzOHQwNDlmrDaBF6x2a9ZFL7zswxQ7w==","permissions":"Full"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:32 GMT
+  recorded_at: Mon, 12 Mar 2018 09:35:23 GMT
 - request:
     method: get
     uri: https://miqazuretest18686.blob.core.windows.net/?comp=list
@@ -2457,13 +2503,13 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:21:32 GMT
+      - Mon, 12 Mar 2018 09:35:23 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
       - 'true'
       Authorization:
-      - SharedKey miqazuretest18686:ifCoGnnMFXsXecVBQfCDPCur7cDTH1brYISWsIOVLek=
+      - SharedKey miqazuretest18686:uM9XZuWV/xtNgCwUBgU+b8xj3GzItFAfxvAPuMXRHQQ=
   response:
     status:
       code: 200
@@ -2476,17 +2522,17 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - d5b3bfad-001e-0062-2351-b661a7000000
+      - cd5ff92f-001e-0066-01e5-b99425000000
       X-Ms-Version:
       - '2016-05-31'
       Date:
-      - Wed, 07 Mar 2018 20:21:32 GMT
+      - Mon, 12 Mar 2018 09:35:19 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9taXFhenVyZXRlc3QxODY4Ni5ibG9iLmNvcmUud2luZG93cy5uZXQvIj48Q29udGFpbmVycz48Q29udGFpbmVyPjxOYW1lPmJvb3RkaWFnbm9zdGljcy1taXF0ZXN0cmgtMDNlODQ2N2ItYmFhYi00ODY3LTljYzQtMTU3MzM2YjdlMmU0PC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPkZyaSwgMTggTWFyIDIwMTYgMTc6MjM6MjggR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPiIweDhEMzRGNTIwNTFCRENDMCI8L0V0YWc+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQ29udGFpbmVyPjxDb250YWluZXI+PE5hbWU+dmhkczwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5GcmksIDE4IE1hciAyMDE2IDE3OjIzOjI4IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4iMHg4RDM0RjUyMDU0RDgwMDUiPC9FdGFnPjxMZWFzZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJhdGlvbj5pbmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48L1Byb3BlcnRpZXM+PC9Db250YWluZXI+PC9Db250YWluZXJzPjxOZXh0TWFya2VyIC8+PC9FbnVtZXJhdGlvblJlc3VsdHM+
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:33 GMT
+  recorded_at: Mon, 12 Mar 2018 09:35:24 GMT
 - request:
     method: get
     uri: https://miqazuretest18686.blob.core.windows.net/vhds?comp=list&restype=container
@@ -2503,13 +2549,13 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:21:33 GMT
+      - Mon, 12 Mar 2018 09:35:24 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
       - 'true'
       Authorization:
-      - SharedKey miqazuretest18686:gNNaWSxIoVrGDMOvR32LS5WDbBeg1EqeZIHJnC3btVk=
+      - SharedKey miqazuretest18686:ylyjAKWOvwwne6x/l0s9fsyuowZN4SQ2VOQXZJSAeqM=
   response:
     status:
       code: 200
@@ -2522,17 +2568,17 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 919b0580-001e-0135-4351-b6ce7f000000
+      - 1401d0ff-001e-00cd-64e5-b94337000000
       X-Ms-Version:
       - '2016-05-31'
       Date:
-      - Wed, 07 Mar 2018 20:21:33 GMT
+      - Mon, 12 Mar 2018 09:35:19 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9taXFhenVyZXRlc3QxODY4Ni5ibG9iLmNvcmUud2luZG93cy5uZXQvIiBDb250YWluZXJOYW1lPSJ2aGRzIj48QmxvYnM+PEJsb2I+PE5hbWU+bWlxLXRlc3QtcmhlbDEyMDE2MjE4MTEyMjQzLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5XZWQsIDA3IE1hciAyMDE4IDIwOjIxOjMzIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhENTg0NjkwNTEyQjlCNDwvRXRhZz48Q29udGVudC1MZW5ndGg+MzIyMTIyNTUyMzI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5kUUwrWEhqRk5QZG9NRXdlSTYzZndRPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4zNzE8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+bG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5sZWFzZWQ8L0xlYXNlU3RhdGU+PExlYXNlRHVyYXRpb24+aW5maW5pdGU8L0xlYXNlRHVyYXRpb24+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PC9CbG9icz48TmV4dE1hcmtlciAvPjwvRW51bWVyYXRpb25SZXN1bHRzPg==
+        77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9taXFhenVyZXRlc3QxODY4Ni5ibG9iLmNvcmUud2luZG93cy5uZXQvIiBDb250YWluZXJOYW1lPSJ2aGRzIj48QmxvYnM+PEJsb2I+PE5hbWU+bWlxLXRlc3QtcmhlbDEyMDE2MjE4MTEyMjQzLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5Nb24sIDEyIE1hciAyMDE4IDA5OjM1OjE1IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhENTg3RkM4RkU5QUU2MTwvRXRhZz48Q29udGVudC1MZW5ndGg+MzIyMTIyNTUyMzI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5kUUwrWEhqRk5QZG9NRXdlSTYzZndRPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4zNzI8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+bG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5sZWFzZWQ8L0xlYXNlU3RhdGU+PExlYXNlRHVyYXRpb24+aW5maW5pdGU8L0xlYXNlRHVyYXRpb24+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PC9CbG9icz48TmV4dE1hcmtlciAvPjwvRW51bWVyYXRpb25SZXN1bHRzPg==
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:33 GMT
+  recorded_at: Mon, 12 Mar 2018 09:35:24 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047/listKeys?api-version=2017-10-01
@@ -2549,7 +2595,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3ODQsIm5iZiI6MTUyMDQ1Mzc4NCwiZXhwIjoxNTIwNDU3Njg0LCJhaW8iOiJZMk5nWUpnU2xxeG4vSTJOMTBmYWNkZHltZXE3QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoicDBsS2ZuYXRORVd2a3VaVmttQUFBQSIsInZlciI6IjEuMCJ9.iC1HIh7EJhSg4gWNwK-4-iAm1Y57QbVEKhbqmrgwOPUjVEl83aDkQcFgk_LTJlYJxuWt32jXyPTVllnJyz8dQlAV3NbzVr2Ob3u7Tma1NOOnxZkLpH9EE8B1SgQypHRbWQa5OXi98OEU429EDLTLzRPhb0ePBhu9oz0AtzI8jHVr46i_X7jxoTKLQsx83mOyBS68htVskAiZtMVcl38z5OHFZ15jBJJfCsbMEVL632TFBKiKwwwKKgMvTbgR9lRqXNgLsCl4sYWtuXD1i5vKr9GHvFE4byo7KUAmecWPb9ZdogYjVVEpoXXh5IkbAY-T7K_JTEBJL7lWK1t640tBjw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcwMTMsIm5iZiI6MTUyMDg0NzAxMywiZXhwIjoxNTIwODUwOTEzLCJhaW8iOiJZMk5nWUhCMFludmpjNGN6aE5NNTh0M0t5a1FYQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoialE5U1hFcjVIRWVCX0dyQ1pta2pBQSIsInZlciI6IjEuMCJ9.CNps7ehQ4gjIipFpeHtH1uayoFrjNQmz9DNt8X_pu3FJIMidCRl8zafvhLybkMt3jBTg3ilWiyWZfJ-LaCVtgzQqXRZh4TitdGaw6BtQXx5BndCxbJdfQQWyDDtaXijWD6EjF5OpGZJ0nBglCx-KPAAPhSZXRIvjPNXgsDseRlJxWTSzxYkOUfGY5gn9E9CT6Qe54gFtFsID7PIhBmFOLFrgEjl9dEidPDaLO9f7lba8LHWTjDFozQ_FgyhD_PqDzJYySpX8wTabcb1A1tynX-1rd5v9e4pPrxjRLEvJ_VLaP9RN8XVqo2YoZadQ9FlTwiv4l7aY36nqd2QffgkYsg
       Content-Length:
       - '0'
   response:
@@ -2570,26 +2616,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 61e8dd64-1b91-4c39-bd45-18d742005d74
+      - 74ecbcc0-3372-467b-b150-5a41cd597e5d
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1197'
+      - '1199'
       X-Ms-Correlation-Request-Id:
-      - cb63cfcf-b74c-4ca0-a8a2-ff0b1fd918cd
+      - 55cc17d8-1e65-4a83-a9b7-9f023cc87215
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202133Z:cb63cfcf-b74c-4ca0-a8a2-ff0b1fd918cd
+      - WESTEUROPE:20180312T093521Z:55cc17d8-1e65-4a83-a9b7-9f023cc87215
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:21:33 GMT
+      - Mon, 12 Mar 2018 09:35:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keys":[{"keyName":"key1","value":"9hGLwV9mjvAc1ARzeGwpsS9oZPLqOBzHCCHjeixyt1wpPYVn32cXmm3Gs9ogFPXZhDH61PAXxud0Dg/qwOnJ1w==","permissions":"Full"},{"keyName":"key2","value":"FfW8btVjJE2LkKHvN8Prr3FDX71BrS4SnMkONq2fLVPPm6x7vqqjeDSWDh17aI4CBLYf3Y1pc6njkbz53HdMYg==","permissions":"Full"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:34 GMT
+  recorded_at: Mon, 12 Mar 2018 09:35:26 GMT
 - request:
     method: get
     uri: https://miqazuretest14047.blob.core.windows.net/?comp=list
@@ -2606,13 +2652,13 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:21:34 GMT
+      - Mon, 12 Mar 2018 09:35:26 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
       - 'true'
       Authorization:
-      - SharedKey miqazuretest14047:mwXY6bSKakfLzj63VIBRxuT5DWjZMM5NoUb4caC5yW4=
+      - SharedKey miqazuretest14047:6XLcOAC/pSkLIe2Aq+Rs6lmfTksfL9Fq2DNHZKiZZvQ=
   response:
     status:
       code: 200
@@ -2625,17 +2671,17 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 13fe075a-001e-00f5-6c51-b6026e000000
+      - 44041976-001e-000c-5ee5-b9c88e000000
       X-Ms-Version:
       - '2016-05-31'
       Date:
-      - Wed, 07 Mar 2018 20:21:34 GMT
+      - Mon, 12 Mar 2018 09:35:21 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9taXFhenVyZXRlc3QxNDA0Ny5ibG9iLmNvcmUud2luZG93cy5uZXQvIj48Q29udGFpbmVycz48Q29udGFpbmVyPjxOYW1lPmJvb3RkaWFnbm9zdGljcy1taXFhenVyZWMtNzk2YzViY2MtMzM4YS00NDhkLWI2MWMtMTY1Mjc5YTdmYjNlPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPk1vbiwgMjEgTWFyIDIwMTYgMTY6NTA6MTMgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPiIweDhEMzUxQThERjlBNjcxNCI8L0V0YWc+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQ29udGFpbmVyPjxDb250YWluZXI+PE5hbWU+Ym9vdGRpYWdub3N0aWNzLW1pcXRlc3R3aS02ZTU1NWI4OC0zZmQ0LTRiNzItYTQwNC00YmJhNWQxMWRlOTM8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+RnJpLCAxOCBNYXIgMjAxNiAxNzozMDo1OSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+IjB4OEQzNEY1MzEyNTlFMTY1IjwvRXRhZz48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9Db250YWluZXI+PENvbnRhaW5lcj48TmFtZT5ib290ZGlhZ25vc3RpY3MtbWlxdGVzdHdpLWI5N2ZmNDg4LWUxMTQtNDBlZC04ZDdhLWY0NTAwZDczZWVjMDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UdWUsIDIyIE1hciAyMDE2IDE2OjE3OjA2IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4iMHg4RDM1MjZENjk4RUQxODkiPC9FdGFnPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0NvbnRhaW5lcj48Q29udGFpbmVyPjxOYW1lPmJvb3RkaWFnbm9zdGljcy1taXF0ZXN0d2ktZTE3YTk1YjAtZjRmYi00MTk2LTkzYzUtMGM4YmU3ZDVjNTM2PC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlR1ZSwgMjIgTWFyIDIwMTYgMTY6NDA6MzEgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPiIweDhEMzUyNzBBRURCNTBBQiI8L0V0YWc+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQ29udGFpbmVyPjxDb250YWluZXI+PE5hbWU+Y29waWVzPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPkZyaSwgMTcgSnVuIDIwMTYgMTQ6MDk6MDUgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPiIweDhEMzk2QjhGMTE4M0QzMiI8L0V0YWc+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQ29udGFpbmVyPjxDb250YWluZXI+PE5hbWU+bWFuYWdlaXE8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+V2VkLCAyMCBBcHIgMjAxNiAxNjowNDo1NCBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+IjB4OEQzNjkzNTgyRkJENTg0IjwvRXRhZz48TGVhc2VTdGF0dXM+bG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5sZWFzZWQ8L0xlYXNlU3RhdGU+PExlYXNlRHVyYXRpb24+aW5maW5pdGU8L0xlYXNlRHVyYXRpb24+PC9Qcm9wZXJ0aWVzPjwvQ29udGFpbmVyPjxDb250YWluZXI+PE5hbWU+c3lzdGVtPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlR1ZSwgMjIgTWFyIDIwMTYgMTc6MDg6MDEgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPiIweDhEMzUyNzQ4NjUxNkJGOCI8L0V0YWc+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQ29udGFpbmVyPjxDb250YWluZXI+PE5hbWU+dmhkczwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5GcmksIDE4IE1hciAyMDE2IDE3OjMwOjU5IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4iMHg4RDM0RjUzMTI3NjQ5RUUiPC9FdGFnPjxMZWFzZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJhdGlvbj5pbmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48L1Byb3BlcnRpZXM+PC9Db250YWluZXI+PC9Db250YWluZXJzPjxOZXh0TWFya2VyIC8+PC9FbnVtZXJhdGlvblJlc3VsdHM+
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:34 GMT
+  recorded_at: Mon, 12 Mar 2018 09:35:26 GMT
 - request:
     method: get
     uri: https://miqazuretest14047.blob.core.windows.net/copies?comp=list&restype=container
@@ -2652,13 +2698,13 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:21:34 GMT
+      - Mon, 12 Mar 2018 09:35:26 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
       - 'true'
       Authorization:
-      - SharedKey miqazuretest14047:lSD46fy4nfGYYXprTZK/9aeEMN/O1yPnYXiDv4ZPzXk=
+      - SharedKey miqazuretest14047:XPbA9HM26tm5iUFHeJmJ+qY3xqWh4k0fpMofmgCTtvM=
   response:
     status:
       code: 200
@@ -2671,17 +2717,17 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 8787a97b-001e-0085-7651-b671aa000000
+      - 7a6d3572-001e-0074-0de5-b9a039000000
       X-Ms-Version:
       - '2016-05-31'
       Date:
-      - Wed, 07 Mar 2018 20:21:34 GMT
+      - Mon, 12 Mar 2018 09:35:21 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9taXFhenVyZXRlc3QxNDA0Ny5ibG9iLmNvcmUud2luZG93cy5uZXQvIiBDb250YWluZXJOYW1lPSJjb3BpZXMiPjxCbG9icz48QmxvYj48TmFtZT50ZXN0LXdpbjJrMTItY29waWVkLXsxMjM0NX08L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+RnJpLCAxNyBKdW4gMjAxNiAxNDoxMzozMCBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDM5NkI5OEYyOUQ3NEM8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjE8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48L0Jsb2JzPjxOZXh0TWFya2VyIC8+PC9FbnVtZXJhdGlvblJlc3VsdHM+
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:35 GMT
+  recorded_at: Mon, 12 Mar 2018 09:35:27 GMT
 - request:
     method: get
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq?comp=list&restype=container
@@ -2698,13 +2744,13 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:21:35 GMT
+      - Mon, 12 Mar 2018 09:35:27 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
       - 'true'
       Authorization:
-      - SharedKey miqazuretest14047:ViRElutUusAm8pm45M9vjNXOXstzi7NPJAYxWZTPWOU=
+      - SharedKey miqazuretest14047:XdB7SVODuSLK4gyfvEDV5DPm+eaoE4diar6HDuwVVEU=
   response:
     status:
       code: 200
@@ -2717,17 +2763,17 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 6da617f8-001e-00dd-5151-b675d1000000
+      - 9eeb5527-001e-0027-21e5-b9bc36000000
       X-Ms-Version:
       - '2016-05-31'
       Date:
-      - Wed, 07 Mar 2018 20:21:35 GMT
+      - Mon, 12 Mar 2018 09:35:22 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9taXFhenVyZXRlc3QxNDA0Ny5ibG9iLmNvcmUud2luZG93cy5uZXQvIiBDb250YWluZXJOYW1lPSJtYW5hZ2VpcSI+PEJsb2JzPjxCbG9iPjxOYW1lPmF6ZG11MDAwNF85YzcwNjBiYi0yN2Y5LTRmOTAtYjc4NS1lMTg5NzE2MjY5ZjgudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlR1ZSwgMjcgU2VwIDIwMTYgMTg6MzU6MjUgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzRTcwNTBCRjU2NDJEPC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj40PC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+YXpkbXUwMDA1X2IyZDkxYTdlLWY0ZTEtNDI4OS1iNGU3LTFjNWZhMmRkZTQyZS52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VGh1LCAwNiBPY3QgMjAxNiAxODozNTo0NSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDNFRTE3OTYwRjUxREI8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjE8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5hemRtdTAwMDZfYmZhMTEzNTctNmE4MC00ZGUxLWIzOTUtNjdlODcwYzE0YTkxLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UaHUsIDA2IE9jdCAyMDE2IDE4OjM1OjQ2IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0VFMTc5NjM3MDdDNzwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MTwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmF6ZG11MDAwNy42ZDQ1Y2VjZC00N2U2LTRjNGMtYjFlMi1hYmQzYzFkNmRlOTcuc3RhdHVzPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlNhdCwgMDggT2N0IDIwMTYgMTQ6MDE6NTcgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzRUY4M0FBODk5NjE3PC9FdGFnPjxDb250ZW50LUxlbmd0aD41MTc8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5PR3Vxb1pIVThNUCtwT3RlWGZuTzNBPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48QmxvYlR5cGU+QmxvY2tCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5hemRtdTAwMDdfNmZmY2VhOWMtZDM2Zi00ZGVhLThjMDMtY2NiNWM2NWY3YjAxLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5TYXQsIDA4IE9jdCAyMDE2IDE0OjAyOjEwIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0VGODNCMjU2QkREMzwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MzwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJhdGlvbj5pbmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5hemRtdTAwMDguOWNjYTAwOGQtYzY2Zi00YzI1LWJmMjEtYjgyZDQ1OWM4YWIyLnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5TYXQsIDE1IE9jdCAyMDE2IDE0OjAyOjEzIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0Y1MDNERDBEQTk0RDwvRXRhZz48Q29udGVudC1MZW5ndGg+NTE3PC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+cTI5OTBmRkU1TGMwZHlUM0QrdVpzQT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+YXpkbXUwMDA4XzM3NzAwMDlmLWMzMjUtNDNmYS1hODMwLTFlMmJkNGNhMmFmOC52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+U2F0LCAxNSBPY3QgMjAxNiAxNDowMjoyMyBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDNGNTAzRTJFRUIyMTE8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjk8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+bG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5sZWFzZWQ8L0xlYXNlU3RhdGU+PExlYXNlRHVyYXRpb24+aW5maW5pdGU8L0xlYXNlRHVyYXRpb24+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+YXpkbXUwMDA5LmRhNDMxZTJjLWIwZjktNGFhYy1iZDMyLWMxYThiNTQzYWU1MC5zdGF0dXM8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+U2F0LCAxNSBPY3QgMjAxNiAxNDowNTo0MiBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDNGNTA0NTlDQTNCODM8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjUxNzwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PjVqNklnZHByRW15Y2p4WkdJTEQ1cWc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjxCbG9iVHlwZT5CbG9ja0Jsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmF6ZG11MDAwOV8yMWRmMzc2MC03MzBlLTRkNjYtYTUwOS04ZmQ3YmQzY2FhMWMudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlNhdCwgMTUgT2N0IDIwMTYgMTQ6MDU6NTUgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzRjUwNDYxNjNCRkY4PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4xMTwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJhdGlvbj5pbmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5hemRtdTAwMTAuYTIxMmY0NTAtMmVmYi00YTQwLWIyMmUtMGMzNzExZWJlYzU2LnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5TYXQsIDE1IE9jdCAyMDE2IDE0OjA3OjE5IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0Y1MDQ5M0JGMEUyMTwvRXRhZz48Q29udGVudC1MZW5ndGg+NTE3PC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+Y3hNbEJPSmNNODBFaGpWTnEvM0VhQT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+YXpkbXUwMDEwXzM0NGQ2M2ZkLTU2ODMtNDg3ZS1iM2VmLWI4NjMzZmIxYzdmMi52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+U2F0LCAxNSBPY3QgMjAxNiAxNDowNzozNSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDNGNTA0OUQyMEEyNTQ8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjk8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+bG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5sZWFzZWQ8L0xlYXNlU3RhdGU+PExlYXNlRHVyYXRpb24+aW5maW5pdGU8L0xlYXNlRHVyYXRpb24+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+YXpkbXUwMDExLmRjNzU0YmVkLTMyZDgtNGY1MC05NTJkLTRkMDk1OGNjY2Q5OS5zdGF0dXM8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+U2F0LCAxNSBPY3QgMjAxNiAxNDoxMDoxOCBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDNGNTA0RkU2RkU2OTQ8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjUxNzwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlBCaXZKVXV0MlVMaXE3bjhPN2ZzSXc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjxCbG9iVHlwZT5CbG9ja0Jsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmF6ZG11MDAxMV81YWJjMDZiOC0zOTczLTRmNDAtYWJkOC0zNGRhMDJlMzFlZjYudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlNhdCwgMTUgT2N0IDIwMTYgMTQ6MTA6MzcgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzRjUwNTA5OEM4RjM1PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4zPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+bGVhc2VkPC9MZWFzZVN0YXRlPjxMZWFzZUR1cmF0aW9uPmluZmluaXRlPC9MZWFzZUR1cmF0aW9uPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmF6ZG11MDAxMi5hZDUyYzIxYi1hZjNiLTQ2ZTItYWRmYy1kODc5ODQ2MTM0YWYuc3RhdHVzPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlNhdCwgMTUgT2N0IDIwMTYgMTQ6MTM6MTcgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzRjUwNTY5NEM2RDlGPC9FdGFnPjxDb250ZW50LUxlbmd0aD41MTc8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5LdDdVQmdSbUh4Y0VxdkpUUk1WZmdnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48QmxvYlR5cGU+QmxvY2tCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5hemRtdTAwMTJfYmZjMTIxMTktYWI1My00ZjgyLWJlOWItZDQ3MTcwYWI4YWIyLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5TYXQsIDE1IE9jdCAyMDE2IDE0OjEzOjM0IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0Y1MDU3MkUwREUyNTwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+NjwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJhdGlvbj5pbmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5iaWxseTFfMjA0MDFiMjctOWRhNC00Mjc2LWEzOTAtZDU5NDk1YWVhOTU0LnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UaHUsIDE1IFNlcCAyMDE2IDIyOjEwOjUxIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0REQjUyNzk4OEU0RDwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MTwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmJpbGx5Ml8yZGZiODYxMy1jMWMxLTQ1NjItOTMwNy1kYjhjOWIxYjI0MjYudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPkZyaSwgMTYgU2VwIDIwMTYgMTI6NDM6NTUgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzREUyRjFGMDMyNTg0PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4xPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+YnJvbmFnaDAzMTZpXzRjZmMyYjY2LWFiYmYtNDVkYS04YTlmLTMwNzQ2YmQ1NWQ2ZC52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+V2VkLCAyNiBKdWwgMjAxNyAyMDo1ODo1MCBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDRENDY5MURERDk5RUU8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjkxPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+YnJvbmFnaDMxNmdfMjEzN2NlYzEtYTM2ZC00YmJkLWE4ZDMtNTlkNjg2MmMyYmI5LnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5Nb24sIDMwIE9jdCAyMDE3IDE5OjUyOjEyIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhENTFGQ0ZCNkFCRjg3MDwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MjMwNDwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmJyb25hZ2gzMTZoX2JmY2Q1YTA5LTEwZjUtNDY2NC04MTMzLWYzZjUzNTU0Yjg2OC52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+V2VkLCAyNCBKYW4gMjAxOCAxOTo1MDowNSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDU2MzYzQUEzNDNFRDM8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjMyNzwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJhdGlvbj5pbmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5icm9uYWdoNDI3Xzk1NDU4NDk0LTQ0NDYtNDUwZC05YTRhLTc5MmQxNGQwOTcxNy52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+TW9uLCAzMCBPY3QgMjAxNyAxOTo1NTozNSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDUxRkQwMkY4ODdBNTk8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjY1PC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+YnJvbmFnaGZpcDcxNGFfNGE2M2RmOTktOWY3My00YjhkLTkyM2YtZGMwNjYxN2Q2NjBkLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5XZWQsIDAzIEF1ZyAyMDE2IDE1OjM0OjAxIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0JCQjM5ODA0MUFCNDwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MTE5PC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+YnJvbmFnaG5vcG9ydF85OTQzYTQ5OS1iMmVjLTQxZTMtOWE4NS1jMTQ0OTRmMThjZWMudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPk1vbiwgMjUgSnVsIDIwMTYgMTY6Mzg6NTEgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzQjRBQTI5MEIwRDE1PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4xMDc8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5icm9uYWdocmV1c2VpcF9jMzNhNjU0OS1jYzRkLTRlM2YtOTQ1ZC0yOGI2Y2EwODgwZjAudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPldlZCwgMDMgQXVnIDIwMTYgMTU6MzM6NDggR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzQkJCMzkwMUJERTJFPC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4xMDI8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5icm9uYWdocnNwZWMzXzAzNGM5MzhiLWVhYTktNDM5OS04ZWQyLWNiNzIxNmZhYmYwYi52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VGh1LCAyOCBBcHIgMjAxNiAxNDoxMjo0OSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDM2RjZGMkUyOTk2MkY8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjEzPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+YnJvbmFnaHRlc3QyM19lMjM2MDlmYi05YzdjLTQxM2MtOWJlNi05YTBlMWM5Y2RiZDcudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPkZyaSwgMTMgTWF5IDIwMTYgMjE6MTE6NDggR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzN0I3MzMyNzI4RTNDPC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4yPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+YnJvbmFnaHdpdGhzXzczYjlhOTVhLWRkZTEtNDNiNS04MTM5LTJiYjA0NjVkMzkxYS52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VGh1LCAyOCBBcHIgMjAxNiAxNDo1NjozNSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDM2Rjc1NEI0Qjg0RTY8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjM8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5ic21ldHJpY3NfMjA3NTNhZjgtNWFiOC00NWFmLTg1NDUtNGVjMDk2OTg1YWE0LnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UaHUsIDE3IE5vdiAyMDE2IDE5OjIxOjUwIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhENDBGMUVGQjM2MTU3MTwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MTM8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5id2VpdGVzdF8wMDAyX2ExNTZiZTljLTJmYmUtNDFlYi05NTY0LWZiY2IyNTUzZWUzMy52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VHVlLCAyOSBOb3YgMjAxNiAxNDo1NzoxNiBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDQxODY4MDJDNTY2NzE8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjk5NjwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmRiZXJnZXItZGVsZXRlX2EyYTVkNDNmLWFhMDUtNGQ2MS04ZGE4LTk1MDg2YTRkMzU3ZS52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+V2VkLCAxMiBBcHIgMjAxNyAxNzo1Mzo0NSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDQ4MUNDRERCNUUzRjk8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjc8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5kYmVyZ2VyLWRlbGV0ZW1lMV9lZWZjMTcyNy0wMTliLTQyODUtYTVmOC0wODY5ZWZlOGEwMzcudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPkZyaSwgMjYgQXVnIDIwMTYgMjI6NDg6MDIgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzQ0UwMzA5NDY5RUM0PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4xPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+ZGJlcmdlcnByb3YxLmY3YmEyZGUxLTJiMzMtNDU4NS05YTdiLTJiYWQyZGFkZjY2NC5zdGF0dXM8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+U2F0LCAwMyBTZXAgMjAxNiAxNDowODoxNyBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDNENDAzQzBFODU2OUI8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjQ2MTY8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5mRnhTek9RUjVEUFNzSnphRmMvV1l3PT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48QmxvYlR5cGU+QmxvY2tCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5kYmVyZ2VycHJvdjFfN2I3MjdiYWQtY2I4My00YWEyLWE3NjgtMDc0Yzg3N2Q2YjNiLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5TYXQsIDAzIFNlcCAyMDE2IDE0OjA4OjMxIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0Q0MDNDOTMwNzYyMzwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+OTg8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+bG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5sZWFzZWQ8L0xlYXNlU3RhdGU+PExlYXNlRHVyYXRpb24+aW5maW5pdGU8L0xlYXNlRHVyYXRpb24+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+ZGJlcmdlcnByb3YxXzlhNzhhYTRjLWQ1ZjYtNGQ1OC1iMDgzLTkwNjkxZWRhN2I2NC52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VGh1LCAwMSBTZXAgMjAxNiAxOTo0ODo0NSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDNEMkEwRkJDQUNERDM8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjIzODwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmRiZXJnZXJwcm92Ml9hN2JlNmQzNi1kMGNhLTRmYWQtOGNkMC1mYzJmMDQ4ZTA0NDYudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlRodSwgMDEgU2VwIDIwMTYgMTk6NDg6NTQgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzRDJBMTAxQTU0QTU4PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4xNjU8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5kYmVyZ2VyeF82MDg3M2E2ZS03MDllLTQwOWYtODA0OC05ZGNhYmMwOWQ0NjcudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPk1vbiwgMDMgQXByIDIwMTcgMTg6NTY6MDAgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQ0N0FDMzExQjgzMDZCPC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj41PC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+ZHJldzFfNWMzNWY2OTUtYjJhZS00ZDg2LTkzN2YtZmNjNmZjYmI5ZmIwLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UaHUsIDE1IFNlcCAyMDE2IDIyOjI4OjQ4IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0REQjdBOTZCODAwMDwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MTwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmRyZXdhenVyZTAwMDEuYTAxNWQ4YzYtNDlhYy00ZDhmLTg0MzMtZjUzZTViODkxNWQyLnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5TYXQsIDE1IE9jdCAyMDE2IDE0OjE2OjI2IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0Y1MDVEOTZDRkFFRjwvRXRhZz48Q29udGVudC1MZW5ndGg+NTE3PC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+ODZTUmhRdVlOcFo4SnpINEIyLzVpZz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+ZHJld2F6dXJlMDAwMV80YmM3ZDEyMi1jYzMxLTQxNTAtYWJjZS1jMTdlMGJiOWE5Y2YudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlNhdCwgMTUgT2N0IDIwMTYgMTQ6MTY6MzggR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzRjUwNUUwQTY5NEI4PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj43PC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+bGVhc2VkPC9MZWFzZVN0YXRlPjxMZWFzZUR1cmF0aW9uPmluZmluaXRlPC9MZWFzZUR1cmF0aW9uPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmRyZXdhenVyZTAwMDIuMzA4ZGFhYWUtZGFjMS00ODRlLThhYzgtOThkYjA0NGFjYzMyLnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5TYXQsIDE1IE9jdCAyMDE2IDE0OjE5OjI3IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0Y1MDY0NUI2RDg5MDwvRXRhZz48Q29udGVudC1MZW5ndGg+NTE3PC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+NWdKbVFmakZ3VTNBcEhUdEFFbVp4Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+ZHJld2F6dXJlMDAwMl9lZTlmNjhlMC00ZGIyLTQ3NjctOTFjNi0wMjI1NTRkNjVhOGIudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlNhdCwgMTUgT2N0IDIwMTYgMTQ6MTk6NDIgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzRjUwNjRFNDExMjI2PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj42PC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+bGVhc2VkPC9MZWFzZVN0YXRlPjxMZWFzZUR1cmF0aW9uPmluZmluaXRlPC9MZWFzZUR1cmF0aW9uPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmpiX3dpbl9kZW1vX3ZtX2FkODljMDgwLThiMWQtNDdhMi04YTczLWVlNmQ3YTUzYzZjYy52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VHVlLCAwOSBNYXkgMjAxNyAxOTozNjo1NiBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDQ5NzEyQzBGNzExMzU8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjU8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5qdWxpYW5fdGVzdF8wMDFfNzJjNDBhYTgtMGIxNi00MWE5LTlhZTgtYTFhYTc3YjBlOTk2LnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5XZWQsIDA3IE1hciAyMDE4IDIwOjIxOjMzIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhENTg0NjkwNEU5RjIzMTwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MjwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJhdGlvbj5pbmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5sdWN5XzJfZWVmMDc4YTgtOWJmZS00NjllLTkzNDAtZTAzNDJhNGZlM2JjLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UdWUsIDI5IE5vdiAyMDE2IDE2OjA3OjA3IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhENDE4NzFDNEU1QUM0QjwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MjwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmx1Y3lfM19kMTI0YjQyYy03Y2YxLTQxODQtOTY4My03OTljNTg0YTU5MTkudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlRodSwgMDMgQXVnIDIwMTcgMjA6Mzc6MDcgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQ0REFBRjY4NUFCMjk3PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj40PC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+bHVjeV80XzI2MTg1N2IxLWZiMzUtNGNlMC1iN2I3LWZkMTQ4YzdlNmViZC52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VHVlLCAyOSBOb3YgMjAxNiAxODo0Njo1NSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDQxODg4MTc2OThBNDg8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjE8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5zZWN0ZXN0Ml84NGFkN2IyYi05MTAwLTQwZGItODk5Ny1hMzE5MTJjZjI3YzEudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPldlZCwgMjAgQXByIDIwMTYgMTg6MTg6MjYgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzNjk0ODJBOTI3Rjk1PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4xPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+dGVzdC1iaWxseS1henVyZTMzX2E2NzZjYTM0LWM0M2YtNGY1OC1hOTZjLTMwY2YwNjQ1ZjZlYS52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+TW9uLCAxMiBTZXAgMjAxNiAxNzoyNTozOSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDNEQjMxRDBEREY5RUY8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjM8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT50ZXN0LWJpbGx5LWF6dXJlMzRfM2MxY2MyYjYtMTc0YS00M2JiLTlkMzAtYjM0OTU0NDRkOWY2LnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5Nb24sIDEyIFNlcCAyMDE2IDE3OjIwOjM5IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0RCMzExRTJCOERGRDwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MTwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPnRlc3QtYmlsbHktYXp1cmUzNV9jYWVhZjRhZi1iNDg2LTRlZGMtOTg0Ny1iNjU4YTBlMTk3YzIudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlR1ZSwgMTMgU2VwIDIwMTYgMTU6NDQ6NTcgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzREJFQ0U5RTkxRkNEPC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4xPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+dGVzdC1iaWxseS1henVyZTM2X2Y4OGY1OWE3LWNjNmYtNDQ2NC04OGJhLTYxYWRjYTc5MmVjYy52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VHVlLCAxMyBTZXAgMjAxNiAxNjoxNjoyNyBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDNEQkYxNTA5QTkyOUM8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjE8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT50ZXN0LWJpbGx5LWF6dXJlMzhfZTkzNGUzZjAtZjNkOC00YjViLTgwMTUtNTVlNWJkMzkyY2JjLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UdWUsIDEzIFNlcCAyMDE2IDIxOjIyOjU5IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0RDMUMyMkZEMjlCNTwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MTwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPnRlc3QtYmlsbHktYXp1cmU0MF83OGMwYWUxYy0yYjEyLTRhYTgtYmIzYy1iZjYyNzBjMTFkMWMudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlRodSwgMTUgU2VwIDIwMTYgMjE6MDU6MTcgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzRERBQkZGMjVBRDlGPC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4xPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+dGVzdC1iaWxseS1henVyZTUxX2Q4ZDE1ODgwLTE5MWYtNDIyMS05OWNjLWNiMTAyYmE0ZGNmOC52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+RnJpLCAyMyBTZXAgMjAxNiAxNDoxODo0NiBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDNFM0JDODdGNkU3NDA8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjE8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT50ZXN0LWJpbGx5YTM3X2YyZjBlOTYyLWQzYzctNDAyOS05YjJkLTE0OTgyZTY2NzAxNi52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VGh1LCAxNSBTZXAgMjAxNiAxNDo1OTowNCBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDNERDc4RDYxN0ZFQzM8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjE8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT50ZXN0YmlsbHlhYWFfOTUzZTkxM2QtNjYyNS00NzFmLWI2ZjAtNGU5MzUzNzIzYzM5LnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UaHUsIDE1IFNlcCAyMDE2IDE0OjU5OjM5IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0RENzhFQUFBMTdDRjwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MTwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPnRlc3RiaWxseXp6enpfNDNjZmEzMGUtMmQ3Mi00OWFmLWE3MmQtMWU3NjRkZmJmNzU2LnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UaHUsIDE1IFNlcCAyMDE2IDE1OjA0OjMxIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0RENzk5OEY2MUNCMjwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MjwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjwvQmxvYnM+PE5leHRNYXJrZXIgLz48L0VudW1lcmF0aW9uUmVzdWx0cz4=
+        77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9taXFhenVyZXRlc3QxNDA0Ny5ibG9iLmNvcmUud2luZG93cy5uZXQvIiBDb250YWluZXJOYW1lPSJtYW5hZ2VpcSI+PEJsb2JzPjxCbG9iPjxOYW1lPmF6ZG11MDAwNF85YzcwNjBiYi0yN2Y5LTRmOTAtYjc4NS1lMTg5NzE2MjY5ZjgudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlR1ZSwgMjcgU2VwIDIwMTYgMTg6MzU6MjUgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzRTcwNTBCRjU2NDJEPC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj40PC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+YXpkbXUwMDA1X2IyZDkxYTdlLWY0ZTEtNDI4OS1iNGU3LTFjNWZhMmRkZTQyZS52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VGh1LCAwNiBPY3QgMjAxNiAxODozNTo0NSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDNFRTE3OTYwRjUxREI8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjE8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5hemRtdTAwMDZfYmZhMTEzNTctNmE4MC00ZGUxLWIzOTUtNjdlODcwYzE0YTkxLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UaHUsIDA2IE9jdCAyMDE2IDE4OjM1OjQ2IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0VFMTc5NjM3MDdDNzwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MTwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmF6ZG11MDAwNy42ZDQ1Y2VjZC00N2U2LTRjNGMtYjFlMi1hYmQzYzFkNmRlOTcuc3RhdHVzPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlNhdCwgMDggT2N0IDIwMTYgMTQ6MDE6NTcgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzRUY4M0FBODk5NjE3PC9FdGFnPjxDb250ZW50LUxlbmd0aD41MTc8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5PR3Vxb1pIVThNUCtwT3RlWGZuTzNBPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48QmxvYlR5cGU+QmxvY2tCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5hemRtdTAwMDdfNmZmY2VhOWMtZDM2Zi00ZGVhLThjMDMtY2NiNWM2NWY3YjAxLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5TYXQsIDA4IE9jdCAyMDE2IDE0OjAyOjEwIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0VGODNCMjU2QkREMzwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MzwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJhdGlvbj5pbmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5hemRtdTAwMDguOWNjYTAwOGQtYzY2Zi00YzI1LWJmMjEtYjgyZDQ1OWM4YWIyLnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5TYXQsIDE1IE9jdCAyMDE2IDE0OjAyOjEzIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0Y1MDNERDBEQTk0RDwvRXRhZz48Q29udGVudC1MZW5ndGg+NTE3PC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+cTI5OTBmRkU1TGMwZHlUM0QrdVpzQT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+YXpkbXUwMDA4XzM3NzAwMDlmLWMzMjUtNDNmYS1hODMwLTFlMmJkNGNhMmFmOC52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+U2F0LCAxNSBPY3QgMjAxNiAxNDowMjoyMyBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDNGNTAzRTJFRUIyMTE8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjk8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+bG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5sZWFzZWQ8L0xlYXNlU3RhdGU+PExlYXNlRHVyYXRpb24+aW5maW5pdGU8L0xlYXNlRHVyYXRpb24+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+YXpkbXUwMDA5LmRhNDMxZTJjLWIwZjktNGFhYy1iZDMyLWMxYThiNTQzYWU1MC5zdGF0dXM8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+U2F0LCAxNSBPY3QgMjAxNiAxNDowNTo0MiBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDNGNTA0NTlDQTNCODM8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjUxNzwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PjVqNklnZHByRW15Y2p4WkdJTEQ1cWc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjxCbG9iVHlwZT5CbG9ja0Jsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmF6ZG11MDAwOV8yMWRmMzc2MC03MzBlLTRkNjYtYTUwOS04ZmQ3YmQzY2FhMWMudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlNhdCwgMTUgT2N0IDIwMTYgMTQ6MDU6NTUgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzRjUwNDYxNjNCRkY4PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4xMTwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJhdGlvbj5pbmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5hemRtdTAwMTAuYTIxMmY0NTAtMmVmYi00YTQwLWIyMmUtMGMzNzExZWJlYzU2LnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5TYXQsIDE1IE9jdCAyMDE2IDE0OjA3OjE5IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0Y1MDQ5M0JGMEUyMTwvRXRhZz48Q29udGVudC1MZW5ndGg+NTE3PC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+Y3hNbEJPSmNNODBFaGpWTnEvM0VhQT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+YXpkbXUwMDEwXzM0NGQ2M2ZkLTU2ODMtNDg3ZS1iM2VmLWI4NjMzZmIxYzdmMi52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+U2F0LCAxNSBPY3QgMjAxNiAxNDowNzozNSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDNGNTA0OUQyMEEyNTQ8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjk8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+bG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5sZWFzZWQ8L0xlYXNlU3RhdGU+PExlYXNlRHVyYXRpb24+aW5maW5pdGU8L0xlYXNlRHVyYXRpb24+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+YXpkbXUwMDExLmRjNzU0YmVkLTMyZDgtNGY1MC05NTJkLTRkMDk1OGNjY2Q5OS5zdGF0dXM8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+U2F0LCAxNSBPY3QgMjAxNiAxNDoxMDoxOCBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDNGNTA0RkU2RkU2OTQ8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjUxNzwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlBCaXZKVXV0MlVMaXE3bjhPN2ZzSXc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjxCbG9iVHlwZT5CbG9ja0Jsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmF6ZG11MDAxMV81YWJjMDZiOC0zOTczLTRmNDAtYWJkOC0zNGRhMDJlMzFlZjYudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlNhdCwgMTUgT2N0IDIwMTYgMTQ6MTA6MzcgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzRjUwNTA5OEM4RjM1PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4zPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+bGVhc2VkPC9MZWFzZVN0YXRlPjxMZWFzZUR1cmF0aW9uPmluZmluaXRlPC9MZWFzZUR1cmF0aW9uPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmF6ZG11MDAxMi5hZDUyYzIxYi1hZjNiLTQ2ZTItYWRmYy1kODc5ODQ2MTM0YWYuc3RhdHVzPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlNhdCwgMTUgT2N0IDIwMTYgMTQ6MTM6MTcgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzRjUwNTY5NEM2RDlGPC9FdGFnPjxDb250ZW50LUxlbmd0aD41MTc8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5LdDdVQmdSbUh4Y0VxdkpUUk1WZmdnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48QmxvYlR5cGU+QmxvY2tCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5hemRtdTAwMTJfYmZjMTIxMTktYWI1My00ZjgyLWJlOWItZDQ3MTcwYWI4YWIyLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5TYXQsIDE1IE9jdCAyMDE2IDE0OjEzOjM0IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0Y1MDU3MkUwREUyNTwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+NjwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJhdGlvbj5pbmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5iaWxseTFfMjA0MDFiMjctOWRhNC00Mjc2LWEzOTAtZDU5NDk1YWVhOTU0LnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UaHUsIDE1IFNlcCAyMDE2IDIyOjEwOjUxIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0REQjUyNzk4OEU0RDwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MTwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmJpbGx5Ml8yZGZiODYxMy1jMWMxLTQ1NjItOTMwNy1kYjhjOWIxYjI0MjYudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPkZyaSwgMTYgU2VwIDIwMTYgMTI6NDM6NTUgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzREUyRjFGMDMyNTg0PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4xPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+YnJvbmFnaDAzMTZpXzRjZmMyYjY2LWFiYmYtNDVkYS04YTlmLTMwNzQ2YmQ1NWQ2ZC52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+V2VkLCAyNiBKdWwgMjAxNyAyMDo1ODo1MCBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDRENDY5MURERDk5RUU8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjkxPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+YnJvbmFnaDMxNmdfMjEzN2NlYzEtYTM2ZC00YmJkLWE4ZDMtNTlkNjg2MmMyYmI5LnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5Nb24sIDMwIE9jdCAyMDE3IDE5OjUyOjEyIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhENTFGQ0ZCNkFCRjg3MDwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MjMwNDwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmJyb25hZ2gzMTZoX2JmY2Q1YTA5LTEwZjUtNDY2NC04MTMzLWYzZjUzNTU0Yjg2OC52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+V2VkLCAyNCBKYW4gMjAxOCAxOTo1MDowNSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDU2MzYzQUEzNDNFRDM8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjMyNzwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJhdGlvbj5pbmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5icm9uYWdoNDI3Xzk1NDU4NDk0LTQ0NDYtNDUwZC05YTRhLTc5MmQxNGQwOTcxNy52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+TW9uLCAzMCBPY3QgMjAxNyAxOTo1NTozNSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDUxRkQwMkY4ODdBNTk8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjY1PC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+YnJvbmFnaGZpcDcxNGFfNGE2M2RmOTktOWY3My00YjhkLTkyM2YtZGMwNjYxN2Q2NjBkLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5XZWQsIDAzIEF1ZyAyMDE2IDE1OjM0OjAxIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0JCQjM5ODA0MUFCNDwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MTE5PC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+YnJvbmFnaG5vcG9ydF85OTQzYTQ5OS1iMmVjLTQxZTMtOWE4NS1jMTQ0OTRmMThjZWMudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPk1vbiwgMjUgSnVsIDIwMTYgMTY6Mzg6NTEgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzQjRBQTI5MEIwRDE1PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4xMDc8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5icm9uYWdocmV1c2VpcF9jMzNhNjU0OS1jYzRkLTRlM2YtOTQ1ZC0yOGI2Y2EwODgwZjAudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPldlZCwgMDMgQXVnIDIwMTYgMTU6MzM6NDggR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzQkJCMzkwMUJERTJFPC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4xMDI8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5icm9uYWdocnNwZWMzXzAzNGM5MzhiLWVhYTktNDM5OS04ZWQyLWNiNzIxNmZhYmYwYi52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VGh1LCAyOCBBcHIgMjAxNiAxNDoxMjo0OSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDM2RjZGMkUyOTk2MkY8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjEzPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+YnJvbmFnaHRlc3QyM19lMjM2MDlmYi05YzdjLTQxM2MtOWJlNi05YTBlMWM5Y2RiZDcudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPkZyaSwgMTMgTWF5IDIwMTYgMjE6MTE6NDggR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzN0I3MzMyNzI4RTNDPC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4yPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+YnJvbmFnaHdpdGhzXzczYjlhOTVhLWRkZTEtNDNiNS04MTM5LTJiYjA0NjVkMzkxYS52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VGh1LCAyOCBBcHIgMjAxNiAxNDo1NjozNSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDM2Rjc1NEI0Qjg0RTY8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjM8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5ic21ldHJpY3NfMjA3NTNhZjgtNWFiOC00NWFmLTg1NDUtNGVjMDk2OTg1YWE0LnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UaHUsIDE3IE5vdiAyMDE2IDE5OjIxOjUwIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhENDBGMUVGQjM2MTU3MTwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MTM8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5id2VpdGVzdF8wMDAyX2ExNTZiZTljLTJmYmUtNDFlYi05NTY0LWZiY2IyNTUzZWUzMy52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VHVlLCAyOSBOb3YgMjAxNiAxNDo1NzoxNiBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDQxODY4MDJDNTY2NzE8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjk5NjwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmRiZXJnZXItZGVsZXRlX2EyYTVkNDNmLWFhMDUtNGQ2MS04ZGE4LTk1MDg2YTRkMzU3ZS52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+V2VkLCAxMiBBcHIgMjAxNyAxNzo1Mzo0NSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDQ4MUNDRERCNUUzRjk8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjc8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5kYmVyZ2VyLWRlbGV0ZW1lMV9lZWZjMTcyNy0wMTliLTQyODUtYTVmOC0wODY5ZWZlOGEwMzcudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPkZyaSwgMjYgQXVnIDIwMTYgMjI6NDg6MDIgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzQ0UwMzA5NDY5RUM0PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4xPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+ZGJlcmdlcnByb3YxLmY3YmEyZGUxLTJiMzMtNDU4NS05YTdiLTJiYWQyZGFkZjY2NC5zdGF0dXM8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+U2F0LCAwMyBTZXAgMjAxNiAxNDowODoxNyBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDNENDAzQzBFODU2OUI8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjQ2MTY8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5mRnhTek9RUjVEUFNzSnphRmMvV1l3PT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48QmxvYlR5cGU+QmxvY2tCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5kYmVyZ2VycHJvdjFfN2I3MjdiYWQtY2I4My00YWEyLWE3NjgtMDc0Yzg3N2Q2YjNiLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5TYXQsIDAzIFNlcCAyMDE2IDE0OjA4OjMxIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0Q0MDNDOTMwNzYyMzwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+OTg8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+bG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5sZWFzZWQ8L0xlYXNlU3RhdGU+PExlYXNlRHVyYXRpb24+aW5maW5pdGU8L0xlYXNlRHVyYXRpb24+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+ZGJlcmdlcnByb3YxXzlhNzhhYTRjLWQ1ZjYtNGQ1OC1iMDgzLTkwNjkxZWRhN2I2NC52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VGh1LCAwMSBTZXAgMjAxNiAxOTo0ODo0NSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDNEMkEwRkJDQUNERDM8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjIzODwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmRiZXJnZXJwcm92Ml9hN2JlNmQzNi1kMGNhLTRmYWQtOGNkMC1mYzJmMDQ4ZTA0NDYudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlRodSwgMDEgU2VwIDIwMTYgMTk6NDg6NTQgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzRDJBMTAxQTU0QTU4PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4xNjU8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5kYmVyZ2VyeF82MDg3M2E2ZS03MDllLTQwOWYtODA0OC05ZGNhYmMwOWQ0NjcudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPk1vbiwgMDMgQXByIDIwMTcgMTg6NTY6MDAgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQ0N0FDMzExQjgzMDZCPC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj41PC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+ZHJlMDAwMV9kZDM4MDMyMC03YWQxLTQ4NTktYWY3YS04YTg1OTA5NGQzZDcudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPk1vbiwgMTIgTWFyIDIwMTggMDk6MzU6MjAgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQ1ODdGQzkyRDI4RUI4PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4zPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+bGVhc2VkPC9MZWFzZVN0YXRlPjxMZWFzZUR1cmF0aW9uPmluZmluaXRlPC9MZWFzZUR1cmF0aW9uPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmRyZTAwMDJfZDU5MzUzMzgtOTljOC00YjQyLThjNmItMDkzMjMzZDM4ZGNmLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5Nb24sIDEyIE1hciAyMDE4IDA5OjM1OjIzIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhENTg3RkM5NDdCNEU4MTwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MjwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJhdGlvbj5pbmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5kcmUwMDAzXzYyYzhhZjA1LTY1ZjgtNDI0Yy04OTU0LWRjY2MwYWM4ZTI3Yi52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+TW9uLCAxMiBNYXIgMjAxOCAwOTozNToyMyBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDU4N0ZDOTQ4NjlCRDk8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjI8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+bG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5sZWFzZWQ8L0xlYXNlU3RhdGU+PExlYXNlRHVyYXRpb24+aW5maW5pdGU8L0xlYXNlRHVyYXRpb24+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+ZHJldzFfNWMzNWY2OTUtYjJhZS00ZDg2LTkzN2YtZmNjNmZjYmI5ZmIwLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UaHUsIDE1IFNlcCAyMDE2IDIyOjI4OjQ4IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0REQjdBOTZCODAwMDwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MTwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmRyZXdBenVyZVRlc3QxMDAwNF8zMWQyYzk1OC0wNjQ2LTQ5NGQtOWZjYi00ZDNkMGQyNTgwMWIudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPk1vbiwgMTIgTWFyIDIwMTggMDk6MzU6MTggR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQ1ODdGQzkxQkIwRTk5PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4zPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+bGVhc2VkPC9MZWFzZVN0YXRlPjxMZWFzZUR1cmF0aW9uPmluZmluaXRlPC9MZWFzZUR1cmF0aW9uPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmRyZXdhenVyZTAwMDEuYTAxNWQ4YzYtNDlhYy00ZDhmLTg0MzMtZjUzZTViODkxNWQyLnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5TYXQsIDE1IE9jdCAyMDE2IDE0OjE2OjI2IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0Y1MDVEOTZDRkFFRjwvRXRhZz48Q29udGVudC1MZW5ndGg+NTE3PC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+ODZTUmhRdVlOcFo4SnpINEIyLzVpZz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+ZHJld2F6dXJlMDAwMV80YmM3ZDEyMi1jYzMxLTQxNTAtYWJjZS1jMTdlMGJiOWE5Y2YudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlNhdCwgMTUgT2N0IDIwMTYgMTQ6MTY6MzggR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzRjUwNUUwQTY5NEI4PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj43PC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+bGVhc2VkPC9MZWFzZVN0YXRlPjxMZWFzZUR1cmF0aW9uPmluZmluaXRlPC9MZWFzZUR1cmF0aW9uPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmRyZXdhenVyZTAwMDIuMzA4ZGFhYWUtZGFjMS00ODRlLThhYzgtOThkYjA0NGFjYzMyLnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5TYXQsIDE1IE9jdCAyMDE2IDE0OjE5OjI3IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0Y1MDY0NUI2RDg5MDwvRXRhZz48Q29udGVudC1MZW5ndGg+NTE3PC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+NWdKbVFmakZ3VTNBcEhUdEFFbVp4Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+ZHJld2F6dXJlMDAwMl9lZTlmNjhlMC00ZGIyLTQ3NjctOTFjNi0wMjI1NTRkNjVhOGIudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlNhdCwgMTUgT2N0IDIwMTYgMTQ6MTk6NDIgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzRjUwNjRFNDExMjI2PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj42PC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+bGVhc2VkPC9MZWFzZVN0YXRlPjxMZWFzZUR1cmF0aW9uPmluZmluaXRlPC9MZWFzZUR1cmF0aW9uPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmpiX3dpbl9kZW1vX3ZtX2FkODljMDgwLThiMWQtNDdhMi04YTczLWVlNmQ3YTUzYzZjYy52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VHVlLCAwOSBNYXkgMjAxNyAxOTozNjo1NiBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDQ5NzEyQzBGNzExMzU8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjU8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5qdWxpYW5fdGVzdF8wMDFfNzJjNDBhYTgtMGIxNi00MWE5LTlhZTgtYTFhYTc3YjBlOTk2LnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5Nb24sIDEyIE1hciAyMDE4IDA5OjM1OjIwIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhENTg3RkM5MjdDQjhDRTwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MjwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJhdGlvbj5pbmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5sdWN5XzJfZWVmMDc4YTgtOWJmZS00NjllLTkzNDAtZTAzNDJhNGZlM2JjLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UdWUsIDI5IE5vdiAyMDE2IDE2OjA3OjA3IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhENDE4NzFDNEU1QUM0QjwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MjwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmx1Y3lfM19kMTI0YjQyYy03Y2YxLTQxODQtOTY4My03OTljNTg0YTU5MTkudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlRodSwgMDMgQXVnIDIwMTcgMjA6Mzc6MDcgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQ0REFBRjY4NUFCMjk3PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj40PC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+bHVjeV80XzI2MTg1N2IxLWZiMzUtNGNlMC1iN2I3LWZkMTQ4YzdlNmViZC52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VHVlLCAyOSBOb3YgMjAxNiAxODo0Njo1NSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDQxODg4MTc2OThBNDg8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjE8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5zZWN0ZXN0Ml84NGFkN2IyYi05MTAwLTQwZGItODk5Ny1hMzE5MTJjZjI3YzEudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPldlZCwgMjAgQXByIDIwMTYgMTg6MTg6MjYgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzNjk0ODJBOTI3Rjk1PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4xPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+dGVzdC1iaWxseS1henVyZTMzX2E2NzZjYTM0LWM0M2YtNGY1OC1hOTZjLTMwY2YwNjQ1ZjZlYS52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+TW9uLCAxMiBTZXAgMjAxNiAxNzoyNTozOSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDNEQjMxRDBEREY5RUY8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjM8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT50ZXN0LWJpbGx5LWF6dXJlMzRfM2MxY2MyYjYtMTc0YS00M2JiLTlkMzAtYjM0OTU0NDRkOWY2LnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5Nb24sIDEyIFNlcCAyMDE2IDE3OjIwOjM5IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0RCMzExRTJCOERGRDwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MTwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPnRlc3QtYmlsbHktYXp1cmUzNV9jYWVhZjRhZi1iNDg2LTRlZGMtOTg0Ny1iNjU4YTBlMTk3YzIudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlR1ZSwgMTMgU2VwIDIwMTYgMTU6NDQ6NTcgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzREJFQ0U5RTkxRkNEPC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4xPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+dGVzdC1iaWxseS1henVyZTM2X2Y4OGY1OWE3LWNjNmYtNDQ2NC04OGJhLTYxYWRjYTc5MmVjYy52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VHVlLCAxMyBTZXAgMjAxNiAxNjoxNjoyNyBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDNEQkYxNTA5QTkyOUM8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjE8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT50ZXN0LWJpbGx5LWF6dXJlMzhfZTkzNGUzZjAtZjNkOC00YjViLTgwMTUtNTVlNWJkMzkyY2JjLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UdWUsIDEzIFNlcCAyMDE2IDIxOjIyOjU5IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0RDMUMyMkZEMjlCNTwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MTwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPnRlc3QtYmlsbHktYXp1cmU0MF83OGMwYWUxYy0yYjEyLTRhYTgtYmIzYy1iZjYyNzBjMTFkMWMudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlRodSwgMTUgU2VwIDIwMTYgMjE6MDU6MTcgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzRERBQkZGMjVBRDlGPC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4xPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+dGVzdC1iaWxseS1henVyZTUxX2Q4ZDE1ODgwLTE5MWYtNDIyMS05OWNjLWNiMTAyYmE0ZGNmOC52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+RnJpLCAyMyBTZXAgMjAxNiAxNDoxODo0NiBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDNFM0JDODdGNkU3NDA8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjE8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT50ZXN0LWJpbGx5YTM3X2YyZjBlOTYyLWQzYzctNDAyOS05YjJkLTE0OTgyZTY2NzAxNi52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VGh1LCAxNSBTZXAgMjAxNiAxNDo1OTowNCBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDNERDc4RDYxN0ZFQzM8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjE8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT50ZXN0YmlsbHlhYWFfOTUzZTkxM2QtNjYyNS00NzFmLWI2ZjAtNGU5MzUzNzIzYzM5LnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UaHUsIDE1IFNlcCAyMDE2IDE0OjU5OjM5IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0RENzhFQUFBMTdDRjwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MTwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPnRlc3RiaWxseXp6enpfNDNjZmEzMGUtMmQ3Mi00OWFmLWE3MmQtMWU3NjRkZmJmNzU2LnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UaHUsIDE1IFNlcCAyMDE2IDE1OjA0OjMxIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0RENzk5OEY2MUNCMjwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MjwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjwvQmxvYnM+PE5leHRNYXJrZXIgLz48L0VudW1lcmF0aW9uUmVzdWx0cz4=
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:36 GMT
+  recorded_at: Mon, 12 Mar 2018 09:35:28 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/azdmu0004_9c7060bb-27f9-4f90-b785-e189716269f8.vhd
@@ -2744,7 +2790,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:21:36 GMT
+      - Mon, 12 Mar 2018 09:35:28 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -2752,7 +2798,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:it0euTJCaduYP63sosGyBpbsSPbOZFwogiCQrznfxDo=
+      - SharedKey miqazuretest14047:JUnf6CiwPzMRYjPYCgFvVn0Ug6r5OqwUzNLqUOZb7tw=
   response:
     status:
       code: 200
@@ -2773,7 +2819,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - e4814502-001e-0041-3051-b60e6c000000
+      - 3a473ec2-001e-0109-5fe5-b97aa4000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -2797,12 +2843,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:21:36 GMT
+      - Mon, 12 Mar 2018 09:35:23 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:36 GMT
+  recorded_at: Mon, 12 Mar 2018 09:35:28 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/azdmu0005_b2d91a7e-f4e1-4289-b4e7-1c5fa2dde42e.vhd
@@ -2819,7 +2865,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:21:36 GMT
+      - Mon, 12 Mar 2018 09:35:28 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -2827,7 +2873,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:ih8Y1TahoR/jgJIxyGIAgO6gT6a8jFh5nGaAzHPUVpQ=
+      - SharedKey miqazuretest14047:ZYn9JNUXevpJ/gfnGDX78E7q1uFugnV1C/sRFNkEP+w=
   response:
     status:
       code: 200
@@ -2848,7 +2894,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 972a3d65-001e-006d-6c51-b68c51000000
+      - ff000dee-001e-0121-1ce5-b90d1b000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -2872,12 +2918,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:21:36 GMT
+      - Mon, 12 Mar 2018 09:35:24 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:37 GMT
+  recorded_at: Mon, 12 Mar 2018 09:35:29 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/azdmu0006_bfa11357-6a80-4de1-b395-67e870c14a91.vhd
@@ -2894,7 +2940,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:21:37 GMT
+      - Mon, 12 Mar 2018 09:35:29 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -2902,7 +2948,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:kYF4yDDP2P5jksVMgqt0rnI/jYF5UqmhKwLSYAqAUAI=
+      - SharedKey miqazuretest14047:a7XWkhoCMclA/kVbqa/w6NAc+ZLv+1f/XgoF7X5qprQ=
   response:
     status:
       code: 200
@@ -2923,7 +2969,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 273edb8d-001e-0061-4051-b662a0000000
+      - e28a83a1-001e-00d4-4ae5-b96f5f000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -2947,12 +2993,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:21:36 GMT
+      - Mon, 12 Mar 2018 09:35:24 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:38 GMT
+  recorded_at: Mon, 12 Mar 2018 09:35:30 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/billy1_20401b27-9da4-4276-a390-d59495aea954.vhd
@@ -2969,7 +3015,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:21:38 GMT
+      - Mon, 12 Mar 2018 09:35:30 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -2977,7 +3023,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:SplytHjLoNTtNL02yUniiZKkMh6XT9wvKM5KMXrRHF0=
+      - SharedKey miqazuretest14047:1RiVrUwlGOqNxQdqptq2SLntyGzIhkbOmq2Jkf61zcA=
   response:
     status:
       code: 200
@@ -2998,7 +3044,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - d31620c7-001e-00a4-6c51-b61c9b000000
+      - 259fb821-001e-0128-5be5-b91795000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -3022,12 +3068,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:21:37 GMT
+      - Mon, 12 Mar 2018 09:35:25 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:38 GMT
+  recorded_at: Mon, 12 Mar 2018 09:35:30 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/billy2_2dfb8613-c1c1-4562-9307-db8c9b1b2426.vhd
@@ -3044,7 +3090,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:21:38 GMT
+      - Mon, 12 Mar 2018 09:35:30 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -3052,7 +3098,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:yR+y+Vnm71hi56B8V8T57gV6KG/UALW6Bg57l9yLZtM=
+      - SharedKey miqazuretest14047:RXkiHh+3eYoVjUofz/vGuOR9te4/k2/o9tb9VBCqems=
   response:
     status:
       code: 200
@@ -3073,7 +3119,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 131b3ac3-001e-001c-2151-b6fe68000000
+      - 25b4321c-001e-00c7-2ee5-b95abe000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -3097,12 +3143,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:21:38 GMT
+      - Mon, 12 Mar 2018 09:35:26 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:39 GMT
+  recorded_at: Mon, 12 Mar 2018 09:35:31 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/bronagh0316i_4cfc2b66-abbf-45da-8a9f-30746bd55d6d.vhd
@@ -3119,7 +3165,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:21:39 GMT
+      - Mon, 12 Mar 2018 09:35:31 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -3127,7 +3173,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:aSsjBOM6mX0ZQkQU/CsRwqpufIcK5nrvePy2whIVLeo=
+      - SharedKey miqazuretest14047:+FQlWNXj1h799B7lBysqw0LVF7m6QSy4xJZTlqPRJQw=
   response:
     status:
       code: 200
@@ -3148,7 +3194,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - a8e1599a-001e-00c4-6451-b659b9000000
+      - 2c0332f4-001e-00a2-5ae5-b9ebe3000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -3172,12 +3218,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:21:38 GMT
+      - Mon, 12 Mar 2018 09:35:26 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:39 GMT
+  recorded_at: Mon, 12 Mar 2018 09:35:31 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/bronagh316g_2137cec1-a36d-4bbd-a8d3-59d6862c2bb9.vhd
@@ -3194,7 +3240,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:21:39 GMT
+      - Mon, 12 Mar 2018 09:35:31 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -3202,7 +3248,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:WPg3M0N+3SD4ObVrEnMyM9oUW6ed4y5FeroaMI7dgy8=
+      - SharedKey miqazuretest14047:YAFdQiW7cvfdblgFGuj+ww4pd83kLokCVak2yYhc0d8=
   response:
     status:
       code: 200
@@ -3223,7 +3269,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 59d922f2-001e-00a0-0d51-b6e919000000
+      - 206eccd7-001e-002e-40e5-b9a6b8000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -3247,12 +3293,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:21:39 GMT
+      - Mon, 12 Mar 2018 09:35:26 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:40 GMT
+  recorded_at: Mon, 12 Mar 2018 09:35:32 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/bronagh427_95458494-4446-450d-9a4a-792d14d09717.vhd
@@ -3269,7 +3315,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:21:40 GMT
+      - Mon, 12 Mar 2018 09:35:32 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -3277,7 +3323,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:ZU5mEkl/on1IaBqw6bi+TfsvU9n3lN+hxJMug9nAZYk=
+      - SharedKey miqazuretest14047:YqFCtOffJqHv7zBmCSUTb4VwqHSOemHnpGV1PQkQkcQ=
   response:
     status:
       code: 200
@@ -3298,7 +3344,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - b6834124-001e-00d0-1e51-b69add000000
+      - ce2995f8-001e-00f9-66e5-b9ec9f000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -3322,12 +3368,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:21:40 GMT
+      - Mon, 12 Mar 2018 09:35:28 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:40 GMT
+  recorded_at: Mon, 12 Mar 2018 09:35:32 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/bronaghfip714a_4a63df99-9f73-4b8d-923f-dc06617d660d.vhd
@@ -3344,7 +3390,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:21:40 GMT
+      - Mon, 12 Mar 2018 09:35:32 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -3352,7 +3398,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:vRKUx+zn4ZMkp+9tpepMv35rgAf9Mt0x31rODhJggpM=
+      - SharedKey miqazuretest14047:gUtv0OrfkkddNfWr0d7s4fV0SVDQXyNiGooHquv+UaY=
   response:
     status:
       code: 200
@@ -3373,7 +3419,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 65adfa23-001e-0124-4e51-b6f964000000
+      - b051741c-001e-000f-06e5-b9cb89000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -3397,12 +3443,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:21:40 GMT
+      - Mon, 12 Mar 2018 09:35:28 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:41 GMT
+  recorded_at: Mon, 12 Mar 2018 09:35:33 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/bronaghnoport_9943a499-b2ec-41e3-9a85-c14494f18cec.vhd
@@ -3419,7 +3465,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:21:41 GMT
+      - Mon, 12 Mar 2018 09:35:33 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -3427,7 +3473,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:moNB+IVH4jGdgmulAgxraEK+OLHh5XCcy9exzacsKyY=
+      - SharedKey miqazuretest14047:QXJOpN0r9iWdzSwJYb3QamMX7k5g9P8zTU7FxyIXVpw=
   response:
     status:
       code: 200
@@ -3448,7 +3494,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 120e976c-001e-0050-0651-b63977000000
+      - 72cea7cb-001e-00b2-7de5-b9dd05000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -3472,12 +3518,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:21:41 GMT
+      - Mon, 12 Mar 2018 09:35:28 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:42 GMT
+  recorded_at: Mon, 12 Mar 2018 09:35:34 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/bronaghreuseip_c33a6549-cc4d-4e3f-945d-28b6ca0880f0.vhd
@@ -3494,7 +3540,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:21:42 GMT
+      - Mon, 12 Mar 2018 09:35:34 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -3502,7 +3548,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:6vXuZz8exT0kfuYAswIvRz1+nWhb3OlfxYN9GnEuHkQ=
+      - SharedKey miqazuretest14047:8MewAdkZv6SoETS5IcoA7rCD66oLeoLRO3ARX6w3ZhE=
   response:
     status:
       code: 200
@@ -3523,7 +3569,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 4e738e74-001e-006c-4151-b68dac000000
+      - 22551380-001e-011a-5de5-b94f45000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -3547,12 +3593,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:21:42 GMT
+      - Mon, 12 Mar 2018 09:35:29 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:42 GMT
+  recorded_at: Mon, 12 Mar 2018 09:35:34 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/bronaghrspec3_034c938b-eaa9-4399-8ed2-cb7216fabf0b.vhd
@@ -3569,7 +3615,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:21:42 GMT
+      - Mon, 12 Mar 2018 09:35:34 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -3577,7 +3623,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:vDZEwRtD3zC/22PBqw5VaIrbiafGw06AJdQMZqDMXJw=
+      - SharedKey miqazuretest14047:47BQYcM6mdSbE7Zou28c/Um2b63dNXnOpf/AMi7QL2g=
   response:
     status:
       code: 200
@@ -3598,7 +3644,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 72eb581c-001e-0074-3551-b6a039000000
+      - cbd335b7-001e-002d-68e5-b9a5bf000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -3622,12 +3668,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:21:42 GMT
+      - Mon, 12 Mar 2018 09:35:30 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:43 GMT
+  recorded_at: Mon, 12 Mar 2018 09:35:35 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/bronaghtest23_e23609fb-9c7c-413c-9be6-9a0e1c9cdbd7.vhd
@@ -3644,7 +3690,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:21:43 GMT
+      - Mon, 12 Mar 2018 09:35:35 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -3652,7 +3698,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:PyfMBK0c097mt1kTbGc79o51io+ohG/V5NjkByRf9Xo=
+      - SharedKey miqazuretest14047:b7T+0OUVQKfj1At9lATIBXjhg7Gn9/NxfpGKpcjHxTY=
   response:
     status:
       code: 200
@@ -3673,7 +3719,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 9e63d40d-001e-012f-2051-b6e110000000
+      - 1e3fed0e-001e-001c-3fe5-b9fe68000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -3697,12 +3743,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:21:42 GMT
+      - Mon, 12 Mar 2018 09:35:31 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:43 GMT
+  recorded_at: Mon, 12 Mar 2018 09:35:36 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/bronaghwiths_73b9a95a-dde1-43b5-8139-2bb0465d391a.vhd
@@ -3719,7 +3765,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:21:43 GMT
+      - Mon, 12 Mar 2018 09:35:36 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -3727,7 +3773,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:qY7fZ+u4hZ7TC2DAW1ERxFIBOg1MULi/YRfYrJjqyYQ=
+      - SharedKey miqazuretest14047:wP5dFnvxqV0+pcfvZMTMeFoTYVkF4JDkFvGalrdbstY=
   response:
     status:
       code: 200
@@ -3748,7 +3794,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 68720280-001e-00fb-2d51-b6ee65000000
+      - 2fcbfe35-001e-005c-21e5-b9d786000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -3772,12 +3818,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:21:42 GMT
+      - Mon, 12 Mar 2018 09:35:31 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:44 GMT
+  recorded_at: Mon, 12 Mar 2018 09:35:36 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/bsmetrics_20753af8-5ab8-45af-8545-4ec096985aa4.vhd
@@ -3794,7 +3840,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:21:44 GMT
+      - Mon, 12 Mar 2018 09:35:36 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -3802,7 +3848,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:T+Xfmjmk6EINwDz5J4Jw+jrURMPYSa45YLeG3Rq/5Eg=
+      - SharedKey miqazuretest14047:fxfwOZ/g+fD8GmBsq/viLYR46BN/kIMBny5zI1TF9Uk=
   response:
     status:
       code: 200
@@ -3823,7 +3869,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 5122cf7c-001e-0077-5b51-b6a33e000000
+      - a4b92897-001e-004b-56e5-b917e5000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -3847,12 +3893,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:21:44 GMT
+      - Mon, 12 Mar 2018 09:35:32 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:44 GMT
+  recorded_at: Mon, 12 Mar 2018 09:35:37 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/bweitest_0002_a156be9c-2fbe-41eb-9564-fbcb2553ee33.vhd
@@ -3869,7 +3915,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:21:44 GMT
+      - Mon, 12 Mar 2018 09:35:37 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -3877,7 +3923,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:UbuXdN2MC4a2oyD7/DR7ag2SEFfRwOS0ZcKYJwkGsKc=
+      - SharedKey miqazuretest14047:IngbbYsQfYj1L7OliMkbYKY5HaxgXH7uxLLDhODrsYk=
   response:
     status:
       code: 200
@@ -3898,7 +3944,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - cb9a9478-001e-00f7-6551-b60094000000
+      - '08cb100f-001e-012a-5ae5-b9156f000000'
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -3922,12 +3968,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:21:44 GMT
+      - Mon, 12 Mar 2018 09:35:32 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:45 GMT
+  recorded_at: Mon, 12 Mar 2018 09:35:37 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/dberger-delete_a2a5d43f-aa05-4d61-8da8-95086a4d357e.vhd
@@ -3944,7 +3990,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:21:45 GMT
+      - Mon, 12 Mar 2018 09:35:37 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -3952,7 +3998,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:fcnFKo33lvk90d7MBLQVbKaAkIjrjk5M64gnlBgvIv4=
+      - SharedKey miqazuretest14047:lgTdUxg+y6AAX8RNSmw2e3j8c+auq79vcY0kpPMPjI4=
   response:
     status:
       code: 200
@@ -3973,7 +4019,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 40ad5f8e-001e-009f-1751-b65ec5000000
+      - 845fd572-001e-002a-1fe5-b9533a000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -3997,12 +4043,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:21:45 GMT
+      - Mon, 12 Mar 2018 09:35:34 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:45 GMT
+  recorded_at: Mon, 12 Mar 2018 09:35:38 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/dberger-deleteme1_eefc1727-019b-4285-a5f8-0869efe8a037.vhd
@@ -4019,7 +4065,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:21:45 GMT
+      - Mon, 12 Mar 2018 09:35:38 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -4027,7 +4073,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:EYIwvsiTFJjC4CyaMAeQ3tlJyZ3nhixsAOY+vbHyTK0=
+      - SharedKey miqazuretest14047:KiyIUz3YfqNFZkPHfY1EJO3cS2yWsFzXU9FszTH+jG0=
   response:
     status:
       code: 200
@@ -4048,7 +4094,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - '09233f4c-001e-008e-2c51-b669de000000'
+      - 2debbe3d-001e-00e1-50e5-b9c10a000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -4072,12 +4118,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:21:45 GMT
+      - Mon, 12 Mar 2018 09:35:34 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:46 GMT
+  recorded_at: Mon, 12 Mar 2018 09:35:39 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/dbergerprov1_9a78aa4c-d5f6-4d58-b083-90691eda7b64.vhd
@@ -4094,7 +4140,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:21:46 GMT
+      - Mon, 12 Mar 2018 09:35:39 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -4102,7 +4148,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:uaCpqUNalA8AaOJ5Fuxap6ijuArkGteM7z6ojteZ4Yc=
+      - SharedKey miqazuretest14047:C2TQld74O/5xZScWLqTOu+kbfYK3JBIpcwLeQ9ospvg=
   response:
     status:
       code: 200
@@ -4123,7 +4169,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 87ee0333-001e-00ba-6c51-b6c676000000
+      - 4bb9f59e-001e-00f8-15e5-b9ed62000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -4147,12 +4193,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:21:46 GMT
+      - Mon, 12 Mar 2018 09:35:35 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:47 GMT
+  recorded_at: Mon, 12 Mar 2018 09:35:40 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/dbergerprov2_a7be6d36-d0ca-4fad-8cd0-fc2f048e0446.vhd
@@ -4169,7 +4215,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:21:47 GMT
+      - Mon, 12 Mar 2018 09:35:40 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -4177,7 +4223,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:74R1MEXHphT91+w2AtGpkBhjl2q4gcOOEAe7Met0MNM=
+      - SharedKey miqazuretest14047:tsV5JrekP5InXvRSj0PHfyS8mbMNIdohw51xavFH0TE=
   response:
     status:
       code: 200
@@ -4198,7 +4244,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 3e4d7cdd-001e-005a-2951-b620fe000000
+      - 35824ea3-001e-0098-3ce5-b9a840000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -4222,12 +4268,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:21:47 GMT
+      - Mon, 12 Mar 2018 09:35:35 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:47 GMT
+  recorded_at: Mon, 12 Mar 2018 09:35:40 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/dbergerx_60873a6e-709e-409f-8048-9dcabc09d467.vhd
@@ -4244,7 +4290,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:21:47 GMT
+      - Mon, 12 Mar 2018 09:35:40 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -4252,7 +4298,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:hISea91ufOTGYbeV3sgHQgEq1xunF5SnPrXt8uUUbVM=
+      - SharedKey miqazuretest14047:j5fYOiXCDyHJI1hFOSBa+8ooOCEBAoA/eFQmpKUbjSc=
   response:
     status:
       code: 200
@@ -4273,7 +4319,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - a36f444c-001e-000e-3851-b6ca74000000
+      - c70fcffd-001e-005f-17e5-b9d481000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -4297,12 +4343,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:21:47 GMT
+      - Mon, 12 Mar 2018 09:35:36 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:48 GMT
+  recorded_at: Mon, 12 Mar 2018 09:35:41 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/drew1_5c35f695-b2ae-4d86-937f-fcc6fcbb9fb0.vhd
@@ -4319,7 +4365,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:21:48 GMT
+      - Mon, 12 Mar 2018 09:35:41 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -4327,7 +4373,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:8ZeDqvOodk+YfH7unmTmlnpbKO+Wzo6psfG1oI6ba90=
+      - SharedKey miqazuretest14047:D0sHTthSE8Q3CazGS84g8HOvTlOYD6jk6bA6HxmOXK4=
   response:
     status:
       code: 200
@@ -4348,7 +4394,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 987bc034-001e-00da-0551-b68354000000
+      - 21e7d9fd-001e-0002-19e5-b92485000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -4372,12 +4418,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:21:48 GMT
+      - Mon, 12 Mar 2018 09:35:36 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:49 GMT
+  recorded_at: Mon, 12 Mar 2018 09:35:42 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/jb_win_demo_vm_ad89c080-8b1d-47a2-8a73-ee6d7a53c6cc.vhd
@@ -4394,7 +4440,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:21:49 GMT
+      - Mon, 12 Mar 2018 09:35:42 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -4402,7 +4448,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:CRDfoj/M6IoJOhxO8hs/eU3fMKiGW3WoM+4Yg4n/C3A=
+      - SharedKey miqazuretest14047:vH8hwwsQpq/4DWv+crrOusSDRSDn4bwLglevZ4LwvzY=
   response:
     status:
       code: 200
@@ -4423,7 +4469,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 203296cb-001e-00ca-4151-b6b5b2000000
+      - dc095e50-001e-0055-6ee5-b9cd08000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -4447,12 +4493,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:21:49 GMT
+      - Mon, 12 Mar 2018 09:35:37 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:49 GMT
+  recorded_at: Mon, 12 Mar 2018 09:35:42 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/lucy_2_eef078a8-9bfe-469e-9340-e0342a4fe3bc.vhd
@@ -4469,7 +4515,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:21:49 GMT
+      - Mon, 12 Mar 2018 09:35:42 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -4477,7 +4523,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:RroRze3/5d4sNYYnl6r7lJbobOC2k+31qw0m5diT68k=
+      - SharedKey miqazuretest14047:kTeKACS5b54M8L5HxKkirki1Ip5qE9hbSLA3rcopA9Y=
   response:
     status:
       code: 200
@@ -4498,7 +4544,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 82863e23-001e-0042-2251-b60d6b000000
+      - 5068e95c-001e-0095-43e5-b9474c000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -4522,12 +4568,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:21:49 GMT
+      - Mon, 12 Mar 2018 09:35:38 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:50 GMT
+  recorded_at: Mon, 12 Mar 2018 09:35:43 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/lucy_3_d124b42c-7cf1-4184-9683-799c584a5919.vhd
@@ -4544,7 +4590,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:21:50 GMT
+      - Mon, 12 Mar 2018 09:35:43 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -4552,7 +4598,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:owFDsz9Y/MxRtiyvYpRm1wLGx4Jj9VbIJ0tDBxBnbJ4=
+      - SharedKey miqazuretest14047:QteGaSnadLhtQAm9AK+CG2Uk8rf+LWP+eXJENkERdtE=
   response:
     status:
       code: 200
@@ -4573,7 +4619,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - e682e696-001e-000a-2451-b63ff6000000
+      - 2fe7d383-001e-0070-38e5-b955bb000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -4597,12 +4643,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:21:49 GMT
+      - Mon, 12 Mar 2018 09:35:38 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:50 GMT
+  recorded_at: Mon, 12 Mar 2018 09:35:44 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/lucy_4_261857b1-fb35-4ce0-b7b7-fd148c7e6ebd.vhd
@@ -4619,7 +4665,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:21:50 GMT
+      - Mon, 12 Mar 2018 09:35:44 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -4627,7 +4673,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:Qhnx4bMsf3tzS7Z3P4A1uDtCCreMvkCFoc7fCcKVTWg=
+      - SharedKey miqazuretest14047:FQqcj9Yu/87i/QATuKkDqRpvmQVIYnE8efWqXfJKkGc=
   response:
     status:
       code: 200
@@ -4648,7 +4694,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 9cbdbd80-001e-0126-5751-b6fb9e000000
+      - 1f14975c-001e-009b-1de5-b9ab47000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -4672,12 +4718,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:21:50 GMT
+      - Mon, 12 Mar 2018 09:35:40 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:51 GMT
+  recorded_at: Mon, 12 Mar 2018 09:35:44 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/sectest2_84ad7b2b-9100-40db-8997-a31912cf27c1.vhd
@@ -4694,7 +4740,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:21:51 GMT
+      - Mon, 12 Mar 2018 09:35:44 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -4702,7 +4748,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:+aWhGNwYVxakmcSty8PKUag4XakLG0PBqxDSkGWkKms=
+      - SharedKey miqazuretest14047:+mJm3ws6vQCskFGukt+HGEA95wm/5NEmNncMrR0cR2g=
   response:
     status:
       code: 200
@@ -4723,7 +4769,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - d759a38b-001e-009e-4651-b65f38000000
+      - 7226c59b-001e-0013-26e5-b9139e000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -4747,12 +4793,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:21:49 GMT
+      - Mon, 12 Mar 2018 09:35:40 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:51 GMT
+  recorded_at: Mon, 12 Mar 2018 09:35:45 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/test-billy-azure33_a676ca34-c43f-4f58-a96c-30cf0645f6ea.vhd
@@ -4769,7 +4815,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:21:51 GMT
+      - Mon, 12 Mar 2018 09:35:45 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -4777,7 +4823,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:T3gMlRWxB3gDCl9rA8sbalk2fwAbbUBPlHjEp886Mpo=
+      - SharedKey miqazuretest14047:wfgz06XABXmf3z8Gx7LK5+bGTzM7agHn3RTYgyozZ5k=
   response:
     status:
       code: 200
@@ -4798,7 +4844,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 2aaeeaa1-001e-00f2-3c51-b6f4eb000000
+      - 7fd21a53-001e-012e-66e5-b9e0ed000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -4822,12 +4868,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:21:52 GMT
+      - Mon, 12 Mar 2018 09:35:41 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:52 GMT
+  recorded_at: Mon, 12 Mar 2018 09:35:46 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/test-billy-azure34_3c1cc2b6-174a-43bb-9d30-b3495444d9f6.vhd
@@ -4844,7 +4890,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:21:52 GMT
+      - Mon, 12 Mar 2018 09:35:46 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -4852,7 +4898,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:HrMBWkDGQ6AsdsrSu4w3QecsGD2mffo/rpCAIeLJiu4=
+      - SharedKey miqazuretest14047:Z7GzRn0uBWU2dRG+55L26joCabVCBJSKVuEmeDQbk10=
   response:
     status:
       code: 200
@@ -4873,7 +4919,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 4402e09a-001e-010a-8051-b679a3000000
+      - c8f10bee-001e-0069-51e5-b979d3000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -4897,12 +4943,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:21:52 GMT
+      - Mon, 12 Mar 2018 09:35:41 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:53 GMT
+  recorded_at: Mon, 12 Mar 2018 09:35:46 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/test-billy-azure35_caeaf4af-b486-4edc-9847-b658a0e197c2.vhd
@@ -4919,7 +4965,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:21:53 GMT
+      - Mon, 12 Mar 2018 09:35:46 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -4927,7 +4973,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:mMsBwuNY69HLpmvfnpIGjWQ1Yur/GgrbvaZElm5s6sI=
+      - SharedKey miqazuretest14047:d5OAEweC1AEQc3sDuYCfQiaDDt9zCpaFSJrMXidQT5M=
   response:
     status:
       code: 200
@@ -4948,7 +4994,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - d5477320-001e-0136-4851-b6cd78000000
+      - 9edab8b7-001e-006d-0ee5-b98c51000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -4972,12 +5018,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:21:52 GMT
+      - Mon, 12 Mar 2018 09:35:41 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:53 GMT
+  recorded_at: Mon, 12 Mar 2018 09:35:47 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/test-billy-azure36_f88f59a7-cc6f-4464-88ba-61adca792ecc.vhd
@@ -4994,7 +5040,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:21:53 GMT
+      - Mon, 12 Mar 2018 09:35:47 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -5002,7 +5048,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:2c/Gm7P+d7Ext3xRQYJH2jNv+SxYSo2hLNmvw9ubGCA=
+      - SharedKey miqazuretest14047:5u+zC69ZD3ndLk22WOCukL0PC+5l7ZChWAo3hs/e19M=
   response:
     status:
       code: 200
@@ -5023,7 +5069,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - c9e96264-001e-00c1-1551-b6adc6000000
+      - cd9941d3-001e-0084-24e5-b97057000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -5047,12 +5093,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:21:53 GMT
+      - Mon, 12 Mar 2018 09:35:42 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:54 GMT
+  recorded_at: Mon, 12 Mar 2018 09:35:48 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/test-billy-azure38_e934e3f0-f3d8-4b5b-8015-55e5bd392cbc.vhd
@@ -5069,7 +5115,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:21:54 GMT
+      - Mon, 12 Mar 2018 09:35:48 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -5077,7 +5123,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:X5uakrpHHe8dfb7SRaz+mbg99TKQVXcHLErlSNzvuV4=
+      - SharedKey miqazuretest14047:ZObRc77/NFfFmTtFB/CgF0tCZXDSqVC76BAOeAvTD7o=
   response:
     status:
       code: 200
@@ -5098,7 +5144,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - d267ca69-001e-0129-4e51-b61668000000
+      - 7f1f59eb-001e-0038-22e5-b96726000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -5122,12 +5168,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:21:53 GMT
+      - Mon, 12 Mar 2018 09:35:43 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:54 GMT
+  recorded_at: Mon, 12 Mar 2018 09:35:48 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/test-billy-azure40_78c0ae1c-2b12-4aa8-bb3c-bf6270c11d1c.vhd
@@ -5144,7 +5190,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:21:54 GMT
+      - Mon, 12 Mar 2018 09:35:48 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -5152,7 +5198,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:VTwqCd+ONHW1PF/VnuiToiuxY1LKqGdTaJi1dwjuMbE=
+      - SharedKey miqazuretest14047:iUDO1TNSUYtlF11bXeTC8Z22rgI6Ceaa2Ng+hURl4wk=
   response:
     status:
       code: 200
@@ -5173,7 +5219,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 84e237f2-001e-00a1-7e51-b6e8e4000000
+      - 63546acc-001e-0117-70e5-b9a049000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -5197,12 +5243,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:21:54 GMT
+      - Mon, 12 Mar 2018 09:35:44 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:55 GMT
+  recorded_at: Mon, 12 Mar 2018 09:35:49 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/test-billy-azure51_d8d15880-191f-4221-99cc-cb102ba4dcf8.vhd
@@ -5219,7 +5265,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:21:55 GMT
+      - Mon, 12 Mar 2018 09:35:49 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -5227,7 +5273,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:KY4eO4/MwuOfA+C3R204f8SGIj4B60v5nmg1xgi47dc=
+      - SharedKey miqazuretest14047:bIq1NcJ1i3Do+gK2mTL3djeWoWJuBc3bl2a8pY2ShfU=
   response:
     status:
       code: 200
@@ -5248,7 +5294,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - d393c8bf-001e-0055-5051-b6cd08000000
+      - 2dc45b54-001e-00b6-7be5-b92887000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -5272,12 +5318,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:21:55 GMT
+      - Mon, 12 Mar 2018 09:35:43 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:55 GMT
+  recorded_at: Mon, 12 Mar 2018 09:35:49 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/test-billya37_f2f0e962-d3c7-4029-9b2d-14982e667016.vhd
@@ -5294,7 +5340,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:21:55 GMT
+      - Mon, 12 Mar 2018 09:35:49 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -5302,7 +5348,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:IJmwOaMDO4Qe/HBfEJudpTXDtINfC7E4O99wlQ9XHvY=
+      - SharedKey miqazuretest14047:kDZX6Y3DoODipaxOKZIGQ4kPfxPN41M3O/jvlCrQPwc=
   response:
     status:
       code: 200
@@ -5323,7 +5369,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 1e31ca2d-001e-00a9-1651-b6f397000000
+      - 0dcb32bb-001e-007e-1de5-b9b9b0000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -5347,12 +5393,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:21:55 GMT
+      - Mon, 12 Mar 2018 09:35:45 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:56 GMT
+  recorded_at: Mon, 12 Mar 2018 09:35:50 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/testbillyaaa_953e913d-6625-471f-b6f0-4e9353723c39.vhd
@@ -5369,7 +5415,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:21:56 GMT
+      - Mon, 12 Mar 2018 09:35:50 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -5377,7 +5423,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:qLItoVEt/tqKQhJAA/xiSfkt37C1L+YNLvLUjON4cco=
+      - SharedKey miqazuretest14047:hIPGs0BC6cKQ+xWyi1ccZIk698WpHlUSl5FrPB0Kf6k=
   response:
     status:
       code: 200
@@ -5398,7 +5444,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - ae7656f2-001e-005d-7f51-b6d67b000000
+      - e467eccc-001e-0081-1ce5-b98428000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -5422,12 +5468,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:21:56 GMT
+      - Mon, 12 Mar 2018 09:35:46 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:56 GMT
+  recorded_at: Mon, 12 Mar 2018 09:35:51 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/testbillyzzzz_43cfa30e-2d72-49af-a72d-1e764dfbf756.vhd
@@ -5444,7 +5490,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:21:56 GMT
+      - Mon, 12 Mar 2018 09:35:51 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -5452,7 +5498,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:dQicDCQW62DIY2RRsAtC3I/hJHkCyml8qtwdDxkkGx8=
+      - SharedKey miqazuretest14047:WCyk3oJcS664iUMT6cCLUdvZlat/ZfdyoAMfYR+wV3g=
   response:
     status:
       code: 200
@@ -5473,7 +5519,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 56adddc7-001e-0051-4251-b6388a000000
+      - f5f8e817-001e-00fc-18e5-b918e0000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -5497,12 +5543,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:21:57 GMT
+      - Mon, 12 Mar 2018 09:35:46 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:57 GMT
+  recorded_at: Mon, 12 Mar 2018 09:35:51 GMT
 - request:
     method: get
     uri: https://miqazuretest14047.blob.core.windows.net/system?comp=list&restype=container
@@ -5519,13 +5565,13 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:21:57 GMT
+      - Mon, 12 Mar 2018 09:35:51 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
       - 'true'
       Authorization:
-      - SharedKey miqazuretest14047:CYk4D2dCjN/jWu/FH/NL5S93FYsKFJd7STHhhWOPV9Q=
+      - SharedKey miqazuretest14047:agN/S/t/3jRSE5oBNO0d8odIHzjvFBKJSqFWnath/R0=
   response:
     status:
       code: 200
@@ -5538,17 +5584,17 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 4c065c70-001e-011d-3d51-b6b9c0000000
+      - 15133890-001e-0100-51e5-b9602a000000
       X-Ms-Version:
       - '2016-05-31'
       Date:
-      - Wed, 07 Mar 2018 20:21:57 GMT
+      - Mon, 12 Mar 2018 09:35:46 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9taXFhenVyZXRlc3QxNDA0Ny5ibG9iLmNvcmUud2luZG93cy5uZXQvIiBDb250YWluZXJOYW1lPSJzeXN0ZW0iPjxCbG9icz48QmxvYj48TmFtZT5NaWNyb3NvZnQuQ29tcHV0ZS9JbWFnZXMvbWlxLXRlc3QtY29udGFpbmVyL3Rlc3Qtd2luMmsxMi1pbWctb3NEaXNrLmUxN2E5NWIwLWY0ZmItNDE5Ni05M2M1LTBjOGJlN2Q1YzUzNi52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VHVlLCAyMiBNYXIgMjAxNiAxNzowODowMiBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDM1Mjc0ODc1QjRGOTE8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjE8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5NaWNyb3NvZnQuQ29tcHV0ZS9JbWFnZXMvbWlxLXRlc3QtY29udGFpbmVyL3Rlc3Qtd2luMmsxMi1pbWctdm1UZW1wbGF0ZS5lMTdhOTViMC1mNGZiLTQxOTYtOTNjNS0wYzhiZTdkNWM1MzYuanNvbjwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UdWUsIDIyIE1hciAyMDE2IDE3OjA4OjAzIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMzUyNzQ4Nzk3QTNCMDwvRXRhZz48Q29udGVudC1MZW5ndGg+MjAyNDwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9qc29uPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5zdURBYnR6RnBBVEpGYk55RDRLVWhBPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48QmxvYlR5cGU+QmxvY2tCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48L0Jsb2JzPjxOZXh0TWFya2VyIC8+PC9FbnVtZXJhdGlvblJlc3VsdHM+
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:58 GMT
+  recorded_at: Mon, 12 Mar 2018 09:35:52 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/system/Microsoft.Compute/Images/miq-test-container/test-win2k12-img-osDisk.e17a95b0-f4fb-4196-93c5-0c8be7d5c536.vhd
@@ -5565,7 +5611,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:21:58 GMT
+      - Mon, 12 Mar 2018 09:35:52 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -5573,7 +5619,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:7G3mi3oBh+u26zfLpYzHL+QMFfHI47uwMaFWHpUw5ic=
+      - SharedKey miqazuretest14047:suL1H2z7JwQVx2EMZDzIFpzrYPn674nL/WymnaLGukg=
   response:
     status:
       code: 200
@@ -5594,7 +5640,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - f22edeb9-001e-0121-7f51-b60d1b000000
+      - 5d000009-001e-0077-3ae5-b9a33e000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Microsoftazurecompute-Capturedvmkey:
@@ -5626,12 +5672,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:21:58 GMT
+      - Mon, 12 Mar 2018 09:35:47 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:58 GMT
+  recorded_at: Mon, 12 Mar 2018 09:35:52 GMT
 - request:
     method: get
     uri: https://miqazuretest14047.blob.core.windows.net/vhds?comp=list&restype=container
@@ -5648,13 +5694,13 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:21:58 GMT
+      - Mon, 12 Mar 2018 09:35:52 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
       - 'true'
       Authorization:
-      - SharedKey miqazuretest14047:KV8U30yTmnC43cq8xWLpCDEvzbhRG3xSVZDuseS0YLw=
+      - SharedKey miqazuretest14047:5Kf4VmQUcpIFQf91ePxJRauscvr6XE0pWgq3D7UivIY=
   response:
     status:
       code: 200
@@ -5667,17 +5713,17 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 617133da-001e-00d5-4b51-b66ea2000000
+      - f935c17f-001e-003e-6be5-b9905e000000
       X-Ms-Version:
       - '2016-05-31'
       Date:
-      - Wed, 07 Mar 2018 20:21:58 GMT
+      - Mon, 12 Mar 2018 09:35:49 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9taXFhenVyZXRlc3QxNDA0Ny5ibG9iLmNvcmUud2luZG93cy5uZXQvIiBDb250YWluZXJOYW1lPSJ2aGRzIj48QmxvYnM+PEJsb2I+PE5hbWU+bWlxLXRlc3Qtd2luMTIyMDE2MjE4MTEzMDE0LnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UaHUsIDE5IE9jdCAyMDE3IDAyOjAxOjM2IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhENTE2OTU1NDUyOTlERTwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MjkzPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+bGVhc2VkPC9MZWFzZVN0YXRlPjxMZWFzZUR1cmF0aW9uPmluZmluaXRlPC9MZWFzZUR1cmF0aW9uPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPm1pcS10ZXN0LXdpbmltZy5iOTdmZjQ4OC1lMTE0LTQwZWQtOGQ3YS1mNDUwMGQ3M2VlYzAuc3RhdHVzPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlR1ZSwgMjIgTWFyIDIwMTYgMTY6MzA6MjkgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzNTI2RjQ4MUUyQzQ3PC9FdGFnPjxDb250ZW50LUxlbmd0aD44ODQ8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT4xSytsTEp6c3U0SjVBbW5qcUJ1dVhBPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48QmxvYlR5cGU+QmxvY2tCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5taXEtdGVzdC13aW5pbWcuZTE3YTk1YjAtZjRmYi00MTk2LTkzYzUtMGM4YmU3ZDVjNTM2LnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UdWUsIDIyIE1hciAyMDE2IDE2OjU4OjQwIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMzUyNzMzN0VGQTA4MTwvRXRhZz48Q29udGVudC1MZW5ndGg+ODg0PC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+RFNCbitSZkhBZ0JGRFgrUzh6OVd1QT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+bWlxLXRlc3Qtd2luaW1nMjAxNjIyMjEwMTY0My52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VHVlLCAyMiBNYXIgMjAxNiAxNjozNzo0MiBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDM1MjcwNEEzQjFFQTY8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjE8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5taXEtdGVzdC13aW5pbWcyMDE2MjIyMTA0MDcudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlR1ZSwgMjIgTWFyIDIwMTYgMTY6NTk6MDAgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzNTI3MzQzQkEzMTUyPC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4xPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+bGVhc2VkPC9MZWFzZVN0YXRlPjxMZWFzZUR1cmF0aW9uPmluZmluaXRlPC9MZWFzZUR1cmF0aW9uPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPm1pcWF6dXJlLWNlbnRvczEuNzk2YzViY2MtMzM4YS00NDhkLWI2MWMtMTY1Mjc5YTdmYjNlLnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5GcmksIDIyIEFwciAyMDE2IDE5OjA1OjQ2IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMzZBRTExQzQ3ODkxMDwvRXRhZz48Q29udGVudC1MZW5ndGg+NjgzPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+eExRZy9FbWJRNnVRR0VGaStiWG0zZz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+bWlxYXp1cmUtY2VudG9zMTIwMTYyMjExMDQ5NDYudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPkZyaSwgMjIgQXByIDIwMTYgMTk6MDU6NTggR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzNkFFMTIzOTU0QjM1PC9FdGFnPjxDb250ZW50LUxlbmd0aD4zMjIxMjI1NTIzMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PmJMSzdyZ1Q3SWdNTlgyWXhMOUJDeWc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjE8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+bG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5sZWFzZWQ8L0xlYXNlU3RhdGU+PExlYXNlRHVyYXRpb24+aW5maW5pdGU8L0xlYXNlRHVyYXRpb24+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PC9CbG9icz48TmV4dE1hcmtlciAvPjwvRW51bWVyYXRpb25SZXN1bHRzPg==
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:59 GMT
+  recorded_at: Mon, 12 Mar 2018 09:35:53 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/vhds/miq-test-winimg2016222101643.vhd
@@ -5694,7 +5740,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:21:59 GMT
+      - Mon, 12 Mar 2018 09:35:53 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -5702,7 +5748,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:CVNwYuq+jHbXGOIZp6FAp3VlV8eUQrTOoQ5zCIA0CLI=
+      - SharedKey miqazuretest14047:vgy1tK8CY5U6dmCAuJssart5dYB7U/MwFHgsGl8Usgs=
   response:
     status:
       code: 200
@@ -5723,7 +5769,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 71541ff4-001e-0029-7451-b6503d000000
+      - 4d442881-001e-010a-73e5-b979a3000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -5747,12 +5793,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:21:59 GMT
+      - Mon, 12 Mar 2018 09:35:48 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:59 GMT
+  recorded_at: Mon, 12 Mar 2018 09:35:54 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb/listKeys?api-version=2017-10-01
@@ -5769,7 +5815,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3ODQsIm5iZiI6MTUyMDQ1Mzc4NCwiZXhwIjoxNTIwNDU3Njg0LCJhaW8iOiJZMk5nWUpnU2xxeG4vSTJOMTBmYWNkZHltZXE3QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoicDBsS2ZuYXRORVd2a3VaVmttQUFBQSIsInZlciI6IjEuMCJ9.iC1HIh7EJhSg4gWNwK-4-iAm1Y57QbVEKhbqmrgwOPUjVEl83aDkQcFgk_LTJlYJxuWt32jXyPTVllnJyz8dQlAV3NbzVr2Ob3u7Tma1NOOnxZkLpH9EE8B1SgQypHRbWQa5OXi98OEU429EDLTLzRPhb0ePBhu9oz0AtzI8jHVr46i_X7jxoTKLQsx83mOyBS68htVskAiZtMVcl38z5OHFZ15jBJJfCsbMEVL632TFBKiKwwwKKgMvTbgR9lRqXNgLsCl4sYWtuXD1i5vKr9GHvFE4byo7KUAmecWPb9ZdogYjVVEpoXXh5IkbAY-T7K_JTEBJL7lWK1t640tBjw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcwMTMsIm5iZiI6MTUyMDg0NzAxMywiZXhwIjoxNTIwODUwOTEzLCJhaW8iOiJZMk5nWUhCMFludmpjNGN6aE5NNTh0M0t5a1FYQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoialE5U1hFcjVIRWVCX0dyQ1pta2pBQSIsInZlciI6IjEuMCJ9.CNps7ehQ4gjIipFpeHtH1uayoFrjNQmz9DNt8X_pu3FJIMidCRl8zafvhLybkMt3jBTg3ilWiyWZfJ-LaCVtgzQqXRZh4TitdGaw6BtQXx5BndCxbJdfQQWyDDtaXijWD6EjF5OpGZJ0nBglCx-KPAAPhSZXRIvjPNXgsDseRlJxWTSzxYkOUfGY5gn9E9CT6Qe54gFtFsID7PIhBmFOLFrgEjl9dEidPDaLO9f7lba8LHWTjDFozQ_FgyhD_PqDzJYySpX8wTabcb1A1tynX-1rd5v9e4pPrxjRLEvJ_VLaP9RN8XVqo2YoZadQ9FlTwiv4l7aY36nqd2QffgkYsg
       Content-Length:
       - '0'
   response:
@@ -5790,26 +5836,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - cf5a0a4b-4a49-4cb9-8264-32a68ef3c403
+      - e6aa1624-83a8-4bc5-a575-b08ebd357b3f
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1198'
+      - '1199'
       X-Ms-Correlation-Request-Id:
-      - b83cedc0-a4b0-4ef8-aea2-bddc411cc01a
+      - 2f3c9161-fd83-48f4-add5-5257e877f87f
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202200Z:b83cedc0-a4b0-4ef8-aea2-bddc411cc01a
+      - WESTEUROPE:20180312T093551Z:2f3c9161-fd83-48f4-add5-5257e877f87f
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:21:59 GMT
+      - Mon, 12 Mar 2018 09:35:50 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keys":[{"keyName":"key1","value":"xMvZwiumnKCZnYVJjdtGLqaO1c2v6ERPx4XPDZO7TM1l7/jM1TxAAgtfCMkRn72aRPhqLqwWAn8n5a1iSGRHtA==","permissions":"Full"},{"keyName":"key2","value":"3nDvKhjGAIAvgnH2reuv7tzyeb/0dddgVeUT13VODYD5xO/jeAvQ7tkF3JqP2BAuFrmQqMB4GLkB4/cW4veYeA==","permissions":"Full"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:22:00 GMT
+  recorded_at: Mon, 12 Mar 2018 09:35:55 GMT
 - request:
     method: get
     uri: https://rspeclb.blob.core.windows.net/?comp=list
@@ -5826,13 +5872,13 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:22:00 GMT
+      - Mon, 12 Mar 2018 09:35:55 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
       - 'true'
       Authorization:
-      - SharedKey rspeclb:GFrHwDWsAKddywtqn/Q73r3mSMJ4CyJaJJx3sVm08yI=
+      - SharedKey rspeclb:w2+ZAR0F0h6WdI58LVwFsiHRxtJKevTDSkUPavBbHls=
   response:
     status:
       code: 200
@@ -5847,17 +5893,17 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 52eb2760-a01c-0079-0551-b60c8d000000
+      - dedc3a11-e01c-0031-4ae5-b93e10000000
       X-Ms-Version:
       - '2016-05-31'
       Date:
-      - Wed, 07 Mar 2018 20:21:59 GMT
+      - Mon, 12 Mar 2018 09:35:51 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPEVudW1lcmF0aW9uUmVzdWx0cyBTZXJ2aWNlRW5kcG9pbnQ9Imh0dHBzOi8vcnNwZWNsYi5ibG9iLmNvcmUud2luZG93cy5uZXQvIj48Q29udGFpbmVycz48Q29udGFpbmVyPjxOYW1lPnZoZHM8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+RnJpLCAwMiBTZXAgMjAxNiAxNjoyOTo0MSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+JnF1b3Q7MHg4RDNEMzRFNTcwREZDMEEmcXVvdDs8L0V0YWc+PExlYXNlU3RhdHVzPmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+bGVhc2VkPC9MZWFzZVN0YXRlPjxMZWFzZUR1cmF0aW9uPmluZmluaXRlPC9MZWFzZUR1cmF0aW9uPjwvUHJvcGVydGllcz48L0NvbnRhaW5lcj48L0NvbnRhaW5lcnM+PE5leHRNYXJrZXIvPjwvRW51bWVyYXRpb25SZXN1bHRzPg==
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:22:01 GMT
+  recorded_at: Mon, 12 Mar 2018 09:35:56 GMT
 - request:
     method: get
     uri: https://rspeclb.blob.core.windows.net/vhds?comp=list&restype=container
@@ -5874,13 +5920,13 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:22:01 GMT
+      - Mon, 12 Mar 2018 09:35:56 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
       - 'true'
       Authorization:
-      - SharedKey rspeclb:VK1TGVLJB8adDMuOpWVgHq8r52gdqVc8w1Mn1f7f7xc=
+      - SharedKey rspeclb:2CQCI7m0P8Er3A5anTwQAYXiMrr8ShdwonITHPIHTHY=
   response:
     status:
       code: 200
@@ -5895,17 +5941,17 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 65999aca-e01c-0057-1551-b68c4a000000
+      - 0dd48a38-601c-0064-2ae5-b9d567000000
       X-Ms-Version:
       - '2016-05-31'
       Date:
-      - Wed, 07 Mar 2018 20:22:00 GMT
+      - Mon, 12 Mar 2018 09:35:51 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPEVudW1lcmF0aW9uUmVzdWx0cyBTZXJ2aWNlRW5kcG9pbnQ9Imh0dHBzOi8vcnNwZWNsYi5ibG9iLmNvcmUud2luZG93cy5uZXQvIiBDb250YWluZXJOYW1lPSJ2aGRzIj48QmxvYnM+PEJsb2I+PE5hbWU+cnNwZWMtbGItYTIwMTY4MjEyMjgzOS52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+U2F0LCAwMyBTZXAgMjAxNiAxNDowMzoxNSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDNENDAzMENBMEFCRUY8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjMyMjEyMjU1MjMyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nLz48Q29udGVudC1MYW5ndWFnZS8+PENvbnRlbnQtTUQ1PjhCVzVocXJuT0xvUUlObFowNW9keEE9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wvPjxDb250ZW50LURpc3Bvc2l0aW9uLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4xPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+bGVhc2VkPC9MZWFzZVN0YXRlPjxMZWFzZUR1cmF0aW9uPmluZmluaXRlPC9MZWFzZUR1cmF0aW9uPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPnJzcGVjLWxiLWIyMDE2ODIxMjM2NTAudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlNhdCwgMDMgU2VwIDIwMTYgMTQ6MDU6NDAgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzRDQwMzYyRkUzODk4PC9FdGFnPjxDb250ZW50LUxlbmd0aD4zMjIxMjI1NTIzMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZy8+PENvbnRlbnQtTGFuZ3VhZ2UvPjxDb250ZW50LU1ENT44Qlc1aHFybk9Mb1FJTmxaMDVvZHhBPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sLz48Q29udGVudC1EaXNwb3NpdGlvbi8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MTwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJhdGlvbj5pbmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48L0Jsb2JzPjxOZXh0TWFya2VyLz48L0VudW1lcmF0aW9uUmVzdWx0cz4=
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:22:01 GMT
+  recorded_at: Mon, 12 Mar 2018 09:35:56 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor/listKeys?api-version=2017-10-01
@@ -5922,7 +5968,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3ODQsIm5iZiI6MTUyMDQ1Mzc4NCwiZXhwIjoxNTIwNDU3Njg0LCJhaW8iOiJZMk5nWUpnU2xxeG4vSTJOMTBmYWNkZHltZXE3QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoicDBsS2ZuYXRORVd2a3VaVmttQUFBQSIsInZlciI6IjEuMCJ9.iC1HIh7EJhSg4gWNwK-4-iAm1Y57QbVEKhbqmrgwOPUjVEl83aDkQcFgk_LTJlYJxuWt32jXyPTVllnJyz8dQlAV3NbzVr2Ob3u7Tma1NOOnxZkLpH9EE8B1SgQypHRbWQa5OXi98OEU429EDLTLzRPhb0ePBhu9oz0AtzI8jHVr46i_X7jxoTKLQsx83mOyBS68htVskAiZtMVcl38z5OHFZ15jBJJfCsbMEVL632TFBKiKwwwKKgMvTbgR9lRqXNgLsCl4sYWtuXD1i5vKr9GHvFE4byo7KUAmecWPb9ZdogYjVVEpoXXh5IkbAY-T7K_JTEBJL7lWK1t640tBjw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcwMTMsIm5iZiI6MTUyMDg0NzAxMywiZXhwIjoxNTIwODUwOTEzLCJhaW8iOiJZMk5nWUhCMFludmpjNGN6aE5NNTh0M0t5a1FYQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoialE5U1hFcjVIRWVCX0dyQ1pta2pBQSIsInZlciI6IjEuMCJ9.CNps7ehQ4gjIipFpeHtH1uayoFrjNQmz9DNt8X_pu3FJIMidCRl8zafvhLybkMt3jBTg3ilWiyWZfJ-LaCVtgzQqXRZh4TitdGaw6BtQXx5BndCxbJdfQQWyDDtaXijWD6EjF5OpGZJ0nBglCx-KPAAPhSZXRIvjPNXgsDseRlJxWTSzxYkOUfGY5gn9E9CT6Qe54gFtFsID7PIhBmFOLFrgEjl9dEidPDaLO9f7lba8LHWTjDFozQ_FgyhD_PqDzJYySpX8wTabcb1A1tynX-1rd5v9e4pPrxjRLEvJ_VLaP9RN8XVqo2YoZadQ9FlTwiv4l7aY36nqd2QffgkYsg
       Content-Length:
       - '0'
   response:
@@ -5943,26 +5989,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 815ac919-5bbf-418d-981d-95b63701dfca
+      - 54d2bb89-1b64-4c26-8fd9-a0f7b1bbd0c0
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1197'
+      - '1198'
       X-Ms-Correlation-Request-Id:
-      - 0d269cdd-2cb6-461d-af5d-998d6096c8ad
+      - 11e5f921-02d2-44f3-9993-686aee198910
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202201Z:0d269cdd-2cb6-461d-af5d-998d6096c8ad
+      - WESTEUROPE:20180312T093552Z:11e5f921-02d2-44f3-9993-686aee198910
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:22:00 GMT
+      - Mon, 12 Mar 2018 09:35:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keys":[{"keyName":"key1","value":"68JHlwL/JgyPmvNCqop65JbepxzK0RGKJ4uD6EKszcgv1nRUJKkxO6u4OoyW/6YPT+FMJxvzEBrCGD/bduFGJQ==","permissions":"Full"},{"keyName":"key2","value":"NCT/sPC/+mrVRzXq/V5IwjN2SPaWRF4kY2coPHzJ8f+IkWMUIyfUgYTAN//h4KnxeWuX9OkY1CPyssDhDs91fw==","permissions":"Full"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:22:01 GMT
+  recorded_at: Mon, 12 Mar 2018 09:35:57 GMT
 - request:
     method: get
     uri: https://spec0deply1stor.blob.core.windows.net/?comp=list
@@ -5979,13 +6025,13 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:22:01 GMT
+      - Mon, 12 Mar 2018 09:35:57 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
       - 'true'
       Authorization:
-      - SharedKey spec0deply1stor:duqWcDrCJZqRFp9KP71cVfS5yJtuEC5GhKvuR+1p1jI=
+      - SharedKey spec0deply1stor:iMz6ETdicRnaV+tZl3MpKYmwDsCVmy0PZjGn5AFn2ZU=
   response:
     status:
       code: 200
@@ -5998,17 +6044,17 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 673551ce-001e-011c-3d51-b6b83d000000
+      - 1bfc3009-001e-0106-22e5-b99752000000
       X-Ms-Version:
       - '2016-05-31'
       Date:
-      - Wed, 07 Mar 2018 20:22:01 GMT
+      - Mon, 12 Mar 2018 09:35:52 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9zcGVjMGRlcGx5MXN0b3IuYmxvYi5jb3JlLndpbmRvd3MubmV0LyI+PENvbnRhaW5lcnM+PENvbnRhaW5lcj48TmFtZT5ib290ZGlhZ25vc3RpY3Mtc3BlYzBkZXBsLTRkMTUwMmQ1LTM1MWEtNDJmNC04NTY5LTIyMjg0ZjkwNmQ2ODwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5Nb24sIDA0IEFwciAyMDE2IDIzOjI0OjU2IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4iMHg4RDM1Q0UwNTU2MzlCQjMiPC9FdGFnPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0NvbnRhaW5lcj48Q29udGFpbmVyPjxOYW1lPmJvb3RkaWFnbm9zdGljcy1zcGVjMGRlcGwtZDcwMjIwMDgtZjZiMS00ZjRjLThiZTgtZTJkNjc3ZWYzMjYxPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPk1vbiwgMDQgQXByIDIwMTYgMjM6MjQ6NTYgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPiIweDhEMzVDRTA1NTg1QjcwQyI8L0V0YWc+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQ29udGFpbmVyPjxDb250YWluZXI+PE5hbWU+dmhkczwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5Nb24sIDA0IEFwciAyMDE2IDIzOjI0OjU3IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4iMHg4RDM1Q0UwNTVDRkEzN0IiPC9FdGFnPjxMZWFzZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJhdGlvbj5pbmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48L1Byb3BlcnRpZXM+PC9Db250YWluZXI+PC9Db250YWluZXJzPjxOZXh0TWFya2VyIC8+PC9FbnVtZXJhdGlvblJlc3VsdHM+
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:22:02 GMT
+  recorded_at: Mon, 12 Mar 2018 09:35:58 GMT
 - request:
     method: get
     uri: https://spec0deply1stor.blob.core.windows.net/vhds?comp=list&restype=container
@@ -6025,13 +6071,13 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:22:02 GMT
+      - Mon, 12 Mar 2018 09:35:58 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
       - 'true'
       Authorization:
-      - SharedKey spec0deply1stor:k/CL+d3Tr3IAESvjahkK4ciO9Wlq9iesEC1lz8DgYbk=
+      - SharedKey spec0deply1stor:K3VLzNreWNxf+2aYoMJzSiclvLN26fcftpC9QSnkuDg=
   response:
     status:
       code: 200
@@ -6044,17 +6090,17 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 39ff5106-001e-00bc-2051-b6310e000000
+      - c2596e5b-001e-001a-55e5-b90910000000
       X-Ms-Version:
       - '2016-05-31'
       Date:
-      - Wed, 07 Mar 2018 20:22:03 GMT
+      - Mon, 12 Mar 2018 09:35:53 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9zcGVjMGRlcGx5MXN0b3IuYmxvYi5jb3JlLndpbmRvd3MubmV0LyIgQ29udGFpbmVyTmFtZT0idmhkcyI+PEJsb2JzPjxCbG9iPjxOYW1lPm9zZGlzazAudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlNhdCwgMDMgU2VwIDIwMTYgMDI6MDQ6MzggR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzRDM5RUE4RjcxNzE1PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj40MzwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJhdGlvbj5pbmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5vc2Rpc2sxLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5TYXQsIDAzIFNlcCAyMDE2IDAyOjA2OjM3IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0QzOUVGMDJFMTZCNzwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+NTM8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+bG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5sZWFzZWQ8L0xlYXNlU3RhdGU+PExlYXNlRHVyYXRpb24+aW5maW5pdGU8L0xlYXNlRHVyYXRpb24+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+c3BlYzBkZXBseTF2bTAuZDcwMjIwMDgtZjZiMS00ZjRjLThiZTgtZTJkNjc3ZWYzMjYxLnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5TYXQsIDAzIFNlcCAyMDE2IDAyOjA0OjIxIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0QzOUU5RUU4ODdGQzwvRXRhZz48Q29udGVudC1MZW5ndGg+MjQyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+TjBqdys3eUJtbnA2c3hMTEkzbmNFQT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+c3BlYzBkZXBseTF2bTEuNGQxNTAyZDUtMzUxYS00MmY0LTg1NjktMjIyODRmOTA2ZDY4LnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5TYXQsIDAzIFNlcCAyMDE2IDAyOjA2OjMwIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0QzOUVFQkNEMEUyMjwvRXRhZz48Q29udGVudC1MZW5ndGg+MjQyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+ZTNZVWlxWHBZcU81bGcvZnhabzRUQT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PC9CbG9icz48TmV4dE1hcmtlciAvPjwvRW51bWVyYXRpb25SZXN1bHRzPg==
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:22:03 GMT
+  recorded_at: Mon, 12 Mar 2018 09:35:58 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Storage/storageAccounts/miqazuretest26611/listKeys?api-version=2017-10-01
@@ -6071,7 +6117,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3ODQsIm5iZiI6MTUyMDQ1Mzc4NCwiZXhwIjoxNTIwNDU3Njg0LCJhaW8iOiJZMk5nWUpnU2xxeG4vSTJOMTBmYWNkZHltZXE3QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoicDBsS2ZuYXRORVd2a3VaVmttQUFBQSIsInZlciI6IjEuMCJ9.iC1HIh7EJhSg4gWNwK-4-iAm1Y57QbVEKhbqmrgwOPUjVEl83aDkQcFgk_LTJlYJxuWt32jXyPTVllnJyz8dQlAV3NbzVr2Ob3u7Tma1NOOnxZkLpH9EE8B1SgQypHRbWQa5OXi98OEU429EDLTLzRPhb0ePBhu9oz0AtzI8jHVr46i_X7jxoTKLQsx83mOyBS68htVskAiZtMVcl38z5OHFZ15jBJJfCsbMEVL632TFBKiKwwwKKgMvTbgR9lRqXNgLsCl4sYWtuXD1i5vKr9GHvFE4byo7KUAmecWPb9ZdogYjVVEpoXXh5IkbAY-T7K_JTEBJL7lWK1t640tBjw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcwMTMsIm5iZiI6MTUyMDg0NzAxMywiZXhwIjoxNTIwODUwOTEzLCJhaW8iOiJZMk5nWUhCMFludmpjNGN6aE5NNTh0M0t5a1FYQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoialE5U1hFcjVIRWVCX0dyQ1pta2pBQSIsInZlciI6IjEuMCJ9.CNps7ehQ4gjIipFpeHtH1uayoFrjNQmz9DNt8X_pu3FJIMidCRl8zafvhLybkMt3jBTg3ilWiyWZfJ-LaCVtgzQqXRZh4TitdGaw6BtQXx5BndCxbJdfQQWyDDtaXijWD6EjF5OpGZJ0nBglCx-KPAAPhSZXRIvjPNXgsDseRlJxWTSzxYkOUfGY5gn9E9CT6Qe54gFtFsID7PIhBmFOLFrgEjl9dEidPDaLO9f7lba8LHWTjDFozQ_FgyhD_PqDzJYySpX8wTabcb1A1tynX-1rd5v9e4pPrxjRLEvJ_VLaP9RN8XVqo2YoZadQ9FlTwiv4l7aY36nqd2QffgkYsg
       Content-Length:
       - '0'
   response:
@@ -6092,26 +6138,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 0acf5402-5d72-4277-8c22-d92ad3022b15
+      - 4a133033-9a23-48b4-bd5e-9847cae32889
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1198'
+      - '1199'
       X-Ms-Correlation-Request-Id:
-      - 987d9501-bb70-481b-9cfd-51c8c49009a3
+      - bd2162a8-05d3-4dcf-9885-489ed5df1eda
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202204Z:987d9501-bb70-481b-9cfd-51c8c49009a3
+      - WESTEUROPE:20180312T093556Z:bd2162a8-05d3-4dcf-9885-489ed5df1eda
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:22:03 GMT
+      - Mon, 12 Mar 2018 09:35:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keys":[{"keyName":"key1","value":"Hh1rIrLFYOsfGuufnXsDBIZhDPUM0RWfl1XnZojGXRDo2TRjpQFisw3U7OfrizJ0J7fcN1535PrBniNUt/sVcw==","permissions":"Full"},{"keyName":"key2","value":"EZOKcIq7u+qCjHAIWfhDG0VGJe6sez+D+lYt5cbevX1njlWq+Z2lkffcTOsR/Pe4cDZg4OBCO1SymcWm3A35RA==","permissions":"Full"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:22:04 GMT
+  recorded_at: Mon, 12 Mar 2018 09:36:01 GMT
 - request:
     method: get
     uri: https://miqazuretest26611.blob.core.windows.net/?comp=list
@@ -6128,13 +6174,13 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:22:04 GMT
+      - Mon, 12 Mar 2018 09:36:01 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
       - 'true'
       Authorization:
-      - SharedKey miqazuretest26611:w3xgsz0wqpwGeGu52fk7MmYCuCz/lbwFwAM5GJm52+E=
+      - SharedKey miqazuretest26611:j0fTWkQfLc226rKYQ21e7nAapYvBK1UU8vg7WQcBhgA=
   response:
     status:
       code: 200
@@ -6147,17 +6193,17 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - b7d29d42-f01e-006b-7d51-b69519000000
+      - 2d2e897a-601e-00c4-0ce5-b9b789000000
       X-Ms-Version:
       - '2016-05-31'
       Date:
-      - Wed, 07 Mar 2018 20:22:03 GMT
+      - Mon, 12 Mar 2018 09:35:56 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9taXFhenVyZXRlc3QyNjYxMS5ibG9iLmNvcmUud2luZG93cy5uZXQvIj48Q29udGFpbmVycz48Q29udGFpbmVyPjxOYW1lPmJvb3RkaWFnbm9zdGljcy1qZm1ldHJpY3MtOTA0Y2M5ODEtZmE0ZC00ZGFmLWI4YjEtZGZjMGYwMTkzOGI1PC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPk1vbiwgMDIgTWF5IDIwMTYgMTg6MDI6MDEgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPiIweDhEMzcyQjNEQzk5NTRCRCI8L0V0YWc+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQ29udGFpbmVyPjxDb250YWluZXI+PE5hbWU+bWFuYWdlaXE8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VHVlLCAxNyBNYXkgMjAxNiAxODo0Mzo0NiBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+IjB4OEQzN0U4MzJFMjMwNEVEIjwvRXRhZz48TGVhc2VTdGF0dXM+bG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5sZWFzZWQ8L0xlYXNlU3RhdGU+PExlYXNlRHVyYXRpb24+aW5maW5pdGU8L0xlYXNlRHVyYXRpb24+PC9Qcm9wZXJ0aWVzPjwvQ29udGFpbmVyPjxDb250YWluZXI+PE5hbWU+dmhkczwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5Nb24sIDAyIE1heSAyMDE2IDE4OjAyOjAxIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4iMHg4RDM3MkIzRENCNjBCNTEiPC9FdGFnPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0NvbnRhaW5lcj48L0NvbnRhaW5lcnM+PE5leHRNYXJrZXIgLz48L0VudW1lcmF0aW9uUmVzdWx0cz4=
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:22:04 GMT
+  recorded_at: Mon, 12 Mar 2018 09:36:01 GMT
 - request:
     method: get
     uri: https://miqazuretest26611.blob.core.windows.net/manageiq?comp=list&restype=container
@@ -6174,13 +6220,13 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:22:04 GMT
+      - Mon, 12 Mar 2018 09:36:01 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
       - 'true'
       Authorization:
-      - SharedKey miqazuretest26611:nXjl7Vj2bGa4y2lYkRSyX8rbP/UpzRKowPTIcs1sWjk=
+      - SharedKey miqazuretest26611:4hapE46khvP465+/11Yyiyl5Hy1QoJVE7MPS2JrSNok=
   response:
     status:
       code: 200
@@ -6193,17 +6239,17 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 5200b21c-201e-0087-2351-b69d60000000
+      - 8f1e2994-801e-012f-24e5-b90f20000000
       X-Ms-Version:
       - '2016-05-31'
       Date:
-      - Wed, 07 Mar 2018 20:22:04 GMT
+      - Mon, 12 Mar 2018 09:35:56 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9taXFhenVyZXRlc3QyNjYxMS5ibG9iLmNvcmUud2luZG93cy5uZXQvIiBDb250YWluZXJOYW1lPSJtYW5hZ2VpcSI+PEJsb2JzPjxCbG9iPjxOYW1lPm1pcW1pc21hdGNoMV81NzMwMmVlZS00NDJlLTRkYzUtOWIxMC04OTBlYjI5Njc0Y2QudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlR1ZSwgMTcgTWF5IDIwMTYgMTk6MTU6NDQgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzN0U4N0E1NTY0N0E1PC9FdGFnPjxDb250ZW50LUxlbmd0aD4zMTQ1NzI4MDUxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PmhLZE9qa2F1cDdzQi9uemtXZXVoV0E9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjM8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5taXFtaXNtYXRjaDFfODAyMTc0M2EtNTk1Ny00ZGMxLWE2NDUtY2EyMTBkNWQ3ZmM1LnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UdWUsIDA2IE1hciAyMDE4IDIyOjI3OjUzIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhENTgzQjE4MEMwMkEzODwvRXRhZz48Q29udGVudC1MZW5ndGg+MzE0NTcyODA1MTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5oS2RPamthdXA3c0IvbnprV2V1aFdBPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4xNTU8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+bG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5sZWFzZWQ8L0xlYXNlU3RhdGU+PExlYXNlRHVyYXRpb24+aW5maW5pdGU8L0xlYXNlRHVyYXRpb24+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+bWlxbWlzbWF0Y2gxXzgxOGExZjI3LTAxYTYtNDdkYS1hNjU1LWQ5YjcyOTQ4MzRiNS52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VHVlLCAxNyBNYXkgMjAxNiAxOTo1Nzo1NSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDM3RThEODk3RUZDOEE8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjMxNDU3MjgwNTEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+aEtkT2prYXVwN3NCL256a1dldWhXQT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MTwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjwvQmxvYnM+PE5leHRNYXJrZXIgLz48L0VudW1lcmF0aW9uUmVzdWx0cz4=
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:22:05 GMT
+  recorded_at: Mon, 12 Mar 2018 09:36:02 GMT
 - request:
     method: head
     uri: https://miqazuretest26611.blob.core.windows.net/manageiq/miqmismatch1_57302eee-442e-4dc5-9b10-890eb29674cd.vhd
@@ -6220,7 +6266,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:22:05 GMT
+      - Mon, 12 Mar 2018 09:36:02 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -6228,7 +6274,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest26611:3clEWKd1LC6gor1zTY3YGqQUPlVKlWCn15rSKgs6iUQ=
+      - SharedKey miqazuretest26611:1bv6TVeqyrtJXvkHnqg283usHh3xvHPbIVEeIOw5aG4=
   response:
     status:
       code: 200
@@ -6249,7 +6295,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 18400225-601e-00ed-3551-b6c1cb000000
+      - 7db61161-501e-00aa-31e5-b91ea0000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -6273,12 +6319,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:22:05 GMT
+      - Mon, 12 Mar 2018 09:35:57 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:22:06 GMT
+  recorded_at: Mon, 12 Mar 2018 09:36:02 GMT
 - request:
     method: head
     uri: https://miqazuretest26611.blob.core.windows.net/manageiq/miqmismatch1_818a1f27-01a6-47da-a655-d9b7294834b5.vhd
@@ -6295,7 +6341,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:22:06 GMT
+      - Mon, 12 Mar 2018 09:36:02 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -6303,7 +6349,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest26611:E9PW2HR8mXZA1F9ucE/YoC0STX8Nj+BlzuDeyjDk5D8=
+      - SharedKey miqazuretest26611:fIkJIhkwVn04BlDKOCnhDfGBpPxk844wrzO9W29/DrQ=
   response:
     status:
       code: 200
@@ -6324,7 +6370,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 20e95d54-401e-00d3-2c51-b677ea000000
+      - 1c5c76e0-101e-0061-3ce5-b98c90000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -6348,12 +6394,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:22:06 GMT
+      - Mon, 12 Mar 2018 09:35:58 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:22:06 GMT
+  recorded_at: Mon, 12 Mar 2018 09:36:03 GMT
 - request:
     method: get
     uri: https://miqazuretest26611.blob.core.windows.net/vhds?comp=list&restype=container
@@ -6370,13 +6416,13 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:22:06 GMT
+      - Mon, 12 Mar 2018 09:36:03 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
       - 'true'
       Authorization:
-      - SharedKey miqazuretest26611:qDxW7l1sgVDrGYj806dWEWmr/Vwr8wFPQ6Y2IbGupgY=
+      - SharedKey miqazuretest26611:XMfz4+tqNhLw7XPc8mSxe74oA05l0qIeGv0YE/uRkOc=
   response:
     status:
       code: 200
@@ -6389,17 +6435,17 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 274badef-e01e-005d-2051-b6384b000000
+      - 80ec335c-301e-00f5-61e5-b9ec5e000000
       X-Ms-Version:
       - '2016-05-31'
       Date:
-      - Wed, 07 Mar 2018 20:22:06 GMT
+      - Mon, 12 Mar 2018 09:35:59 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9taXFhenVyZXRlc3QyNjYxMS5ibG9iLmNvcmUud2luZG93cy5uZXQvIiBDb250YWluZXJOYW1lPSJ2aGRzIj48QmxvYnM+PEJsb2I+PE5hbWU+amYtbWV0cmljcy0xMjAxNjQyMTQxMjAudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPk1vbiwgMDIgTWF5IDIwMTYgMjA6MDE6NTUgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzNzJDNDlDQ0UzMUNGPC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj40PC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PC9CbG9icz48TmV4dE1hcmtlciAvPjwvRW51bWVyYXRpb25SZXN1bHRzPg==
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:22:07 GMT
+  recorded_at: Mon, 12 Mar 2018 09:36:03 GMT
 - request:
     method: head
     uri: https://miqazuretest26611.blob.core.windows.net/vhds/jf-metrics-120164214120.vhd
@@ -6416,7 +6462,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:22:07 GMT
+      - Mon, 12 Mar 2018 09:36:03 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -6424,7 +6470,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest26611:ze9i2eGPg1b/cN5HCPfigsYDpO5QXa/SLf8t1O1nY2g=
+      - SharedKey miqazuretest26611:isj3JPEz4ufyzeshj3as1Phje9CCmBEdefyDgxaAYnA=
   response:
     status:
       code: 200
@@ -6445,7 +6491,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - c5f6376e-601e-00cf-7f51-b6affd000000
+      - 223eb5c0-801e-0124-39e5-b91754000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -6469,12 +6515,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:22:07 GMT
+      - Mon, 12 Mar 2018 09:35:59 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:22:07 GMT
+  recorded_at: Mon, 12 Mar 2018 09:36:04 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487/listKeys?api-version=2017-10-01
@@ -6491,7 +6537,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3ODQsIm5iZiI6MTUyMDQ1Mzc4NCwiZXhwIjoxNTIwNDU3Njg0LCJhaW8iOiJZMk5nWUpnU2xxeG4vSTJOMTBmYWNkZHltZXE3QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoicDBsS2ZuYXRORVd2a3VaVmttQUFBQSIsInZlciI6IjEuMCJ9.iC1HIh7EJhSg4gWNwK-4-iAm1Y57QbVEKhbqmrgwOPUjVEl83aDkQcFgk_LTJlYJxuWt32jXyPTVllnJyz8dQlAV3NbzVr2Ob3u7Tma1NOOnxZkLpH9EE8B1SgQypHRbWQa5OXi98OEU429EDLTLzRPhb0ePBhu9oz0AtzI8jHVr46i_X7jxoTKLQsx83mOyBS68htVskAiZtMVcl38z5OHFZ15jBJJfCsbMEVL632TFBKiKwwwKKgMvTbgR9lRqXNgLsCl4sYWtuXD1i5vKr9GHvFE4byo7KUAmecWPb9ZdogYjVVEpoXXh5IkbAY-T7K_JTEBJL7lWK1t640tBjw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcwMTMsIm5iZiI6MTUyMDg0NzAxMywiZXhwIjoxNTIwODUwOTEzLCJhaW8iOiJZMk5nWUhCMFludmpjNGN6aE5NNTh0M0t5a1FYQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoialE5U1hFcjVIRWVCX0dyQ1pta2pBQSIsInZlciI6IjEuMCJ9.CNps7ehQ4gjIipFpeHtH1uayoFrjNQmz9DNt8X_pu3FJIMidCRl8zafvhLybkMt3jBTg3ilWiyWZfJ-LaCVtgzQqXRZh4TitdGaw6BtQXx5BndCxbJdfQQWyDDtaXijWD6EjF5OpGZJ0nBglCx-KPAAPhSZXRIvjPNXgsDseRlJxWTSzxYkOUfGY5gn9E9CT6Qe54gFtFsID7PIhBmFOLFrgEjl9dEidPDaLO9f7lba8LHWTjDFozQ_FgyhD_PqDzJYySpX8wTabcb1A1tynX-1rd5v9e4pPrxjRLEvJ_VLaP9RN8XVqo2YoZadQ9FlTwiv4l7aY36nqd2QffgkYsg
       Content-Length:
       - '0'
   response:
@@ -6512,7 +6558,7 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 1d5c2578-a7c6-47f6-a7fd-cf5da6b3ef0b
+      - 92cf204a-dabf-42a7-ad21-1f1f095c2278
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
@@ -6520,18 +6566,18 @@ http_interactions:
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
       - '1198'
       X-Ms-Correlation-Request-Id:
-      - 5a97966b-644e-48eb-a699-ed320a86227f
+      - 2568d8bb-d88f-467a-aa66-b16b5f381cb4
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202207Z:5a97966b-644e-48eb-a699-ed320a86227f
+      - WESTEUROPE:20180312T093600Z:2568d8bb-d88f-467a-aa66-b16b5f381cb4
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:22:07 GMT
+      - Mon, 12 Mar 2018 09:35:59 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keys":[{"keyName":"key1","value":"ELTQwCiFqVImh96hlGId6JwT3r2zczvyeG7cA2HURT1oTYsFnPeRQjgVTV/j4GSG+XCYe5YOthB26dPcd/8JXQ==","permissions":"Full"},{"keyName":"key2","value":"uNJn8gcE3/hHHewm5z+vzty/mieLySe+jKn3t0ZKcivOk95ggorfeXAxvsiehK2HiqQWMAvdhQKU+3Ero0YHyA==","permissions":"Full"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:22:08 GMT
+  recorded_at: Mon, 12 Mar 2018 09:36:05 GMT
 - request:
     method: get
     uri: https://miqazuretest16487.blob.core.windows.net/?comp=list
@@ -6548,13 +6594,13 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:22:08 GMT
+      - Mon, 12 Mar 2018 09:36:05 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
       - 'true'
       Authorization:
-      - SharedKey miqazuretest16487:XPFX75eEbdmnBMyA4XUxekg4ZmClnfNsr9QtXtCHyrY=
+      - SharedKey miqazuretest16487:QFhErhVnq3fCsDVa3Dewad86+r2Tnm86xiYMJd6PVg0=
   response:
     status:
       code: 200
@@ -6567,17 +6613,17 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - c4a4bf9e-001e-0127-4a51-b6fa63000000
+      - d90e104a-001e-0088-08e5-b99ea6000000
       X-Ms-Version:
       - '2016-05-31'
       Date:
-      - Wed, 07 Mar 2018 20:22:08 GMT
+      - Mon, 12 Mar 2018 09:36:00 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9taXFhenVyZXRlc3QxNjQ4Ny5ibG9iLmNvcmUud2luZG93cy5uZXQvIj48Q29udGFpbmVycz48Q29udGFpbmVyPjxOYW1lPmJvb3RkaWFnbm9zdGljcy1taXF0ZXN0dWItYzRkNTc3YWUtNGJlOC00MWMxLTg0ZjgtNjQyMzIwOTEwYTVlPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPkZyaSwgMTggTWFyIDIwMTYgMTc6Mjc6MzAgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPiIweDhEMzRGNTI5NUM2RTcwQyI8L0V0YWc+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQ29udGFpbmVyPjxDb250YWluZXI+PE5hbWU+Ym9vdGRpYWdub3N0aWNzLXJzcGVjbGJhLTIzYjBiZWFiLTE2ZDItNDEzNS1hMDFmLTJmZTcxMzIxN2ZkMDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5GcmksIDAyIFNlcCAyMDE2IDE2OjI5OjQwIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4iMHg4RDNEMzRFNTZFNEJCMkIiPC9FdGFnPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0NvbnRhaW5lcj48Q29udGFpbmVyPjxOYW1lPnZoZHM8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+RnJpLCAxOCBNYXIgMjAxNiAxNzoyNzozMCBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+IjB4OEQzNEY1Mjk1REZDQzIyIjwvRXRhZz48TGVhc2VTdGF0dXM+bG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5sZWFzZWQ8L0xlYXNlU3RhdGU+PExlYXNlRHVyYXRpb24+aW5maW5pdGU8L0xlYXNlRHVyYXRpb24+PC9Qcm9wZXJ0aWVzPjwvQ29udGFpbmVyPjwvQ29udGFpbmVycz48TmV4dE1hcmtlciAvPjwvRW51bWVyYXRpb25SZXN1bHRzPg==
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:22:08 GMT
+  recorded_at: Mon, 12 Mar 2018 09:36:05 GMT
 - request:
     method: get
     uri: https://miqazuretest16487.blob.core.windows.net/vhds?comp=list&restype=container
@@ -6594,13 +6640,13 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:22:08 GMT
+      - Mon, 12 Mar 2018 09:36:05 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
       - 'true'
       Authorization:
-      - SharedKey miqazuretest16487:doCJEeEp0m8O6ZMaEsVHaUEJKQ7SNjxRhdie+qThvH4=
+      - SharedKey miqazuretest16487:VfL9WVSj1rS5X7X3zXV9xe/4rFlJ44e+M3zQtwahY0A=
   response:
     status:
       code: 200
@@ -6613,15 +6659,15 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 259a9979-001e-00b3-7951-b6dcf8000000
+      - 18fee72a-001e-008b-16e5-b99da1000000
       X-Ms-Version:
       - '2016-05-31'
       Date:
-      - Wed, 07 Mar 2018 20:22:09 GMT
+      - Mon, 12 Mar 2018 09:36:01 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9taXFhenVyZXRlc3QxNjQ4Ny5ibG9iLmNvcmUud2luZG93cy5uZXQvIiBDb250YWluZXJOYW1lPSJ2aGRzIj48QmxvYnM+PEJsb2I+PE5hbWU+bWlxLXRlc3QtdWJ1bnR1MS5jNGQ1NzdhZS00YmU4LTQxYzEtODRmOC02NDIzMjA5MTBhNWUuc3RhdHVzPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPldlZCwgMjIgSnVuIDIwMTYgMjE6NTc6MDUgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzOUFFODI2NjgyQTA1PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xNzY2PC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+WlVyb1NISk1HTFRDZkRwOSt0dkNyUT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+bWlxLXRlc3QtdWJ1bnR1MTIwMTYyMTgxMTI2NDcudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPldlZCwgMjIgSnVuIDIwMTYgMjE6NTc6MzMgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzOUFFODM3MEJGOTBDPC9FdGFnPjxDb250ZW50LUxlbmd0aD4zMTQ1NzI4MDUxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PmhLZE9qa2F1cDdzQi9uemtXZXVoV0E9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjI2NDwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJhdGlvbj5pbmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48L0Jsb2JzPjxOZXh0TWFya2VyIC8+PC9FbnVtZXJhdGlvblJlc3VsdHM+
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:22:09 GMT
+  recorded_at: Mon, 12 Mar 2018 09:36:06 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_0/vm_with_managed_disk_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_0/vm_with_managed_disk_refresh.yml
@@ -1,6 +1,62 @@
 ---
 http_interactions:
 - request:
+    method: post
+    uri: https://login.microsoftonline.com/AZURE_TENANT_ID/oauth2/token
+    body:
+      encoding: UTF-8
+      string: grant_type=client_credentials&client_id=AZURE_CLIENT_ID&client_secret=AZURE_CLIENT_SECRET&resource=https%3A%2F%2Fmanagement.azure.com%2F
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Server:
+      - Microsoft-IIS/10.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Request-Id:
+      - b3def657-4c3a-4426-9727-6f5f5d962200
+      P3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Set-Cookie:
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzCaAHh4AwFDu7nTdqTUwQhLRyOL1Fx0LU4LoIx0d2xqTE4wj_wDAtgefPmd9-gqPvu3CrenQb2ybAbC0RPoRNnXqXpKsnH1aEu882AWsB7eTOgYOZUtBECYXnsjvKisGm-9TRoHMiUt_6eYyp0hXvZitdbHREtTBta1p2HqINPhwgAA;
+        domain=.login.microsoftonline.com; path=/; secure; HttpOnly
+      - stsservicecookie=ests; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=002; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 12 Mar 2018 09:32:40 GMT
+      Content-Length:
+      - '1505'
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1520850761","not_before":"1520846861","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDY4NjEsIm5iZiI6MTUyMDg0Njg2MSwiZXhwIjoxNTIwODUwNzYxLCJhaW8iOiJZMk5nWU9BNzd0MVE5WExDVWhQalA5eGZ4WHhmQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVl9iZXN6cE1Ka1NYSjI5ZlhaWWlBQSIsInZlciI6IjEuMCJ9.WI1TBHaE4Hhvef2mZVyyNhPpKLglnhiSTpr9uxb3DSkev8xpkcEE1Aga8NQjst7JfS6Hti9KC3tfTBGgmY6agZMUOMGrVk41LIcebmGHqwM3PIyxFxkUrzTvUA83XRBJOniivcHQSW4ffEUDr6c2Lsj24z0f713D34lK7iVgApHwDzu1u2nesP8q-DBz9wld7HkM3QCgVo-eJqFo2L61LkS-z11r7IQqbNk1hVNng4d38RWu1axm4rbigScwPUC7Hautv98fKMN1jc5-4yL8SKGvDkWvdsiQhxr7toBEPDaQCvV3JWkD6EIequwpl7v96z6CKyQeCDvskoBJjBjolg"}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:32:46 GMT
+- request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
     body:
@@ -16,7 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDY4NjEsIm5iZiI6MTUyMDg0Njg2MSwiZXhwIjoxNTIwODUwNzYxLCJhaW8iOiJZMk5nWU9BNzd0MVE5WExDVWhQalA5eGZ4WHhmQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVl9iZXN6cE1Ka1NYSjI5ZlhaWWlBQSIsInZlciI6IjEuMCJ9.WI1TBHaE4Hhvef2mZVyyNhPpKLglnhiSTpr9uxb3DSkev8xpkcEE1Aga8NQjst7JfS6Hti9KC3tfTBGgmY6agZMUOMGrVk41LIcebmGHqwM3PIyxFxkUrzTvUA83XRBJOniivcHQSW4ffEUDr6c2Lsj24z0f713D34lK7iVgApHwDzu1u2nesP8q-DBz9wld7HkM3QCgVo-eJqFo2L61LkS-z11r7IQqbNk1hVNng4d38RWu1axm4rbigScwPUC7Hautv98fKMN1jc5-4yL8SKGvDkWvdsiQhxr7toBEPDaQCvV3JWkD6EIequwpl7v96z6CKyQeCDvskoBJjBjolg
   response:
     status:
       code: 200
@@ -35,26 +91,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14997'
+      - '14998'
       X-Ms-Request-Id:
-      - cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - 726a4ba8-b9e6-4774-89ea-1ad7a64fd627
       X-Ms-Correlation-Request-Id:
-      - cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - 726a4ba8-b9e6-4774-89ea-1ad7a64fd627
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102417Z:cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - WESTEUROPE:20180312T093241Z:726a4ba8-b9e6-4774-89ea-1ad7a64fd627
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:17 GMT
+      - Mon, 12 Mar 2018 09:32:41 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID","subscriptionId":"AZURE_SUBSCRIPTION_ID","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:22 GMT
+  recorded_at: Mon, 12 Mar 2018 09:32:46 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers?api-version=2015-01-01
@@ -71,7 +127,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDY4NjEsIm5iZiI6MTUyMDg0Njg2MSwiZXhwIjoxNTIwODUwNzYxLCJhaW8iOiJZMk5nWU9BNzd0MVE5WExDVWhQalA5eGZ4WHhmQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVl9iZXN6cE1Ka1NYSjI5ZlhaWWlBQSIsInZlciI6IjEuMCJ9.WI1TBHaE4Hhvef2mZVyyNhPpKLglnhiSTpr9uxb3DSkev8xpkcEE1Aga8NQjst7JfS6Hti9KC3tfTBGgmY6agZMUOMGrVk41LIcebmGHqwM3PIyxFxkUrzTvUA83XRBJOniivcHQSW4ffEUDr6c2Lsj24z0f713D34lK7iVgApHwDzu1u2nesP8q-DBz9wld7HkM3QCgVo-eJqFo2L61LkS-z11r7IQqbNk1hVNng4d38RWu1axm4rbigScwPUC7Hautv98fKMN1jc5-4yL8SKGvDkWvdsiQhxr7toBEPDaQCvV3JWkD6EIequwpl7v96z6CKyQeCDvskoBJjBjolg
   response:
     status:
       code: 200
@@ -88,19 +144,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - '14998'
       X-Ms-Request-Id:
-      - fe3532ca-59a2-474e-9094-8a3697b82bef
+      - 2ecff1bb-77ca-45de-8769-5ed1df6f024c
       X-Ms-Correlation-Request-Id:
-      - fe3532ca-59a2-474e-9094-8a3697b82bef
+      - 2ecff1bb-77ca-45de-8769-5ed1df6f024c
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102419Z:fe3532ca-59a2-474e-9094-8a3697b82bef
+      - WESTEUROPE:20180312T093242Z:2ecff1bb-77ca-45de-8769-5ed1df6f024c
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:18 GMT
+      - Mon, 12 Mar 2018 09:32:42 GMT
       Content-Length:
       - '320853'
     body:
@@ -2322,10 +2378,10 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:23 GMT
+  recorded_at: Mon, 12 Mar 2018 09:32:47 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed?api-version=2017-12-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2339,7 +2395,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDY4NjEsIm5iZiI6MTUyMDg0Njg2MSwiZXhwIjoxNTIwODUwNzYxLCJhaW8iOiJZMk5nWU9BNzd0MVE5WExDVWhQalA5eGZ4WHhmQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVl9iZXN6cE1Ka1NYSjI5ZlhaWWlBQSIsInZlciI6IjEuMCJ9.WI1TBHaE4Hhvef2mZVyyNhPpKLglnhiSTpr9uxb3DSkev8xpkcEE1Aga8NQjst7JfS6Hti9KC3tfTBGgmY6agZMUOMGrVk41LIcebmGHqwM3PIyxFxkUrzTvUA83XRBJOniivcHQSW4ffEUDr6c2Lsj24z0f713D34lK7iVgApHwDzu1u2nesP8q-DBz9wld7HkM3QCgVo-eJqFo2L61LkS-z11r7IQqbNk1hVNng4d38RWu1axm4rbigScwPUC7Hautv98fKMN1jc5-4yL8SKGvDkWvdsiQhxr7toBEPDaQCvV3JWkD6EIequwpl7v96z6CKyQeCDvskoBJjBjolg
   response:
     status:
       code: 200
@@ -2355,88 +2411,56 @@ http_interactions:
       - application/json; charset=utf-8
       Expires:
       - "-1"
-      Etag:
-      - W/"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67"
       Vary:
       - Accept-Encoding
-      X-Ms-Request-Id:
-      - '080de667-081e-4d58-9e94-9e7243d4200e'
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/LowCostGet3Min;4741,Microsoft.Compute/LowCostGet30Min;37878
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      X-Ms-Request-Id:
+      - daee9ab2-fd3f-406f-8c4b-7deebdfb62fb
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
+      - '14997'
       X-Ms-Correlation-Request-Id:
-      - '093d49ac-c85f-440e-956b-955b6698dd19'
+      - 0cac3c8e-ac82-4af4-8250-73247734d339
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102419Z:093d49ac-c85f-440e-956b-955b6698dd19
+      - WESTEUROPE:20180312T093246Z:0cac3c8e-ac82-4af4-8250-73247734d339
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:19 GMT
+      - Mon, 12 Mar 2018 09:32:46 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1\",\r\n
-        \ \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"7ab88756-810f-4083-95db-8b05d50e38f2\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ],\r\n          \"inboundNatRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"backendIPConfigurations\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\"\r\n
-        \           }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-rule\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\":
-        80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\"\r\n
-        \         },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n
-        \       \"name\": \"rspec-lb-probe\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-NAT\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 3441,\r\n          \"backendPort\":
-        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
+      string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"61b7c052-1d09-4898-b995-cce5676aaab0\",\r\n
+        \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Basic_A0\"\r\n    },\r\n
+        \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
+        \"RedHat\",\r\n        \"offer\": \"RHEL\",\r\n        \"sku\": \"7.3\",\r\n
+        \       \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
+        \"Linux\",\r\n        \"name\": \"miqazure-linux-managed_OsDisk_1_7b2bdf790a7d4379ace2846d307730cd\",\r\n
+        \       \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n
+        \       \"managedDisk\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/disks/miqazure-linux-managed_OsDisk_1_7b2bdf790a7d4379ace2846d307730cd\"\r\n
+        \       }\r\n      },\r\n      \"dataDisks\": [\r\n        {\r\n          \"lun\":
+        0,\r\n          \"name\": \"miqazure-linux-managed-data-disk\",\r\n          \"createOption\":
+        \"Attach\",\r\n          \"caching\": \"None\",\r\n          \"managedDisk\":
+        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/disks/miqazure-linux-managed-data-disk\"\r\n
+        \         }\r\n        }\r\n      ]\r\n    },\r\n    \"osProfile\": {\r\n
+        \     \"computerName\": \"miqazure-linux-managed\",\r\n      \"adminUsername\":
+        \"dberger\",\r\n      \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\":
+        false\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\":
+        {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944\"}]},\r\n
+        \   \"provisioningState\": \"Succeeded\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n
+        \ \"location\": \"eastus\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed\",\r\n
+        \ \"name\": \"miqazure-linux-managed\"\r\n}"
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:24 GMT
+  recorded_at: Mon, 12 Mar 2018 09:32:50 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944?api-version=2018-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2450,7 +2474,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDY4NjEsIm5iZiI6MTUyMDg0Njg2MSwiZXhwIjoxNTIwODUwNzYxLCJhaW8iOiJZMk5nWU9BNzd0MVE5WExDVWhQalA5eGZ4WHhmQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVl9iZXN6cE1Ka1NYSjI5ZlhaWWlBQSIsInZlciI6IjEuMCJ9.WI1TBHaE4Hhvef2mZVyyNhPpKLglnhiSTpr9uxb3DSkev8xpkcEE1Aga8NQjst7JfS6Hti9KC3tfTBGgmY6agZMUOMGrVk41LIcebmGHqwM3PIyxFxkUrzTvUA83XRBJOniivcHQSW4ffEUDr6c2Lsj24z0f713D34lK7iVgApHwDzu1u2nesP8q-DBz9wld7HkM3QCgVo-eJqFo2L61LkS-z11r7IQqbNk1hVNng4d38RWu1axm4rbigScwPUC7Hautv98fKMN1jc5-4yL8SKGvDkWvdsiQhxr7toBEPDaQCvV3JWkD6EIequwpl7v96z6CKyQeCDvskoBJjBjolg
   response:
     status:
       code: 200
@@ -2467,123 +2491,52 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"7a8e5fe7-f777-4435-992b-a54f28c2f28c"
+      - W/"b6339880-8ead-4c9e-b5c0-f38c4f8612d5"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - bd22ca22-a01f-4ecf-9230-a4558fb66931
+      - 00ed96b2-17aa-4d12-af19-e2118fb9f068
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
+      - '14994'
       X-Ms-Correlation-Request-Id:
-      - 19c674a8-c8da-4b5e-8265-5ebc21926459
+      - 9caafdb9-996d-4843-9ea0-a5c59e68bf8c
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102420Z:19c674a8-c8da-4b5e-8265-5ebc21926459
+      - WESTEUROPE:20180312T093246Z:9caafdb9-996d-4843-9ea0-a5c59e68bf8c
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:19 GMT
+      - Mon, 12 Mar 2018 09:32:45 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb2\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2\",\r\n
-        \ \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"e2e30a77-f81b-43fc-9693-08303e43deed\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/backendAddressPools/rspec-lb2-pool\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\r\n
-        \       }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\": [],\r\n    \"probes\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-probe\",\r\n        \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/probes/rspec-lb2-probe\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\": [],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:25 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"a38434c8-7b23-4092-b7c6-402238eac0dc"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 0fd15240-6a1c-4b39-a4f6-aa53fd8591c2
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Correlation-Request-Id:
-      - 5cc03163-922e-41a1-9601-dba2d7cf2a81
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102421Z:5cc03163-922e-41a1-9601-dba2d7cf2a81
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Mon, 12 Mar 2018 10:24:20 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb1-LoadBalancerFrontEnd\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\",\r\n
-        \ \"etag\": \"W/\\\"a38434c8-7b23-4092-b7c6-402238eac0dc\\\"\",\r\n  \"location\":
+      string: "{\r\n  \"name\": \"miqazure-linux-manag944\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944\",\r\n
+        \ \"etag\": \"W/\\\"b6339880-8ead-4c9e-b5c0-f38c4f8612d5\\\"\",\r\n  \"location\":
         \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"f28e0f25-b372-4edf-97d9-13a9e3b4ba2d\",\r\n    \"ipAddress\":
-        \"40.71.82.83\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\":
-        \"Static\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipTags\": [],\r\n
-        \   \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
-        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
+        \   \"resourceGuid\": \"c5e8b90e-5a78-49b0-b224-b70ed3fb45e5\",\r\n    \"ipConfigurations\":
+        [\r\n      {\r\n        \"name\": \"ipconfig1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944/ipConfigurations/ipconfig1\",\r\n
+        \       \"etag\": \"W/\\\"b6339880-8ead-4c9e-b5c0-f38c4f8612d5\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"privateIPAddress\": \"172.25.0.4\",\r\n          \"privateIPAllocationMethod\":
+        \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqazure-linux-managed-ip\"\r\n
+        \         },\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2/subnets/default\"\r\n
+        \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
+        \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\":
+        [],\r\n      \"appliedDnsServers\": []\r\n    },\r\n    \"enableAcceleratedNetworking\":
+        false,\r\n    \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\":
+        {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg\"\r\n
+        \   },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed\"\r\n
+        \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
+        \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:25 GMT
+  recorded_at: Mon, 12 Mar 2018 09:32:51 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed/instanceView?api-version=2017-12-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2597,7 +2550,696 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDY4NjEsIm5iZiI6MTUyMDg0Njg2MSwiZXhwIjoxNTIwODUwNzYxLCJhaW8iOiJZMk5nWU9BNzd0MVE5WExDVWhQalA5eGZ4WHhmQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVl9iZXN6cE1Ka1NYSjI5ZlhaWWlBQSIsInZlciI6IjEuMCJ9.WI1TBHaE4Hhvef2mZVyyNhPpKLglnhiSTpr9uxb3DSkev8xpkcEE1Aga8NQjst7JfS6Hti9KC3tfTBGgmY6agZMUOMGrVk41LIcebmGHqwM3PIyxFxkUrzTvUA83XRBJOniivcHQSW4ffEUDr6c2Lsj24z0f713D34lK7iVgApHwDzu1u2nesP8q-DBz9wld7HkM3QCgVo-eJqFo2L61LkS-z11r7IQqbNk1hVNng4d38RWu1axm4rbigScwPUC7Hautv98fKMN1jc5-4yL8SKGvDkWvdsiQhxr7toBEPDaQCvV3JWkD6EIequwpl7v96z6CKyQeCDvskoBJjBjolg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/GetInstanceView3Min;4796,Microsoft.Compute/GetInstanceView30Min;23916
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      X-Ms-Request-Id:
+      - b6421164-8d6b-4660-8739-943c01465a67
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Correlation-Request-Id:
+      - 8214a7f8-a65e-4104-95e1-f2c41a37e64a
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T093258Z:8214a7f8-a65e-4104-95e1-f2c41a37e64a
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:32:58 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"miqazure-linux-managed_OsDisk_1_7b2bdf790a7d4379ace2846d307730cd\",\r\n
+        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
+        succeeded\",\r\n          \"time\": \"2018-01-23T20:06:17.9818931+00:00\"\r\n
+        \       }\r\n      ]\r\n    },\r\n    {\r\n      \"name\": \"miqazure-linux-managed-data-disk\",\r\n
+        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
+        succeeded\",\r\n          \"time\": \"2018-01-23T20:06:17.9818931+00:00\"\r\n
+        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\":
+        \"ProvisioningState/succeeded\",\r\n      \"level\": \"Info\",\r\n      \"displayStatus\":
+        \"Provisioning succeeded\",\r\n      \"time\": \"2018-01-23T20:06:17.9975145+00:00\"\r\n
+        \   },\r\n    {\r\n      \"code\": \"PowerState/deallocated\",\r\n      \"level\":
+        \"Info\",\r\n      \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:33:02 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups/miq-azure-test4?api-version=2017-08-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDY4NjEsIm5iZiI6MTUyMDg0Njg2MSwiZXhwIjoxNTIwODUwNzYxLCJhaW8iOiJZMk5nWU9BNzd0MVE5WExDVWhQalA5eGZ4WHhmQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVl9iZXN6cE1Ka1NYSjI5ZlhaWWlBQSIsInZlciI6IjEuMCJ9.WI1TBHaE4Hhvef2mZVyyNhPpKLglnhiSTpr9uxb3DSkev8xpkcEE1Aga8NQjst7JfS6Hti9KC3tfTBGgmY6agZMUOMGrVk41LIcebmGHqwM3PIyxFxkUrzTvUA83XRBJOniivcHQSW4ffEUDr6c2Lsj24z0f713D34lK7iVgApHwDzu1u2nesP8q-DBz9wld7HkM3QCgVo-eJqFo2L61LkS-z11r7IQqbNk1hVNng4d38RWu1axm4rbigScwPUC7Hautv98fKMN1jc5-4yL8SKGvDkWvdsiQhxr7toBEPDaQCvV3JWkD6EIequwpl7v96z6CKyQeCDvskoBJjBjolg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Request-Id:
+      - fe94b9aa-3cab-43e9-8dd2-a55393003273
+      X-Ms-Correlation-Request-Id:
+      - fe94b9aa-3cab-43e9-8dd2-a55393003273
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T093300Z:fe94b9aa-3cab-43e9-8dd2-a55393003273
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:32:59 GMT
+      Content-Length:
+      - '183'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4","name":"miq-azure-test4","location":"eastus","properties":{"provisioningState":"Succeeded"}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:33:05 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute/locations/eastus/vmSizes?api-version=2017-12-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDY4NjEsIm5iZiI6MTUyMDg0Njg2MSwiZXhwIjoxNTIwODUwNzYxLCJhaW8iOiJZMk5nWU9BNzd0MVE5WExDVWhQalA5eGZ4WHhmQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVl9iZXN6cE1Ka1NYSjI5ZlhaWWlBQSIsInZlciI6IjEuMCJ9.WI1TBHaE4Hhvef2mZVyyNhPpKLglnhiSTpr9uxb3DSkev8xpkcEE1Aga8NQjst7JfS6Hti9KC3tfTBGgmY6agZMUOMGrVk41LIcebmGHqwM3PIyxFxkUrzTvUA83XRBJOniivcHQSW4ffEUDr6c2Lsj24z0f713D34lK7iVgApHwDzu1u2nesP8q-DBz9wld7HkM3QCgVo-eJqFo2L61LkS-z11r7IQqbNk1hVNng4d38RWu1axm4rbigScwPUC7Hautv98fKMN1jc5-4yL8SKGvDkWvdsiQhxr7toBEPDaQCvV3JWkD6EIequwpl7v96z6CKyQeCDvskoBJjBjolg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/LowCostGet3Min;4751,Microsoft.Compute/LowCostGet30Min;37874
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      X-Ms-Request-Id:
+      - c5290234-6dc2-4fe1-b7ff-69e4de0c9bdc
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Correlation-Request-Id:
+      - '08bbc2d4-a921-4a26-bad0-006deef68fec'
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T093301Z:08bbc2d4-a921-4a26-bad0-006deef68fec
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:33:00 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"Standard_B1ms\",\r\n
+        \     \"numberOfCores\": 1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        4096,\r\n      \"memoryInMB\": 2048,\r\n      \"maxDataDiskCount\": 2\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_B1s\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        2048,\r\n      \"memoryInMB\": 1024,\r\n      \"maxDataDiskCount\": 2\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_B2ms\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        16384,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_B2s\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        8192,\r\n      \"memoryInMB\": 4096,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_B4ms\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        32768,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_B8ms\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS1_v2\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        7168,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS2_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        14336,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS3_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS4_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS5_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS11-1_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS11_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS12-1_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS12-2_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS12_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS13-2_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS13-4_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS13_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS14-4_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        229376,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS14-8_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        229376,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS14_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        229376,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS15_v2\",\r\n      \"numberOfCores\":
+        20,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        286720,\r\n      \"memoryInMB\": 143360,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS2_v2_Promo\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        14336,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS3_v2_Promo\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS4_v2_Promo\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS5_v2_Promo\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS11_v2_Promo\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS12_v2_Promo\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS13_v2_Promo\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS14_v2_Promo\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        229376,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F1s\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        4096,\r\n      \"memoryInMB\": 2048,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F2s\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        8192,\r\n      \"memoryInMB\": 4096,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F4s\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        16384,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F8s\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        32768,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F16s\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D2s_v3\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        16384,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D4s_v3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        32768,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D8s_v3\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D16s_v3\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        131072,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D32s_v3\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        262144,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A0\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        20480,\r\n      \"memoryInMB\": 768,\r\n      \"maxDataDiskCount\": 1\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A1\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        71680,\r\n      \"memoryInMB\": 1792,\r\n      \"maxDataDiskCount\": 2\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        138240,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        291840,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A5\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        138240,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A4\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        619520,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A6\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        291840,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A7\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        619520,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Basic_A0\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        20480,\r\n      \"memoryInMB\": 768,\r\n      \"maxDataDiskCount\": 1\r\n
+        \   },\r\n    {\r\n      \"name\": \"Basic_A1\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        40960,\r\n      \"memoryInMB\": 1792,\r\n      \"maxDataDiskCount\": 2\r\n
+        \   },\r\n    {\r\n      \"name\": \"Basic_A2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        61440,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Basic_A3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        122880,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Basic_A4\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        245760,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D1_v2\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        51200,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D2_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D3_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D4_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D5_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D11_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D12_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D13_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D14_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D15_v2\",\r\n      \"numberOfCores\":
+        20,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        286720,\r\n      \"memoryInMB\": 143360,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D2_v2_Promo\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D3_v2_Promo\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D4_v2_Promo\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D5_v2_Promo\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D11_v2_Promo\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D12_v2_Promo\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D13_v2_Promo\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D14_v2_Promo\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F1\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        16384,\r\n      \"memoryInMB\": 2048,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        32768,\r\n      \"memoryInMB\": 4096,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F4\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F8\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        131072,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F16\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        262144,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A1_v2\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        10240,\r\n      \"memoryInMB\": 2048,\r\n      \"maxDataDiskCount\": 2\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A2m_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        20480,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A2_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        20480,\r\n      \"memoryInMB\": 4096,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A4m_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        40960,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A4_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        40960,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A8m_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        81920,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A8_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        81920,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D2_v3\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        51200,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D4_v3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D8_v3\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D16_v3\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 65636,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D32_v3\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_H8\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1024000,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_H16\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        2048000,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_H8m\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1024000,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_H16m\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        2048000,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_H16r\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        2048000,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_H16mr\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        2048000,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D1\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        51200,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D4\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D11\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D12\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D13\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D14\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NV6\",\r\n      \"numberOfCores\":
+        6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        389120,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 24\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NV12\",\r\n      \"numberOfCores\":
+        12,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        696320,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 48\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NV24\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1474560,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC6s_v2\",\r\n      \"numberOfCores\":
+        6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        344064,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 12\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC12s_v2\",\r\n      \"numberOfCores\":
+        12,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        688128,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 24\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC24rs_v2\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1376256,\r\n      \"memoryInMB\": 458752,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC24s_v2\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1376256,\r\n      \"memoryInMB\": 458752,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC6\",\r\n      \"numberOfCores\":
+        6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        389120,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 24\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC12\",\r\n      \"numberOfCores\":
+        12,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        696320,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 48\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC24\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1474560,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC24r\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1474560,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS1\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        7168,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        14336,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS4\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS11\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS12\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS13\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS14\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        229376,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC6s_v3\",\r\n      \"numberOfCores\":
+        6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        344064,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 12\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC12s_v3\",\r\n      \"numberOfCores\":
+        12,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        688128,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 24\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC24rs_v3\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1376256,\r\n      \"memoryInMB\": 458752,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC24s_v3\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1376256,\r\n      \"memoryInMB\": 458752,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D64_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1638400,\r\n      \"memoryInMB\": 262144,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D64s_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        524288,\r\n      \"memoryInMB\": 262144,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E2_v3\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        51200,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E4_v3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E8_v3\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E16_v3\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E32_v3\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 262144,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E64i_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1638400,\r\n      \"memoryInMB\": 442368,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E64_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1638400,\r\n      \"memoryInMB\": 442368,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E2s_v3\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        32768,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E4-2s_v3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E4s_v3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E8-2s_v3\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        131072,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E8-4s_v3\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        131072,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E8s_v3\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        131072,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E16-4s_v3\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        262144,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E16-8s_v3\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        262144,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E16s_v3\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        262144,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E32-8s_v3\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        524288,\r\n      \"memoryInMB\": 262144,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E32-16s_v3\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        524288,\r\n      \"memoryInMB\": 262144,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E32s_v3\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        524288,\r\n      \"memoryInMB\": 262144,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E64-16s_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        884736,\r\n      \"memoryInMB\": 442368,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E64-32s_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        884736,\r\n      \"memoryInMB\": 442368,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E64is_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        884736,\r\n      \"memoryInMB\": 442368,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E64s_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        884736,\r\n      \"memoryInMB\": 442368,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F2s_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        16384,\r\n      \"memoryInMB\": 4096,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F4s_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        32768,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F8s_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F16s_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        131072,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F32s_v2\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        262144,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F64s_v2\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        524288,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F72s_v2\",\r\n      \"numberOfCores\":
+        72,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        589824,\r\n      \"memoryInMB\": 147456,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_L8s_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1811981,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_L16s_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        3623962,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_ND6s\",\r\n      \"numberOfCores\":
+        6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        344064,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 12\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_ND12s\",\r\n      \"numberOfCores\":
+        12,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        688128,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 24\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_ND24rs\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1376256,\r\n      \"memoryInMB\": 458752,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_ND24s\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1376256,\r\n      \"memoryInMB\": 458752,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A8\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        391168,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A9\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        391168,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A10\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        391168,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A11\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        391168,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   }\r\n  ]\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:33:05 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqazure-linux-managed-ip?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDY4NjEsIm5iZiI6MTUyMDg0Njg2MSwiZXhwIjoxNTIwODUwNzYxLCJhaW8iOiJZMk5nWU9BNzd0MVE5WExDVWhQalA5eGZ4WHhmQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVl9iZXN6cE1Ka1NYSjI5ZlhaWWlBQSIsInZlciI6IjEuMCJ9.WI1TBHaE4Hhvef2mZVyyNhPpKLglnhiSTpr9uxb3DSkev8xpkcEE1Aga8NQjst7JfS6Hti9KC3tfTBGgmY6agZMUOMGrVk41LIcebmGHqwM3PIyxFxkUrzTvUA83XRBJOniivcHQSW4ffEUDr6c2Lsj24z0f713D34lK7iVgApHwDzu1u2nesP8q-DBz9wld7HkM3QCgVo-eJqFo2L61LkS-z11r7IQqbNk1hVNng4d38RWu1axm4rbigScwPUC7Hautv98fKMN1jc5-4yL8SKGvDkWvdsiQhxr7toBEPDaQCvV3JWkD6EIequwpl7v96z6CKyQeCDvskoBJjBjolg
   response:
     status:
       code: 200
@@ -2614,36 +3256,381 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"cddd97d1-6111-4477-8a00-3dc885237a1d"
+      - W/"0efc9684-fb7d-4fb7-b9b9-f33dbac04a28"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 1403e5b6-8fa0-4cd3-89b1-76b6c4fd805b
+      - f05b063b-2eb8-4aad-a82f-192a961bf5ae
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - '14996'
       X-Ms-Correlation-Request-Id:
-      - e4a5f369-a742-466f-bd8f-42e17eaaf9c9
+      - aa66e924-4168-4482-9853-d2e0eab9bb9b
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102421Z:e4a5f369-a742-466f-bd8f-42e17eaaf9c9
+      - WESTEUROPE:20180312T093301Z:aa66e924-4168-4482-9853-d2e0eab9bb9b
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:21 GMT
+      - Mon, 12 Mar 2018 09:33:01 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb2-publicip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\",\r\n
-        \ \"etag\": \"W/\\\"cddd97d1-6111-4477-8a00-3dc885237a1d\\\"\",\r\n  \"location\":
+      string: "{\r\n  \"name\": \"miqazure-linux-managed-ip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqazure-linux-managed-ip\",\r\n
+        \ \"etag\": \"W/\\\"0efc9684-fb7d-4fb7-b9b9-f33dbac04a28\\\"\",\r\n  \"location\":
         \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"83e7257d-ab94-4229-8eb5-4798f37ef28d\",\r\n    \"publicIPAddressVersion\":
+        \   \"resourceGuid\": \"6a2a9142-26e8-45cd-93bf-7318192f3528\",\r\n    \"publicIPAddressVersion\":
         \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
-        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
+        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944/ipConfigurations/ipconfig1\"\r\n
         \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
         \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:26 GMT
+  recorded_at: Mon, 12 Mar 2018 09:33:06 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/disks/miqazure-linux-managed-data-disk?api-version=2017-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDY4NjEsIm5iZiI6MTUyMDg0Njg2MSwiZXhwIjoxNTIwODUwNzYxLCJhaW8iOiJZMk5nWU9BNzd0MVE5WExDVWhQalA5eGZ4WHhmQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVl9iZXN6cE1Ka1NYSjI5ZlhaWWlBQSIsInZlciI6IjEuMCJ9.WI1TBHaE4Hhvef2mZVyyNhPpKLglnhiSTpr9uxb3DSkev8xpkcEE1Aga8NQjst7JfS6Hti9KC3tfTBGgmY6agZMUOMGrVk41LIcebmGHqwM3PIyxFxkUrzTvUA83XRBJOniivcHQSW4ffEUDr6c2Lsj24z0f713D34lK7iVgApHwDzu1u2nesP8q-DBz9wld7HkM3QCgVo-eJqFo2L61LkS-z11r7IQqbNk1hVNng4d38RWu1axm4rbigScwPUC7Hautv98fKMN1jc5-4yL8SKGvDkWvdsiQhxr7toBEPDaQCvV3JWkD6EIequwpl7v96z6CKyQeCDvskoBJjBjolg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/LowCostGet3Min;4998,Microsoft.Compute/LowCostGet30Min;19994
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131626781321631045
+      X-Ms-Request-Id:
+      - e63e7206-8ab2-4e6b-8652-4446b45d8e00
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Correlation-Request-Id:
+      - 335a56e4-af91-42ea-b390-e10dc13c903b
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T093302Z:335a56e4-af91-42ea-b390-e10dc13c903b
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:33:02 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"managedBy\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed\",\r\n
+        \ \"sku\": {\r\n    \"name\": \"Standard_LRS\",\r\n    \"tier\": \"Standard\"\r\n
+        \ },\r\n  \"properties\": {\r\n    \"creationData\": {\r\n      \"createOption\":
+        \"Empty\"\r\n    },\r\n    \"diskSizeGB\": 1,\r\n    \"timeCreated\": \"2017-10-23T17:34:14.7022771+00:00\",\r\n
+        \   \"provisioningState\": \"Succeeded\",\r\n    \"diskState\": \"Reserved\"\r\n
+        \ },\r\n  \"type\": \"Microsoft.Compute/disks\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/disks/miqazure-linux-managed-data-disk\",\r\n
+        \ \"name\": \"miqazure-linux-managed-data-disk\"\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:33:07 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/disks/miqazure-linux-managed_OsDisk_1_7b2bdf790a7d4379ace2846d307730cd?api-version=2017-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDY4NjEsIm5iZiI6MTUyMDg0Njg2MSwiZXhwIjoxNTIwODUwNzYxLCJhaW8iOiJZMk5nWU9BNzd0MVE5WExDVWhQalA5eGZ4WHhmQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVl9iZXN6cE1Ka1NYSjI5ZlhaWWlBQSIsInZlciI6IjEuMCJ9.WI1TBHaE4Hhvef2mZVyyNhPpKLglnhiSTpr9uxb3DSkev8xpkcEE1Aga8NQjst7JfS6Hti9KC3tfTBGgmY6agZMUOMGrVk41LIcebmGHqwM3PIyxFxkUrzTvUA83XRBJOniivcHQSW4ffEUDr6c2Lsj24z0f713D34lK7iVgApHwDzu1u2nesP8q-DBz9wld7HkM3QCgVo-eJqFo2L61LkS-z11r7IQqbNk1hVNng4d38RWu1axm4rbigScwPUC7Hautv98fKMN1jc5-4yL8SKGvDkWvdsiQhxr7toBEPDaQCvV3JWkD6EIequwpl7v96z6CKyQeCDvskoBJjBjolg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/LowCostGet3Min;4997,Microsoft.Compute/LowCostGet30Min;19993
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131626781321631045
+      X-Ms-Request-Id:
+      - 3a33fe62-8353-4f0b-8ac8-b0698abe8773
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Correlation-Request-Id:
+      - ad61d263-1af7-4f64-b6eb-e8141e3d47d2
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T093303Z:ad61d263-1af7-4f64-b6eb-e8141e3d47d2
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:33:03 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"managedBy\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed\",\r\n
+        \ \"sku\": {\r\n    \"name\": \"Standard_LRS\",\r\n    \"tier\": \"Standard\"\r\n
+        \ },\r\n  \"properties\": {\r\n    \"osType\": \"Linux\",\r\n    \"creationData\":
+        {\r\n      \"createOption\": \"FromImage\",\r\n      \"imageReference\": {\r\n
+        \       \"id\": \"/Subscriptions/AZURE_SUBSCRIPTION_ID/Providers/Microsoft.Compute/Locations/eastus/Publishers/RedHat/ArtifactTypes/VMImage/Offers/RHEL/Skus/7.3/Versions/latest\"\r\n
+        \     }\r\n    },\r\n    \"diskSizeGB\": 32,\r\n    \"timeCreated\": \"2017-05-04T21:21:55.7801928+00:00\",\r\n
+        \   \"provisioningState\": \"Succeeded\",\r\n    \"diskState\": \"Reserved\"\r\n
+        \ },\r\n  \"type\": \"Microsoft.Compute/disks\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"tags\": {\r\n    \"delete\": \"false\"\r\n  },\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/disks/miqazure-linux-managed_OsDisk_1_7b2bdf790a7d4379ace2846d307730cd\",\r\n
+        \ \"name\": \"miqazure-linux-managed_OsDisk_1_7b2bdf790a7d4379ace2846d307730cd\"\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:33:08 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDY4NjEsIm5iZiI6MTUyMDg0Njg2MSwiZXhwIjoxNTIwODUwNzYxLCJhaW8iOiJZMk5nWU9BNzd0MVE5WExDVWhQalA5eGZ4WHhmQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVl9iZXN6cE1Ka1NYSjI5ZlhaWWlBQSIsInZlciI6IjEuMCJ9.WI1TBHaE4Hhvef2mZVyyNhPpKLglnhiSTpr9uxb3DSkev8xpkcEE1Aga8NQjst7JfS6Hti9KC3tfTBGgmY6agZMUOMGrVk41LIcebmGHqwM3PIyxFxkUrzTvUA83XRBJOniivcHQSW4ffEUDr6c2Lsj24z0f713D34lK7iVgApHwDzu1u2nesP8q-DBz9wld7HkM3QCgVo-eJqFo2L61LkS-z11r7IQqbNk1hVNng4d38RWu1axm4rbigScwPUC7Hautv98fKMN1jc5-4yL8SKGvDkWvdsiQhxr7toBEPDaQCvV3JWkD6EIequwpl7v96z6CKyQeCDvskoBJjBjolg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 92588a1c-39a5-44a8-8272-2b2a5e6a2ede
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Correlation-Request-Id:
+      - 1de00cff-ce63-472f-9f35-e5a39492b8c7
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T093304Z:1de00cff-ce63-472f-9f35-e5a39492b8c7
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:33:03 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"miqazure-linux-managed-nsg\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg\",\r\n
+        \ \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/networkSecurityGroups\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
+        \"b4611f96-94a8-4486-94c5-16bb6c7a5c84\",\r\n    \"securityRules\": [\r\n
+        \     {\r\n        \"name\": \"default-allow-ssh\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/securityRules/default-allow-ssh\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"protocol\": \"TCP\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"22\",\r\n          \"sourceAddressPrefix\":
+        \"*\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n          \"access\":
+        \"Allow\",\r\n          \"priority\": 1000,\r\n          \"direction\": \"Inbound\",\r\n
+        \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      }\r\n    ],\r\n    \"defaultSecurityRules\": [\r\n
+        \     {\r\n        \"name\": \"AllowVnetInBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/AllowVnetInBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow inbound traffic from all VMs in VNET\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"VirtualNetwork\",\r\n          \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n          \"direction\":
+        \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowAzureLoadBalancerInBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/AllowAzureLoadBalancerInBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow inbound traffic from azure load balancer\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"AzureLoadBalancer\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65001,\r\n          \"direction\":
+        \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllInBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/DenyAllInBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Deny all inbound traffic\",\r\n          \"protocol\":
+        \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\":
+        \"*\",\r\n          \"sourceAddressPrefix\": \"*\",\r\n          \"destinationAddressPrefix\":
+        \"*\",\r\n          \"access\": \"Deny\",\r\n          \"priority\": 65500,\r\n
+        \         \"direction\": \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n
+        \         \"destinationPortRanges\": [],\r\n          \"sourceAddressPrefixes\":
+        [],\r\n          \"destinationAddressPrefixes\": []\r\n        }\r\n      },\r\n
+        \     {\r\n        \"name\": \"AllowVnetOutBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/AllowVnetOutBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow outbound traffic from all VMs to all VMs
+        in VNET\",\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\":
+        \"*\",\r\n          \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"VirtualNetwork\",\r\n          \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n          \"direction\":
+        \"Outbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowInternetOutBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/AllowInternetOutBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow outbound traffic from all VMs to Internet\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"*\",\r\n          \"destinationAddressPrefix\": \"Internet\",\r\n          \"access\":
+        \"Allow\",\r\n          \"priority\": 65001,\r\n          \"direction\": \"Outbound\",\r\n
+        \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllOutBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/DenyAllOutBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Deny all outbound traffic\",\r\n          \"protocol\":
+        \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\":
+        \"*\",\r\n          \"sourceAddressPrefix\": \"*\",\r\n          \"destinationAddressPrefix\":
+        \"*\",\r\n          \"access\": \"Deny\",\r\n          \"priority\": 65500,\r\n
+        \         \"direction\": \"Outbound\",\r\n          \"sourcePortRanges\":
+        [],\r\n          \"destinationPortRanges\": [],\r\n          \"sourceAddressPrefixes\":
+        [],\r\n          \"destinationAddressPrefixes\": []\r\n        }\r\n      }\r\n
+        \   ],\r\n    \"networkInterfaces\": [\r\n      {\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944\"\r\n
+        \     }\r\n    ]\r\n  }\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:33:08 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDY4NjEsIm5iZiI6MTUyMDg0Njg2MSwiZXhwIjoxNTIwODUwNzYxLCJhaW8iOiJZMk5nWU9BNzd0MVE5WExDVWhQalA5eGZ4WHhmQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVl9iZXN6cE1Ka1NYSjI5ZlhaWWlBQSIsInZlciI6IjEuMCJ9.WI1TBHaE4Hhvef2mZVyyNhPpKLglnhiSTpr9uxb3DSkev8xpkcEE1Aga8NQjst7JfS6Hti9KC3tfTBGgmY6agZMUOMGrVk41LIcebmGHqwM3PIyxFxkUrzTvUA83XRBJOniivcHQSW4ffEUDr6c2Lsj24z0f713D34lK7iVgApHwDzu1u2nesP8q-DBz9wld7HkM3QCgVo-eJqFo2L61LkS-z11r7IQqbNk1hVNng4d38RWu1axm4rbigScwPUC7Hautv98fKMN1jc5-4yL8SKGvDkWvdsiQhxr7toBEPDaQCvV3JWkD6EIequwpl7v96z6CKyQeCDvskoBJjBjolg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"f5bbd20f-7ae4-4b6d-89c8-eb3481fcbe05"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - b1622a0b-e88e-44aa-a299-d967defb5a38
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Correlation-Request-Id:
+      - b8ddb118-db83-4e64-99b7-ef1d665ed3fd
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T093304Z:b8ddb118-db83-4e64-99b7-ef1d665ed3fd
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:33:04 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"miq-azure-test2\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2\",\r\n
+        \ \"etag\": \"W/\\\"f5bbd20f-7ae4-4b6d-89c8-eb3481fcbe05\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
+        \"f950a3cf-749a-49d5-a7fb-33a400b0e93c\",\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\":
+        [\r\n        \"172.25.0.0/16\"\r\n      ]\r\n    },\r\n    \"subnets\": [\r\n
+        \     {\r\n        \"name\": \"default\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2/subnets/default\",\r\n
+        \       \"etag\": \"W/\\\"f5bbd20f-7ae4-4b6d-89c8-eb3481fcbe05\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"addressPrefix\": \"172.25.0.0/24\",\r\n          \"ipConfigurations\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944/ipConfigurations/ipconfig1\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"virtualNetworkPeerings\":
+        [],\r\n    \"enableDdosProtection\": false,\r\n    \"enableVmProtection\":
+        false\r\n  }\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:33:09 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_500/cloud_network_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_500/cloud_network_refresh.yml
@@ -1,6 +1,62 @@
 ---
 http_interactions:
 - request:
+    method: post
+    uri: https://login.microsoftonline.com/AZURE_TENANT_ID/oauth2/token
+    body:
+      encoding: UTF-8
+      string: grant_type=client_credentials&client_id=AZURE_CLIENT_ID&client_secret=AZURE_CLIENT_SECRET&resource=https%3A%2F%2Fmanagement.azure.com%2F
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Server:
+      - Microsoft-IIS/10.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Request-Id:
+      - 04f92515-66a0-4c15-acc7-82520ec92f00
+      P3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Set-Cookie:
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHz2F1B63pk6qoEd28g4I4zfdk2t-I8tlEYd6oHXnrsLpXq_6xmWRoG0jj2a5YXyAFb6kD62OeXeNJBxPyRhVD4hlaWo3brcQPE_Y5fkj-0yVDKctkRrxFk0R-DByygq1rvaPUNEIDi4HLiehDvXvL0GP8q8h-5zwJRngGvCrDjZPogAA;
+        domain=.login.microsoftonline.com; path=/; secure; HttpOnly
+      - stsservicecookie=ests; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=006; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Tue, 13 Mar 2018 09:02:46 GMT
+      Content-Length:
+      - '1505'
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1520935366","not_before":"1520931466","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA5MzE0NjYsIm5iZiI6MTUyMDkzMTQ2NiwiZXhwIjoxNTIwOTM1MzY2LCJhaW8iOiJZMk5nWUpodFB0a2k2MFo1cHgyTHlWdHU5NzI3QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRlNYNUJLQm1GVXlzeDRKU0Rza3ZBQSIsInZlciI6IjEuMCJ9.LOXGqbA45pjWCfw4rpBRTXfEnGRF8CSca7vbVwwI5pBqyRA3Yv4Lb8Vype6chOYSxkjvyf95SjYb22uSyan-nN-EVvZBgEgV_tDHMr7nYHlPLR2N4hYV4TyFzwKYHPxutefxZXW0PCh6KJ3V1z6a1A139khn8Rs4M-WpY7GEvJFwi9uaxudsdu2lwnxch19BZI4KpX8VoSPOPkUBydoX0h3lpSBfSiubYNRf-Qw2UqdHu0fiFQBqns53MQYSuv4k7nBCjXeV5TLZVIopJCqjQbFjYQIy4jkALks7MUWzatu9LscBZm-7ZA1-LVw7OkmlNDTe6wMddvPbrem144KOpw"}'
+    http_version: 
+  recorded_at: Tue, 13 Mar 2018 09:02:47 GMT
+- request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
     body:
@@ -16,7 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA5MzE0NjYsIm5iZiI6MTUyMDkzMTQ2NiwiZXhwIjoxNTIwOTM1MzY2LCJhaW8iOiJZMk5nWUpodFB0a2k2MFo1cHgyTHlWdHU5NzI3QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRlNYNUJLQm1GVXlzeDRKU0Rza3ZBQSIsInZlciI6IjEuMCJ9.LOXGqbA45pjWCfw4rpBRTXfEnGRF8CSca7vbVwwI5pBqyRA3Yv4Lb8Vype6chOYSxkjvyf95SjYb22uSyan-nN-EVvZBgEgV_tDHMr7nYHlPLR2N4hYV4TyFzwKYHPxutefxZXW0PCh6KJ3V1z6a1A139khn8Rs4M-WpY7GEvJFwi9uaxudsdu2lwnxch19BZI4KpX8VoSPOPkUBydoX0h3lpSBfSiubYNRf-Qw2UqdHu0fiFQBqns53MQYSuv4k7nBCjXeV5TLZVIopJCqjQbFjYQIy4jkALks7MUWzatu9LscBZm-7ZA1-LVw7OkmlNDTe6wMddvPbrem144KOpw
   response:
     status:
       code: 200
@@ -35,26 +91,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14997'
+      - '14999'
       X-Ms-Request-Id:
-      - cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - cc5e7310-3e78-42b7-8765-ea6dc394daed
       X-Ms-Correlation-Request-Id:
-      - cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - cc5e7310-3e78-42b7-8765-ea6dc394daed
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102417Z:cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - WESTEUROPE:20180313T090247Z:cc5e7310-3e78-42b7-8765-ea6dc394daed
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:17 GMT
+      - Tue, 13 Mar 2018 09:02:46 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID","subscriptionId":"AZURE_SUBSCRIPTION_ID","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:22 GMT
+  recorded_at: Tue, 13 Mar 2018 09:02:47 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers?api-version=2015-01-01
@@ -71,7 +127,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA5MzE0NjYsIm5iZiI6MTUyMDkzMTQ2NiwiZXhwIjoxNTIwOTM1MzY2LCJhaW8iOiJZMk5nWUpodFB0a2k2MFo1cHgyTHlWdHU5NzI3QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRlNYNUJLQm1GVXlzeDRKU0Rza3ZBQSIsInZlciI6IjEuMCJ9.LOXGqbA45pjWCfw4rpBRTXfEnGRF8CSca7vbVwwI5pBqyRA3Yv4Lb8Vype6chOYSxkjvyf95SjYb22uSyan-nN-EVvZBgEgV_tDHMr7nYHlPLR2N4hYV4TyFzwKYHPxutefxZXW0PCh6KJ3V1z6a1A139khn8Rs4M-WpY7GEvJFwi9uaxudsdu2lwnxch19BZI4KpX8VoSPOPkUBydoX0h3lpSBfSiubYNRf-Qw2UqdHu0fiFQBqns53MQYSuv4k7nBCjXeV5TLZVIopJCqjQbFjYQIy4jkALks7MUWzatu9LscBZm-7ZA1-LVw7OkmlNDTe6wMddvPbrem144KOpw
   response:
     status:
       code: 200
@@ -88,21 +144,21 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - '14929'
       X-Ms-Request-Id:
-      - fe3532ca-59a2-474e-9094-8a3697b82bef
+      - fdaa3e45-3759-4577-bbf6-3e54d5338afc
       X-Ms-Correlation-Request-Id:
-      - fe3532ca-59a2-474e-9094-8a3697b82bef
+      - fdaa3e45-3759-4577-bbf6-3e54d5338afc
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102419Z:fe3532ca-59a2-474e-9094-8a3697b82bef
+      - WESTEUROPE:20180313T090248Z:fdaa3e45-3759-4577-bbf6-3e54d5338afc
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:18 GMT
+      - Tue, 13 Mar 2018 09:02:48 GMT
       Content-Length:
-      - '320853'
+      - '322992'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"},{"applicationId":"d87dcbc6-a371-462e-88e3-28ad15ec4e64","roleDefinitionId":"861776c5-e0df-4f95-be4f-ac1eec193323"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["East
@@ -442,7 +498,10 @@ http_interactions:
         Central US","West Europe","North Europe","East US","UK West","UK South","West
         Central US","West US 2","South India","Central India","West India","Canada
         East","Canada Central","Korea South","Korea Central"],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"managedClusters","locations":["East
-        US","West Europe","Central US","Canada Central","Canada East"],"apiVersions":["2017-08-31"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
+        US","West Europe","Central US","Canada Central","Canada East"],"apiVersions":["2017-08-31"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operationresults","locations":["East
+        US","West Europe","Central US","UK West","UK South","West Central US","West
+        US 2","South India","Central India","West India","Canada East","Canada Central","Korea
+        South","Korea Central"],"apiVersions":["2017-08-31","2016-03-30"]},{"resourceType":"locations/operations","locations":["Japan
         East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
@@ -510,7 +569,7 @@ http_interactions:
         US","South Central US","North Europe","West Europe","Southeast Asia","West
         US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"listMigrationdate","locations":["East
         US","South Central US","North Europe","West Europe","Southeast Asia","West
-        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2018-03-01","2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
@@ -612,47 +671,47 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"networkWatchers/lenses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"networkWatchers/lenses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -662,47 +721,52 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2018-02-01","2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"ddosProtectionPlans","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","West
         US 2","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
@@ -1438,57 +1502,57 @@ http_interactions:
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/asyncoperations","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/asyncoperations","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/listAccountSas","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/listAccountSas","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/listServiceSas","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/listServiceSas","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/blobServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/blobServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/tableServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/tableServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/queueServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/queueServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/fileServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/fileServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01","2016-01-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01","2016-01-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
         US","West US","West Europe","North Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":["East
         US","West US","West Europe","North Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.visualstudio","namespace":"microsoft.visualstudio","authorization":{"applicationId":"499b84ac-1321-427f-aa17-267ca6975798","roleDefinitionId":"6a18f445-86f0-4e2e-b8a9-6b9b5677e3d8"},"resourceTypes":[{"resourceType":"account","locations":["North
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.visualstudio","namespace":"microsoft.visualstudio","authorization":{"applicationId":"499b84ac-1321-427f-aa17-267ca6975798","roleDefinitionId":"6a18f445-86f0-4e2e-b8a9-6b9b5677e3d8"},"resourceTypes":[{"resourceType":"account","locations":["North
         Central US","South Central US","East US","West US","Central US","North Europe","West
         Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
         East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/project","locations":["North
@@ -2173,7 +2237,8 @@ http_interactions:
         US","West US 2","East US","East US 2","North Europe","West Europe","Southeast
         Asia","East Asia","North Central US","South Central US","Japan West","Australia
         East","Brazil South","Central India","West Central US","Canada Central","UK
-        South"],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ServiceBus","namespace":"Microsoft.ServiceBus","authorization":{"applicationId":"80a10ef9-8168-493d-abf9-3297c4ef6e3c","roleDefinitionId":"2b7763f7-bbe2-4e19-befe-28c79f1cf7f7"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        South"],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.SecurityGraph","namespace":"Microsoft.SecurityGraph","resourceTypes":[{"resourceType":"operations","locations":["West
+        US"],"apiVersions":["2017-04-01-preview"]},{"resourceType":"diagnosticSettings","locations":[],"apiVersions":["2017-04-01-preview"]},{"resourceType":"diagnosticSettingsCategories","locations":[],"apiVersions":["2017-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ServiceBus","namespace":"Microsoft.ServiceBus","authorization":{"applicationId":"80a10ef9-8168-493d-abf9-3297c4ef6e3c","roleDefinitionId":"2b7763f7-bbe2-4e19-befe-28c79f1cf7f7"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US 2","West
         US","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
@@ -2322,10 +2387,10 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:23 GMT
+  recorded_at: Tue, 13 Mar 2018 09:02:49 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2?api-version=2018-03-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2339,7 +2404,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA5MzE0NjYsIm5iZiI6MTUyMDkzMTQ2NiwiZXhwIjoxNTIwOTM1MzY2LCJhaW8iOiJZMk5nWUpodFB0a2k2MFo1cHgyTHlWdHU5NzI3QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRlNYNUJLQm1GVXlzeDRKU0Rza3ZBQSIsInZlciI6IjEuMCJ9.LOXGqbA45pjWCfw4rpBRTXfEnGRF8CSca7vbVwwI5pBqyRA3Yv4Lb8Vype6chOYSxkjvyf95SjYb22uSyan-nN-EVvZBgEgV_tDHMr7nYHlPLR2N4hYV4TyFzwKYHPxutefxZXW0PCh6KJ3V1z6a1A139khn8Rs4M-WpY7GEvJFwi9uaxudsdu2lwnxch19BZI4KpX8VoSPOPkUBydoX0h3lpSBfSiubYNRf-Qw2UqdHu0fiFQBqns53MQYSuv4k7nBCjXeV5TLZVIopJCqjQbFjYQIy4jkALks7MUWzatu9LscBZm-7ZA1-LVw7OkmlNDTe6wMddvPbrem144KOpw
   response:
     status:
       code: 200
@@ -2356,294 +2421,42 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67"
+      - W/"f5bbd20f-7ae4-4b6d-89c8-eb3481fcbe05"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - '080de667-081e-4d58-9e94-9e7243d4200e'
+      - 72897033-e6ea-42a0-863a-26c8f22f3554
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
+      - '14915'
       X-Ms-Correlation-Request-Id:
-      - '093d49ac-c85f-440e-956b-955b6698dd19'
+      - ff19a40f-7af0-42d4-9004-4a4123278516
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102419Z:093d49ac-c85f-440e-956b-955b6698dd19
+      - WESTEUROPE:20180313T090250Z:ff19a40f-7af0-42d4-9004-4a4123278516
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:19 GMT
+      - Tue, 13 Mar 2018 09:02:50 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1\",\r\n
-        \ \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"7ab88756-810f-4083-95db-8b05d50e38f2\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
+      string: "{\r\n  \"name\": \"miq-azure-test2\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2\",\r\n
+        \ \"etag\": \"W/\\\"f5bbd20f-7ae4-4b6d-89c8-eb3481fcbe05\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
+        \"f950a3cf-749a-49d5-a7fb-33a400b0e93c\",\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\":
+        [\r\n        \"172.25.0.0/16\"\r\n      ]\r\n    },\r\n    \"subnets\": [\r\n
+        \     {\r\n        \"name\": \"default\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2/subnets/default\",\r\n
+        \       \"etag\": \"W/\\\"f5bbd20f-7ae4-4b6d-89c8-eb3481fcbe05\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ],\r\n          \"inboundNatRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"backendIPConfigurations\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\"\r\n
-        \           }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-rule\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\":
-        80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\"\r\n
-        \         },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n
-        \       \"name\": \"rspec-lb-probe\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-NAT\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 3441,\r\n          \"backendPort\":
-        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
+        \         \"addressPrefix\": \"172.25.0.0/24\",\r\n          \"ipConfigurations\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944/ipConfigurations/ipconfig1\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"virtualNetworkPeerings\":
+        [],\r\n    \"enableDdosProtection\": false,\r\n    \"enableVmProtection\":
+        false\r\n  }\r\n}"
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:24 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"7a8e5fe7-f777-4435-992b-a54f28c2f28c"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - bd22ca22-a01f-4ecf-9230-a4558fb66931
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Correlation-Request-Id:
-      - 19c674a8-c8da-4b5e-8265-5ebc21926459
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102420Z:19c674a8-c8da-4b5e-8265-5ebc21926459
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Mon, 12 Mar 2018 10:24:19 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb2\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2\",\r\n
-        \ \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"e2e30a77-f81b-43fc-9693-08303e43deed\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/backendAddressPools/rspec-lb2-pool\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\r\n
-        \       }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\": [],\r\n    \"probes\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-probe\",\r\n        \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/probes/rspec-lb2-probe\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\": [],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:25 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"a38434c8-7b23-4092-b7c6-402238eac0dc"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 0fd15240-6a1c-4b39-a4f6-aa53fd8591c2
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Correlation-Request-Id:
-      - 5cc03163-922e-41a1-9601-dba2d7cf2a81
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102421Z:5cc03163-922e-41a1-9601-dba2d7cf2a81
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Mon, 12 Mar 2018 10:24:20 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb1-LoadBalancerFrontEnd\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\",\r\n
-        \ \"etag\": \"W/\\\"a38434c8-7b23-4092-b7c6-402238eac0dc\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"f28e0f25-b372-4edf-97d9-13a9e3b4ba2d\",\r\n    \"ipAddress\":
-        \"40.71.82.83\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\":
-        \"Static\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipTags\": [],\r\n
-        \   \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
-        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:25 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"cddd97d1-6111-4477-8a00-3dc885237a1d"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 1403e5b6-8fa0-4cd3-89b1-76b6c4fd805b
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
-      X-Ms-Correlation-Request-Id:
-      - e4a5f369-a742-466f-bd8f-42e17eaaf9c9
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102421Z:e4a5f369-a742-466f-bd8f-42e17eaaf9c9
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Mon, 12 Mar 2018 10:24:21 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb2-publicip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\",\r\n
-        \ \"etag\": \"W/\\\"cddd97d1-6111-4477-8a00-3dc885237a1d\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"83e7257d-ab94-4229-8eb5-4798f37ef28d\",\r\n    \"publicIPAddressVersion\":
-        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
-        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
-        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:26 GMT
+  recorded_at: Tue, 13 Mar 2018 09:02:50 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_500/lb_created_by_stack_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_500/lb_created_by_stack_refresh.yml
@@ -1,6 +1,62 @@
 ---
 http_interactions:
 - request:
+    method: post
+    uri: https://login.microsoftonline.com/AZURE_TENANT_ID/oauth2/token
+    body:
+      encoding: UTF-8
+      string: grant_type=client_credentials&client_id=AZURE_CLIENT_ID&client_secret=AZURE_CLIENT_SECRET&resource=https%3A%2F%2Fmanagement.azure.com%2F
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Server:
+      - Microsoft-IIS/10.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Request-Id:
+      - 9c781c1b-7a30-4ce6-a629-340e97e72100
+      P3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Set-Cookie:
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzWmfjDgsHXoDvEy5oA5TMJEbDdO8zxBXdS7RHHjN7zPZOlM42Qtczm08JIw1KrShlSy93xWjbn4B13n7mV-Cvwtwlf1RfANgJIYQCaxYw1Ihboq97aFTxgMnw9pPuFfmo54bL8ERCYg9lbwTH5SsE71X3n1MECwoQKkwRlsPNg6kgAA;
+        domain=.login.microsoftonline.com; path=/; secure; HttpOnly
+      - stsservicecookie=ests; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=002; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 12 Mar 2018 09:39:26 GMT
+      Content-Length:
+      - '1505'
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"Bearer","expires_in":"3600","ext_expires_in":"0","expires_on":"1520851166","not_before":"1520847266","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcyNjYsIm5iZiI6MTUyMDg0NzI2NiwiZXhwIjoxNTIwODUxMTY2LCJhaW8iOiJZMk5nWU9pZjhIM2h2ZG1iNVp0K21NbjdkcjI1QkFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiR3h4NG5EQjY1a3ltS1RRT2wtY2hBQSIsInZlciI6IjEuMCJ9.b5p2WqzxZ7hC1qKjvFRL22Z_MIE9xpftr5y_9MsIxUahEmGDY6vICoRrwDDPM7HhQZvZpCzU-rXlwkTGA_skkaKaqGKgNwU3nYJNu6x3QEv5q1ir79clNo6jAjFc8dRfgzFQ_9MfJoPdZiDKkXNuan7Vuv2STIXcad3XyvAiodhwkj6ZYw30rV-6mhl0r_g4ho-qserXO_yB9T9FJqaosr8fNxeu99TSIC4xXpSotSwJT9NyyPanDhwnsmureyVGn8WY8HpTziN-sFaBd8VI2PwU_CWag30sn5qWpqvyrAO7_ukM64W7xtwtZre_lAn9ULZC-IBFon6QkLFBdtBjvg"}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:39:31 GMT
+- request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
     body:
@@ -16,7 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcyNjYsIm5iZiI6MTUyMDg0NzI2NiwiZXhwIjoxNTIwODUxMTY2LCJhaW8iOiJZMk5nWU9pZjhIM2h2ZG1iNVp0K21NbjdkcjI1QkFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiR3h4NG5EQjY1a3ltS1RRT2wtY2hBQSIsInZlciI6IjEuMCJ9.b5p2WqzxZ7hC1qKjvFRL22Z_MIE9xpftr5y_9MsIxUahEmGDY6vICoRrwDDPM7HhQZvZpCzU-rXlwkTGA_skkaKaqGKgNwU3nYJNu6x3QEv5q1ir79clNo6jAjFc8dRfgzFQ_9MfJoPdZiDKkXNuan7Vuv2STIXcad3XyvAiodhwkj6ZYw30rV-6mhl0r_g4ho-qserXO_yB9T9FJqaosr8fNxeu99TSIC4xXpSotSwJT9NyyPanDhwnsmureyVGn8WY8HpTziN-sFaBd8VI2PwU_CWag30sn5qWpqvyrAO7_ukM64W7xtwtZre_lAn9ULZC-IBFon6QkLFBdtBjvg
   response:
     status:
       code: 200
@@ -35,26 +91,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14997'
+      - '14999'
       X-Ms-Request-Id:
-      - cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - 35c8ef15-132a-4bab-8c14-855bc2e33529
       X-Ms-Correlation-Request-Id:
-      - cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - 35c8ef15-132a-4bab-8c14-855bc2e33529
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102417Z:cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - WESTEUROPE:20180312T093926Z:35c8ef15-132a-4bab-8c14-855bc2e33529
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:17 GMT
+      - Mon, 12 Mar 2018 09:39:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID","subscriptionId":"AZURE_SUBSCRIPTION_ID","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:22 GMT
+  recorded_at: Mon, 12 Mar 2018 09:39:31 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers?api-version=2015-01-01
@@ -71,7 +127,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcyNjYsIm5iZiI6MTUyMDg0NzI2NiwiZXhwIjoxNTIwODUxMTY2LCJhaW8iOiJZMk5nWU9pZjhIM2h2ZG1iNVp0K21NbjdkcjI1QkFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiR3h4NG5EQjY1a3ltS1RRT2wtY2hBQSIsInZlciI6IjEuMCJ9.b5p2WqzxZ7hC1qKjvFRL22Z_MIE9xpftr5y_9MsIxUahEmGDY6vICoRrwDDPM7HhQZvZpCzU-rXlwkTGA_skkaKaqGKgNwU3nYJNu6x3QEv5q1ir79clNo6jAjFc8dRfgzFQ_9MfJoPdZiDKkXNuan7Vuv2STIXcad3XyvAiodhwkj6ZYw30rV-6mhl0r_g4ho-qserXO_yB9T9FJqaosr8fNxeu99TSIC4xXpSotSwJT9NyyPanDhwnsmureyVGn8WY8HpTziN-sFaBd8VI2PwU_CWag30sn5qWpqvyrAO7_ukM64W7xtwtZre_lAn9ULZC-IBFon6QkLFBdtBjvg
   response:
     status:
       code: 200
@@ -88,19 +144,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - '14994'
       X-Ms-Request-Id:
-      - fe3532ca-59a2-474e-9094-8a3697b82bef
+      - b731bdda-1c41-4860-be63-1e5cd8e4d306
       X-Ms-Correlation-Request-Id:
-      - fe3532ca-59a2-474e-9094-8a3697b82bef
+      - b731bdda-1c41-4860-be63-1e5cd8e4d306
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102419Z:fe3532ca-59a2-474e-9094-8a3697b82bef
+      - WESTEUROPE:20180312T093928Z:b731bdda-1c41-4860-be63-1e5cd8e4d306
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:18 GMT
+      - Mon, 12 Mar 2018 09:39:27 GMT
       Content-Length:
       - '320853'
     body:
@@ -2322,10 +2378,10 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:23 GMT
+  recorded_at: Mon, 12 Mar 2018 09:39:33 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb?api-version=2018-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2339,7 +2395,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcyNjYsIm5iZiI6MTUyMDg0NzI2NiwiZXhwIjoxNTIwODUxMTY2LCJhaW8iOiJZMk5nWU9pZjhIM2h2ZG1iNVp0K21NbjdkcjI1QkFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiR3h4NG5EQjY1a3ltS1RRT2wtY2hBQSIsInZlciI6IjEuMCJ9.b5p2WqzxZ7hC1qKjvFRL22Z_MIE9xpftr5y_9MsIxUahEmGDY6vICoRrwDDPM7HhQZvZpCzU-rXlwkTGA_skkaKaqGKgNwU3nYJNu6x3QEv5q1ir79clNo6jAjFc8dRfgzFQ_9MfJoPdZiDKkXNuan7Vuv2STIXcad3XyvAiodhwkj6ZYw30rV-6mhl0r_g4ho-qserXO_yB9T9FJqaosr8fNxeu99TSIC4xXpSotSwJT9NyyPanDhwnsmureyVGn8WY8HpTziN-sFaBd8VI2PwU_CWag30sn5qWpqvyrAO7_ukM64W7xtwtZre_lAn9ULZC-IBFon6QkLFBdtBjvg
   response:
     status:
       code: 200
@@ -2356,87 +2412,96 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67"
+      - W/"92982330-0f29-406e-bba9-ad19198579a5"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - '080de667-081e-4d58-9e94-9e7243d4200e'
+      - 78d1076e-92f3-4324-a22b-9f88f4d88043
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
+      - '14993'
       X-Ms-Correlation-Request-Id:
-      - '093d49ac-c85f-440e-956b-955b6698dd19'
+      - fa0cd948-4f63-4975-8d66-2e81428158f7
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102419Z:093d49ac-c85f-440e-956b-955b6698dd19
+      - WESTEUROPE:20180312T093929Z:fa0cd948-4f63-4975-8d66-2e81428158f7
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:19 GMT
+      - Mon, 12 Mar 2018 09:39:29 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1\",\r\n
-        \ \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n  \"type\":
+      string: "{\r\n  \"name\": \"spec0deply1lb\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb\",\r\n
+        \ \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n  \"type\":
         \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"7ab88756-810f-4083-95db-8b05d50e38f2\",\r\n
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"8cd72f7c-03bd-4584-abc6-d9ce77ae6202\",\r\n
         \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
+        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\"\r\n
+        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip\"\r\n
         \         },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
         \           }\r\n          ],\r\n          \"inboundNatRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\"\r\n
+        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1\"\r\n
         \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
+        [\r\n      {\r\n        \"name\": \"BackendPool1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\",\r\n
+        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"backendIPConfigurations\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\"\r\n
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1\"\r\n
         \           }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
+        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
         \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-rule\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
+        [\r\n      {\r\n        \"name\": \"LBRule\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\",\r\n
+        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
+        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
         \         },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\":
         80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
+        5,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
         false,\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\"\r\n
-        \         },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\"\r\n
+        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\"\r\n
+        \         },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/probes/tcpProbe\"\r\n
         \         }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n
-        \       \"name\": \"rspec-lb-probe\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
+        \       \"name\": \"tcpProbe\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/probes/tcpProbe\",\r\n
+        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
+        \         \"protocol\": \"Tcp\",\r\n          \"port\": 80,\r\n          \"intervalInSeconds\":
+        5,\r\n          \"numberOfProbes\": 2,\r\n          \"loadBalancingRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
         \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-NAT\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
+        [\r\n      {\r\n        \"name\": \"RDP-VM0\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0\",\r\n
+        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 3441,\r\n          \"backendPort\":
+        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
+        \         },\r\n          \"frontendPort\": 50001,\r\n          \"backendPort\":
         3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
         4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
+        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1\"\r\n
+        \         }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"RDP-VM1\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1\",\r\n
+        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
+        \         },\r\n          \"frontendPort\": 50002,\r\n          \"backendPort\":
+        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
+        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
+        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1\"\r\n
         \         }\r\n        }\r\n      }\r\n    ],\r\n    \"outboundNatRules\":
         [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
         \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:24 GMT
+  recorded_at: Mon, 12 Mar 2018 09:39:34 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip?api-version=2018-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2450,7 +2515,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcyNjYsIm5iZiI6MTUyMDg0NzI2NiwiZXhwIjoxNTIwODUxMTY2LCJhaW8iOiJZMk5nWU9pZjhIM2h2ZG1iNVp0K21NbjdkcjI1QkFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiR3h4NG5EQjY1a3ltS1RRT2wtY2hBQSIsInZlciI6IjEuMCJ9.b5p2WqzxZ7hC1qKjvFRL22Z_MIE9xpftr5y_9MsIxUahEmGDY6vICoRrwDDPM7HhQZvZpCzU-rXlwkTGA_skkaKaqGKgNwU3nYJNu6x3QEv5q1ir79clNo6jAjFc8dRfgzFQ_9MfJoPdZiDKkXNuan7Vuv2STIXcad3XyvAiodhwkj6ZYw30rV-6mhl0r_g4ho-qserXO_yB9T9FJqaosr8fNxeu99TSIC4xXpSotSwJT9NyyPanDhwnsmureyVGn8WY8HpTziN-sFaBd8VI2PwU_CWag30sn5qWpqvyrAO7_ukM64W7xtwtZre_lAn9ULZC-IBFon6QkLFBdtBjvg
   response:
     status:
       code: 200
@@ -2467,183 +2532,38 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"7a8e5fe7-f777-4435-992b-a54f28c2f28c"
+      - W/"2080997a-38a6-420d-ba86-e9582e1331c7"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - bd22ca22-a01f-4ecf-9230-a4558fb66931
+      - 5d907d8b-933f-45bb-abd1-197a518a8e97
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
+      - '14993'
       X-Ms-Correlation-Request-Id:
-      - 19c674a8-c8da-4b5e-8265-5ebc21926459
+      - 9e8fe4dc-17f2-48a8-9b48-839d19b69c9e
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102420Z:19c674a8-c8da-4b5e-8265-5ebc21926459
+      - WESTEUROPE:20180312T093930Z:9e8fe4dc-17f2-48a8-9b48-839d19b69c9e
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:19 GMT
+      - Mon, 12 Mar 2018 09:39:29 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb2\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2\",\r\n
-        \ \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"e2e30a77-f81b-43fc-9693-08303e43deed\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/backendAddressPools/rspec-lb2-pool\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\r\n
-        \       }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\": [],\r\n    \"probes\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-probe\",\r\n        \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/probes/rspec-lb2-probe\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\": [],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:25 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"a38434c8-7b23-4092-b7c6-402238eac0dc"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 0fd15240-6a1c-4b39-a4f6-aa53fd8591c2
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Correlation-Request-Id:
-      - 5cc03163-922e-41a1-9601-dba2d7cf2a81
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102421Z:5cc03163-922e-41a1-9601-dba2d7cf2a81
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Mon, 12 Mar 2018 10:24:20 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb1-LoadBalancerFrontEnd\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\",\r\n
-        \ \"etag\": \"W/\\\"a38434c8-7b23-4092-b7c6-402238eac0dc\\\"\",\r\n  \"location\":
+      string: "{\r\n  \"name\": \"spec0deply1ip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip\",\r\n
+        \ \"etag\": \"W/\\\"2080997a-38a6-420d-ba86-e9582e1331c7\\\"\",\r\n  \"location\":
         \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"f28e0f25-b372-4edf-97d9-13a9e3b4ba2d\",\r\n    \"ipAddress\":
-        \"40.71.82.83\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\":
-        \"Static\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipTags\": [],\r\n
-        \   \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
-        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:25 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"cddd97d1-6111-4477-8a00-3dc885237a1d"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 1403e5b6-8fa0-4cd3-89b1-76b6c4fd805b
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
-      X-Ms-Correlation-Request-Id:
-      - e4a5f369-a742-466f-bd8f-42e17eaaf9c9
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102421Z:e4a5f369-a742-466f-bd8f-42e17eaaf9c9
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Mon, 12 Mar 2018 10:24:21 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb2-publicip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\",\r\n
-        \ \"etag\": \"W/\\\"cddd97d1-6111-4477-8a00-3dc885237a1d\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"83e7257d-ab94-4229-8eb5-4798f37ef28d\",\r\n    \"publicIPAddressVersion\":
+        \   \"resourceGuid\": \"a08b891e-e45a-4970-aefc-f6c996989490\",\r\n    \"publicIPAddressVersion\":
         \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
-        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
+        4,\r\n    \"dnsSettings\": {\r\n      \"domainNameLabel\": \"spec0deply1dns\",\r\n
+        \     \"fqdn\": \"spec0deply1dns.eastus.cloudapp.azure.com\"\r\n    },\r\n
+        \   \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
         \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
         \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:26 GMT
+  recorded_at: Mon, 12 Mar 2018 09:39:35 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_500/lb_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_500/lb_refresh.yml
@@ -1,6 +1,62 @@
 ---
 http_interactions:
 - request:
+    method: post
+    uri: https://login.microsoftonline.com/AZURE_TENANT_ID/oauth2/token
+    body:
+      encoding: UTF-8
+      string: grant_type=client_credentials&client_id=AZURE_CLIENT_ID&client_secret=AZURE_CLIENT_SECRET&resource=https%3A%2F%2Fmanagement.azure.com%2F
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Server:
+      - Microsoft-IIS/10.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Request-Id:
+      - 51ad7e41-aee4-4300-8796-dfede85c1600
+      P3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Set-Cookie:
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzdD0NXdtWGv8XZtEFw4wBhMw1DuI8OigMw0e2MjYDw9yr8LZubk3eB5OfCIkLuzgvjpm1-Mpbk9Uv0kALLUGcJzN8k10iI068s57lkPT8Je_10xnAQ4APJ4lCp89ZYt-fRLiuxXX3tAV78ibj0csQnL2oNLH72_urM_kxum5-06YgAA;
+        domain=.login.microsoftonline.com; path=/; secure; HttpOnly
+      - stsservicecookie=ests; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=007; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 12 Mar 2018 09:40:04 GMT
+      Content-Length:
+      - '1505'
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1520851204","not_before":"1520847304","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDczMDQsIm5iZiI6MTUyMDg0NzMwNCwiZXhwIjoxNTIwODUxMjA0LCJhaW8iOiJZMk5nWUZDTURXN1VtdTh0c09Udk9hdDMveGVmQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUVg2dFVlU3VBRU9IbHRfdDZGd1dBQSIsInZlciI6IjEuMCJ9.oPK9UvP2DtpWBm9uVnbNsfDLmkJ3ERXY3m_QNp4Z8DTXC9CKG6Tc0vPXYM8iK8DCpAR4qTjeaWdl7ZRAinffuY_b8nKX9uPzHB_ud93QnQm5i53BWSFDrRAjoKoEHERXjA8ZuoBppE4Q4kMqjbV_kEAGKYR4Lj2KvElJyNn3lV3FpaMixpKWz1r6tqTylz1rC7ae7vvj5qPXvdiJ-YOMxk-gQ3WB6dyH_y1mKG7jxlUhBQldD_2nZ61KXrJsR_Hib0rHimogtki9dUAc5iXetEIanJuvWvLk0J67punVbSeXgVaf-1HUlXl0i9VkzMZX3l8OtRpWcZYzUJiiywKbKg"}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:40:08 GMT
+- request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
     body:
@@ -16,7 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDczMDQsIm5iZiI6MTUyMDg0NzMwNCwiZXhwIjoxNTIwODUxMjA0LCJhaW8iOiJZMk5nWUZDTURXN1VtdTh0c09Udk9hdDMveGVmQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUVg2dFVlU3VBRU9IbHRfdDZGd1dBQSIsInZlciI6IjEuMCJ9.oPK9UvP2DtpWBm9uVnbNsfDLmkJ3ERXY3m_QNp4Z8DTXC9CKG6Tc0vPXYM8iK8DCpAR4qTjeaWdl7ZRAinffuY_b8nKX9uPzHB_ud93QnQm5i53BWSFDrRAjoKoEHERXjA8ZuoBppE4Q4kMqjbV_kEAGKYR4Lj2KvElJyNn3lV3FpaMixpKWz1r6tqTylz1rC7ae7vvj5qPXvdiJ-YOMxk-gQ3WB6dyH_y1mKG7jxlUhBQldD_2nZ61KXrJsR_Hib0rHimogtki9dUAc5iXetEIanJuvWvLk0J67punVbSeXgVaf-1HUlXl0i9VkzMZX3l8OtRpWcZYzUJiiywKbKg
   response:
     status:
       code: 200
@@ -35,26 +91,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14997'
+      - '14999'
       X-Ms-Request-Id:
-      - cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - 3f419b4e-d259-4c9c-baec-b421033f0e82
       X-Ms-Correlation-Request-Id:
-      - cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - 3f419b4e-d259-4c9c-baec-b421033f0e82
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102417Z:cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - WESTEUROPE:20180312T094004Z:3f419b4e-d259-4c9c-baec-b421033f0e82
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:17 GMT
+      - Mon, 12 Mar 2018 09:40:03 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID","subscriptionId":"AZURE_SUBSCRIPTION_ID","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:22 GMT
+  recorded_at: Mon, 12 Mar 2018 09:40:09 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers?api-version=2015-01-01
@@ -71,7 +127,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDczMDQsIm5iZiI6MTUyMDg0NzMwNCwiZXhwIjoxNTIwODUxMjA0LCJhaW8iOiJZMk5nWUZDTURXN1VtdTh0c09Udk9hdDMveGVmQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUVg2dFVlU3VBRU9IbHRfdDZGd1dBQSIsInZlciI6IjEuMCJ9.oPK9UvP2DtpWBm9uVnbNsfDLmkJ3ERXY3m_QNp4Z8DTXC9CKG6Tc0vPXYM8iK8DCpAR4qTjeaWdl7ZRAinffuY_b8nKX9uPzHB_ud93QnQm5i53BWSFDrRAjoKoEHERXjA8ZuoBppE4Q4kMqjbV_kEAGKYR4Lj2KvElJyNn3lV3FpaMixpKWz1r6tqTylz1rC7ae7vvj5qPXvdiJ-YOMxk-gQ3WB6dyH_y1mKG7jxlUhBQldD_2nZ61KXrJsR_Hib0rHimogtki9dUAc5iXetEIanJuvWvLk0J67punVbSeXgVaf-1HUlXl0i9VkzMZX3l8OtRpWcZYzUJiiywKbKg
   response:
     status:
       code: 200
@@ -88,19 +144,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - '14996'
       X-Ms-Request-Id:
-      - fe3532ca-59a2-474e-9094-8a3697b82bef
+      - 52fa9352-60cf-453a-aff2-b5d66282d265
       X-Ms-Correlation-Request-Id:
-      - fe3532ca-59a2-474e-9094-8a3697b82bef
+      - 52fa9352-60cf-453a-aff2-b5d66282d265
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102419Z:fe3532ca-59a2-474e-9094-8a3697b82bef
+      - WESTEUROPE:20180312T094007Z:52fa9352-60cf-453a-aff2-b5d66282d265
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:18 GMT
+      - Mon, 12 Mar 2018 09:40:07 GMT
       Content-Length:
       - '320853'
     body:
@@ -2322,7 +2378,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:23 GMT
+  recorded_at: Mon, 12 Mar 2018 09:40:12 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1?api-version=2018-01-01
@@ -2339,7 +2395,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDczMDQsIm5iZiI6MTUyMDg0NzMwNCwiZXhwIjoxNTIwODUxMjA0LCJhaW8iOiJZMk5nWUZDTURXN1VtdTh0c09Udk9hdDMveGVmQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUVg2dFVlU3VBRU9IbHRfdDZGd1dBQSIsInZlciI6IjEuMCJ9.oPK9UvP2DtpWBm9uVnbNsfDLmkJ3ERXY3m_QNp4Z8DTXC9CKG6Tc0vPXYM8iK8DCpAR4qTjeaWdl7ZRAinffuY_b8nKX9uPzHB_ud93QnQm5i53BWSFDrRAjoKoEHERXjA8ZuoBppE4Q4kMqjbV_kEAGKYR4Lj2KvElJyNn3lV3FpaMixpKWz1r6tqTylz1rC7ae7vvj5qPXvdiJ-YOMxk-gQ3WB6dyH_y1mKG7jxlUhBQldD_2nZ61KXrJsR_Hib0rHimogtki9dUAc5iXetEIanJuvWvLk0J67punVbSeXgVaf-1HUlXl0i9VkzMZX3l8OtRpWcZYzUJiiywKbKg
   response:
     status:
       code: 200
@@ -2360,22 +2416,22 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - '080de667-081e-4d58-9e94-9e7243d4200e'
+      - 3233ae61-5dfa-4080-a0e1-49a77d84dca9
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
+      - '14996'
       X-Ms-Correlation-Request-Id:
-      - '093d49ac-c85f-440e-956b-955b6698dd19'
+      - bb819b9b-6a2d-4cf2-b3c3-83de4c24da1f
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102419Z:093d49ac-c85f-440e-956b-955b6698dd19
+      - WESTEUROPE:20180312T094008Z:bb819b9b-6a2d-4cf2-b3c3-83de4c24da1f
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:19 GMT
+      - Mon, 12 Mar 2018 09:40:08 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"rspec-lb1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1\",\r\n
@@ -2433,88 +2489,7 @@ http_interactions:
         [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
         \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:24 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"7a8e5fe7-f777-4435-992b-a54f28c2f28c"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - bd22ca22-a01f-4ecf-9230-a4558fb66931
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Correlation-Request-Id:
-      - 19c674a8-c8da-4b5e-8265-5ebc21926459
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102420Z:19c674a8-c8da-4b5e-8265-5ebc21926459
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Mon, 12 Mar 2018 10:24:19 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb2\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2\",\r\n
-        \ \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"e2e30a77-f81b-43fc-9693-08303e43deed\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/backendAddressPools/rspec-lb2-pool\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\r\n
-        \       }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\": [],\r\n    \"probes\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-probe\",\r\n        \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/probes/rspec-lb2-probe\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\": [],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:25 GMT
+  recorded_at: Mon, 12 Mar 2018 09:40:13 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd?api-version=2018-01-01
@@ -2531,7 +2506,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDczMDQsIm5iZiI6MTUyMDg0NzMwNCwiZXhwIjoxNTIwODUxMjA0LCJhaW8iOiJZMk5nWUZDTURXN1VtdTh0c09Udk9hdDMveGVmQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiUVg2dFVlU3VBRU9IbHRfdDZGd1dBQSIsInZlciI6IjEuMCJ9.oPK9UvP2DtpWBm9uVnbNsfDLmkJ3ERXY3m_QNp4Z8DTXC9CKG6Tc0vPXYM8iK8DCpAR4qTjeaWdl7ZRAinffuY_b8nKX9uPzHB_ud93QnQm5i53BWSFDrRAjoKoEHERXjA8ZuoBppE4Q4kMqjbV_kEAGKYR4Lj2KvElJyNn3lV3FpaMixpKWz1r6tqTylz1rC7ae7vvj5qPXvdiJ-YOMxk-gQ3WB6dyH_y1mKG7jxlUhBQldD_2nZ61KXrJsR_Hib0rHimogtki9dUAc5iXetEIanJuvWvLk0J67punVbSeXgVaf-1HUlXl0i9VkzMZX3l8OtRpWcZYzUJiiywKbKg
   response:
     status:
       code: 200
@@ -2552,22 +2527,22 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 0fd15240-6a1c-4b39-a4f6-aa53fd8591c2
+      - b0c48bad-90e4-4a7e-b57c-4714954d9884
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
+      - '14993'
       X-Ms-Correlation-Request-Id:
-      - 5cc03163-922e-41a1-9601-dba2d7cf2a81
+      - 95240eb0-1ccb-4867-a4f4-2ebf071c6f29
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102421Z:5cc03163-922e-41a1-9601-dba2d7cf2a81
+      - WESTEUROPE:20180312T094012Z:95240eb0-1ccb-4867-a4f4-2ebf071c6f29
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:20 GMT
+      - Mon, 12 Mar 2018 09:40:12 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"rspec-lb1-LoadBalancerFrontEnd\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\",\r\n
@@ -2580,70 +2555,5 @@ http_interactions:
         \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
         \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:25 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"cddd97d1-6111-4477-8a00-3dc885237a1d"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 1403e5b6-8fa0-4cd3-89b1-76b6c4fd805b
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
-      X-Ms-Correlation-Request-Id:
-      - e4a5f369-a742-466f-bd8f-42e17eaaf9c9
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102421Z:e4a5f369-a742-466f-bd8f-42e17eaaf9c9
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Mon, 12 Mar 2018 10:24:21 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb2-publicip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\",\r\n
-        \ \"etag\": \"W/\\\"cddd97d1-6111-4477-8a00-3dc885237a1d\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"83e7257d-ab94-4229-8eb5-4798f37ef28d\",\r\n    \"publicIPAddressVersion\":
-        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
-        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
-        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:26 GMT
+  recorded_at: Mon, 12 Mar 2018 09:40:17 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_500/lb_vms_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_500/lb_vms_refresh.yml
@@ -1,6 +1,62 @@
 ---
 http_interactions:
 - request:
+    method: post
+    uri: https://login.microsoftonline.com/AZURE_TENANT_ID/oauth2/token
+    body:
+      encoding: UTF-8
+      string: grant_type=client_credentials&client_id=AZURE_CLIENT_ID&client_secret=AZURE_CLIENT_SECRET&resource=https%3A%2F%2Fmanagement.azure.com%2F
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Server:
+      - Microsoft-IIS/10.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Request-Id:
+      - 2b2c4ad8-f26e-49e1-80c6-ad027e3f2100
+      P3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Set-Cookie:
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzvA6RSXDddf4H1DkUFohD_NUVDvTDc0p2wZq4uxP2jIaGxy1O_g7vLpCRqk4MGfbGXAGz9vBtoj_VIcBFoNL3oW0gfSX4nyHuNbxUlQJO8jmKc1-yc0pLfXubTw40WstYoT_VqUHj1UbRubaz_IiE90UVWPhYoAj9Q50jC1hpYdsgAA;
+        domain=.login.microsoftonline.com; path=/; secure; HttpOnly
+      - stsservicecookie=ests; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=003; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 12 Mar 2018 09:42:19 GMT
+      Content-Length:
+      - '1505'
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1520851340","not_before":"1520847440","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDc0NDAsIm5iZiI6MTUyMDg0NzQ0MCwiZXhwIjoxNTIwODUxMzQwLCJhaW8iOiJZMk5nWURBTjFDdDJkcHEzYjE1K2V1Lys2UnRMQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMkVvc0syN3k0VW1BeHEwQ2ZqOGhBQSIsInZlciI6IjEuMCJ9.eFsuzFJ2JcJ7ej1pMyVOYq1w05gE3MmhvpMTnucMlw6-Trc-u7Yk4_jr1X09KZNEsUBc58DomvhqvC_Iv6VHmnvO4fHpyEn3WLwkVhKhTb9LIJJqCT2w7-P6zLNgIC-wcITEBzea1qHk2X5heiR3TbzTiNSO2CkCSUEiPy_F6SFQHHWeo4JrVUC45Rd_BJybz4WGfo6LIy1GVCAVQbdDYhlZ00JwM4STh02tbHL2yW4h_qjCqeE9lmxx1jNiQXAEvkcnJOhCXYKkRCixxbnzCxMva91yx43fOvqO7XaFfCgKB8eCqkh0-f3xkePPjlcOkiTxeFvYPjckYrCXIn5p_g"}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:42:24 GMT
+- request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
     body:
@@ -16,7 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDc0NDAsIm5iZiI6MTUyMDg0NzQ0MCwiZXhwIjoxNTIwODUxMzQwLCJhaW8iOiJZMk5nWURBTjFDdDJkcHEzYjE1K2V1Lys2UnRMQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMkVvc0syN3k0VW1BeHEwQ2ZqOGhBQSIsInZlciI6IjEuMCJ9.eFsuzFJ2JcJ7ej1pMyVOYq1w05gE3MmhvpMTnucMlw6-Trc-u7Yk4_jr1X09KZNEsUBc58DomvhqvC_Iv6VHmnvO4fHpyEn3WLwkVhKhTb9LIJJqCT2w7-P6zLNgIC-wcITEBzea1qHk2X5heiR3TbzTiNSO2CkCSUEiPy_F6SFQHHWeo4JrVUC45Rd_BJybz4WGfo6LIy1GVCAVQbdDYhlZ00JwM4STh02tbHL2yW4h_qjCqeE9lmxx1jNiQXAEvkcnJOhCXYKkRCixxbnzCxMva91yx43fOvqO7XaFfCgKB8eCqkh0-f3xkePPjlcOkiTxeFvYPjckYrCXIn5p_g
   response:
     status:
       code: 200
@@ -37,24 +93,24 @@ http_interactions:
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
       - '14997'
       X-Ms-Request-Id:
-      - cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - 8f0569ed-ccb1-42d9-a1ca-4e26497c5655
       X-Ms-Correlation-Request-Id:
-      - cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - 8f0569ed-ccb1-42d9-a1ca-4e26497c5655
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102417Z:cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - WESTEUROPE:20180312T094220Z:8f0569ed-ccb1-42d9-a1ca-4e26497c5655
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:17 GMT
+      - Mon, 12 Mar 2018 09:42:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID","subscriptionId":"AZURE_SUBSCRIPTION_ID","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:22 GMT
+  recorded_at: Mon, 12 Mar 2018 09:42:25 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers?api-version=2015-01-01
@@ -71,7 +127,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDc0NDAsIm5iZiI6MTUyMDg0NzQ0MCwiZXhwIjoxNTIwODUxMzQwLCJhaW8iOiJZMk5nWURBTjFDdDJkcHEzYjE1K2V1Lys2UnRMQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMkVvc0syN3k0VW1BeHEwQ2ZqOGhBQSIsInZlciI6IjEuMCJ9.eFsuzFJ2JcJ7ej1pMyVOYq1w05gE3MmhvpMTnucMlw6-Trc-u7Yk4_jr1X09KZNEsUBc58DomvhqvC_Iv6VHmnvO4fHpyEn3WLwkVhKhTb9LIJJqCT2w7-P6zLNgIC-wcITEBzea1qHk2X5heiR3TbzTiNSO2CkCSUEiPy_F6SFQHHWeo4JrVUC45Rd_BJybz4WGfo6LIy1GVCAVQbdDYhlZ00JwM4STh02tbHL2yW4h_qjCqeE9lmxx1jNiQXAEvkcnJOhCXYKkRCixxbnzCxMva91yx43fOvqO7XaFfCgKB8eCqkh0-f3xkePPjlcOkiTxeFvYPjckYrCXIn5p_g
   response:
     status:
       code: 200
@@ -88,19 +144,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - '14986'
       X-Ms-Request-Id:
-      - fe3532ca-59a2-474e-9094-8a3697b82bef
+      - 1f9252e4-0385-4980-846a-cfed32afa9f4
       X-Ms-Correlation-Request-Id:
-      - fe3532ca-59a2-474e-9094-8a3697b82bef
+      - 1f9252e4-0385-4980-846a-cfed32afa9f4
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102419Z:fe3532ca-59a2-474e-9094-8a3697b82bef
+      - WESTEUROPE:20180312T094221Z:1f9252e4-0385-4980-846a-cfed32afa9f4
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:18 GMT
+      - Mon, 12 Mar 2018 09:42:20 GMT
       Content-Length:
       - '320853'
     body:
@@ -2322,10 +2378,10 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:23 GMT
+  recorded_at: Mon, 12 Mar 2018 09:42:26 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a?api-version=2017-12-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2339,7 +2395,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDc0NDAsIm5iZiI6MTUyMDg0NzQ0MCwiZXhwIjoxNTIwODUxMzQwLCJhaW8iOiJZMk5nWURBTjFDdDJkcHEzYjE1K2V1Lys2UnRMQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMkVvc0syN3k0VW1BeHEwQ2ZqOGhBQSIsInZlciI6IjEuMCJ9.eFsuzFJ2JcJ7ej1pMyVOYq1w05gE3MmhvpMTnucMlw6-Trc-u7Yk4_jr1X09KZNEsUBc58DomvhqvC_Iv6VHmnvO4fHpyEn3WLwkVhKhTb9LIJJqCT2w7-P6zLNgIC-wcITEBzea1qHk2X5heiR3TbzTiNSO2CkCSUEiPy_F6SFQHHWeo4JrVUC45Rd_BJybz4WGfo6LIy1GVCAVQbdDYhlZ00JwM4STh02tbHL2yW4h_qjCqeE9lmxx1jNiQXAEvkcnJOhCXYKkRCixxbnzCxMva91yx43fOvqO7XaFfCgKB8eCqkh0-f3xkePPjlcOkiTxeFvYPjckYrCXIn5p_g
   response:
     status:
       code: 200
@@ -2355,88 +2411,63 @@ http_interactions:
       - application/json; charset=utf-8
       Expires:
       - "-1"
-      Etag:
-      - W/"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67"
       Vary:
       - Accept-Encoding
-      X-Ms-Request-Id:
-      - '080de667-081e-4d58-9e94-9e7243d4200e'
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/LowCostGet3Min;4755,Microsoft.Compute/LowCostGet30Min;38355
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344652126238
+      X-Ms-Request-Id:
+      - 1c7f21c7-2c49-4042-a4e3-da31085d9b62
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
       - '14986'
       X-Ms-Correlation-Request-Id:
-      - '093d49ac-c85f-440e-956b-955b6698dd19'
+      - f1101d4a-a191-479a-b915-f2a984b7d4df
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102419Z:093d49ac-c85f-440e-956b-955b6698dd19
+      - WESTEUROPE:20180312T094223Z:f1101d4a-a191-479a-b915-f2a984b7d4df
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:19 GMT
+      - Mon, 12 Mar 2018 09:42:23 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1\",\r\n
-        \ \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"7ab88756-810f-4083-95db-8b05d50e38f2\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ],\r\n          \"inboundNatRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"backendIPConfigurations\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\"\r\n
-        \           }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-rule\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\":
-        80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\"\r\n
-        \         },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n
-        \       \"name\": \"rspec-lb-probe\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-NAT\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 3441,\r\n          \"backendPort\":
-        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
+      string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"23b0beab-16d2-4135-a01f-2fe713217fd0\",\r\n
+        \   \"availabilitySet\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/RSPEC-LB\"\r\n
+        \   },\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_F1s\"\r\n
+        \   },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
+        \"RedHat\",\r\n        \"offer\": \"RHEL\",\r\n        \"sku\": \"6.7\",\r\n
+        \       \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
+        \"Linux\",\r\n        \"name\": \"rspec-lb-a\",\r\n        \"createOption\":
+        \"FromImage\",\r\n        \"vhd\": {\r\n          \"uri\": \"https://rspeclb.blob.core.windows.net/vhds/rspec-lb-a201682122839.vhd\"\r\n
+        \       },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n      \"dataDisks\":
+        []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"rspec-lb-a\",\r\n
+        \     \"adminUsername\": \"bronaghs\",\r\n      \"linuxConfiguration\": {\r\n
+        \       \"disablePasswordAuthentication\": false\r\n      },\r\n      \"secrets\":
+        []\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670\"}]},\r\n
+        \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
+        true,\r\n        \"storageUri\": \"https://miqazuretest16487.blob.core.windows.net/\"\r\n
+        \     }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n
+        \ \"resources\": [\r\n    {\r\n      \"properties\": {\r\n        \"publisher\":
+        \"Microsoft.OSTCExtensions\",\r\n        \"type\": \"LinuxDiagnostic\",\r\n
+        \       \"typeHandlerVersion\": \"2.3\",\r\n        \"autoUpgradeMinorVersion\":
+        true,\r\n        \"settings\": {\"xmlCfg\":\"PFdhZENmZz48RGlhZ25vc3RpY01vbml0b3JDb25maWd1cmF0aW9uIG92ZXJhbGxRdW90YUluTUI9IjQwOTYiPjxEaWFnbm9zdGljSW5mcmFzdHJ1Y3R1cmVMb2dzIHNjaGVkdWxlZFRyYW5zZmVyUGVyaW9kPSJQVDFNIiBzY2hlZHVsZWRUcmFuc2ZlckxvZ0xldmVsRmlsdGVyPSJXYXJuaW5nIi8+PFBlcmZvcm1hbmNlQ291bnRlcnMgc2NoZWR1bGVkVHJhbnNmZXJQZXJpb2Q9IlBUMU0iPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlTWVtb3J5IiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQnl0ZXMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcUGVyY2VudEF2YWlsYWJsZU1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iTWVtb3J5IHVzZWQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50VXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgcGVyY2VudGFnZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkQnlDYWNoZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHVzZWQgYnkgY2FjaGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1BlclNlYyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50UGVyU2Vjb25kIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFnZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1JlYWRQZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2UgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1dyaXR0ZW5QZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2Ugd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iU3dhcCBhdmFpbGFibGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50QXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZFN3YXAiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlN3YXAgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRJZGxlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgaWRsZSB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFVzZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iUGVyY2VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkNQVSB1c2VyIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50TmljZVRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIG5pY2UgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRQcml2aWxlZ2VkVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgcHJpdmlsZWdlZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudEludGVycnVwdFRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIGludGVycnVwdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudERQQ1RpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIERQQyB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFByb2Nlc3NvclRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIHBlcmNlbnRhZ2UgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50SU9XYWl0VGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgSU8gd2FpdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xSZWFkQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCBndWVzdCBPUyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXFdyaXRlQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGUgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xUcmFuc2ZlcnNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXJzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcUmVhZHNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xXcml0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVJlYWRUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVdyaXRlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlNlY29uZHMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJEaXNrIHdyaXRlIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xBdmVyYWdlVHJhbnNmZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXIgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXEF2ZXJhZ2VEaXNrUXVldWVMZW5ndGgiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcXVldWUgbGVuZ3RoIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVHJhbnNtaXR0ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgb3V0IGd1ZXN0IE9TIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzUmVjZWl2ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgaW4gZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1RyYW5zbWl0dGVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHNlbnQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1JlY2VpdmVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHJlY2VpdmVkIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVG90YWwiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxSeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyByZWNlaXZlZCBlcnJvcnMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxUeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyBzZW50IGVycm9ycyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTmV0d29ya0ludGVyZmFjZVxUb3RhbENvbGxpc2lvbnMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgY29sbGlzaW9ucyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48L1BlcmZvcm1hbmNlQ291bnRlcnM+PE1ldHJpY3MgcmVzb3VyY2VJZD0iL3N1YnNjcmlwdGlvbnMvMjU4NmM2NGItMzhiNC00NTI3LWExNDAtMDEyZDQ5ZGZjMDJjL3Jlc291cmNlR3JvdXBzL21pcS1henVyZS10ZXN0MS9wcm92aWRlcnMvTWljcm9zb2Z0LkNvbXB1dGUvdmlydHVhbE1hY2hpbmVzL3JzcGVjLWxiLWEiPjxNZXRyaWNBZ2dyZWdhdGlvbiBzY2hlZHVsZWRUcmFuc2ZlclBlcmlvZD0iUFQxSCIvPjxNZXRyaWNBZ2dyZWdhdGlvbiBzY2hlZHVsZWRUcmFuc2ZlclBlcmlvZD0iUFQxTSIvPjwvTWV0cmljcz48L0RpYWdub3N0aWNNb25pdG9yQ29uZmlndXJhdGlvbj48L1dhZENmZz4=\",\"StorageAccount\":\"miqazuretest16487\"},\r\n
+        \       \"provisioningState\": \"Succeeded\"\r\n      },\r\n      \"type\":
+        \"Microsoft.Compute/virtualMachines/extensions\",\r\n      \"location\": \"eastus\",\r\n
+        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a/extensions/Microsoft.Insights.VMDiagnosticsSettings\",\r\n
+        \     \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n    }\r\n
+        \ ],\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\":
+        \"eastus\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a\",\r\n
+        \ \"name\": \"rspec-lb-a\"\r\n}"
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:24 GMT
+  recorded_at: Mon, 12 Mar 2018 09:42:28 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b?api-version=2017-12-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2450,7 +2481,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDc0NDAsIm5iZiI6MTUyMDg0NzQ0MCwiZXhwIjoxNTIwODUxMzQwLCJhaW8iOiJZMk5nWURBTjFDdDJkcHEzYjE1K2V1Lys2UnRMQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMkVvc0syN3k0VW1BeHEwQ2ZqOGhBQSIsInZlciI6IjEuMCJ9.eFsuzFJ2JcJ7ej1pMyVOYq1w05gE3MmhvpMTnucMlw6-Trc-u7Yk4_jr1X09KZNEsUBc58DomvhqvC_Iv6VHmnvO4fHpyEn3WLwkVhKhTb9LIJJqCT2w7-P6zLNgIC-wcITEBzea1qHk2X5heiR3TbzTiNSO2CkCSUEiPy_F6SFQHHWeo4JrVUC45Rd_BJybz4WGfo6LIy1GVCAVQbdDYhlZ00JwM4STh02tbHL2yW4h_qjCqeE9lmxx1jNiQXAEvkcnJOhCXYKkRCixxbnzCxMva91yx43fOvqO7XaFfCgKB8eCqkh0-f3xkePPjlcOkiTxeFvYPjckYrCXIn5p_g
   response:
     status:
       code: 200
@@ -2466,58 +2497,63 @@ http_interactions:
       - application/json; charset=utf-8
       Expires:
       - "-1"
-      Etag:
-      - W/"7a8e5fe7-f777-4435-992b-a54f28c2f28c"
       Vary:
       - Accept-Encoding
-      X-Ms-Request-Id:
-      - bd22ca22-a01f-4ecf-9230-a4558fb66931
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/LowCostGet3Min;4754,Microsoft.Compute/LowCostGet30Min;38354
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344652126238
+      X-Ms-Request-Id:
+      - ebc12d44-9469-49e7-a6f7-f0a239d9da79
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
+      - '14985'
       X-Ms-Correlation-Request-Id:
-      - 19c674a8-c8da-4b5e-8265-5ebc21926459
+      - 2c8edf36-1c50-4808-a038-ee32d912ec76
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102420Z:19c674a8-c8da-4b5e-8265-5ebc21926459
+      - WESTEUROPE:20180312T094224Z:2c8edf36-1c50-4808-a038-ee32d912ec76
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:19 GMT
+      - Mon, 12 Mar 2018 09:42:23 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb2\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2\",\r\n
-        \ \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"e2e30a77-f81b-43fc-9693-08303e43deed\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/backendAddressPools/rspec-lb2-pool\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\r\n
-        \       }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\": [],\r\n    \"probes\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-probe\",\r\n        \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/probes/rspec-lb2-probe\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\": [],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
+      string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"834a70b5-868d-4466-9dda-14e0f6b2caaf\",\r\n
+        \   \"availabilitySet\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/RSPEC-LB\"\r\n
+        \   },\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n
+        \   },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
+        \"RedHat\",\r\n        \"offer\": \"RHEL\",\r\n        \"sku\": \"6.7\",\r\n
+        \       \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
+        \"Linux\",\r\n        \"name\": \"rspec-lb-b\",\r\n        \"createOption\":
+        \"FromImage\",\r\n        \"vhd\": {\r\n          \"uri\": \"https://rspeclb.blob.core.windows.net/vhds/rspec-lb-b201682123650.vhd\"\r\n
+        \       },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n      \"dataDisks\":
+        []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"rspec-lb-b\",\r\n
+        \     \"adminUsername\": \"bronaghs\",\r\n      \"linuxConfiguration\": {\r\n
+        \       \"disablePasswordAuthentication\": false\r\n      },\r\n      \"secrets\":
+        []\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843\"}]},\r\n
+        \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
+        true,\r\n        \"storageUri\": \"https://amissteastorage.blob.core.windows.net/\"\r\n
+        \     }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n
+        \ \"resources\": [\r\n    {\r\n      \"properties\": {\r\n        \"publisher\":
+        \"Microsoft.OSTCExtensions\",\r\n        \"type\": \"LinuxDiagnostic\",\r\n
+        \       \"typeHandlerVersion\": \"2.3\",\r\n        \"autoUpgradeMinorVersion\":
+        true,\r\n        \"settings\": {\"xmlCfg\":\"PFdhZENmZz48RGlhZ25vc3RpY01vbml0b3JDb25maWd1cmF0aW9uIG92ZXJhbGxRdW90YUluTUI9IjQwOTYiPjxEaWFnbm9zdGljSW5mcmFzdHJ1Y3R1cmVMb2dzIHNjaGVkdWxlZFRyYW5zZmVyUGVyaW9kPSJQVDFNIiBzY2hlZHVsZWRUcmFuc2ZlckxvZ0xldmVsRmlsdGVyPSJXYXJuaW5nIi8+PFBlcmZvcm1hbmNlQ291bnRlcnMgc2NoZWR1bGVkVHJhbnNmZXJQZXJpb2Q9IlBUMU0iPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlTWVtb3J5IiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQnl0ZXMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcUGVyY2VudEF2YWlsYWJsZU1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iTWVtb3J5IHVzZWQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50VXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgcGVyY2VudGFnZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkQnlDYWNoZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHVzZWQgYnkgY2FjaGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1BlclNlYyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50UGVyU2Vjb25kIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFnZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1JlYWRQZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2UgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1dyaXR0ZW5QZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2Ugd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iU3dhcCBhdmFpbGFibGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50QXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZFN3YXAiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlN3YXAgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRJZGxlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgaWRsZSB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFVzZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iUGVyY2VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkNQVSB1c2VyIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50TmljZVRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIG5pY2UgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRQcml2aWxlZ2VkVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgcHJpdmlsZWdlZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudEludGVycnVwdFRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIGludGVycnVwdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudERQQ1RpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIERQQyB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFByb2Nlc3NvclRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIHBlcmNlbnRhZ2UgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50SU9XYWl0VGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgSU8gd2FpdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xSZWFkQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCBndWVzdCBPUyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXFdyaXRlQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGUgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xUcmFuc2ZlcnNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXJzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcUmVhZHNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xXcml0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVJlYWRUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVdyaXRlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlNlY29uZHMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJEaXNrIHdyaXRlIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xBdmVyYWdlVHJhbnNmZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXIgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXEF2ZXJhZ2VEaXNrUXVldWVMZW5ndGgiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcXVldWUgbGVuZ3RoIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVHJhbnNtaXR0ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgb3V0IGd1ZXN0IE9TIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzUmVjZWl2ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgaW4gZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1RyYW5zbWl0dGVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHNlbnQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1JlY2VpdmVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHJlY2VpdmVkIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVG90YWwiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxSeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyByZWNlaXZlZCBlcnJvcnMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxUeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyBzZW50IGVycm9ycyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTmV0d29ya0ludGVyZmFjZVxUb3RhbENvbGxpc2lvbnMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgY29sbGlzaW9ucyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48L1BlcmZvcm1hbmNlQ291bnRlcnM+PE1ldHJpY3MgcmVzb3VyY2VJZD0iL3N1YnNjcmlwdGlvbnMvMjU4NmM2NGItMzhiNC00NTI3LWExNDAtMDEyZDQ5ZGZjMDJjL3Jlc291cmNlR3JvdXBzL21pcS1henVyZS10ZXN0MS9wcm92aWRlcnMvTWljcm9zb2Z0LkNvbXB1dGUvdmlydHVhbE1hY2hpbmVzL3JzcGVjLWxiLWIiPjxNZXRyaWNBZ2dyZWdhdGlvbiBzY2hlZHVsZWRUcmFuc2ZlclBlcmlvZD0iUFQxSCIvPjxNZXRyaWNBZ2dyZWdhdGlvbiBzY2hlZHVsZWRUcmFuc2ZlclBlcmlvZD0iUFQxTSIvPjwvTWV0cmljcz48L0RpYWdub3N0aWNNb25pdG9yQ29uZmlndXJhdGlvbj48L1dhZENmZz4=\",\"StorageAccount\":\"amissteastorage\"},\r\n
+        \       \"provisioningState\": \"Succeeded\"\r\n      },\r\n      \"type\":
+        \"Microsoft.Compute/virtualMachines/extensions\",\r\n      \"location\": \"eastus\",\r\n
+        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b/extensions/Microsoft.Insights.VMDiagnosticsSettings\",\r\n
+        \     \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n    }\r\n
+        \ ],\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\":
+        \"eastus\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b\",\r\n
+        \ \"name\": \"rspec-lb-b\"\r\n}"
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:25 GMT
+  recorded_at: Mon, 12 Mar 2018 09:42:28 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670?api-version=2018-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2531,7 +2567,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDc0NDAsIm5iZiI6MTUyMDg0NzQ0MCwiZXhwIjoxNTIwODUxMzQwLCJhaW8iOiJZMk5nWURBTjFDdDJkcHEzYjE1K2V1Lys2UnRMQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMkVvc0syN3k0VW1BeHEwQ2ZqOGhBQSIsInZlciI6IjEuMCJ9.eFsuzFJ2JcJ7ej1pMyVOYq1w05gE3MmhvpMTnucMlw6-Trc-u7Yk4_jr1X09KZNEsUBc58DomvhqvC_Iv6VHmnvO4fHpyEn3WLwkVhKhTb9LIJJqCT2w7-P6zLNgIC-wcITEBzea1qHk2X5heiR3TbzTiNSO2CkCSUEiPy_F6SFQHHWeo4JrVUC45Rd_BJybz4WGfo6LIy1GVCAVQbdDYhlZ00JwM4STh02tbHL2yW4h_qjCqeE9lmxx1jNiQXAEvkcnJOhCXYKkRCixxbnzCxMva91yx43fOvqO7XaFfCgKB8eCqkh0-f3xkePPjlcOkiTxeFvYPjckYrCXIn5p_g
   response:
     status:
       code: 200
@@ -2548,42 +2584,57 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"a38434c8-7b23-4092-b7c6-402238eac0dc"
+      - W/"cf3a0b0d-d596-4f33-bc31-749f92ba4f00"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 0fd15240-6a1c-4b39-a4f6-aa53fd8591c2
+      - 240e3b93-251e-4186-828d-bde77ade1fb5
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
+      - '14991'
       X-Ms-Correlation-Request-Id:
-      - 5cc03163-922e-41a1-9601-dba2d7cf2a81
+      - 9c47a70b-5252-4477-b43c-6a1ea4e2690d
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102421Z:5cc03163-922e-41a1-9601-dba2d7cf2a81
+      - WESTEUROPE:20180312T094224Z:9c47a70b-5252-4477-b43c-6a1ea4e2690d
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:20 GMT
+      - Mon, 12 Mar 2018 09:42:24 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb1-LoadBalancerFrontEnd\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\",\r\n
-        \ \"etag\": \"W/\\\"a38434c8-7b23-4092-b7c6-402238eac0dc\\\"\",\r\n  \"location\":
+      string: "{\r\n  \"name\": \"rspec-lb-a670\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670\",\r\n
+        \ \"etag\": \"W/\\\"cf3a0b0d-d596-4f33-bc31-749f92ba4f00\\\"\",\r\n  \"location\":
         \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"f28e0f25-b372-4edf-97d9-13a9e3b4ba2d\",\r\n    \"ipAddress\":
-        \"40.71.82.83\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\":
-        \"Static\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipTags\": [],\r\n
-        \   \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
-        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
+        \   \"resourceGuid\": \"46cb8216-786e-408e-9d86-c0855b357349\",\r\n    \"ipConfigurations\":
+        [\r\n      {\r\n        \"name\": \"ipconfig1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\",\r\n
+        \       \"etag\": \"W/\\\"cf3a0b0d-d596-4f33-bc31-749f92ba4f00\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"privateIPAddress\": \"10.16.0.6\",\r\n          \"privateIPAllocationMethod\":
+        \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-a-ip\"\r\n
+        \         },\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\"\r\n
+        \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
+        \"IPv4\",\r\n          \"loadBalancerBackendAddressPools\": [\r\n            {\r\n
+        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\"\r\n
+        \           }\r\n          ],\r\n          \"loadBalancerInboundNatRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\":
+        {\r\n      \"dnsServers\": [],\r\n      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\":
+        \"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net\"\r\n    },\r\n    \"enableAcceleratedNetworking\":
+        false,\r\n    \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\":
+        {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg\"\r\n
+        \   },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a\"\r\n
+        \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
+        \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:25 GMT
+  recorded_at: Mon, 12 Mar 2018 09:42:29 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843?api-version=2018-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2597,7 +2648,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDc0NDAsIm5iZiI6MTUyMDg0NzQ0MCwiZXhwIjoxNTIwODUxMzQwLCJhaW8iOiJZMk5nWURBTjFDdDJkcHEzYjE1K2V1Lys2UnRMQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMkVvc0syN3k0VW1BeHEwQ2ZqOGhBQSIsInZlciI6IjEuMCJ9.eFsuzFJ2JcJ7ej1pMyVOYq1w05gE3MmhvpMTnucMlw6-Trc-u7Yk4_jr1X09KZNEsUBc58DomvhqvC_Iv6VHmnvO4fHpyEn3WLwkVhKhTb9LIJJqCT2w7-P6zLNgIC-wcITEBzea1qHk2X5heiR3TbzTiNSO2CkCSUEiPy_F6SFQHHWeo4JrVUC45Rd_BJybz4WGfo6LIy1GVCAVQbdDYhlZ00JwM4STh02tbHL2yW4h_qjCqeE9lmxx1jNiQXAEvkcnJOhCXYKkRCixxbnzCxMva91yx43fOvqO7XaFfCgKB8eCqkh0-f3xkePPjlcOkiTxeFvYPjckYrCXIn5p_g
   response:
     status:
       code: 200
@@ -2614,36 +2665,1594 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"cddd97d1-6111-4477-8a00-3dc885237a1d"
+      - W/"76aabe0c-8678-43f0-81a5-2f15784a4b99"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 1403e5b6-8fa0-4cd3-89b1-76b6c4fd805b
+      - ac25d4a4-ad46-4142-885b-7d8ce6381e3f
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - '14985'
       X-Ms-Correlation-Request-Id:
-      - e4a5f369-a742-466f-bd8f-42e17eaaf9c9
+      - 02f50574-f7e0-4e42-b49c-ff7d0be604d5
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102421Z:e4a5f369-a742-466f-bd8f-42e17eaaf9c9
+      - WESTEUROPE:20180312T094225Z:02f50574-f7e0-4e42-b49c-ff7d0be604d5
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:21 GMT
+      - Mon, 12 Mar 2018 09:42:25 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb2-publicip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\",\r\n
-        \ \"etag\": \"W/\\\"cddd97d1-6111-4477-8a00-3dc885237a1d\\\"\",\r\n  \"location\":
+      string: "{\r\n  \"name\": \"rspec-lb-b843\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843\",\r\n
+        \ \"etag\": \"W/\\\"76aabe0c-8678-43f0-81a5-2f15784a4b99\\\"\",\r\n  \"location\":
         \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"83e7257d-ab94-4229-8eb5-4798f37ef28d\",\r\n    \"publicIPAddressVersion\":
+        \   \"resourceGuid\": \"3ef6fa01-ac34-43a1-8fd7-67c706b4d8ef\",\r\n    \"ipConfigurations\":
+        [\r\n      {\r\n        \"name\": \"ipconfig1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\",\r\n
+        \       \"etag\": \"W/\\\"76aabe0c-8678-43f0-81a5-2f15784a4b99\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"privateIPAddress\": \"10.16.0.11\",\r\n          \"privateIPAllocationMethod\":
+        \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-b-ip\"\r\n
+        \         },\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\"\r\n
+        \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
+        \"IPv4\",\r\n          \"loadBalancerBackendAddressPools\": [\r\n            {\r\n
+        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\":
+        {\r\n      \"dnsServers\": [],\r\n      \"appliedDnsServers\": []\r\n    },\r\n
+        \   \"enableAcceleratedNetworking\": false,\r\n    \"enableIPForwarding\":
+        false,\r\n    \"networkSecurityGroup\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg\"\r\n
+        \   },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b\"\r\n
+        \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
+        \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:42:30 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a/instanceView?api-version=2017-12-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDc0NDAsIm5iZiI6MTUyMDg0NzQ0MCwiZXhwIjoxNTIwODUxMzQwLCJhaW8iOiJZMk5nWURBTjFDdDJkcHEzYjE1K2V1Lys2UnRMQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMkVvc0syN3k0VW1BeHEwQ2ZqOGhBQSIsInZlciI6IjEuMCJ9.eFsuzFJ2JcJ7ej1pMyVOYq1w05gE3MmhvpMTnucMlw6-Trc-u7Yk4_jr1X09KZNEsUBc58DomvhqvC_Iv6VHmnvO4fHpyEn3WLwkVhKhTb9LIJJqCT2w7-P6zLNgIC-wcITEBzea1qHk2X5heiR3TbzTiNSO2CkCSUEiPy_F6SFQHHWeo4JrVUC45Rd_BJybz4WGfo6LIy1GVCAVQbdDYhlZ00JwM4STh02tbHL2yW4h_qjCqeE9lmxx1jNiQXAEvkcnJOhCXYKkRCixxbnzCxMva91yx43fOvqO7XaFfCgKB8eCqkh0-f3xkePPjlcOkiTxeFvYPjckYrCXIn5p_g
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/GetInstanceView3Min;4795,Microsoft.Compute/GetInstanceView30Min;23995
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344652126238
+      X-Ms-Request-Id:
+      - dafff622-dd2a-4dc7-9e71-ad2fd0025792
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14984'
+      X-Ms-Correlation-Request-Id:
+      - 9c9c99ee-a807-44b8-beb0-7a61ab16db8c
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T094235Z:9c9c99ee-a807-44b8-beb0-7a61ab16db8c
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:42:35 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"platformUpdateDomain\": 0,\r\n  \"platformFaultDomain\": 0,\r\n
+        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
+        [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
+        \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
+        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2018-03-12T09:42:25+00:00\"\r\n
+        \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"rspec-lb-a\",\r\n
+        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
+        succeeded\",\r\n          \"time\": \"2016-09-03T14:04:26.7359609+00:00\"\r\n
+        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
+        \"https://miqazuretest16487.blob.core.windows.net/bootdiagnostics-rspeclba-23b0beab-16d2-4135-a01f-2fe713217fd0/rspec-lb-a.23b0beab-16d2-4135-a01f-2fe713217fd0.screenshot.bmp\",\r\n
+        \   \"serialConsoleLogBlobUri\": \"https://miqazuretest16487.blob.core.windows.net/bootdiagnostics-rspeclba-23b0beab-16d2-4135-a01f-2fe713217fd0/rspec-lb-a.23b0beab-16d2-4135-a01f-2fe713217fd0.serialconsole.log\"\r\n
+        \ },\r\n  \"extensions\": [\r\n    {\r\n      \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n
+        \   }\r\n  ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n
+        \     \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n
+        \     \"time\": \"2016-09-03T14:04:26.7828345+00:00\"\r\n    },\r\n    {\r\n
+        \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
+        \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:42:40 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b/instanceView?api-version=2017-12-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDc0NDAsIm5iZiI6MTUyMDg0NzQ0MCwiZXhwIjoxNTIwODUxMzQwLCJhaW8iOiJZMk5nWURBTjFDdDJkcHEzYjE1K2V1Lys2UnRMQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMkVvc0syN3k0VW1BeHEwQ2ZqOGhBQSIsInZlciI6IjEuMCJ9.eFsuzFJ2JcJ7ej1pMyVOYq1w05gE3MmhvpMTnucMlw6-Trc-u7Yk4_jr1X09KZNEsUBc58DomvhqvC_Iv6VHmnvO4fHpyEn3WLwkVhKhTb9LIJJqCT2w7-P6zLNgIC-wcITEBzea1qHk2X5heiR3TbzTiNSO2CkCSUEiPy_F6SFQHHWeo4JrVUC45Rd_BJybz4WGfo6LIy1GVCAVQbdDYhlZ00JwM4STh02tbHL2yW4h_qjCqeE9lmxx1jNiQXAEvkcnJOhCXYKkRCixxbnzCxMva91yx43fOvqO7XaFfCgKB8eCqkh0-f3xkePPjlcOkiTxeFvYPjckYrCXIn5p_g
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/GetInstanceView3Min;4794,Microsoft.Compute/GetInstanceView30Min;23994
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344652126238
+      X-Ms-Request-Id:
+      - '039d674f-7f7b-49b6-b3ea-b030606e59a6'
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14985'
+      X-Ms-Correlation-Request-Id:
+      - c90f23f3-211d-4933-8744-1ea5fd4535f0
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T094236Z:c90f23f3-211d-4933-8744-1ea5fd4535f0
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:42:36 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"platformUpdateDomain\": 1,\r\n  \"platformFaultDomain\": 1,\r\n
+        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
+        [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
+        \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
+        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2018-03-12T09:42:36+00:00\"\r\n
+        \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"rspec-lb-b\",\r\n
+        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
+        succeeded\",\r\n          \"time\": \"2016-09-03T14:07:52.9377685+00:00\"\r\n
+        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
+        \"https://amissteastorage.blob.core.windows.net/bootdiagnostics-rspeclbb-834a70b5-868d-4466-9dda-14e0f6b2caaf/rspec-lb-b.834a70b5-868d-4466-9dda-14e0f6b2caaf.screenshot.bmp\",\r\n
+        \   \"serialConsoleLogBlobUri\": \"https://amissteastorage.blob.core.windows.net/bootdiagnostics-rspeclbb-834a70b5-868d-4466-9dda-14e0f6b2caaf/rspec-lb-b.834a70b5-868d-4466-9dda-14e0f6b2caaf.serialconsole.log\"\r\n
+        \ },\r\n  \"extensions\": [\r\n    {\r\n      \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n
+        \   }\r\n  ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n
+        \     \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n
+        \     \"time\": \"2016-09-03T14:07:52.9846158+00:00\"\r\n    },\r\n    {\r\n
+        \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
+        \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:42:41 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups/miq-azure-test1?api-version=2017-08-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDc0NDAsIm5iZiI6MTUyMDg0NzQ0MCwiZXhwIjoxNTIwODUxMzQwLCJhaW8iOiJZMk5nWURBTjFDdDJkcHEzYjE1K2V1Lys2UnRMQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMkVvc0syN3k0VW1BeHEwQ2ZqOGhBQSIsInZlciI6IjEuMCJ9.eFsuzFJ2JcJ7ej1pMyVOYq1w05gE3MmhvpMTnucMlw6-Trc-u7Yk4_jr1X09KZNEsUBc58DomvhqvC_Iv6VHmnvO4fHpyEn3WLwkVhKhTb9LIJJqCT2w7-P6zLNgIC-wcITEBzea1qHk2X5heiR3TbzTiNSO2CkCSUEiPy_F6SFQHHWeo4JrVUC45Rd_BJybz4WGfo6LIy1GVCAVQbdDYhlZ00JwM4STh02tbHL2yW4h_qjCqeE9lmxx1jNiQXAEvkcnJOhCXYKkRCixxbnzCxMva91yx43fOvqO7XaFfCgKB8eCqkh0-f3xkePPjlcOkiTxeFvYPjckYrCXIn5p_g
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14986'
+      X-Ms-Request-Id:
+      - 6b72a595-c27e-43ed-b47b-b8107f33e25c
+      X-Ms-Correlation-Request-Id:
+      - 6b72a595-c27e-43ed-b47b-b8107f33e25c
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T094237Z:6b72a595-c27e-43ed-b47b-b8107f33e25c
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:42:36 GMT
+      Content-Length:
+      - '183'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1","name":"miq-azure-test1","location":"eastus","properties":{"provisioningState":"Succeeded"}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:42:41 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute/locations/eastus/vmSizes?api-version=2017-12-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDc0NDAsIm5iZiI6MTUyMDg0NzQ0MCwiZXhwIjoxNTIwODUxMzQwLCJhaW8iOiJZMk5nWURBTjFDdDJkcHEzYjE1K2V1Lys2UnRMQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMkVvc0syN3k0VW1BeHEwQ2ZqOGhBQSIsInZlciI6IjEuMCJ9.eFsuzFJ2JcJ7ej1pMyVOYq1w05gE3MmhvpMTnucMlw6-Trc-u7Yk4_jr1X09KZNEsUBc58DomvhqvC_Iv6VHmnvO4fHpyEn3WLwkVhKhTb9LIJJqCT2w7-P6zLNgIC-wcITEBzea1qHk2X5heiR3TbzTiNSO2CkCSUEiPy_F6SFQHHWeo4JrVUC45Rd_BJybz4WGfo6LIy1GVCAVQbdDYhlZ00JwM4STh02tbHL2yW4h_qjCqeE9lmxx1jNiQXAEvkcnJOhCXYKkRCixxbnzCxMva91yx43fOvqO7XaFfCgKB8eCqkh0-f3xkePPjlcOkiTxeFvYPjckYrCXIn5p_g
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/LowCostGet3Min;4748,Microsoft.Compute/LowCostGet30Min;38348
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344652126238
+      X-Ms-Request-Id:
+      - c5bd62a7-5573-4614-a28e-fa9b1fc92c84
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Correlation-Request-Id:
+      - 251976d3-285c-4ed2-909c-92a8e4fbacf8
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T094238Z:251976d3-285c-4ed2-909c-92a8e4fbacf8
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:42:37 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"Standard_B1ms\",\r\n
+        \     \"numberOfCores\": 1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        4096,\r\n      \"memoryInMB\": 2048,\r\n      \"maxDataDiskCount\": 2\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_B1s\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        2048,\r\n      \"memoryInMB\": 1024,\r\n      \"maxDataDiskCount\": 2\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_B2ms\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        16384,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_B2s\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        8192,\r\n      \"memoryInMB\": 4096,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_B4ms\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        32768,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_B8ms\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS1_v2\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        7168,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS2_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        14336,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS3_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS4_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS5_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS11-1_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS11_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS12-1_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS12-2_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS12_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS13-2_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS13-4_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS13_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS14-4_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        229376,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS14-8_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        229376,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS14_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        229376,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS15_v2\",\r\n      \"numberOfCores\":
+        20,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        286720,\r\n      \"memoryInMB\": 143360,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS2_v2_Promo\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        14336,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS3_v2_Promo\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS4_v2_Promo\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS5_v2_Promo\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS11_v2_Promo\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS12_v2_Promo\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS13_v2_Promo\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS14_v2_Promo\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        229376,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F1s\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        4096,\r\n      \"memoryInMB\": 2048,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F2s\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        8192,\r\n      \"memoryInMB\": 4096,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F4s\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        16384,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F8s\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        32768,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F16s\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D2s_v3\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        16384,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D4s_v3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        32768,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D8s_v3\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D16s_v3\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        131072,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D32s_v3\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        262144,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A0\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        20480,\r\n      \"memoryInMB\": 768,\r\n      \"maxDataDiskCount\": 1\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A1\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        71680,\r\n      \"memoryInMB\": 1792,\r\n      \"maxDataDiskCount\": 2\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        138240,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        291840,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A5\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        138240,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A4\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        619520,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A6\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        291840,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A7\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        619520,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Basic_A0\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        20480,\r\n      \"memoryInMB\": 768,\r\n      \"maxDataDiskCount\": 1\r\n
+        \   },\r\n    {\r\n      \"name\": \"Basic_A1\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        40960,\r\n      \"memoryInMB\": 1792,\r\n      \"maxDataDiskCount\": 2\r\n
+        \   },\r\n    {\r\n      \"name\": \"Basic_A2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        61440,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Basic_A3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        122880,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Basic_A4\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        245760,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D1_v2\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        51200,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D2_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D3_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D4_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D5_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D11_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D12_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D13_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D14_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D15_v2\",\r\n      \"numberOfCores\":
+        20,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        286720,\r\n      \"memoryInMB\": 143360,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D2_v2_Promo\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D3_v2_Promo\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D4_v2_Promo\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D5_v2_Promo\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D11_v2_Promo\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D12_v2_Promo\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D13_v2_Promo\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D14_v2_Promo\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F1\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        16384,\r\n      \"memoryInMB\": 2048,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        32768,\r\n      \"memoryInMB\": 4096,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F4\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F8\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        131072,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F16\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        262144,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A1_v2\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        10240,\r\n      \"memoryInMB\": 2048,\r\n      \"maxDataDiskCount\": 2\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A2m_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        20480,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A2_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        20480,\r\n      \"memoryInMB\": 4096,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A4m_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        40960,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A4_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        40960,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A8m_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        81920,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A8_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        81920,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D2_v3\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        51200,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D4_v3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D8_v3\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D16_v3\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 65636,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D32_v3\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_H8\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1024000,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_H16\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        2048000,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_H8m\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1024000,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_H16m\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        2048000,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_H16r\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        2048000,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_H16mr\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        2048000,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D1\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        51200,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D4\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D11\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D12\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D13\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D14\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NV6\",\r\n      \"numberOfCores\":
+        6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        389120,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 24\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NV12\",\r\n      \"numberOfCores\":
+        12,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        696320,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 48\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NV24\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1474560,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC6s_v2\",\r\n      \"numberOfCores\":
+        6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        344064,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 12\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC12s_v2\",\r\n      \"numberOfCores\":
+        12,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        688128,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 24\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC24rs_v2\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1376256,\r\n      \"memoryInMB\": 458752,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC24s_v2\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1376256,\r\n      \"memoryInMB\": 458752,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC6\",\r\n      \"numberOfCores\":
+        6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        389120,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 24\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC12\",\r\n      \"numberOfCores\":
+        12,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        696320,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 48\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC24\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1474560,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC24r\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1474560,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS1\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        7168,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        14336,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS4\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS11\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS12\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS13\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS14\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        229376,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC6s_v3\",\r\n      \"numberOfCores\":
+        6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        344064,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 12\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC12s_v3\",\r\n      \"numberOfCores\":
+        12,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        688128,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 24\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC24rs_v3\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1376256,\r\n      \"memoryInMB\": 458752,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC24s_v3\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1376256,\r\n      \"memoryInMB\": 458752,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D64_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1638400,\r\n      \"memoryInMB\": 262144,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D64s_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        524288,\r\n      \"memoryInMB\": 262144,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E2_v3\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        51200,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E4_v3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E8_v3\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E16_v3\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E32_v3\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 262144,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E64i_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1638400,\r\n      \"memoryInMB\": 442368,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E64_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1638400,\r\n      \"memoryInMB\": 442368,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E2s_v3\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        32768,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E4-2s_v3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E4s_v3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E8-2s_v3\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        131072,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E8-4s_v3\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        131072,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E8s_v3\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        131072,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E16-4s_v3\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        262144,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E16-8s_v3\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        262144,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E16s_v3\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        262144,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E32-8s_v3\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        524288,\r\n      \"memoryInMB\": 262144,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E32-16s_v3\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        524288,\r\n      \"memoryInMB\": 262144,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E32s_v3\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        524288,\r\n      \"memoryInMB\": 262144,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E64-16s_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        884736,\r\n      \"memoryInMB\": 442368,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E64-32s_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        884736,\r\n      \"memoryInMB\": 442368,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E64is_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        884736,\r\n      \"memoryInMB\": 442368,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E64s_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        884736,\r\n      \"memoryInMB\": 442368,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F2s_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        16384,\r\n      \"memoryInMB\": 4096,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F4s_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        32768,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F8s_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F16s_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        131072,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F32s_v2\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        262144,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F64s_v2\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        524288,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F72s_v2\",\r\n      \"numberOfCores\":
+        72,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        589824,\r\n      \"memoryInMB\": 147456,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_L8s_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1811981,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_L16s_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        3623962,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_ND6s\",\r\n      \"numberOfCores\":
+        6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        344064,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 12\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_ND12s\",\r\n      \"numberOfCores\":
+        12,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        688128,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 24\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_ND24rs\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1376256,\r\n      \"memoryInMB\": 458752,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_ND24s\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1376256,\r\n      \"memoryInMB\": 458752,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A8\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        391168,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A9\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        391168,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A10\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        391168,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A11\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        391168,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   }\r\n  ]\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:42:42 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-a-ip?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDc0NDAsIm5iZiI6MTUyMDg0NzQ0MCwiZXhwIjoxNTIwODUxMzQwLCJhaW8iOiJZMk5nWURBTjFDdDJkcHEzYjE1K2V1Lys2UnRMQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMkVvc0syN3k0VW1BeHEwQ2ZqOGhBQSIsInZlciI6IjEuMCJ9.eFsuzFJ2JcJ7ej1pMyVOYq1w05gE3MmhvpMTnucMlw6-Trc-u7Yk4_jr1X09KZNEsUBc58DomvhqvC_Iv6VHmnvO4fHpyEn3WLwkVhKhTb9LIJJqCT2w7-P6zLNgIC-wcITEBzea1qHk2X5heiR3TbzTiNSO2CkCSUEiPy_F6SFQHHWeo4JrVUC45Rd_BJybz4WGfo6LIy1GVCAVQbdDYhlZ00JwM4STh02tbHL2yW4h_qjCqeE9lmxx1jNiQXAEvkcnJOhCXYKkRCixxbnzCxMva91yx43fOvqO7XaFfCgKB8eCqkh0-f3xkePPjlcOkiTxeFvYPjckYrCXIn5p_g
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"3ba30997-7d2f-470c-96f6-301158e93b7c"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - c43989d3-c80e-4c98-87ba-e8f00ee3d071
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14983'
+      X-Ms-Correlation-Request-Id:
+      - 38ce108b-6785-4173-a4a6-612907f2ad3b
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T094238Z:38ce108b-6785-4173-a4a6-612907f2ad3b
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:42:38 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"rspec-lb-a-ip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-a-ip\",\r\n
+        \ \"etag\": \"W/\\\"3ba30997-7d2f-470c-96f6-301158e93b7c\\\"\",\r\n  \"location\":
+        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"3c605f75-23c0-46ab-ba2b-6fd4430140fd\",\r\n    \"publicIPAddressVersion\":
         \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
-        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
+        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
         \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
         \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:26 GMT
+  recorded_at: Mon, 12 Mar 2018 09:42:43 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-b-ip?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDc0NDAsIm5iZiI6MTUyMDg0NzQ0MCwiZXhwIjoxNTIwODUxMzQwLCJhaW8iOiJZMk5nWURBTjFDdDJkcHEzYjE1K2V1Lys2UnRMQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMkVvc0syN3k0VW1BeHEwQ2ZqOGhBQSIsInZlciI6IjEuMCJ9.eFsuzFJ2JcJ7ej1pMyVOYq1w05gE3MmhvpMTnucMlw6-Trc-u7Yk4_jr1X09KZNEsUBc58DomvhqvC_Iv6VHmnvO4fHpyEn3WLwkVhKhTb9LIJJqCT2w7-P6zLNgIC-wcITEBzea1qHk2X5heiR3TbzTiNSO2CkCSUEiPy_F6SFQHHWeo4JrVUC45Rd_BJybz4WGfo6LIy1GVCAVQbdDYhlZ00JwM4STh02tbHL2yW4h_qjCqeE9lmxx1jNiQXAEvkcnJOhCXYKkRCixxbnzCxMva91yx43fOvqO7XaFfCgKB8eCqkh0-f3xkePPjlcOkiTxeFvYPjckYrCXIn5p_g
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"cf6012c7-3d47-438f-84d7-332ad1ef4500"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - cac452e3-6668-4419-be60-31e2cf150571
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14984'
+      X-Ms-Correlation-Request-Id:
+      - b9c8deda-779c-4872-87c2-01cfa641eb75
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T094239Z:b9c8deda-779c-4872-87c2-01cfa641eb75
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:42:39 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"rspec-lb-b-ip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-b-ip\",\r\n
+        \ \"etag\": \"W/\\\"cf6012c7-3d47-438f-84d7-332ad1ef4500\\\"\",\r\n  \"location\":
+        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"5d1a2425-a351-4c0f-bc87-37e6500bff22\",\r\n    \"publicIPAddressVersion\":
+        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
+        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\"\r\n
+        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
+        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:42:43 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb?api-version=2017-10-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDc0NDAsIm5iZiI6MTUyMDg0NzQ0MCwiZXhwIjoxNTIwODUxMzQwLCJhaW8iOiJZMk5nWURBTjFDdDJkcHEzYjE1K2V1Lys2UnRMQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMkVvc0syN3k0VW1BeHEwQ2ZqOGhBQSIsInZlciI6IjEuMCJ9.eFsuzFJ2JcJ7ej1pMyVOYq1w05gE3MmhvpMTnucMlw6-Trc-u7Yk4_jr1X09KZNEsUBc58DomvhqvC_Iv6VHmnvO4fHpyEn3WLwkVhKhTb9LIJJqCT2w7-P6zLNgIC-wcITEBzea1qHk2X5heiR3TbzTiNSO2CkCSUEiPy_F6SFQHHWeo4JrVUC45Rd_BJybz4WGfo6LIy1GVCAVQbdDYhlZ00JwM4STh02tbHL2yW4h_qjCqeE9lmxx1jNiQXAEvkcnJOhCXYKkRCixxbnzCxMva91yx43fOvqO7XaFfCgKB8eCqkh0-f3xkePPjlcOkiTxeFvYPjckYrCXIn5p_g
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - c69142d1-4475-4104-823e-d96e8f71188e
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14982'
+      X-Ms-Correlation-Request-Id:
+      - 24a53b0e-3d1a-4b75-921a-4b9e6ce355b7
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T094239Z:24a53b0e-3d1a-4b75-921a-4b9e6ce355b7
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:42:38 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"sku":{"name":"Premium_LRS","tier":"Premium"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb","name":"rspeclb","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-09-02T16:29:11.6823797Z","primaryEndpoints":{"blob":"https://rspeclb.blob.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:42:44 GMT
+- request:
+    method: post
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb/listKeys?api-version=2017-10-01
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDc0NDAsIm5iZiI6MTUyMDg0NzQ0MCwiZXhwIjoxNTIwODUxMzQwLCJhaW8iOiJZMk5nWURBTjFDdDJkcHEzYjE1K2V1Lys2UnRMQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMkVvc0syN3k0VW1BeHEwQ2ZqOGhBQSIsInZlciI6IjEuMCJ9.eFsuzFJ2JcJ7ej1pMyVOYq1w05gE3MmhvpMTnucMlw6-Trc-u7Yk4_jr1X09KZNEsUBc58DomvhqvC_Iv6VHmnvO4fHpyEn3WLwkVhKhTb9LIJJqCT2w7-P6zLNgIC-wcITEBzea1qHk2X5heiR3TbzTiNSO2CkCSUEiPy_F6SFQHHWeo4JrVUC45Rd_BJybz4WGfo6LIy1GVCAVQbdDYhlZ00JwM4STh02tbHL2yW4h_qjCqeE9lmxx1jNiQXAEvkcnJOhCXYKkRCixxbnzCxMva91yx43fOvqO7XaFfCgKB8eCqkh0-f3xkePPjlcOkiTxeFvYPjckYrCXIn5p_g
+      Content-Length:
+      - '0'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 2bcea2a8-7ce3-42d1-8070-8c3c73e76c62
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Writes:
+      - '1198'
+      X-Ms-Correlation-Request-Id:
+      - 9c3b4442-501c-48ca-9b80-00b063f5c9ea
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T094240Z:9c3b4442-501c-48ca-9b80-00b063f5c9ea
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:42:40 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"keys":[{"keyName":"key1","value":"xMvZwiumnKCZnYVJjdtGLqaO1c2v6ERPx4XPDZO7TM1l7/jM1TxAAgtfCMkRn72aRPhqLqwWAn8n5a1iSGRHtA==","permissions":"Full"},{"keyName":"key2","value":"3nDvKhjGAIAvgnH2reuv7tzyeb/0dddgVeUT13VODYD5xO/jeAvQ7tkF3JqP2BAuFrmQqMB4GLkB4/cW4veYeA==","permissions":"Full"}]}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:42:45 GMT
+- request:
+    method: head
+    uri: https://rspeclb.blob.core.windows.net/vhds/rspec-lb-a201682122839.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:42:45 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey rspeclb:jWsLEvNmPQGAyPoRc2BDrRUEiFJHeLCtdj8zqf16h8U=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '32212255232'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - 8BW5hqrnOLoQINlZ05odxA==
+      Last-Modified:
+      - Sat, 03 Sep 2016 14:03:15 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D3D4030CA0ABEF"'
+      Vary:
+      - Origin
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Copy-Id:
+      - f4d64e56-53ed-46e0-9c24-ebfa731c2ac1
+      X-Ms-Copy-Progress:
+      - 32212255232/32212255232
+      X-Ms-Copy-Source:
+      - https://ardfepirv2bl6prdstp02a.blob.core.windows.net/a879bbefc56a43abb0ce65052aac09f3/rhel-67-20160302?sv=2014-02-14&sr=b&si=PirCacheAccountPublisherContainerPolicy&sig=odWVC2Axkv74I6hSj89s9UTQavqFXr29heJIw9TFaCY%3D
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Completion-Time:
+      - Fri, 02 Sep 2016 16:29:41 GMT
+      X-Ms-Meta-Microsoftazurecompute-Diskid:
+      - ecdb0d00-e186-4df6-a7b6-ae626753f7bd
+      X-Ms-Meta-Microsoftazurecompute-Diskname:
+      - rspec-lb-a
+      X-Ms-Meta-Microsoftazurecompute-Disktype:
+      - OSDisk
+      X-Ms-Meta-Microsoftazurecompute-Resourcegroupname:
+      - miq-azure-test1
+      X-Ms-Meta-Microsoftazurecompute-Vmname:
+      - rspec-lb-a
+      X-Ms-Lease-State:
+      - leased
+      X-Ms-Lease-Duration:
+      - infinite
+      X-Ms-Lease-Status:
+      - locked
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '1'
+      X-Ms-Server-Encrypted:
+      - 'false'
+      X-Ms-Request-Id:
+      - b4c62418-a01c-0072-23e6-b914f9000000
+      X-Ms-Version:
+      - '2016-05-31'
+      Date:
+      - Mon, 12 Mar 2018 09:42:40 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:42:45 GMT
+- request:
+    method: head
+    uri: https://rspeclb.blob.core.windows.net/vhds/rspec-lb-b201682123650.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:42:45 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey rspeclb:+zFpsBG48yebjcWdT+ySbBuunWswNqa5LG2KotQHRlY=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '32212255232'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - 8BW5hqrnOLoQINlZ05odxA==
+      Last-Modified:
+      - Sat, 03 Sep 2016 14:05:40 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D3D40362FE3898"'
+      Vary:
+      - Origin
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Copy-Id:
+      - f64a314d-e573-457d-88d4-e16ecfbe2819
+      X-Ms-Copy-Progress:
+      - 32212255232/32212255232
+      X-Ms-Copy-Source:
+      - https://ardfepirv2bl6prdstp02a.blob.core.windows.net/a879bbefc56a43abb0ce65052aac09f3/rhel-67-20160302?sv=2014-02-14&sr=b&si=PirCacheAccountPublisherContainerPolicy&sig=odWVC2Axkv74I6hSj89s9UTQavqFXr29heJIw9TFaCY%3D
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Completion-Time:
+      - Fri, 02 Sep 2016 16:37:29 GMT
+      X-Ms-Meta-Microsoftazurecompute-Diskid:
+      - dbb822a3-53bf-49f9-808d-02390abcee67
+      X-Ms-Meta-Microsoftazurecompute-Diskname:
+      - rspec-lb-b
+      X-Ms-Meta-Microsoftazurecompute-Disktype:
+      - OSDisk
+      X-Ms-Meta-Microsoftazurecompute-Resourcegroupname:
+      - miq-azure-test1
+      X-Ms-Meta-Microsoftazurecompute-Vmname:
+      - rspec-lb-b
+      X-Ms-Lease-State:
+      - leased
+      X-Ms-Lease-Duration:
+      - infinite
+      X-Ms-Lease-Status:
+      - locked
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '1'
+      X-Ms-Server-Encrypted:
+      - 'false'
+      X-Ms-Request-Id:
+      - 3345eaf6-901c-007a-1ee6-b90f8a000000
+      X-Ms-Version:
+      - '2016-05-31'
+      Date:
+      - Mon, 12 Mar 2018 09:42:41 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:42:46 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDc0NDAsIm5iZiI6MTUyMDg0NzQ0MCwiZXhwIjoxNTIwODUxMzQwLCJhaW8iOiJZMk5nWURBTjFDdDJkcHEzYjE1K2V1Lys2UnRMQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMkVvc0syN3k0VW1BeHEwQ2ZqOGhBQSIsInZlciI6IjEuMCJ9.eFsuzFJ2JcJ7ej1pMyVOYq1w05gE3MmhvpMTnucMlw6-Trc-u7Yk4_jr1X09KZNEsUBc58DomvhqvC_Iv6VHmnvO4fHpyEn3WLwkVhKhTb9LIJJqCT2w7-P6zLNgIC-wcITEBzea1qHk2X5heiR3TbzTiNSO2CkCSUEiPy_F6SFQHHWeo4JrVUC45Rd_BJybz4WGfo6LIy1GVCAVQbdDYhlZ00JwM4STh02tbHL2yW4h_qjCqeE9lmxx1jNiQXAEvkcnJOhCXYKkRCixxbnzCxMva91yx43fOvqO7XaFfCgKB8eCqkh0-f3xkePPjlcOkiTxeFvYPjckYrCXIn5p_g
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"1523bcb7-4597-4ae6-bcfc-ba8fc3826026"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 694e6c89-9221-4864-b3f8-25c9518e7631
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Correlation-Request-Id:
+      - ee6d4abd-84d3-43b2-9a21-810edaafdf76
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T094242Z:ee6d4abd-84d3-43b2-9a21-810edaafdf76
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:42:42 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"rspec-lb-a-nsg\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg\",\r\n
+        \ \"etag\": \"W/\\\"1523bcb7-4597-4ae6-bcfc-ba8fc3826026\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/networkSecurityGroups\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
+        \"63d15480-8c5a-4e18-9196-c43384932823\",\r\n    \"securityRules\": [\r\n
+        \     {\r\n        \"name\": \"default-allow-ssh\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg/securityRules/default-allow-ssh\",\r\n
+        \       \"etag\": \"W/\\\"1523bcb7-4597-4ae6-bcfc-ba8fc3826026\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"protocol\": \"TCP\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"22\",\r\n          \"sourceAddressPrefix\":
+        \"*\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n          \"access\":
+        \"Allow\",\r\n          \"priority\": 1000,\r\n          \"direction\": \"Inbound\",\r\n
+        \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      }\r\n    ],\r\n    \"defaultSecurityRules\": [\r\n
+        \     {\r\n        \"name\": \"AllowVnetInBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg/defaultSecurityRules/AllowVnetInBound\",\r\n
+        \       \"etag\": \"W/\\\"1523bcb7-4597-4ae6-bcfc-ba8fc3826026\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow inbound traffic from all VMs in VNET\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"VirtualNetwork\",\r\n          \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n          \"direction\":
+        \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowAzureLoadBalancerInBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg/defaultSecurityRules/AllowAzureLoadBalancerInBound\",\r\n
+        \       \"etag\": \"W/\\\"1523bcb7-4597-4ae6-bcfc-ba8fc3826026\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow inbound traffic from azure load balancer\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"AzureLoadBalancer\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65001,\r\n          \"direction\":
+        \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllInBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg/defaultSecurityRules/DenyAllInBound\",\r\n
+        \       \"etag\": \"W/\\\"1523bcb7-4597-4ae6-bcfc-ba8fc3826026\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Deny all inbound traffic\",\r\n          \"protocol\":
+        \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\":
+        \"*\",\r\n          \"sourceAddressPrefix\": \"*\",\r\n          \"destinationAddressPrefix\":
+        \"*\",\r\n          \"access\": \"Deny\",\r\n          \"priority\": 65500,\r\n
+        \         \"direction\": \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n
+        \         \"destinationPortRanges\": [],\r\n          \"sourceAddressPrefixes\":
+        [],\r\n          \"destinationAddressPrefixes\": []\r\n        }\r\n      },\r\n
+        \     {\r\n        \"name\": \"AllowVnetOutBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg/defaultSecurityRules/AllowVnetOutBound\",\r\n
+        \       \"etag\": \"W/\\\"1523bcb7-4597-4ae6-bcfc-ba8fc3826026\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow outbound traffic from all VMs to all VMs
+        in VNET\",\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\":
+        \"*\",\r\n          \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"VirtualNetwork\",\r\n          \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n          \"direction\":
+        \"Outbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowInternetOutBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg/defaultSecurityRules/AllowInternetOutBound\",\r\n
+        \       \"etag\": \"W/\\\"1523bcb7-4597-4ae6-bcfc-ba8fc3826026\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow outbound traffic from all VMs to Internet\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"*\",\r\n          \"destinationAddressPrefix\": \"Internet\",\r\n          \"access\":
+        \"Allow\",\r\n          \"priority\": 65001,\r\n          \"direction\": \"Outbound\",\r\n
+        \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllOutBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg/defaultSecurityRules/DenyAllOutBound\",\r\n
+        \       \"etag\": \"W/\\\"1523bcb7-4597-4ae6-bcfc-ba8fc3826026\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Deny all outbound traffic\",\r\n          \"protocol\":
+        \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\":
+        \"*\",\r\n          \"sourceAddressPrefix\": \"*\",\r\n          \"destinationAddressPrefix\":
+        \"*\",\r\n          \"access\": \"Deny\",\r\n          \"priority\": 65500,\r\n
+        \         \"direction\": \"Outbound\",\r\n          \"sourcePortRanges\":
+        [],\r\n          \"destinationPortRanges\": [],\r\n          \"sourceAddressPrefixes\":
+        [],\r\n          \"destinationAddressPrefixes\": []\r\n        }\r\n      }\r\n
+        \   ],\r\n    \"networkInterfaces\": [\r\n      {\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670\"\r\n
+        \     }\r\n    ]\r\n  }\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:42:46 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDc0NDAsIm5iZiI6MTUyMDg0NzQ0MCwiZXhwIjoxNTIwODUxMzQwLCJhaW8iOiJZMk5nWURBTjFDdDJkcHEzYjE1K2V1Lys2UnRMQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMkVvc0syN3k0VW1BeHEwQ2ZqOGhBQSIsInZlciI6IjEuMCJ9.eFsuzFJ2JcJ7ej1pMyVOYq1w05gE3MmhvpMTnucMlw6-Trc-u7Yk4_jr1X09KZNEsUBc58DomvhqvC_Iv6VHmnvO4fHpyEn3WLwkVhKhTb9LIJJqCT2w7-P6zLNgIC-wcITEBzea1qHk2X5heiR3TbzTiNSO2CkCSUEiPy_F6SFQHHWeo4JrVUC45Rd_BJybz4WGfo6LIy1GVCAVQbdDYhlZ00JwM4STh02tbHL2yW4h_qjCqeE9lmxx1jNiQXAEvkcnJOhCXYKkRCixxbnzCxMva91yx43fOvqO7XaFfCgKB8eCqkh0-f3xkePPjlcOkiTxeFvYPjckYrCXIn5p_g
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"80e6f7a1-78ee-48b4-9b28-a464ef94de09"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - d7d2fa22-b735-4955-9645-024119d137c5
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14984'
+      X-Ms-Correlation-Request-Id:
+      - 8cf35716-9c6f-4667-816d-e4320bfb196b
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T094242Z:8cf35716-9c6f-4667-816d-e4320bfb196b
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:42:42 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"rspec-lb-b-nsg\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg\",\r\n
+        \ \"etag\": \"W/\\\"80e6f7a1-78ee-48b4-9b28-a464ef94de09\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/networkSecurityGroups\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
+        \"4ee44ca4-a721-4149-ad87-74d4150b4c1e\",\r\n    \"securityRules\": [\r\n
+        \     {\r\n        \"name\": \"default-allow-ssh\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg/securityRules/default-allow-ssh\",\r\n
+        \       \"etag\": \"W/\\\"80e6f7a1-78ee-48b4-9b28-a464ef94de09\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"protocol\": \"TCP\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"22\",\r\n          \"sourceAddressPrefix\":
+        \"*\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n          \"access\":
+        \"Allow\",\r\n          \"priority\": 1000,\r\n          \"direction\": \"Inbound\",\r\n
+        \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      }\r\n    ],\r\n    \"defaultSecurityRules\": [\r\n
+        \     {\r\n        \"name\": \"AllowVnetInBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg/defaultSecurityRules/AllowVnetInBound\",\r\n
+        \       \"etag\": \"W/\\\"80e6f7a1-78ee-48b4-9b28-a464ef94de09\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow inbound traffic from all VMs in VNET\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"VirtualNetwork\",\r\n          \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n          \"direction\":
+        \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowAzureLoadBalancerInBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg/defaultSecurityRules/AllowAzureLoadBalancerInBound\",\r\n
+        \       \"etag\": \"W/\\\"80e6f7a1-78ee-48b4-9b28-a464ef94de09\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow inbound traffic from azure load balancer\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"AzureLoadBalancer\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65001,\r\n          \"direction\":
+        \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllInBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg/defaultSecurityRules/DenyAllInBound\",\r\n
+        \       \"etag\": \"W/\\\"80e6f7a1-78ee-48b4-9b28-a464ef94de09\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Deny all inbound traffic\",\r\n          \"protocol\":
+        \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\":
+        \"*\",\r\n          \"sourceAddressPrefix\": \"*\",\r\n          \"destinationAddressPrefix\":
+        \"*\",\r\n          \"access\": \"Deny\",\r\n          \"priority\": 65500,\r\n
+        \         \"direction\": \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n
+        \         \"destinationPortRanges\": [],\r\n          \"sourceAddressPrefixes\":
+        [],\r\n          \"destinationAddressPrefixes\": []\r\n        }\r\n      },\r\n
+        \     {\r\n        \"name\": \"AllowVnetOutBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg/defaultSecurityRules/AllowVnetOutBound\",\r\n
+        \       \"etag\": \"W/\\\"80e6f7a1-78ee-48b4-9b28-a464ef94de09\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow outbound traffic from all VMs to all VMs
+        in VNET\",\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\":
+        \"*\",\r\n          \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"VirtualNetwork\",\r\n          \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n          \"direction\":
+        \"Outbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowInternetOutBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg/defaultSecurityRules/AllowInternetOutBound\",\r\n
+        \       \"etag\": \"W/\\\"80e6f7a1-78ee-48b4-9b28-a464ef94de09\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow outbound traffic from all VMs to Internet\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"*\",\r\n          \"destinationAddressPrefix\": \"Internet\",\r\n          \"access\":
+        \"Allow\",\r\n          \"priority\": 65001,\r\n          \"direction\": \"Outbound\",\r\n
+        \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllOutBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg/defaultSecurityRules/DenyAllOutBound\",\r\n
+        \       \"etag\": \"W/\\\"80e6f7a1-78ee-48b4-9b28-a464ef94de09\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Deny all outbound traffic\",\r\n          \"protocol\":
+        \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\":
+        \"*\",\r\n          \"sourceAddressPrefix\": \"*\",\r\n          \"destinationAddressPrefix\":
+        \"*\",\r\n          \"access\": \"Deny\",\r\n          \"priority\": 65500,\r\n
+        \         \"direction\": \"Outbound\",\r\n          \"sourcePortRanges\":
+        [],\r\n          \"destinationPortRanges\": [],\r\n          \"sourceAddressPrefixes\":
+        [],\r\n          \"destinationAddressPrefixes\": []\r\n        }\r\n      }\r\n
+        \   ],\r\n    \"networkInterfaces\": [\r\n      {\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843\"\r\n
+        \     }\r\n    ]\r\n  }\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:42:47 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDc0NDAsIm5iZiI6MTUyMDg0NzQ0MCwiZXhwIjoxNTIwODUxMzQwLCJhaW8iOiJZMk5nWURBTjFDdDJkcHEzYjE1K2V1Lys2UnRMQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMkVvc0syN3k0VW1BeHEwQ2ZqOGhBQSIsInZlciI6IjEuMCJ9.eFsuzFJ2JcJ7ej1pMyVOYq1w05gE3MmhvpMTnucMlw6-Trc-u7Yk4_jr1X09KZNEsUBc58DomvhqvC_Iv6VHmnvO4fHpyEn3WLwkVhKhTb9LIJJqCT2w7-P6zLNgIC-wcITEBzea1qHk2X5heiR3TbzTiNSO2CkCSUEiPy_F6SFQHHWeo4JrVUC45Rd_BJybz4WGfo6LIy1GVCAVQbdDYhlZ00JwM4STh02tbHL2yW4h_qjCqeE9lmxx1jNiQXAEvkcnJOhCXYKkRCixxbnzCxMva91yx43fOvqO7XaFfCgKB8eCqkh0-f3xkePPjlcOkiTxeFvYPjckYrCXIn5p_g
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"a8b09238-30fc-4b36-a58d-e3cc69e267c5"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - abe1a7f6-ffee-446d-8f6c-157d5ea74f4e
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14983'
+      X-Ms-Correlation-Request-Id:
+      - dea44e6d-e2a1-4ecc-8748-44fcbe5cbcf5
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T094243Z:dea44e6d-e2a1-4ecc-8748-44fcbe5cbcf5
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:42:42 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"miq-azure-test1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1\",\r\n
+        \ \"etag\": \"W/\\\"a8b09238-30fc-4b36-a58d-e3cc69e267c5\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
+        \"d74c1e5f-50e4-4c8a-a7fe-78eaddc6b915\",\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\":
+        [\r\n        \"10.16.0.0/16\"\r\n      ]\r\n    },\r\n    \"subnets\": [\r\n
+        \     {\r\n        \"name\": \"default\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\",\r\n
+        \       \"etag\": \"W/\\\"a8b09238-30fc-4b36-a58d-e3cc69e267c5\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"addressPrefix\": \"10.16.0.0/24\",\r\n          \"ipConfigurations\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241/ipConfigurations/ipconfig1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1/ipConfigurations/miqmismatch1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/dbergerprov1/ipConfigurations/dbergerprov1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/ladas_test_1/ipConfigurations/ladas_test_1\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"virtualNetworkPeerings\":
+        [],\r\n    \"enableDdosProtection\": false,\r\n    \"enableVmProtection\":
+        false\r\n  }\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:42:47 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_500/lb_with_vms_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_500/lb_with_vms_refresh.yml
@@ -1,6 +1,62 @@
 ---
 http_interactions:
 - request:
+    method: post
+    uri: https://login.microsoftonline.com/AZURE_TENANT_ID/oauth2/token
+    body:
+      encoding: UTF-8
+      string: grant_type=client_credentials&client_id=AZURE_CLIENT_ID&client_secret=AZURE_CLIENT_SECRET&resource=https%3A%2F%2Fmanagement.azure.com%2F
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Server:
+      - Microsoft-IIS/10.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Request-Id:
+      - 9eb7fa2c-dad3-4a32-87be-1756004b2400
+      P3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Set-Cookie:
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHz1dCkECQ6iEtKrxBQRrJ9k9E4Dhm8lJcgCzhWJD2EmzFjTerVkfLDK3aUBsjffZnEP8Bq5Ruup7lufIuI5vN8H-dlmJsvXkv0ko9_pK8AaO-47P9CVQG3928updM5gaytBLaaxy3N03EoQUiw6FG2fL6MIJKLtxPlzovtMmrGZnggAA;
+        domain=.login.microsoftonline.com; path=/; secure; HttpOnly
+      - stsservicecookie=ests; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=005; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 12 Mar 2018 09:41:01 GMT
+      Content-Length:
+      - '1505'
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1520851262","not_before":"1520847362","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDczNjIsIm5iZiI6MTUyMDg0NzM2MiwiZXhwIjoxNTIwODUxMjYyLCJhaW8iOiJZMk5nWVBnYVUzejN3aDFCQjJXemxmTG5tVjV5QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTFBxM250UGFNa3FIdmhkV0FFc2tBQSIsInZlciI6IjEuMCJ9.iQ5v1seAWVNeUlQ3YJ7x7_maWTiCle23ELqyy-L7d_YZk9_EOHx_cOOKz4J-zhEOL5qqAMDPoQm9049jHz-rtx73_PtWcsxLzzXYuiWscG8O_df8whU9KYuie3yJxLvhE6m6ESr8NFmCjv0YMhZSuZ9m8T366vi6CfxJc6rlYynVRrJy4H7FU9ksFocoQ-6wooDhodrtrQQpBS28wxe-6mH4aPnW5IpodnuJPZLrybAfg2TsCijBYc-640Ho0y0Nr8E_xIGTLNEF9E7oQz2MZiq4IqeGHL5WyksheaxV8vbeR4GxucTbqTODxnwtLI-Swe5SHaEaRsVuFdNaY_sW6g"}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:41:07 GMT
+- request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
     body:
@@ -16,7 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDczNjIsIm5iZiI6MTUyMDg0NzM2MiwiZXhwIjoxNTIwODUxMjYyLCJhaW8iOiJZMk5nWVBnYVUzejN3aDFCQjJXemxmTG5tVjV5QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTFBxM250UGFNa3FIdmhkV0FFc2tBQSIsInZlciI6IjEuMCJ9.iQ5v1seAWVNeUlQ3YJ7x7_maWTiCle23ELqyy-L7d_YZk9_EOHx_cOOKz4J-zhEOL5qqAMDPoQm9049jHz-rtx73_PtWcsxLzzXYuiWscG8O_df8whU9KYuie3yJxLvhE6m6ESr8NFmCjv0YMhZSuZ9m8T366vi6CfxJc6rlYynVRrJy4H7FU9ksFocoQ-6wooDhodrtrQQpBS28wxe-6mH4aPnW5IpodnuJPZLrybAfg2TsCijBYc-640Ho0y0Nr8E_xIGTLNEF9E7oQz2MZiq4IqeGHL5WyksheaxV8vbeR4GxucTbqTODxnwtLI-Swe5SHaEaRsVuFdNaY_sW6g
   response:
     status:
       code: 200
@@ -35,26 +91,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14997'
+      - '14999'
       X-Ms-Request-Id:
-      - cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - 3ab44b7d-c4cd-492b-bf38-e7c6ccef653a
       X-Ms-Correlation-Request-Id:
-      - cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - 3ab44b7d-c4cd-492b-bf38-e7c6ccef653a
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102417Z:cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - WESTEUROPE:20180312T094102Z:3ab44b7d-c4cd-492b-bf38-e7c6ccef653a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:17 GMT
+      - Mon, 12 Mar 2018 09:41:02 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID","subscriptionId":"AZURE_SUBSCRIPTION_ID","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:22 GMT
+  recorded_at: Mon, 12 Mar 2018 09:41:07 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers?api-version=2015-01-01
@@ -71,7 +127,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDczNjIsIm5iZiI6MTUyMDg0NzM2MiwiZXhwIjoxNTIwODUxMjYyLCJhaW8iOiJZMk5nWVBnYVUzejN3aDFCQjJXemxmTG5tVjV5QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTFBxM250UGFNa3FIdmhkV0FFc2tBQSIsInZlciI6IjEuMCJ9.iQ5v1seAWVNeUlQ3YJ7x7_maWTiCle23ELqyy-L7d_YZk9_EOHx_cOOKz4J-zhEOL5qqAMDPoQm9049jHz-rtx73_PtWcsxLzzXYuiWscG8O_df8whU9KYuie3yJxLvhE6m6ESr8NFmCjv0YMhZSuZ9m8T366vi6CfxJc6rlYynVRrJy4H7FU9ksFocoQ-6wooDhodrtrQQpBS28wxe-6mH4aPnW5IpodnuJPZLrybAfg2TsCijBYc-640Ho0y0Nr8E_xIGTLNEF9E7oQz2MZiq4IqeGHL5WyksheaxV8vbeR4GxucTbqTODxnwtLI-Swe5SHaEaRsVuFdNaY_sW6g
   response:
     status:
       code: 200
@@ -88,19 +144,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - '14991'
       X-Ms-Request-Id:
-      - fe3532ca-59a2-474e-9094-8a3697b82bef
+      - ca1507a6-47cb-4f7d-b00a-5e8ca58cf082
       X-Ms-Correlation-Request-Id:
-      - fe3532ca-59a2-474e-9094-8a3697b82bef
+      - ca1507a6-47cb-4f7d-b00a-5e8ca58cf082
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102419Z:fe3532ca-59a2-474e-9094-8a3697b82bef
+      - WESTEUROPE:20180312T094105Z:ca1507a6-47cb-4f7d-b00a-5e8ca58cf082
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:18 GMT
+      - Mon, 12 Mar 2018 09:41:05 GMT
       Content-Length:
       - '320853'
     body:
@@ -2322,7 +2378,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:23 GMT
+  recorded_at: Mon, 12 Mar 2018 09:41:10 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1?api-version=2018-01-01
@@ -2339,7 +2395,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDczNjIsIm5iZiI6MTUyMDg0NzM2MiwiZXhwIjoxNTIwODUxMjYyLCJhaW8iOiJZMk5nWVBnYVUzejN3aDFCQjJXemxmTG5tVjV5QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTFBxM250UGFNa3FIdmhkV0FFc2tBQSIsInZlciI6IjEuMCJ9.iQ5v1seAWVNeUlQ3YJ7x7_maWTiCle23ELqyy-L7d_YZk9_EOHx_cOOKz4J-zhEOL5qqAMDPoQm9049jHz-rtx73_PtWcsxLzzXYuiWscG8O_df8whU9KYuie3yJxLvhE6m6ESr8NFmCjv0YMhZSuZ9m8T366vi6CfxJc6rlYynVRrJy4H7FU9ksFocoQ-6wooDhodrtrQQpBS28wxe-6mH4aPnW5IpodnuJPZLrybAfg2TsCijBYc-640Ho0y0Nr8E_xIGTLNEF9E7oQz2MZiq4IqeGHL5WyksheaxV8vbeR4GxucTbqTODxnwtLI-Swe5SHaEaRsVuFdNaY_sW6g
   response:
     status:
       code: 200
@@ -2360,22 +2416,22 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - '080de667-081e-4d58-9e94-9e7243d4200e'
+      - b6a26e17-f443-4768-baaa-3448d687ae84
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
+      - '14992'
       X-Ms-Correlation-Request-Id:
-      - '093d49ac-c85f-440e-956b-955b6698dd19'
+      - 6ae02d00-837f-4e0e-bbe4-9050ad67e740
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102419Z:093d49ac-c85f-440e-956b-955b6698dd19
+      - WESTEUROPE:20180312T094107Z:6ae02d00-837f-4e0e-bbe4-9050ad67e740
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:19 GMT
+      - Mon, 12 Mar 2018 09:41:07 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"rspec-lb1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1\",\r\n
@@ -2433,7 +2489,7 @@ http_interactions:
         [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
         \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:24 GMT
+  recorded_at: Mon, 12 Mar 2018 09:41:12 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2?api-version=2018-01-01
@@ -2450,7 +2506,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDczNjIsIm5iZiI6MTUyMDg0NzM2MiwiZXhwIjoxNTIwODUxMjYyLCJhaW8iOiJZMk5nWVBnYVUzejN3aDFCQjJXemxmTG5tVjV5QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTFBxM250UGFNa3FIdmhkV0FFc2tBQSIsInZlciI6IjEuMCJ9.iQ5v1seAWVNeUlQ3YJ7x7_maWTiCle23ELqyy-L7d_YZk9_EOHx_cOOKz4J-zhEOL5qqAMDPoQm9049jHz-rtx73_PtWcsxLzzXYuiWscG8O_df8whU9KYuie3yJxLvhE6m6ESr8NFmCjv0YMhZSuZ9m8T366vi6CfxJc6rlYynVRrJy4H7FU9ksFocoQ-6wooDhodrtrQQpBS28wxe-6mH4aPnW5IpodnuJPZLrybAfg2TsCijBYc-640Ho0y0Nr8E_xIGTLNEF9E7oQz2MZiq4IqeGHL5WyksheaxV8vbeR4GxucTbqTODxnwtLI-Swe5SHaEaRsVuFdNaY_sW6g
   response:
     status:
       code: 200
@@ -2471,22 +2527,22 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - bd22ca22-a01f-4ecf-9230-a4558fb66931
+      - 20df0312-0e26-45af-b349-4dfc16368057
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
+      - '14989'
       X-Ms-Correlation-Request-Id:
-      - 19c674a8-c8da-4b5e-8265-5ebc21926459
+      - 9295b4bc-cb56-4758-8ddb-47c2f9332544
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102420Z:19c674a8-c8da-4b5e-8265-5ebc21926459
+      - WESTEUROPE:20180312T094109Z:9295b4bc-cb56-4758-8ddb-47c2f9332544
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:19 GMT
+      - Mon, 12 Mar 2018 09:41:09 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"rspec-lb2\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2\",\r\n
@@ -2514,7 +2570,1109 @@ http_interactions:
         [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
         \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:25 GMT
+  recorded_at: Mon, 12 Mar 2018 09:41:14 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a?api-version=2017-12-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDczNjIsIm5iZiI6MTUyMDg0NzM2MiwiZXhwIjoxNTIwODUxMjYyLCJhaW8iOiJZMk5nWVBnYVUzejN3aDFCQjJXemxmTG5tVjV5QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTFBxM250UGFNa3FIdmhkV0FFc2tBQSIsInZlciI6IjEuMCJ9.iQ5v1seAWVNeUlQ3YJ7x7_maWTiCle23ELqyy-L7d_YZk9_EOHx_cOOKz4J-zhEOL5qqAMDPoQm9049jHz-rtx73_PtWcsxLzzXYuiWscG8O_df8whU9KYuie3yJxLvhE6m6ESr8NFmCjv0YMhZSuZ9m8T366vi6CfxJc6rlYynVRrJy4H7FU9ksFocoQ-6wooDhodrtrQQpBS28wxe-6mH4aPnW5IpodnuJPZLrybAfg2TsCijBYc-640Ho0y0Nr8E_xIGTLNEF9E7oQz2MZiq4IqeGHL5WyksheaxV8vbeR4GxucTbqTODxnwtLI-Swe5SHaEaRsVuFdNaY_sW6g
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/LowCostGet3Min;4784,Microsoft.Compute/LowCostGet30Min;38384
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344652126238
+      X-Ms-Request-Id:
+      - cea1f2bb-3139-4508-ab72-8b7dcc392069
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Correlation-Request-Id:
+      - 60adef92-4a0d-44b4-ab27-927701849f31
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T094110Z:60adef92-4a0d-44b4-ab27-927701849f31
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:41:10 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"23b0beab-16d2-4135-a01f-2fe713217fd0\",\r\n
+        \   \"availabilitySet\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/RSPEC-LB\"\r\n
+        \   },\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_F1s\"\r\n
+        \   },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
+        \"RedHat\",\r\n        \"offer\": \"RHEL\",\r\n        \"sku\": \"6.7\",\r\n
+        \       \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
+        \"Linux\",\r\n        \"name\": \"rspec-lb-a\",\r\n        \"createOption\":
+        \"FromImage\",\r\n        \"vhd\": {\r\n          \"uri\": \"https://rspeclb.blob.core.windows.net/vhds/rspec-lb-a201682122839.vhd\"\r\n
+        \       },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n      \"dataDisks\":
+        []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"rspec-lb-a\",\r\n
+        \     \"adminUsername\": \"bronaghs\",\r\n      \"linuxConfiguration\": {\r\n
+        \       \"disablePasswordAuthentication\": false\r\n      },\r\n      \"secrets\":
+        []\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670\"}]},\r\n
+        \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
+        true,\r\n        \"storageUri\": \"https://miqazuretest16487.blob.core.windows.net/\"\r\n
+        \     }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n
+        \ \"resources\": [\r\n    {\r\n      \"properties\": {\r\n        \"publisher\":
+        \"Microsoft.OSTCExtensions\",\r\n        \"type\": \"LinuxDiagnostic\",\r\n
+        \       \"typeHandlerVersion\": \"2.3\",\r\n        \"autoUpgradeMinorVersion\":
+        true,\r\n        \"settings\": {\"xmlCfg\":\"PFdhZENmZz48RGlhZ25vc3RpY01vbml0b3JDb25maWd1cmF0aW9uIG92ZXJhbGxRdW90YUluTUI9IjQwOTYiPjxEaWFnbm9zdGljSW5mcmFzdHJ1Y3R1cmVMb2dzIHNjaGVkdWxlZFRyYW5zZmVyUGVyaW9kPSJQVDFNIiBzY2hlZHVsZWRUcmFuc2ZlckxvZ0xldmVsRmlsdGVyPSJXYXJuaW5nIi8+PFBlcmZvcm1hbmNlQ291bnRlcnMgc2NoZWR1bGVkVHJhbnNmZXJQZXJpb2Q9IlBUMU0iPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlTWVtb3J5IiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQnl0ZXMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcUGVyY2VudEF2YWlsYWJsZU1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iTWVtb3J5IHVzZWQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50VXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgcGVyY2VudGFnZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkQnlDYWNoZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHVzZWQgYnkgY2FjaGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1BlclNlYyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50UGVyU2Vjb25kIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFnZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1JlYWRQZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2UgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1dyaXR0ZW5QZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2Ugd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iU3dhcCBhdmFpbGFibGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50QXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZFN3YXAiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlN3YXAgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRJZGxlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgaWRsZSB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFVzZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iUGVyY2VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkNQVSB1c2VyIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50TmljZVRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIG5pY2UgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRQcml2aWxlZ2VkVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgcHJpdmlsZWdlZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudEludGVycnVwdFRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIGludGVycnVwdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudERQQ1RpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIERQQyB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFByb2Nlc3NvclRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIHBlcmNlbnRhZ2UgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50SU9XYWl0VGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgSU8gd2FpdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xSZWFkQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCBndWVzdCBPUyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXFdyaXRlQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGUgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xUcmFuc2ZlcnNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXJzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcUmVhZHNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xXcml0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVJlYWRUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVdyaXRlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlNlY29uZHMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJEaXNrIHdyaXRlIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xBdmVyYWdlVHJhbnNmZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXIgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXEF2ZXJhZ2VEaXNrUXVldWVMZW5ndGgiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcXVldWUgbGVuZ3RoIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVHJhbnNtaXR0ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgb3V0IGd1ZXN0IE9TIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzUmVjZWl2ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgaW4gZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1RyYW5zbWl0dGVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHNlbnQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1JlY2VpdmVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHJlY2VpdmVkIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVG90YWwiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxSeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyByZWNlaXZlZCBlcnJvcnMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxUeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyBzZW50IGVycm9ycyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTmV0d29ya0ludGVyZmFjZVxUb3RhbENvbGxpc2lvbnMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgY29sbGlzaW9ucyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48L1BlcmZvcm1hbmNlQ291bnRlcnM+PE1ldHJpY3MgcmVzb3VyY2VJZD0iL3N1YnNjcmlwdGlvbnMvMjU4NmM2NGItMzhiNC00NTI3LWExNDAtMDEyZDQ5ZGZjMDJjL3Jlc291cmNlR3JvdXBzL21pcS1henVyZS10ZXN0MS9wcm92aWRlcnMvTWljcm9zb2Z0LkNvbXB1dGUvdmlydHVhbE1hY2hpbmVzL3JzcGVjLWxiLWEiPjxNZXRyaWNBZ2dyZWdhdGlvbiBzY2hlZHVsZWRUcmFuc2ZlclBlcmlvZD0iUFQxSCIvPjxNZXRyaWNBZ2dyZWdhdGlvbiBzY2hlZHVsZWRUcmFuc2ZlclBlcmlvZD0iUFQxTSIvPjwvTWV0cmljcz48L0RpYWdub3N0aWNNb25pdG9yQ29uZmlndXJhdGlvbj48L1dhZENmZz4=\",\"StorageAccount\":\"miqazuretest16487\"},\r\n
+        \       \"provisioningState\": \"Succeeded\"\r\n      },\r\n      \"type\":
+        \"Microsoft.Compute/virtualMachines/extensions\",\r\n      \"location\": \"eastus\",\r\n
+        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a/extensions/Microsoft.Insights.VMDiagnosticsSettings\",\r\n
+        \     \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n    }\r\n
+        \ ],\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\":
+        \"eastus\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a\",\r\n
+        \ \"name\": \"rspec-lb-a\"\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:41:15 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b?api-version=2017-12-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDczNjIsIm5iZiI6MTUyMDg0NzM2MiwiZXhwIjoxNTIwODUxMjYyLCJhaW8iOiJZMk5nWVBnYVUzejN3aDFCQjJXemxmTG5tVjV5QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTFBxM250UGFNa3FIdmhkV0FFc2tBQSIsInZlciI6IjEuMCJ9.iQ5v1seAWVNeUlQ3YJ7x7_maWTiCle23ELqyy-L7d_YZk9_EOHx_cOOKz4J-zhEOL5qqAMDPoQm9049jHz-rtx73_PtWcsxLzzXYuiWscG8O_df8whU9KYuie3yJxLvhE6m6ESr8NFmCjv0YMhZSuZ9m8T366vi6CfxJc6rlYynVRrJy4H7FU9ksFocoQ-6wooDhodrtrQQpBS28wxe-6mH4aPnW5IpodnuJPZLrybAfg2TsCijBYc-640Ho0y0Nr8E_xIGTLNEF9E7oQz2MZiq4IqeGHL5WyksheaxV8vbeR4GxucTbqTODxnwtLI-Swe5SHaEaRsVuFdNaY_sW6g
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/LowCostGet3Min;4783,Microsoft.Compute/LowCostGet30Min;38383
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344652126238
+      X-Ms-Request-Id:
+      - 677e05c7-d2a8-4fb5-9c08-169ea82f9404
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Correlation-Request-Id:
+      - ba3463fa-27ce-4c14-8d20-d44c270d5b39
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T094111Z:ba3463fa-27ce-4c14-8d20-d44c270d5b39
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:41:10 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"834a70b5-868d-4466-9dda-14e0f6b2caaf\",\r\n
+        \   \"availabilitySet\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/RSPEC-LB\"\r\n
+        \   },\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n
+        \   },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
+        \"RedHat\",\r\n        \"offer\": \"RHEL\",\r\n        \"sku\": \"6.7\",\r\n
+        \       \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
+        \"Linux\",\r\n        \"name\": \"rspec-lb-b\",\r\n        \"createOption\":
+        \"FromImage\",\r\n        \"vhd\": {\r\n          \"uri\": \"https://rspeclb.blob.core.windows.net/vhds/rspec-lb-b201682123650.vhd\"\r\n
+        \       },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n      \"dataDisks\":
+        []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"rspec-lb-b\",\r\n
+        \     \"adminUsername\": \"bronaghs\",\r\n      \"linuxConfiguration\": {\r\n
+        \       \"disablePasswordAuthentication\": false\r\n      },\r\n      \"secrets\":
+        []\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843\"}]},\r\n
+        \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
+        true,\r\n        \"storageUri\": \"https://amissteastorage.blob.core.windows.net/\"\r\n
+        \     }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n
+        \ \"resources\": [\r\n    {\r\n      \"properties\": {\r\n        \"publisher\":
+        \"Microsoft.OSTCExtensions\",\r\n        \"type\": \"LinuxDiagnostic\",\r\n
+        \       \"typeHandlerVersion\": \"2.3\",\r\n        \"autoUpgradeMinorVersion\":
+        true,\r\n        \"settings\": {\"xmlCfg\":\"PFdhZENmZz48RGlhZ25vc3RpY01vbml0b3JDb25maWd1cmF0aW9uIG92ZXJhbGxRdW90YUluTUI9IjQwOTYiPjxEaWFnbm9zdGljSW5mcmFzdHJ1Y3R1cmVMb2dzIHNjaGVkdWxlZFRyYW5zZmVyUGVyaW9kPSJQVDFNIiBzY2hlZHVsZWRUcmFuc2ZlckxvZ0xldmVsRmlsdGVyPSJXYXJuaW5nIi8+PFBlcmZvcm1hbmNlQ291bnRlcnMgc2NoZWR1bGVkVHJhbnNmZXJQZXJpb2Q9IlBUMU0iPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlTWVtb3J5IiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQnl0ZXMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcUGVyY2VudEF2YWlsYWJsZU1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iTWVtb3J5IHVzZWQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50VXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgcGVyY2VudGFnZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkQnlDYWNoZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHVzZWQgYnkgY2FjaGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1BlclNlYyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50UGVyU2Vjb25kIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFnZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1JlYWRQZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2UgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1dyaXR0ZW5QZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2Ugd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iU3dhcCBhdmFpbGFibGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50QXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZFN3YXAiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlN3YXAgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRJZGxlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgaWRsZSB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFVzZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iUGVyY2VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkNQVSB1c2VyIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50TmljZVRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIG5pY2UgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRQcml2aWxlZ2VkVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgcHJpdmlsZWdlZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudEludGVycnVwdFRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIGludGVycnVwdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudERQQ1RpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIERQQyB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFByb2Nlc3NvclRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIHBlcmNlbnRhZ2UgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50SU9XYWl0VGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgSU8gd2FpdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xSZWFkQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCBndWVzdCBPUyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXFdyaXRlQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGUgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xUcmFuc2ZlcnNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXJzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcUmVhZHNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xXcml0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVJlYWRUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVdyaXRlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlNlY29uZHMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJEaXNrIHdyaXRlIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xBdmVyYWdlVHJhbnNmZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXIgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXEF2ZXJhZ2VEaXNrUXVldWVMZW5ndGgiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcXVldWUgbGVuZ3RoIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVHJhbnNtaXR0ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgb3V0IGd1ZXN0IE9TIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzUmVjZWl2ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgaW4gZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1RyYW5zbWl0dGVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHNlbnQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1JlY2VpdmVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHJlY2VpdmVkIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVG90YWwiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxSeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyByZWNlaXZlZCBlcnJvcnMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxUeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyBzZW50IGVycm9ycyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTmV0d29ya0ludGVyZmFjZVxUb3RhbENvbGxpc2lvbnMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgY29sbGlzaW9ucyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48L1BlcmZvcm1hbmNlQ291bnRlcnM+PE1ldHJpY3MgcmVzb3VyY2VJZD0iL3N1YnNjcmlwdGlvbnMvMjU4NmM2NGItMzhiNC00NTI3LWExNDAtMDEyZDQ5ZGZjMDJjL3Jlc291cmNlR3JvdXBzL21pcS1henVyZS10ZXN0MS9wcm92aWRlcnMvTWljcm9zb2Z0LkNvbXB1dGUvdmlydHVhbE1hY2hpbmVzL3JzcGVjLWxiLWIiPjxNZXRyaWNBZ2dyZWdhdGlvbiBzY2hlZHVsZWRUcmFuc2ZlclBlcmlvZD0iUFQxSCIvPjxNZXRyaWNBZ2dyZWdhdGlvbiBzY2hlZHVsZWRUcmFuc2ZlclBlcmlvZD0iUFQxTSIvPjwvTWV0cmljcz48L0RpYWdub3N0aWNNb25pdG9yQ29uZmlndXJhdGlvbj48L1dhZENmZz4=\",\"StorageAccount\":\"amissteastorage\"},\r\n
+        \       \"provisioningState\": \"Succeeded\"\r\n      },\r\n      \"type\":
+        \"Microsoft.Compute/virtualMachines/extensions\",\r\n      \"location\": \"eastus\",\r\n
+        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b/extensions/Microsoft.Insights.VMDiagnosticsSettings\",\r\n
+        \     \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n    }\r\n
+        \ ],\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\":
+        \"eastus\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b\",\r\n
+        \ \"name\": \"rspec-lb-b\"\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:41:16 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDczNjIsIm5iZiI6MTUyMDg0NzM2MiwiZXhwIjoxNTIwODUxMjYyLCJhaW8iOiJZMk5nWVBnYVUzejN3aDFCQjJXemxmTG5tVjV5QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTFBxM250UGFNa3FIdmhkV0FFc2tBQSIsInZlciI6IjEuMCJ9.iQ5v1seAWVNeUlQ3YJ7x7_maWTiCle23ELqyy-L7d_YZk9_EOHx_cOOKz4J-zhEOL5qqAMDPoQm9049jHz-rtx73_PtWcsxLzzXYuiWscG8O_df8whU9KYuie3yJxLvhE6m6ESr8NFmCjv0YMhZSuZ9m8T366vi6CfxJc6rlYynVRrJy4H7FU9ksFocoQ-6wooDhodrtrQQpBS28wxe-6mH4aPnW5IpodnuJPZLrybAfg2TsCijBYc-640Ho0y0Nr8E_xIGTLNEF9E7oQz2MZiq4IqeGHL5WyksheaxV8vbeR4GxucTbqTODxnwtLI-Swe5SHaEaRsVuFdNaY_sW6g
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"cf3a0b0d-d596-4f33-bc31-749f92ba4f00"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - b021cb99-7546-43e8-a095-ba93ce49f6fe
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Correlation-Request-Id:
+      - be64041a-9469-4433-84a0-7be2fc1d14d9
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T094112Z:be64041a-9469-4433-84a0-7be2fc1d14d9
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:41:11 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"rspec-lb-a670\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670\",\r\n
+        \ \"etag\": \"W/\\\"cf3a0b0d-d596-4f33-bc31-749f92ba4f00\\\"\",\r\n  \"location\":
+        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"46cb8216-786e-408e-9d86-c0855b357349\",\r\n    \"ipConfigurations\":
+        [\r\n      {\r\n        \"name\": \"ipconfig1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\",\r\n
+        \       \"etag\": \"W/\\\"cf3a0b0d-d596-4f33-bc31-749f92ba4f00\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"privateIPAddress\": \"10.16.0.6\",\r\n          \"privateIPAllocationMethod\":
+        \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-a-ip\"\r\n
+        \         },\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\"\r\n
+        \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
+        \"IPv4\",\r\n          \"loadBalancerBackendAddressPools\": [\r\n            {\r\n
+        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\"\r\n
+        \           }\r\n          ],\r\n          \"loadBalancerInboundNatRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\":
+        {\r\n      \"dnsServers\": [],\r\n      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\":
+        \"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net\"\r\n    },\r\n    \"enableAcceleratedNetworking\":
+        false,\r\n    \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\":
+        {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg\"\r\n
+        \   },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a\"\r\n
+        \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
+        \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:41:16 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDczNjIsIm5iZiI6MTUyMDg0NzM2MiwiZXhwIjoxNTIwODUxMjYyLCJhaW8iOiJZMk5nWVBnYVUzejN3aDFCQjJXemxmTG5tVjV5QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTFBxM250UGFNa3FIdmhkV0FFc2tBQSIsInZlciI6IjEuMCJ9.iQ5v1seAWVNeUlQ3YJ7x7_maWTiCle23ELqyy-L7d_YZk9_EOHx_cOOKz4J-zhEOL5qqAMDPoQm9049jHz-rtx73_PtWcsxLzzXYuiWscG8O_df8whU9KYuie3yJxLvhE6m6ESr8NFmCjv0YMhZSuZ9m8T366vi6CfxJc6rlYynVRrJy4H7FU9ksFocoQ-6wooDhodrtrQQpBS28wxe-6mH4aPnW5IpodnuJPZLrybAfg2TsCijBYc-640Ho0y0Nr8E_xIGTLNEF9E7oQz2MZiq4IqeGHL5WyksheaxV8vbeR4GxucTbqTODxnwtLI-Swe5SHaEaRsVuFdNaY_sW6g
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"76aabe0c-8678-43f0-81a5-2f15784a4b99"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 1fe24b71-afa5-4089-80a4-f21dd08ffa74
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Correlation-Request-Id:
+      - ba5064ae-3b81-4173-bdda-ea5b1b4e09ca
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T094112Z:ba5064ae-3b81-4173-bdda-ea5b1b4e09ca
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:41:12 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"rspec-lb-b843\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843\",\r\n
+        \ \"etag\": \"W/\\\"76aabe0c-8678-43f0-81a5-2f15784a4b99\\\"\",\r\n  \"location\":
+        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"3ef6fa01-ac34-43a1-8fd7-67c706b4d8ef\",\r\n    \"ipConfigurations\":
+        [\r\n      {\r\n        \"name\": \"ipconfig1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\",\r\n
+        \       \"etag\": \"W/\\\"76aabe0c-8678-43f0-81a5-2f15784a4b99\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"privateIPAddress\": \"10.16.0.11\",\r\n          \"privateIPAllocationMethod\":
+        \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-b-ip\"\r\n
+        \         },\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\"\r\n
+        \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
+        \"IPv4\",\r\n          \"loadBalancerBackendAddressPools\": [\r\n            {\r\n
+        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\":
+        {\r\n      \"dnsServers\": [],\r\n      \"appliedDnsServers\": []\r\n    },\r\n
+        \   \"enableAcceleratedNetworking\": false,\r\n    \"enableIPForwarding\":
+        false,\r\n    \"networkSecurityGroup\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg\"\r\n
+        \   },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b\"\r\n
+        \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
+        \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:41:17 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a/instanceView?api-version=2017-12-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDczNjIsIm5iZiI6MTUyMDg0NzM2MiwiZXhwIjoxNTIwODUxMjYyLCJhaW8iOiJZMk5nWVBnYVUzejN3aDFCQjJXemxmTG5tVjV5QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTFBxM250UGFNa3FIdmhkV0FFc2tBQSIsInZlciI6IjEuMCJ9.iQ5v1seAWVNeUlQ3YJ7x7_maWTiCle23ELqyy-L7d_YZk9_EOHx_cOOKz4J-zhEOL5qqAMDPoQm9049jHz-rtx73_PtWcsxLzzXYuiWscG8O_df8whU9KYuie3yJxLvhE6m6ESr8NFmCjv0YMhZSuZ9m8T366vi6CfxJc6rlYynVRrJy4H7FU9ksFocoQ-6wooDhodrtrQQpBS28wxe-6mH4aPnW5IpodnuJPZLrybAfg2TsCijBYc-640Ho0y0Nr8E_xIGTLNEF9E7oQz2MZiq4IqeGHL5WyksheaxV8vbeR4GxucTbqTODxnwtLI-Swe5SHaEaRsVuFdNaY_sW6g
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/GetInstanceView3Min;4799,Microsoft.Compute/GetInstanceView30Min;23999
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344652126238
+      X-Ms-Request-Id:
+      - d9ca446d-176a-450a-8b26-7f854cfeb7f9
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Correlation-Request-Id:
+      - 5a0ca7a7-fbfe-4a5a-b2b6-4908a8bfb837
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T094122Z:5a0ca7a7-fbfe-4a5a-b2b6-4908a8bfb837
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:41:21 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"platformUpdateDomain\": 0,\r\n  \"platformFaultDomain\": 0,\r\n
+        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
+        [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
+        \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
+        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2018-03-12T09:41:15+00:00\"\r\n
+        \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"rspec-lb-a\",\r\n
+        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
+        succeeded\",\r\n          \"time\": \"2016-09-03T14:04:26.7359609+00:00\"\r\n
+        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
+        \"https://miqazuretest16487.blob.core.windows.net/bootdiagnostics-rspeclba-23b0beab-16d2-4135-a01f-2fe713217fd0/rspec-lb-a.23b0beab-16d2-4135-a01f-2fe713217fd0.screenshot.bmp\",\r\n
+        \   \"serialConsoleLogBlobUri\": \"https://miqazuretest16487.blob.core.windows.net/bootdiagnostics-rspeclba-23b0beab-16d2-4135-a01f-2fe713217fd0/rspec-lb-a.23b0beab-16d2-4135-a01f-2fe713217fd0.serialconsole.log\"\r\n
+        \ },\r\n  \"extensions\": [\r\n    {\r\n      \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n
+        \   }\r\n  ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n
+        \     \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n
+        \     \"time\": \"2016-09-03T14:04:26.7828345+00:00\"\r\n    },\r\n    {\r\n
+        \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
+        \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:41:27 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b/instanceView?api-version=2017-12-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDczNjIsIm5iZiI6MTUyMDg0NzM2MiwiZXhwIjoxNTIwODUxMjYyLCJhaW8iOiJZMk5nWVBnYVUzejN3aDFCQjJXemxmTG5tVjV5QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTFBxM250UGFNa3FIdmhkV0FFc2tBQSIsInZlciI6IjEuMCJ9.iQ5v1seAWVNeUlQ3YJ7x7_maWTiCle23ELqyy-L7d_YZk9_EOHx_cOOKz4J-zhEOL5qqAMDPoQm9049jHz-rtx73_PtWcsxLzzXYuiWscG8O_df8whU9KYuie3yJxLvhE6m6ESr8NFmCjv0YMhZSuZ9m8T366vi6CfxJc6rlYynVRrJy4H7FU9ksFocoQ-6wooDhodrtrQQpBS28wxe-6mH4aPnW5IpodnuJPZLrybAfg2TsCijBYc-640Ho0y0Nr8E_xIGTLNEF9E7oQz2MZiq4IqeGHL5WyksheaxV8vbeR4GxucTbqTODxnwtLI-Swe5SHaEaRsVuFdNaY_sW6g
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/GetInstanceView3Min;4798,Microsoft.Compute/GetInstanceView30Min;23998
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344652126238
+      X-Ms-Request-Id:
+      - edbc80c8-5d05-4a08-bc19-05839e6b7ddc
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Correlation-Request-Id:
+      - 3916c9c1-28d7-4e6d-bdf8-b72c654f98fe
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T094125Z:3916c9c1-28d7-4e6d-bdf8-b72c654f98fe
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:41:25 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"platformUpdateDomain\": 1,\r\n  \"platformFaultDomain\": 1,\r\n
+        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
+        [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
+        \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
+        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2018-03-12T09:41:25+00:00\"\r\n
+        \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"rspec-lb-b\",\r\n
+        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
+        succeeded\",\r\n          \"time\": \"2016-09-03T14:07:52.9377685+00:00\"\r\n
+        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
+        \"https://amissteastorage.blob.core.windows.net/bootdiagnostics-rspeclbb-834a70b5-868d-4466-9dda-14e0f6b2caaf/rspec-lb-b.834a70b5-868d-4466-9dda-14e0f6b2caaf.screenshot.bmp\",\r\n
+        \   \"serialConsoleLogBlobUri\": \"https://amissteastorage.blob.core.windows.net/bootdiagnostics-rspeclbb-834a70b5-868d-4466-9dda-14e0f6b2caaf/rspec-lb-b.834a70b5-868d-4466-9dda-14e0f6b2caaf.serialconsole.log\"\r\n
+        \ },\r\n  \"extensions\": [\r\n    {\r\n      \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n
+        \   }\r\n  ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n
+        \     \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n
+        \     \"time\": \"2016-09-03T14:07:52.9846158+00:00\"\r\n    },\r\n    {\r\n
+        \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
+        \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:41:30 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups/miq-azure-test1?api-version=2017-08-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDczNjIsIm5iZiI6MTUyMDg0NzM2MiwiZXhwIjoxNTIwODUxMjYyLCJhaW8iOiJZMk5nWVBnYVUzejN3aDFCQjJXemxmTG5tVjV5QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTFBxM250UGFNa3FIdmhkV0FFc2tBQSIsInZlciI6IjEuMCJ9.iQ5v1seAWVNeUlQ3YJ7x7_maWTiCle23ELqyy-L7d_YZk9_EOHx_cOOKz4J-zhEOL5qqAMDPoQm9049jHz-rtx73_PtWcsxLzzXYuiWscG8O_df8whU9KYuie3yJxLvhE6m6ESr8NFmCjv0YMhZSuZ9m8T366vi6CfxJc6rlYynVRrJy4H7FU9ksFocoQ-6wooDhodrtrQQpBS28wxe-6mH4aPnW5IpodnuJPZLrybAfg2TsCijBYc-640Ho0y0Nr8E_xIGTLNEF9E7oQz2MZiq4IqeGHL5WyksheaxV8vbeR4GxucTbqTODxnwtLI-Swe5SHaEaRsVuFdNaY_sW6g
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Request-Id:
+      - 7d778ae4-43d9-45da-b781-9f1c5b1d10a4
+      X-Ms-Correlation-Request-Id:
+      - 7d778ae4-43d9-45da-b781-9f1c5b1d10a4
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T094125Z:7d778ae4-43d9-45da-b781-9f1c5b1d10a4
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:41:25 GMT
+      Content-Length:
+      - '183'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1","name":"miq-azure-test1","location":"eastus","properties":{"provisioningState":"Succeeded"}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:41:30 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute/locations/eastus/vmSizes?api-version=2017-12-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDczNjIsIm5iZiI6MTUyMDg0NzM2MiwiZXhwIjoxNTIwODUxMjYyLCJhaW8iOiJZMk5nWVBnYVUzejN3aDFCQjJXemxmTG5tVjV5QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTFBxM250UGFNa3FIdmhkV0FFc2tBQSIsInZlciI6IjEuMCJ9.iQ5v1seAWVNeUlQ3YJ7x7_maWTiCle23ELqyy-L7d_YZk9_EOHx_cOOKz4J-zhEOL5qqAMDPoQm9049jHz-rtx73_PtWcsxLzzXYuiWscG8O_df8whU9KYuie3yJxLvhE6m6ESr8NFmCjv0YMhZSuZ9m8T366vi6CfxJc6rlYynVRrJy4H7FU9ksFocoQ-6wooDhodrtrQQpBS28wxe-6mH4aPnW5IpodnuJPZLrybAfg2TsCijBYc-640Ho0y0Nr8E_xIGTLNEF9E7oQz2MZiq4IqeGHL5WyksheaxV8vbeR4GxucTbqTODxnwtLI-Swe5SHaEaRsVuFdNaY_sW6g
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/LowCostGet3Min;4776,Microsoft.Compute/LowCostGet30Min;38376
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344652126238
+      X-Ms-Request-Id:
+      - 3ab7fa74-b788-4ecf-bbec-75c9235d38f0
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Correlation-Request-Id:
+      - 9eecb20e-540f-457f-bc2d-6ff5f9d54740
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T094126Z:9eecb20e-540f-457f-bc2d-6ff5f9d54740
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:41:26 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"Standard_B1ms\",\r\n
+        \     \"numberOfCores\": 1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        4096,\r\n      \"memoryInMB\": 2048,\r\n      \"maxDataDiskCount\": 2\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_B1s\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        2048,\r\n      \"memoryInMB\": 1024,\r\n      \"maxDataDiskCount\": 2\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_B2ms\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        16384,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_B2s\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        8192,\r\n      \"memoryInMB\": 4096,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_B4ms\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        32768,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_B8ms\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS1_v2\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        7168,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS2_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        14336,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS3_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS4_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS5_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS11-1_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS11_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS12-1_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS12-2_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS12_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS13-2_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS13-4_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS13_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS14-4_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        229376,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS14-8_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        229376,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS14_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        229376,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS15_v2\",\r\n      \"numberOfCores\":
+        20,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        286720,\r\n      \"memoryInMB\": 143360,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS2_v2_Promo\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        14336,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS3_v2_Promo\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS4_v2_Promo\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS5_v2_Promo\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS11_v2_Promo\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS12_v2_Promo\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS13_v2_Promo\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS14_v2_Promo\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        229376,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F1s\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        4096,\r\n      \"memoryInMB\": 2048,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F2s\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        8192,\r\n      \"memoryInMB\": 4096,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F4s\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        16384,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F8s\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        32768,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F16s\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D2s_v3\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        16384,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D4s_v3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        32768,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D8s_v3\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D16s_v3\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        131072,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D32s_v3\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        262144,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A0\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        20480,\r\n      \"memoryInMB\": 768,\r\n      \"maxDataDiskCount\": 1\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A1\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        71680,\r\n      \"memoryInMB\": 1792,\r\n      \"maxDataDiskCount\": 2\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        138240,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        291840,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A5\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        138240,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A4\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        619520,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A6\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        291840,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A7\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        619520,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Basic_A0\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        20480,\r\n      \"memoryInMB\": 768,\r\n      \"maxDataDiskCount\": 1\r\n
+        \   },\r\n    {\r\n      \"name\": \"Basic_A1\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        40960,\r\n      \"memoryInMB\": 1792,\r\n      \"maxDataDiskCount\": 2\r\n
+        \   },\r\n    {\r\n      \"name\": \"Basic_A2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        61440,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Basic_A3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        122880,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Basic_A4\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        245760,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D1_v2\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        51200,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D2_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D3_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D4_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D5_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D11_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D12_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D13_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D14_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D15_v2\",\r\n      \"numberOfCores\":
+        20,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        286720,\r\n      \"memoryInMB\": 143360,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D2_v2_Promo\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D3_v2_Promo\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D4_v2_Promo\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D5_v2_Promo\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D11_v2_Promo\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D12_v2_Promo\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D13_v2_Promo\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D14_v2_Promo\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F1\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        16384,\r\n      \"memoryInMB\": 2048,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        32768,\r\n      \"memoryInMB\": 4096,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F4\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F8\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        131072,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F16\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        262144,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A1_v2\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        10240,\r\n      \"memoryInMB\": 2048,\r\n      \"maxDataDiskCount\": 2\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A2m_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        20480,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A2_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        20480,\r\n      \"memoryInMB\": 4096,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A4m_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        40960,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A4_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        40960,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A8m_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        81920,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A8_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        81920,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D2_v3\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        51200,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D4_v3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D8_v3\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D16_v3\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 65636,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D32_v3\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_H8\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1024000,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_H16\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        2048000,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_H8m\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1024000,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_H16m\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        2048000,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_H16r\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        2048000,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_H16mr\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        2048000,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D1\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        51200,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D4\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D11\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D12\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D13\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D14\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NV6\",\r\n      \"numberOfCores\":
+        6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        389120,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 24\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NV12\",\r\n      \"numberOfCores\":
+        12,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        696320,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 48\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NV24\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1474560,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC6s_v2\",\r\n      \"numberOfCores\":
+        6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        344064,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 12\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC12s_v2\",\r\n      \"numberOfCores\":
+        12,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        688128,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 24\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC24rs_v2\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1376256,\r\n      \"memoryInMB\": 458752,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC24s_v2\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1376256,\r\n      \"memoryInMB\": 458752,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC6\",\r\n      \"numberOfCores\":
+        6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        389120,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 24\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC12\",\r\n      \"numberOfCores\":
+        12,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        696320,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 48\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC24\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1474560,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC24r\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1474560,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS1\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        7168,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        14336,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS4\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS11\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS12\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS13\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS14\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        229376,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC6s_v3\",\r\n      \"numberOfCores\":
+        6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        344064,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 12\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC12s_v3\",\r\n      \"numberOfCores\":
+        12,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        688128,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 24\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC24rs_v3\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1376256,\r\n      \"memoryInMB\": 458752,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC24s_v3\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1376256,\r\n      \"memoryInMB\": 458752,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D64_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1638400,\r\n      \"memoryInMB\": 262144,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D64s_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        524288,\r\n      \"memoryInMB\": 262144,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E2_v3\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        51200,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E4_v3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E8_v3\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E16_v3\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E32_v3\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 262144,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E64i_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1638400,\r\n      \"memoryInMB\": 442368,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E64_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1638400,\r\n      \"memoryInMB\": 442368,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E2s_v3\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        32768,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E4-2s_v3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E4s_v3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E8-2s_v3\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        131072,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E8-4s_v3\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        131072,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E8s_v3\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        131072,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E16-4s_v3\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        262144,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E16-8s_v3\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        262144,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E16s_v3\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        262144,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E32-8s_v3\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        524288,\r\n      \"memoryInMB\": 262144,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E32-16s_v3\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        524288,\r\n      \"memoryInMB\": 262144,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E32s_v3\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        524288,\r\n      \"memoryInMB\": 262144,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E64-16s_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        884736,\r\n      \"memoryInMB\": 442368,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E64-32s_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        884736,\r\n      \"memoryInMB\": 442368,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E64is_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        884736,\r\n      \"memoryInMB\": 442368,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E64s_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        884736,\r\n      \"memoryInMB\": 442368,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F2s_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        16384,\r\n      \"memoryInMB\": 4096,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F4s_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        32768,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F8s_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F16s_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        131072,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F32s_v2\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        262144,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F64s_v2\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        524288,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F72s_v2\",\r\n      \"numberOfCores\":
+        72,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        589824,\r\n      \"memoryInMB\": 147456,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_L8s_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1811981,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_L16s_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        3623962,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_ND6s\",\r\n      \"numberOfCores\":
+        6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        344064,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 12\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_ND12s\",\r\n      \"numberOfCores\":
+        12,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        688128,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 24\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_ND24rs\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1376256,\r\n      \"memoryInMB\": 458752,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_ND24s\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1376256,\r\n      \"memoryInMB\": 458752,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A8\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        391168,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A9\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        391168,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A10\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        391168,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A11\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        391168,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   }\r\n  ]\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:41:31 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd?api-version=2018-01-01
@@ -2531,7 +3689,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDczNjIsIm5iZiI6MTUyMDg0NzM2MiwiZXhwIjoxNTIwODUxMjYyLCJhaW8iOiJZMk5nWVBnYVUzejN3aDFCQjJXemxmTG5tVjV5QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTFBxM250UGFNa3FIdmhkV0FFc2tBQSIsInZlciI6IjEuMCJ9.iQ5v1seAWVNeUlQ3YJ7x7_maWTiCle23ELqyy-L7d_YZk9_EOHx_cOOKz4J-zhEOL5qqAMDPoQm9049jHz-rtx73_PtWcsxLzzXYuiWscG8O_df8whU9KYuie3yJxLvhE6m6ESr8NFmCjv0YMhZSuZ9m8T366vi6CfxJc6rlYynVRrJy4H7FU9ksFocoQ-6wooDhodrtrQQpBS28wxe-6mH4aPnW5IpodnuJPZLrybAfg2TsCijBYc-640Ho0y0Nr8E_xIGTLNEF9E7oQz2MZiq4IqeGHL5WyksheaxV8vbeR4GxucTbqTODxnwtLI-Swe5SHaEaRsVuFdNaY_sW6g
   response:
     status:
       code: 200
@@ -2552,22 +3710,22 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 0fd15240-6a1c-4b39-a4f6-aa53fd8591c2
+      - c1e6a4c1-fbe8-4b3b-8c6b-6a8b32626a7b
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
+      - '14991'
       X-Ms-Correlation-Request-Id:
-      - 5cc03163-922e-41a1-9601-dba2d7cf2a81
+      - 2ee03989-9cf8-4f08-a3cc-9cfb28536ef2
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102421Z:5cc03163-922e-41a1-9601-dba2d7cf2a81
+      - WESTEUROPE:20180312T094126Z:2ee03989-9cf8-4f08-a3cc-9cfb28536ef2
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:20 GMT
+      - Mon, 12 Mar 2018 09:41:26 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"rspec-lb1-LoadBalancerFrontEnd\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\",\r\n
@@ -2580,7 +3738,7 @@ http_interactions:
         \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
         \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:25 GMT
+  recorded_at: Mon, 12 Mar 2018 09:41:31 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip?api-version=2018-01-01
@@ -2597,7 +3755,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDczNjIsIm5iZiI6MTUyMDg0NzM2MiwiZXhwIjoxNTIwODUxMjYyLCJhaW8iOiJZMk5nWVBnYVUzejN3aDFCQjJXemxmTG5tVjV5QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTFBxM250UGFNa3FIdmhkV0FFc2tBQSIsInZlciI6IjEuMCJ9.iQ5v1seAWVNeUlQ3YJ7x7_maWTiCle23ELqyy-L7d_YZk9_EOHx_cOOKz4J-zhEOL5qqAMDPoQm9049jHz-rtx73_PtWcsxLzzXYuiWscG8O_df8whU9KYuie3yJxLvhE6m6ESr8NFmCjv0YMhZSuZ9m8T366vi6CfxJc6rlYynVRrJy4H7FU9ksFocoQ-6wooDhodrtrQQpBS28wxe-6mH4aPnW5IpodnuJPZLrybAfg2TsCijBYc-640Ho0y0Nr8E_xIGTLNEF9E7oQz2MZiq4IqeGHL5WyksheaxV8vbeR4GxucTbqTODxnwtLI-Swe5SHaEaRsVuFdNaY_sW6g
   response:
     status:
       code: 200
@@ -2618,22 +3776,22 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 1403e5b6-8fa0-4cd3-89b1-76b6c4fd805b
+      - 3702d7d1-ac0d-4938-ace3-46986ba34d07
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - '14990'
       X-Ms-Correlation-Request-Id:
-      - e4a5f369-a742-466f-bd8f-42e17eaaf9c9
+      - 4160a989-77e3-4333-9531-67d10e59b5a8
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102421Z:e4a5f369-a742-466f-bd8f-42e17eaaf9c9
+      - WESTEUROPE:20180312T094131Z:4160a989-77e3-4333-9531-67d10e59b5a8
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:21 GMT
+      - Mon, 12 Mar 2018 09:41:30 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"rspec-lb2-publicip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\",\r\n
@@ -2645,5 +3803,779 @@ http_interactions:
         \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
         \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:26 GMT
+  recorded_at: Mon, 12 Mar 2018 09:41:36 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-a-ip?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDczNjIsIm5iZiI6MTUyMDg0NzM2MiwiZXhwIjoxNTIwODUxMjYyLCJhaW8iOiJZMk5nWVBnYVUzejN3aDFCQjJXemxmTG5tVjV5QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTFBxM250UGFNa3FIdmhkV0FFc2tBQSIsInZlciI6IjEuMCJ9.iQ5v1seAWVNeUlQ3YJ7x7_maWTiCle23ELqyy-L7d_YZk9_EOHx_cOOKz4J-zhEOL5qqAMDPoQm9049jHz-rtx73_PtWcsxLzzXYuiWscG8O_df8whU9KYuie3yJxLvhE6m6ESr8NFmCjv0YMhZSuZ9m8T366vi6CfxJc6rlYynVRrJy4H7FU9ksFocoQ-6wooDhodrtrQQpBS28wxe-6mH4aPnW5IpodnuJPZLrybAfg2TsCijBYc-640Ho0y0Nr8E_xIGTLNEF9E7oQz2MZiq4IqeGHL5WyksheaxV8vbeR4GxucTbqTODxnwtLI-Swe5SHaEaRsVuFdNaY_sW6g
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"3ba30997-7d2f-470c-96f6-301158e93b7c"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - bfa1ab5d-0537-40d3-9dda-d93329c369da
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14988'
+      X-Ms-Correlation-Request-Id:
+      - 3f177371-64a3-4cde-bce3-f3f11968461b
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T094131Z:3f177371-64a3-4cde-bce3-f3f11968461b
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:41:31 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"rspec-lb-a-ip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-a-ip\",\r\n
+        \ \"etag\": \"W/\\\"3ba30997-7d2f-470c-96f6-301158e93b7c\\\"\",\r\n  \"location\":
+        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"3c605f75-23c0-46ab-ba2b-6fd4430140fd\",\r\n    \"publicIPAddressVersion\":
+        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
+        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
+        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
+        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:41:36 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-b-ip?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDczNjIsIm5iZiI6MTUyMDg0NzM2MiwiZXhwIjoxNTIwODUxMjYyLCJhaW8iOiJZMk5nWVBnYVUzejN3aDFCQjJXemxmTG5tVjV5QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTFBxM250UGFNa3FIdmhkV0FFc2tBQSIsInZlciI6IjEuMCJ9.iQ5v1seAWVNeUlQ3YJ7x7_maWTiCle23ELqyy-L7d_YZk9_EOHx_cOOKz4J-zhEOL5qqAMDPoQm9049jHz-rtx73_PtWcsxLzzXYuiWscG8O_df8whU9KYuie3yJxLvhE6m6ESr8NFmCjv0YMhZSuZ9m8T366vi6CfxJc6rlYynVRrJy4H7FU9ksFocoQ-6wooDhodrtrQQpBS28wxe-6mH4aPnW5IpodnuJPZLrybAfg2TsCijBYc-640Ho0y0Nr8E_xIGTLNEF9E7oQz2MZiq4IqeGHL5WyksheaxV8vbeR4GxucTbqTODxnwtLI-Swe5SHaEaRsVuFdNaY_sW6g
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"cf6012c7-3d47-438f-84d7-332ad1ef4500"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - '086a0842-87a6-40c7-bd11-15912e6c5be4'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Correlation-Request-Id:
+      - fc468fbf-70bc-4044-bd79-ed532ec307a6
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T094134Z:fc468fbf-70bc-4044-bd79-ed532ec307a6
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:41:34 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"rspec-lb-b-ip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-b-ip\",\r\n
+        \ \"etag\": \"W/\\\"cf6012c7-3d47-438f-84d7-332ad1ef4500\\\"\",\r\n  \"location\":
+        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"5d1a2425-a351-4c0f-bc87-37e6500bff22\",\r\n    \"publicIPAddressVersion\":
+        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
+        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\"\r\n
+        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
+        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:41:39 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb?api-version=2017-10-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDczNjIsIm5iZiI6MTUyMDg0NzM2MiwiZXhwIjoxNTIwODUxMjYyLCJhaW8iOiJZMk5nWVBnYVUzejN3aDFCQjJXemxmTG5tVjV5QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTFBxM250UGFNa3FIdmhkV0FFc2tBQSIsInZlciI6IjEuMCJ9.iQ5v1seAWVNeUlQ3YJ7x7_maWTiCle23ELqyy-L7d_YZk9_EOHx_cOOKz4J-zhEOL5qqAMDPoQm9049jHz-rtx73_PtWcsxLzzXYuiWscG8O_df8whU9KYuie3yJxLvhE6m6ESr8NFmCjv0YMhZSuZ9m8T366vi6CfxJc6rlYynVRrJy4H7FU9ksFocoQ-6wooDhodrtrQQpBS28wxe-6mH4aPnW5IpodnuJPZLrybAfg2TsCijBYc-640Ho0y0Nr8E_xIGTLNEF9E7oQz2MZiq4IqeGHL5WyksheaxV8vbeR4GxucTbqTODxnwtLI-Swe5SHaEaRsVuFdNaY_sW6g
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 44ae411c-3b36-44ac-9830-8525f1394df0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Correlation-Request-Id:
+      - 2dfacf0b-607b-4c58-ab90-a9ab0353ebf9
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T094135Z:2dfacf0b-607b-4c58-ab90-a9ab0353ebf9
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:41:34 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"sku":{"name":"Premium_LRS","tier":"Premium"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb","name":"rspeclb","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-09-02T16:29:11.6823797Z","primaryEndpoints":{"blob":"https://rspeclb.blob.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:41:40 GMT
+- request:
+    method: post
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb/listKeys?api-version=2017-10-01
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDczNjIsIm5iZiI6MTUyMDg0NzM2MiwiZXhwIjoxNTIwODUxMjYyLCJhaW8iOiJZMk5nWVBnYVUzejN3aDFCQjJXemxmTG5tVjV5QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTFBxM250UGFNa3FIdmhkV0FFc2tBQSIsInZlciI6IjEuMCJ9.iQ5v1seAWVNeUlQ3YJ7x7_maWTiCle23ELqyy-L7d_YZk9_EOHx_cOOKz4J-zhEOL5qqAMDPoQm9049jHz-rtx73_PtWcsxLzzXYuiWscG8O_df8whU9KYuie3yJxLvhE6m6ESr8NFmCjv0YMhZSuZ9m8T366vi6CfxJc6rlYynVRrJy4H7FU9ksFocoQ-6wooDhodrtrQQpBS28wxe-6mH4aPnW5IpodnuJPZLrybAfg2TsCijBYc-640Ho0y0Nr8E_xIGTLNEF9E7oQz2MZiq4IqeGHL5WyksheaxV8vbeR4GxucTbqTODxnwtLI-Swe5SHaEaRsVuFdNaY_sW6g
+      Content-Length:
+      - '0'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 2c5cd3f7-977a-4dcf-8f6f-fd74aa1d94ed
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Writes:
+      - '1199'
+      X-Ms-Correlation-Request-Id:
+      - 3b0c0cb9-97ef-498f-abb9-596ff18763da
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T094136Z:3b0c0cb9-97ef-498f-abb9-596ff18763da
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:41:35 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"keys":[{"keyName":"key1","value":"xMvZwiumnKCZnYVJjdtGLqaO1c2v6ERPx4XPDZO7TM1l7/jM1TxAAgtfCMkRn72aRPhqLqwWAn8n5a1iSGRHtA==","permissions":"Full"},{"keyName":"key2","value":"3nDvKhjGAIAvgnH2reuv7tzyeb/0dddgVeUT13VODYD5xO/jeAvQ7tkF3JqP2BAuFrmQqMB4GLkB4/cW4veYeA==","permissions":"Full"}]}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:41:41 GMT
+- request:
+    method: head
+    uri: https://rspeclb.blob.core.windows.net/vhds/rspec-lb-a201682122839.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:41:41 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey rspeclb:JTHd/PX4KMAjfxy5zhVduKG3tXCi15JY3jtFhSCLoDs=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '32212255232'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - 8BW5hqrnOLoQINlZ05odxA==
+      Last-Modified:
+      - Sat, 03 Sep 2016 14:03:15 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D3D4030CA0ABEF"'
+      Vary:
+      - Origin
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Copy-Id:
+      - f4d64e56-53ed-46e0-9c24-ebfa731c2ac1
+      X-Ms-Copy-Progress:
+      - 32212255232/32212255232
+      X-Ms-Copy-Source:
+      - https://ardfepirv2bl6prdstp02a.blob.core.windows.net/a879bbefc56a43abb0ce65052aac09f3/rhel-67-20160302?sv=2014-02-14&sr=b&si=PirCacheAccountPublisherContainerPolicy&sig=odWVC2Axkv74I6hSj89s9UTQavqFXr29heJIw9TFaCY%3D
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Completion-Time:
+      - Fri, 02 Sep 2016 16:29:41 GMT
+      X-Ms-Meta-Microsoftazurecompute-Diskid:
+      - ecdb0d00-e186-4df6-a7b6-ae626753f7bd
+      X-Ms-Meta-Microsoftazurecompute-Diskname:
+      - rspec-lb-a
+      X-Ms-Meta-Microsoftazurecompute-Disktype:
+      - OSDisk
+      X-Ms-Meta-Microsoftazurecompute-Resourcegroupname:
+      - miq-azure-test1
+      X-Ms-Meta-Microsoftazurecompute-Vmname:
+      - rspec-lb-a
+      X-Ms-Lease-State:
+      - leased
+      X-Ms-Lease-Duration:
+      - infinite
+      X-Ms-Lease-Status:
+      - locked
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '1'
+      X-Ms-Server-Encrypted:
+      - 'false'
+      X-Ms-Request-Id:
+      - f5c97e12-501c-0045-45e6-b9b856000000
+      X-Ms-Version:
+      - '2016-05-31'
+      Date:
+      - Mon, 12 Mar 2018 09:41:37 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:41:42 GMT
+- request:
+    method: head
+    uri: https://rspeclb.blob.core.windows.net/vhds/rspec-lb-b201682123650.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:41:42 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey rspeclb:F65KEipp+mgsxY00VqtGCU1gcOjKehEjD6mq7PKJlq0=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '32212255232'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - 8BW5hqrnOLoQINlZ05odxA==
+      Last-Modified:
+      - Sat, 03 Sep 2016 14:05:40 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D3D40362FE3898"'
+      Vary:
+      - Origin
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Copy-Id:
+      - f64a314d-e573-457d-88d4-e16ecfbe2819
+      X-Ms-Copy-Progress:
+      - 32212255232/32212255232
+      X-Ms-Copy-Source:
+      - https://ardfepirv2bl6prdstp02a.blob.core.windows.net/a879bbefc56a43abb0ce65052aac09f3/rhel-67-20160302?sv=2014-02-14&sr=b&si=PirCacheAccountPublisherContainerPolicy&sig=odWVC2Axkv74I6hSj89s9UTQavqFXr29heJIw9TFaCY%3D
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Completion-Time:
+      - Fri, 02 Sep 2016 16:37:29 GMT
+      X-Ms-Meta-Microsoftazurecompute-Diskid:
+      - dbb822a3-53bf-49f9-808d-02390abcee67
+      X-Ms-Meta-Microsoftazurecompute-Diskname:
+      - rspec-lb-b
+      X-Ms-Meta-Microsoftazurecompute-Disktype:
+      - OSDisk
+      X-Ms-Meta-Microsoftazurecompute-Resourcegroupname:
+      - miq-azure-test1
+      X-Ms-Meta-Microsoftazurecompute-Vmname:
+      - rspec-lb-b
+      X-Ms-Lease-State:
+      - leased
+      X-Ms-Lease-Duration:
+      - infinite
+      X-Ms-Lease-Status:
+      - locked
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '1'
+      X-Ms-Server-Encrypted:
+      - 'false'
+      X-Ms-Request-Id:
+      - b07026c3-401c-001e-55e6-b9bf2a000000
+      X-Ms-Version:
+      - '2016-05-31'
+      Date:
+      - Mon, 12 Mar 2018 09:41:37 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:41:42 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDczNjIsIm5iZiI6MTUyMDg0NzM2MiwiZXhwIjoxNTIwODUxMjYyLCJhaW8iOiJZMk5nWVBnYVUzejN3aDFCQjJXemxmTG5tVjV5QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTFBxM250UGFNa3FIdmhkV0FFc2tBQSIsInZlciI6IjEuMCJ9.iQ5v1seAWVNeUlQ3YJ7x7_maWTiCle23ELqyy-L7d_YZk9_EOHx_cOOKz4J-zhEOL5qqAMDPoQm9049jHz-rtx73_PtWcsxLzzXYuiWscG8O_df8whU9KYuie3yJxLvhE6m6ESr8NFmCjv0YMhZSuZ9m8T366vi6CfxJc6rlYynVRrJy4H7FU9ksFocoQ-6wooDhodrtrQQpBS28wxe-6mH4aPnW5IpodnuJPZLrybAfg2TsCijBYc-640Ho0y0Nr8E_xIGTLNEF9E7oQz2MZiq4IqeGHL5WyksheaxV8vbeR4GxucTbqTODxnwtLI-Swe5SHaEaRsVuFdNaY_sW6g
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"1523bcb7-4597-4ae6-bcfc-ba8fc3826026"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 1eed507d-0884-4aa3-a7fa-d8184fd265c7
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Correlation-Request-Id:
+      - 6ec19b00-3120-4139-8c12-d4ef63d1e556
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T094138Z:6ec19b00-3120-4139-8c12-d4ef63d1e556
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:41:38 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"rspec-lb-a-nsg\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg\",\r\n
+        \ \"etag\": \"W/\\\"1523bcb7-4597-4ae6-bcfc-ba8fc3826026\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/networkSecurityGroups\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
+        \"63d15480-8c5a-4e18-9196-c43384932823\",\r\n    \"securityRules\": [\r\n
+        \     {\r\n        \"name\": \"default-allow-ssh\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg/securityRules/default-allow-ssh\",\r\n
+        \       \"etag\": \"W/\\\"1523bcb7-4597-4ae6-bcfc-ba8fc3826026\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"protocol\": \"TCP\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"22\",\r\n          \"sourceAddressPrefix\":
+        \"*\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n          \"access\":
+        \"Allow\",\r\n          \"priority\": 1000,\r\n          \"direction\": \"Inbound\",\r\n
+        \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      }\r\n    ],\r\n    \"defaultSecurityRules\": [\r\n
+        \     {\r\n        \"name\": \"AllowVnetInBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg/defaultSecurityRules/AllowVnetInBound\",\r\n
+        \       \"etag\": \"W/\\\"1523bcb7-4597-4ae6-bcfc-ba8fc3826026\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow inbound traffic from all VMs in VNET\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"VirtualNetwork\",\r\n          \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n          \"direction\":
+        \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowAzureLoadBalancerInBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg/defaultSecurityRules/AllowAzureLoadBalancerInBound\",\r\n
+        \       \"etag\": \"W/\\\"1523bcb7-4597-4ae6-bcfc-ba8fc3826026\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow inbound traffic from azure load balancer\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"AzureLoadBalancer\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65001,\r\n          \"direction\":
+        \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllInBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg/defaultSecurityRules/DenyAllInBound\",\r\n
+        \       \"etag\": \"W/\\\"1523bcb7-4597-4ae6-bcfc-ba8fc3826026\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Deny all inbound traffic\",\r\n          \"protocol\":
+        \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\":
+        \"*\",\r\n          \"sourceAddressPrefix\": \"*\",\r\n          \"destinationAddressPrefix\":
+        \"*\",\r\n          \"access\": \"Deny\",\r\n          \"priority\": 65500,\r\n
+        \         \"direction\": \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n
+        \         \"destinationPortRanges\": [],\r\n          \"sourceAddressPrefixes\":
+        [],\r\n          \"destinationAddressPrefixes\": []\r\n        }\r\n      },\r\n
+        \     {\r\n        \"name\": \"AllowVnetOutBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg/defaultSecurityRules/AllowVnetOutBound\",\r\n
+        \       \"etag\": \"W/\\\"1523bcb7-4597-4ae6-bcfc-ba8fc3826026\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow outbound traffic from all VMs to all VMs
+        in VNET\",\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\":
+        \"*\",\r\n          \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"VirtualNetwork\",\r\n          \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n          \"direction\":
+        \"Outbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowInternetOutBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg/defaultSecurityRules/AllowInternetOutBound\",\r\n
+        \       \"etag\": \"W/\\\"1523bcb7-4597-4ae6-bcfc-ba8fc3826026\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow outbound traffic from all VMs to Internet\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"*\",\r\n          \"destinationAddressPrefix\": \"Internet\",\r\n          \"access\":
+        \"Allow\",\r\n          \"priority\": 65001,\r\n          \"direction\": \"Outbound\",\r\n
+        \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllOutBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg/defaultSecurityRules/DenyAllOutBound\",\r\n
+        \       \"etag\": \"W/\\\"1523bcb7-4597-4ae6-bcfc-ba8fc3826026\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Deny all outbound traffic\",\r\n          \"protocol\":
+        \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\":
+        \"*\",\r\n          \"sourceAddressPrefix\": \"*\",\r\n          \"destinationAddressPrefix\":
+        \"*\",\r\n          \"access\": \"Deny\",\r\n          \"priority\": 65500,\r\n
+        \         \"direction\": \"Outbound\",\r\n          \"sourcePortRanges\":
+        [],\r\n          \"destinationPortRanges\": [],\r\n          \"sourceAddressPrefixes\":
+        [],\r\n          \"destinationAddressPrefixes\": []\r\n        }\r\n      }\r\n
+        \   ],\r\n    \"networkInterfaces\": [\r\n      {\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670\"\r\n
+        \     }\r\n    ]\r\n  }\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:41:43 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDczNjIsIm5iZiI6MTUyMDg0NzM2MiwiZXhwIjoxNTIwODUxMjYyLCJhaW8iOiJZMk5nWVBnYVUzejN3aDFCQjJXemxmTG5tVjV5QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTFBxM250UGFNa3FIdmhkV0FFc2tBQSIsInZlciI6IjEuMCJ9.iQ5v1seAWVNeUlQ3YJ7x7_maWTiCle23ELqyy-L7d_YZk9_EOHx_cOOKz4J-zhEOL5qqAMDPoQm9049jHz-rtx73_PtWcsxLzzXYuiWscG8O_df8whU9KYuie3yJxLvhE6m6ESr8NFmCjv0YMhZSuZ9m8T366vi6CfxJc6rlYynVRrJy4H7FU9ksFocoQ-6wooDhodrtrQQpBS28wxe-6mH4aPnW5IpodnuJPZLrybAfg2TsCijBYc-640Ho0y0Nr8E_xIGTLNEF9E7oQz2MZiq4IqeGHL5WyksheaxV8vbeR4GxucTbqTODxnwtLI-Swe5SHaEaRsVuFdNaY_sW6g
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"80e6f7a1-78ee-48b4-9b28-a464ef94de09"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 29bae790-15b0-49ec-951e-e36ab3fdce52
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Correlation-Request-Id:
+      - 4da0a78a-742c-400e-9946-f7e10858e019
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T094139Z:4da0a78a-742c-400e-9946-f7e10858e019
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:41:39 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"rspec-lb-b-nsg\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg\",\r\n
+        \ \"etag\": \"W/\\\"80e6f7a1-78ee-48b4-9b28-a464ef94de09\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/networkSecurityGroups\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
+        \"4ee44ca4-a721-4149-ad87-74d4150b4c1e\",\r\n    \"securityRules\": [\r\n
+        \     {\r\n        \"name\": \"default-allow-ssh\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg/securityRules/default-allow-ssh\",\r\n
+        \       \"etag\": \"W/\\\"80e6f7a1-78ee-48b4-9b28-a464ef94de09\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"protocol\": \"TCP\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"22\",\r\n          \"sourceAddressPrefix\":
+        \"*\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n          \"access\":
+        \"Allow\",\r\n          \"priority\": 1000,\r\n          \"direction\": \"Inbound\",\r\n
+        \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      }\r\n    ],\r\n    \"defaultSecurityRules\": [\r\n
+        \     {\r\n        \"name\": \"AllowVnetInBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg/defaultSecurityRules/AllowVnetInBound\",\r\n
+        \       \"etag\": \"W/\\\"80e6f7a1-78ee-48b4-9b28-a464ef94de09\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow inbound traffic from all VMs in VNET\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"VirtualNetwork\",\r\n          \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n          \"direction\":
+        \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowAzureLoadBalancerInBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg/defaultSecurityRules/AllowAzureLoadBalancerInBound\",\r\n
+        \       \"etag\": \"W/\\\"80e6f7a1-78ee-48b4-9b28-a464ef94de09\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow inbound traffic from azure load balancer\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"AzureLoadBalancer\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65001,\r\n          \"direction\":
+        \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllInBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg/defaultSecurityRules/DenyAllInBound\",\r\n
+        \       \"etag\": \"W/\\\"80e6f7a1-78ee-48b4-9b28-a464ef94de09\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Deny all inbound traffic\",\r\n          \"protocol\":
+        \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\":
+        \"*\",\r\n          \"sourceAddressPrefix\": \"*\",\r\n          \"destinationAddressPrefix\":
+        \"*\",\r\n          \"access\": \"Deny\",\r\n          \"priority\": 65500,\r\n
+        \         \"direction\": \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n
+        \         \"destinationPortRanges\": [],\r\n          \"sourceAddressPrefixes\":
+        [],\r\n          \"destinationAddressPrefixes\": []\r\n        }\r\n      },\r\n
+        \     {\r\n        \"name\": \"AllowVnetOutBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg/defaultSecurityRules/AllowVnetOutBound\",\r\n
+        \       \"etag\": \"W/\\\"80e6f7a1-78ee-48b4-9b28-a464ef94de09\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow outbound traffic from all VMs to all VMs
+        in VNET\",\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\":
+        \"*\",\r\n          \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"VirtualNetwork\",\r\n          \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n          \"direction\":
+        \"Outbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowInternetOutBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg/defaultSecurityRules/AllowInternetOutBound\",\r\n
+        \       \"etag\": \"W/\\\"80e6f7a1-78ee-48b4-9b28-a464ef94de09\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow outbound traffic from all VMs to Internet\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"*\",\r\n          \"destinationAddressPrefix\": \"Internet\",\r\n          \"access\":
+        \"Allow\",\r\n          \"priority\": 65001,\r\n          \"direction\": \"Outbound\",\r\n
+        \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllOutBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg/defaultSecurityRules/DenyAllOutBound\",\r\n
+        \       \"etag\": \"W/\\\"80e6f7a1-78ee-48b4-9b28-a464ef94de09\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Deny all outbound traffic\",\r\n          \"protocol\":
+        \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\":
+        \"*\",\r\n          \"sourceAddressPrefix\": \"*\",\r\n          \"destinationAddressPrefix\":
+        \"*\",\r\n          \"access\": \"Deny\",\r\n          \"priority\": 65500,\r\n
+        \         \"direction\": \"Outbound\",\r\n          \"sourcePortRanges\":
+        [],\r\n          \"destinationPortRanges\": [],\r\n          \"sourceAddressPrefixes\":
+        [],\r\n          \"destinationAddressPrefixes\": []\r\n        }\r\n      }\r\n
+        \   ],\r\n    \"networkInterfaces\": [\r\n      {\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843\"\r\n
+        \     }\r\n    ]\r\n  }\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:41:44 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDczNjIsIm5iZiI6MTUyMDg0NzM2MiwiZXhwIjoxNTIwODUxMjYyLCJhaW8iOiJZMk5nWVBnYVUzejN3aDFCQjJXemxmTG5tVjV5QUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiTFBxM250UGFNa3FIdmhkV0FFc2tBQSIsInZlciI6IjEuMCJ9.iQ5v1seAWVNeUlQ3YJ7x7_maWTiCle23ELqyy-L7d_YZk9_EOHx_cOOKz4J-zhEOL5qqAMDPoQm9049jHz-rtx73_PtWcsxLzzXYuiWscG8O_df8whU9KYuie3yJxLvhE6m6ESr8NFmCjv0YMhZSuZ9m8T366vi6CfxJc6rlYynVRrJy4H7FU9ksFocoQ-6wooDhodrtrQQpBS28wxe-6mH4aPnW5IpodnuJPZLrybAfg2TsCijBYc-640Ho0y0Nr8E_xIGTLNEF9E7oQz2MZiq4IqeGHL5WyksheaxV8vbeR4GxucTbqTODxnwtLI-Swe5SHaEaRsVuFdNaY_sW6g
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"a8b09238-30fc-4b36-a58d-e3cc69e267c5"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - fdcbcabc-48cf-42da-a992-2d5e53e11a16
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Correlation-Request-Id:
+      - 18c7fd29-727b-4245-b299-899280f64532
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T094139Z:18c7fd29-727b-4245-b299-899280f64532
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:41:39 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"miq-azure-test1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1\",\r\n
+        \ \"etag\": \"W/\\\"a8b09238-30fc-4b36-a58d-e3cc69e267c5\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
+        \"d74c1e5f-50e4-4c8a-a7fe-78eaddc6b915\",\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\":
+        [\r\n        \"10.16.0.0/16\"\r\n      ]\r\n    },\r\n    \"subnets\": [\r\n
+        \     {\r\n        \"name\": \"default\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\",\r\n
+        \       \"etag\": \"W/\\\"a8b09238-30fc-4b36-a58d-e3cc69e267c5\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"addressPrefix\": \"10.16.0.0/24\",\r\n          \"ipConfigurations\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241/ipConfigurations/ipconfig1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1/ipConfigurations/miqmismatch1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/dbergerprov1/ipConfigurations/dbergerprov1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/ladas_test_1/ipConfigurations/ladas_test_1\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"virtualNetworkPeerings\":
+        [],\r\n    \"enableDdosProtection\": false,\r\n    \"enableVmProtection\":
+        false\r\n  }\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:41:44 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_500/lbs_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_500/lbs_refresh.yml
@@ -16,7 +16,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDc0NDAsIm5iZiI6MTUyMDg0NzQ0MCwiZXhwIjoxNTIwODUxMzQwLCJhaW8iOiJZMk5nWURBTjFDdDJkcHEzYjE1K2V1Lys2UnRMQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMkVvc0syN3k0VW1BeHEwQ2ZqOGhBQSIsInZlciI6IjEuMCJ9.eFsuzFJ2JcJ7ej1pMyVOYq1w05gE3MmhvpMTnucMlw6-Trc-u7Yk4_jr1X09KZNEsUBc58DomvhqvC_Iv6VHmnvO4fHpyEn3WLwkVhKhTb9LIJJqCT2w7-P6zLNgIC-wcITEBzea1qHk2X5heiR3TbzTiNSO2CkCSUEiPy_F6SFQHHWeo4JrVUC45Rd_BJybz4WGfo6LIy1GVCAVQbdDYhlZ00JwM4STh02tbHL2yW4h_qjCqeE9lmxx1jNiQXAEvkcnJOhCXYKkRCixxbnzCxMva91yx43fOvqO7XaFfCgKB8eCqkh0-f3xkePPjlcOkiTxeFvYPjckYrCXIn5p_g
   response:
     status:
       code: 200
@@ -35,26 +35,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14997'
+      - '14998'
       X-Ms-Request-Id:
-      - cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - a574c186-b817-4557-8da6-664f303a9f22
       X-Ms-Correlation-Request-Id:
-      - cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - a574c186-b817-4557-8da6-664f303a9f22
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102417Z:cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - WESTEUROPE:20180312T094248Z:a574c186-b817-4557-8da6-664f303a9f22
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:17 GMT
+      - Mon, 12 Mar 2018 09:42:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID","subscriptionId":"AZURE_SUBSCRIPTION_ID","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:22 GMT
+  recorded_at: Mon, 12 Mar 2018 09:42:52 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers?api-version=2015-01-01
@@ -71,7 +71,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDc0NDAsIm5iZiI6MTUyMDg0NzQ0MCwiZXhwIjoxNTIwODUxMzQwLCJhaW8iOiJZMk5nWURBTjFDdDJkcHEzYjE1K2V1Lys2UnRMQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMkVvc0syN3k0VW1BeHEwQ2ZqOGhBQSIsInZlciI6IjEuMCJ9.eFsuzFJ2JcJ7ej1pMyVOYq1w05gE3MmhvpMTnucMlw6-Trc-u7Yk4_jr1X09KZNEsUBc58DomvhqvC_Iv6VHmnvO4fHpyEn3WLwkVhKhTb9LIJJqCT2w7-P6zLNgIC-wcITEBzea1qHk2X5heiR3TbzTiNSO2CkCSUEiPy_F6SFQHHWeo4JrVUC45Rd_BJybz4WGfo6LIy1GVCAVQbdDYhlZ00JwM4STh02tbHL2yW4h_qjCqeE9lmxx1jNiQXAEvkcnJOhCXYKkRCixxbnzCxMva91yx43fOvqO7XaFfCgKB8eCqkh0-f3xkePPjlcOkiTxeFvYPjckYrCXIn5p_g
   response:
     status:
       code: 200
@@ -88,19 +88,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - '14984'
       X-Ms-Request-Id:
-      - fe3532ca-59a2-474e-9094-8a3697b82bef
+      - 8142bcd5-593a-41ca-a715-283b729c57cc
       X-Ms-Correlation-Request-Id:
-      - fe3532ca-59a2-474e-9094-8a3697b82bef
+      - 8142bcd5-593a-41ca-a715-283b729c57cc
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102419Z:fe3532ca-59a2-474e-9094-8a3697b82bef
+      - WESTEUROPE:20180312T094250Z:8142bcd5-593a-41ca-a715-283b729c57cc
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:18 GMT
+      - Mon, 12 Mar 2018 09:42:50 GMT
       Content-Length:
       - '320853'
     body:
@@ -2322,7 +2322,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:23 GMT
+  recorded_at: Mon, 12 Mar 2018 09:42:54 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1?api-version=2018-01-01
@@ -2339,7 +2339,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDc0NDAsIm5iZiI6MTUyMDg0NzQ0MCwiZXhwIjoxNTIwODUxMzQwLCJhaW8iOiJZMk5nWURBTjFDdDJkcHEzYjE1K2V1Lys2UnRMQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMkVvc0syN3k0VW1BeHEwQ2ZqOGhBQSIsInZlciI6IjEuMCJ9.eFsuzFJ2JcJ7ej1pMyVOYq1w05gE3MmhvpMTnucMlw6-Trc-u7Yk4_jr1X09KZNEsUBc58DomvhqvC_Iv6VHmnvO4fHpyEn3WLwkVhKhTb9LIJJqCT2w7-P6zLNgIC-wcITEBzea1qHk2X5heiR3TbzTiNSO2CkCSUEiPy_F6SFQHHWeo4JrVUC45Rd_BJybz4WGfo6LIy1GVCAVQbdDYhlZ00JwM4STh02tbHL2yW4h_qjCqeE9lmxx1jNiQXAEvkcnJOhCXYKkRCixxbnzCxMva91yx43fOvqO7XaFfCgKB8eCqkh0-f3xkePPjlcOkiTxeFvYPjckYrCXIn5p_g
   response:
     status:
       code: 200
@@ -2360,22 +2360,22 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - '080de667-081e-4d58-9e94-9e7243d4200e'
+      - ce2c1629-625f-44c2-af3b-105af1e47949
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
+      - '14985'
       X-Ms-Correlation-Request-Id:
-      - '093d49ac-c85f-440e-956b-955b6698dd19'
+      - 7a7103ff-58cc-4a04-a473-c9006e9f386b
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102419Z:093d49ac-c85f-440e-956b-955b6698dd19
+      - WESTEUROPE:20180312T094251Z:7a7103ff-58cc-4a04-a473-c9006e9f386b
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:19 GMT
+      - Mon, 12 Mar 2018 09:42:50 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"rspec-lb1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1\",\r\n
@@ -2433,7 +2433,7 @@ http_interactions:
         [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
         \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:24 GMT
+  recorded_at: Mon, 12 Mar 2018 09:42:55 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2?api-version=2018-01-01
@@ -2450,7 +2450,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDc0NDAsIm5iZiI6MTUyMDg0NzQ0MCwiZXhwIjoxNTIwODUxMzQwLCJhaW8iOiJZMk5nWURBTjFDdDJkcHEzYjE1K2V1Lys2UnRMQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMkVvc0syN3k0VW1BeHEwQ2ZqOGhBQSIsInZlciI6IjEuMCJ9.eFsuzFJ2JcJ7ej1pMyVOYq1w05gE3MmhvpMTnucMlw6-Trc-u7Yk4_jr1X09KZNEsUBc58DomvhqvC_Iv6VHmnvO4fHpyEn3WLwkVhKhTb9LIJJqCT2w7-P6zLNgIC-wcITEBzea1qHk2X5heiR3TbzTiNSO2CkCSUEiPy_F6SFQHHWeo4JrVUC45Rd_BJybz4WGfo6LIy1GVCAVQbdDYhlZ00JwM4STh02tbHL2yW4h_qjCqeE9lmxx1jNiQXAEvkcnJOhCXYKkRCixxbnzCxMva91yx43fOvqO7XaFfCgKB8eCqkh0-f3xkePPjlcOkiTxeFvYPjckYrCXIn5p_g
   response:
     status:
       code: 200
@@ -2471,22 +2471,22 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - bd22ca22-a01f-4ecf-9230-a4558fb66931
+      - e0ab0836-e315-4d66-8f9f-78075eeb0080
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
+      - '14989'
       X-Ms-Correlation-Request-Id:
-      - 19c674a8-c8da-4b5e-8265-5ebc21926459
+      - b0222410-7852-4a48-8f7b-e7eadf29f798
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102420Z:19c674a8-c8da-4b5e-8265-5ebc21926459
+      - WESTEUROPE:20180312T094252Z:b0222410-7852-4a48-8f7b-e7eadf29f798
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:19 GMT
+      - Mon, 12 Mar 2018 09:42:52 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"rspec-lb2\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2\",\r\n
@@ -2514,7 +2514,7 @@ http_interactions:
         [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
         \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:25 GMT
+  recorded_at: Mon, 12 Mar 2018 09:42:57 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd?api-version=2018-01-01
@@ -2531,7 +2531,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDc0NDAsIm5iZiI6MTUyMDg0NzQ0MCwiZXhwIjoxNTIwODUxMzQwLCJhaW8iOiJZMk5nWURBTjFDdDJkcHEzYjE1K2V1Lys2UnRMQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMkVvc0syN3k0VW1BeHEwQ2ZqOGhBQSIsInZlciI6IjEuMCJ9.eFsuzFJ2JcJ7ej1pMyVOYq1w05gE3MmhvpMTnucMlw6-Trc-u7Yk4_jr1X09KZNEsUBc58DomvhqvC_Iv6VHmnvO4fHpyEn3WLwkVhKhTb9LIJJqCT2w7-P6zLNgIC-wcITEBzea1qHk2X5heiR3TbzTiNSO2CkCSUEiPy_F6SFQHHWeo4JrVUC45Rd_BJybz4WGfo6LIy1GVCAVQbdDYhlZ00JwM4STh02tbHL2yW4h_qjCqeE9lmxx1jNiQXAEvkcnJOhCXYKkRCixxbnzCxMva91yx43fOvqO7XaFfCgKB8eCqkh0-f3xkePPjlcOkiTxeFvYPjckYrCXIn5p_g
   response:
     status:
       code: 200
@@ -2552,22 +2552,22 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 0fd15240-6a1c-4b39-a4f6-aa53fd8591c2
+      - bcb4df4f-e01a-4410-9527-e177483aa532
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
+      - '14982'
       X-Ms-Correlation-Request-Id:
-      - 5cc03163-922e-41a1-9601-dba2d7cf2a81
+      - 84f6dff9-7a66-4aea-a106-f0a83cf4b911
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102421Z:5cc03163-922e-41a1-9601-dba2d7cf2a81
+      - WESTEUROPE:20180312T094253Z:84f6dff9-7a66-4aea-a106-f0a83cf4b911
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:20 GMT
+      - Mon, 12 Mar 2018 09:42:52 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"rspec-lb1-LoadBalancerFrontEnd\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\",\r\n
@@ -2580,7 +2580,7 @@ http_interactions:
         \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
         \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:25 GMT
+  recorded_at: Mon, 12 Mar 2018 09:42:57 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip?api-version=2018-01-01
@@ -2597,7 +2597,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDc0NDAsIm5iZiI6MTUyMDg0NzQ0MCwiZXhwIjoxNTIwODUxMzQwLCJhaW8iOiJZMk5nWURBTjFDdDJkcHEzYjE1K2V1Lys2UnRMQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMkVvc0syN3k0VW1BeHEwQ2ZqOGhBQSIsInZlciI6IjEuMCJ9.eFsuzFJ2JcJ7ej1pMyVOYq1w05gE3MmhvpMTnucMlw6-Trc-u7Yk4_jr1X09KZNEsUBc58DomvhqvC_Iv6VHmnvO4fHpyEn3WLwkVhKhTb9LIJJqCT2w7-P6zLNgIC-wcITEBzea1qHk2X5heiR3TbzTiNSO2CkCSUEiPy_F6SFQHHWeo4JrVUC45Rd_BJybz4WGfo6LIy1GVCAVQbdDYhlZ00JwM4STh02tbHL2yW4h_qjCqeE9lmxx1jNiQXAEvkcnJOhCXYKkRCixxbnzCxMva91yx43fOvqO7XaFfCgKB8eCqkh0-f3xkePPjlcOkiTxeFvYPjckYrCXIn5p_g
   response:
     status:
       code: 200
@@ -2618,22 +2618,22 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 1403e5b6-8fa0-4cd3-89b1-76b6c4fd805b
+      - 5c759471-37cf-441c-9def-43b20a289c44
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - '14983'
       X-Ms-Correlation-Request-Id:
-      - e4a5f369-a742-466f-bd8f-42e17eaaf9c9
+      - 650c608f-5648-4774-84cb-8bb8243fb459
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102421Z:e4a5f369-a742-466f-bd8f-42e17eaaf9c9
+      - WESTEUROPE:20180312T094253Z:650c608f-5648-4774-84cb-8bb8243fb459
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:21 GMT
+      - Mon, 12 Mar 2018 09:42:53 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"rspec-lb2-publicip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\",\r\n
@@ -2645,5 +2645,5 @@ http_interactions:
         \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
         \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:26 GMT
+  recorded_at: Mon, 12 Mar 2018 09:42:58 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_500/multiple_targets_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_500/multiple_targets_refresh.yml
@@ -1,6 +1,62 @@
 ---
 http_interactions:
 - request:
+    method: post
+    uri: https://login.microsoftonline.com/AZURE_TENANT_ID/oauth2/token
+    body:
+      encoding: UTF-8
+      string: grant_type=client_credentials&client_id=AZURE_CLIENT_ID&client_secret=AZURE_CLIENT_SECRET&resource=https%3A%2F%2Fmanagement.azure.com%2F
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Server:
+      - Microsoft-IIS/10.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Request-Id:
+      - 6badfe0f-3b76-43ef-ba71-6a53aa622600
+      P3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Set-Cookie:
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHz990acUFOsai4DNOdG03pZAPbtmXmLUDNISiKQMDnLLKg18dA4KqsC71fuugvtRlvfDnbEh5gQhar6SUZCZskelaE6kTMUBajTnw0YdmFcoqDUqfnwgMe46Th-Hl_jwokJ4vYzh3uiI9VgxvAF0Mu4cKBCC7UBBzGmntRIjfbxvogAA;
+        domain=.login.microsoftonline.com; path=/; secure; HttpOnly
+      - stsservicecookie=ests; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=004; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 12 Mar 2018 13:26:23 GMT
+      Content-Length:
+      - '1505'
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1520864784","not_before":"1520860884","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA4ODQsIm5iZiI6MTUyMDg2MDg4NCwiZXhwIjoxNTIwODY0Nzg0LCJhaW8iOiJZMk5nWUdpOG0rOTQycGVadmNIdTZwZnE0d1VkQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRF82dGEzWTc3ME82Y1dwVHFtSW1BQSIsInZlciI6IjEuMCJ9.l5OoUZ1ance2A6NMV32h79ED9Z63ArZd2W_71bGMy-pIkzcdMx-tO5cOs9TOPFdwa4W_-zN0G-r7GEmtFaz54OLS_nk-AvX7UCVIXeBomHZCsAgsjwm1IagK55Cr3i87H4xyxwCN4axso-LvHDPKySu21zE1MqJcQhjXsbNX0WocZK6rFCGIDE2qzIjmiBfSGDqHe1zXA3mzZnfA07iyubU2yeNAPpKL6yni69dhNYGlZUgfhq6K8K5IYAKe8Il9XG9_cg3brFbrWlw71YlkAFLksW-xvr85_KLnZCZrU0Pv-qSjjWXPjqwsYWzvC5XEWFxVZ4QBwlPwgWsuL9G2zQ"}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:26:24 GMT
+- request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
     body:
@@ -16,7 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA4ODQsIm5iZiI6MTUyMDg2MDg4NCwiZXhwIjoxNTIwODY0Nzg0LCJhaW8iOiJZMk5nWUdpOG0rOTQycGVadmNIdTZwZnE0d1VkQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRF82dGEzWTc3ME82Y1dwVHFtSW1BQSIsInZlciI6IjEuMCJ9.l5OoUZ1ance2A6NMV32h79ED9Z63ArZd2W_71bGMy-pIkzcdMx-tO5cOs9TOPFdwa4W_-zN0G-r7GEmtFaz54OLS_nk-AvX7UCVIXeBomHZCsAgsjwm1IagK55Cr3i87H4xyxwCN4axso-LvHDPKySu21zE1MqJcQhjXsbNX0WocZK6rFCGIDE2qzIjmiBfSGDqHe1zXA3mzZnfA07iyubU2yeNAPpKL6yni69dhNYGlZUgfhq6K8K5IYAKe8Il9XG9_cg3brFbrWlw71YlkAFLksW-xvr85_KLnZCZrU0Pv-qSjjWXPjqwsYWzvC5XEWFxVZ4QBwlPwgWsuL9G2zQ
   response:
     status:
       code: 200
@@ -35,26 +91,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14997'
+      - '14999'
       X-Ms-Request-Id:
-      - cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - f3991839-706c-4ff0-a7cf-6d2d1ebb4cd3
       X-Ms-Correlation-Request-Id:
-      - cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - f3991839-706c-4ff0-a7cf-6d2d1ebb4cd3
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102417Z:cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - WESTEUROPE:20180312T132624Z:f3991839-706c-4ff0-a7cf-6d2d1ebb4cd3
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:17 GMT
+      - Mon, 12 Mar 2018 13:26:24 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID","subscriptionId":"AZURE_SUBSCRIPTION_ID","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:22 GMT
+  recorded_at: Mon, 12 Mar 2018 13:26:24 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers?api-version=2015-01-01
@@ -71,7 +127,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA4ODQsIm5iZiI6MTUyMDg2MDg4NCwiZXhwIjoxNTIwODY0Nzg0LCJhaW8iOiJZMk5nWUdpOG0rOTQycGVadmNIdTZwZnE0d1VkQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRF82dGEzWTc3ME82Y1dwVHFtSW1BQSIsInZlciI6IjEuMCJ9.l5OoUZ1ance2A6NMV32h79ED9Z63ArZd2W_71bGMy-pIkzcdMx-tO5cOs9TOPFdwa4W_-zN0G-r7GEmtFaz54OLS_nk-AvX7UCVIXeBomHZCsAgsjwm1IagK55Cr3i87H4xyxwCN4axso-LvHDPKySu21zE1MqJcQhjXsbNX0WocZK6rFCGIDE2qzIjmiBfSGDqHe1zXA3mzZnfA07iyubU2yeNAPpKL6yni69dhNYGlZUgfhq6K8K5IYAKe8Il9XG9_cg3brFbrWlw71YlkAFLksW-xvr85_KLnZCZrU0Pv-qSjjWXPjqwsYWzvC5XEWFxVZ4QBwlPwgWsuL9G2zQ
   response:
     status:
       code: 200
@@ -88,19 +144,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - '14994'
       X-Ms-Request-Id:
-      - fe3532ca-59a2-474e-9094-8a3697b82bef
+      - c2aa8913-313d-4884-b226-a2ebf40aac49
       X-Ms-Correlation-Request-Id:
-      - fe3532ca-59a2-474e-9094-8a3697b82bef
+      - c2aa8913-313d-4884-b226-a2ebf40aac49
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102419Z:fe3532ca-59a2-474e-9094-8a3697b82bef
+      - WESTEUROPE:20180312T132630Z:c2aa8913-313d-4884-b226-a2ebf40aac49
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:18 GMT
+      - Mon, 12 Mar 2018 13:26:30 GMT
       Content-Length:
       - '320853'
     body:
@@ -2322,10 +2378,10 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:23 GMT
+  recorded_at: Mon, 12 Mar 2018 13:26:30 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/non_existent?api-version=2017-08-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2339,7 +2395,61 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA4ODQsIm5iZiI6MTUyMDg2MDg4NCwiZXhwIjoxNTIwODY0Nzg0LCJhaW8iOiJZMk5nWUdpOG0rOTQycGVadmNIdTZwZnE0d1VkQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRF82dGEzWTc3ME82Y1dwVHFtSW1BQSIsInZlciI6IjEuMCJ9.l5OoUZ1ance2A6NMV32h79ED9Z63ArZd2W_71bGMy-pIkzcdMx-tO5cOs9TOPFdwa4W_-zN0G-r7GEmtFaz54OLS_nk-AvX7UCVIXeBomHZCsAgsjwm1IagK55Cr3i87H4xyxwCN4axso-LvHDPKySu21zE1MqJcQhjXsbNX0WocZK6rFCGIDE2qzIjmiBfSGDqHe1zXA3mzZnfA07iyubU2yeNAPpKL6yni69dhNYGlZUgfhq6K8K5IYAKe8Il9XG9_cg3brFbrWlw71YlkAFLksW-xvr85_KLnZCZrU0Pv-qSjjWXPjqwsYWzvC5XEWFxVZ4QBwlPwgWsuL9G2zQ
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      X-Ms-Failure-Cause:
+      - gateway
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14999'
+      X-Ms-Request-Id:
+      - 119490c8-712b-4bca-9fad-1b5a3548351e
+      X-Ms-Correlation-Request-Id:
+      - 119490c8-712b-4bca-9fad-1b5a3548351e
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T132632Z:119490c8-712b-4bca-9fad-1b5a3548351e
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:26:32 GMT
+      Content-Length:
+      - '97'
+    body:
+      encoding: UTF-8
+      string: '{"error":{"code":"DeploymentNotFound","message":"Deployment ''non_existent''
+        could not be found."}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:26:32 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA4ODQsIm5iZiI6MTUyMDg2MDg4NCwiZXhwIjoxNTIwODY0Nzg0LCJhaW8iOiJZMk5nWUdpOG0rOTQycGVadmNIdTZwZnE0d1VkQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRF82dGEzWTc3ME82Y1dwVHFtSW1BQSIsInZlciI6IjEuMCJ9.l5OoUZ1ance2A6NMV32h79ED9Z63ArZd2W_71bGMy-pIkzcdMx-tO5cOs9TOPFdwa4W_-zN0G-r7GEmtFaz54OLS_nk-AvX7UCVIXeBomHZCsAgsjwm1IagK55Cr3i87H4xyxwCN4axso-LvHDPKySu21zE1MqJcQhjXsbNX0WocZK6rFCGIDE2qzIjmiBfSGDqHe1zXA3mzZnfA07iyubU2yeNAPpKL6yni69dhNYGlZUgfhq6K8K5IYAKe8Il9XG9_cg3brFbrWlw71YlkAFLksW-xvr85_KLnZCZrU0Pv-qSjjWXPjqwsYWzvC5XEWFxVZ4QBwlPwgWsuL9G2zQ
   response:
     status:
       code: 200
@@ -2356,87 +2466,96 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67"
+      - W/"92982330-0f29-406e-bba9-ad19198579a5"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - '080de667-081e-4d58-9e94-9e7243d4200e'
+      - 479ae4db-52d8-47e5-a0a4-5dc0503c93f4
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
+      - '14997'
       X-Ms-Correlation-Request-Id:
-      - '093d49ac-c85f-440e-956b-955b6698dd19'
+      - 9754779c-43c5-492c-85f5-97ce4fd1cc5b
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102419Z:093d49ac-c85f-440e-956b-955b6698dd19
+      - WESTEUROPE:20180312T132633Z:9754779c-43c5-492c-85f5-97ce4fd1cc5b
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:19 GMT
+      - Mon, 12 Mar 2018 13:26:33 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1\",\r\n
-        \ \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n  \"type\":
+      string: "{\r\n  \"name\": \"spec0deply1lb\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb\",\r\n
+        \ \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n  \"type\":
         \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"7ab88756-810f-4083-95db-8b05d50e38f2\",\r\n
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"8cd72f7c-03bd-4584-abc6-d9ce77ae6202\",\r\n
         \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
+        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\"\r\n
+        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip\"\r\n
         \         },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
         \           }\r\n          ],\r\n          \"inboundNatRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\"\r\n
+        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1\"\r\n
         \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
+        [\r\n      {\r\n        \"name\": \"BackendPool1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\",\r\n
+        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"backendIPConfigurations\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\"\r\n
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1\"\r\n
         \           }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
+        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
         \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-rule\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
+        [\r\n      {\r\n        \"name\": \"LBRule\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\",\r\n
+        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
+        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
         \         },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\":
         80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
+        5,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
         false,\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\"\r\n
-        \         },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\"\r\n
+        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\"\r\n
+        \         },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/probes/tcpProbe\"\r\n
         \         }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n
-        \       \"name\": \"rspec-lb-probe\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
+        \       \"name\": \"tcpProbe\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/probes/tcpProbe\",\r\n
+        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
+        \         \"protocol\": \"Tcp\",\r\n          \"port\": 80,\r\n          \"intervalInSeconds\":
+        5,\r\n          \"numberOfProbes\": 2,\r\n          \"loadBalancingRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
         \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-NAT\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
+        [\r\n      {\r\n        \"name\": \"RDP-VM0\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0\",\r\n
+        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 3441,\r\n          \"backendPort\":
+        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
+        \         },\r\n          \"frontendPort\": 50001,\r\n          \"backendPort\":
         3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
         4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
+        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1\"\r\n
+        \         }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"RDP-VM1\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1\",\r\n
+        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
+        \         },\r\n          \"frontendPort\": 50002,\r\n          \"backendPort\":
+        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
+        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
+        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1\"\r\n
         \         }\r\n        }\r\n      }\r\n    ],\r\n    \"outboundNatRules\":
         [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
         \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:24 GMT
+  recorded_at: Mon, 12 Mar 2018 13:26:33 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/non_existent_lb?api-version=2018-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2450,74 +2569,45 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA4ODQsIm5iZiI6MTUyMDg2MDg4NCwiZXhwIjoxNTIwODY0Nzg0LCJhaW8iOiJZMk5nWUdpOG0rOTQycGVadmNIdTZwZnE0d1VkQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRF82dGEzWTc3ME82Y1dwVHFtSW1BQSIsInZlciI6IjEuMCJ9.l5OoUZ1ance2A6NMV32h79ED9Z63ArZd2W_71bGMy-pIkzcdMx-tO5cOs9TOPFdwa4W_-zN0G-r7GEmtFaz54OLS_nk-AvX7UCVIXeBomHZCsAgsjwm1IagK55Cr3i87H4xyxwCN4axso-LvHDPKySu21zE1MqJcQhjXsbNX0WocZK6rFCGIDE2qzIjmiBfSGDqHe1zXA3mzZnfA07iyubU2yeNAPpKL6yni69dhNYGlZUgfhq6K8K5IYAKe8Il9XG9_cg3brFbrWlw71YlkAFLksW-xvr85_KLnZCZrU0Pv-qSjjWXPjqwsYWzvC5XEWFxVZ4QBwlPwgWsuL9G2zQ
   response:
     status:
-      code: 200
-      message: OK
+      code: 404
+      message: Not Found
     headers:
       Cache-Control:
       - no-cache
       Pragma:
       - no-cache
-      Transfer-Encoding:
-      - chunked
       Content-Type:
       - application/json; charset=utf-8
       Expires:
       - "-1"
-      Etag:
-      - W/"7a8e5fe7-f777-4435-992b-a54f28c2f28c"
-      Vary:
-      - Accept-Encoding
+      X-Ms-Failure-Cause:
+      - gateway
       X-Ms-Request-Id:
-      - bd22ca22-a01f-4ecf-9230-a4558fb66931
+      - 25a2c326-ce65-4531-b4a5-e618c152f1c0
+      X-Ms-Correlation-Request-Id:
+      - 25a2c326-ce65-4531-b4a5-e618c152f1c0
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T132634Z:25a2c326-ce65-4531-b4a5-e618c152f1c0
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Correlation-Request-Id:
-      - 19c674a8-c8da-4b5e-8265-5ebc21926459
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102420Z:19c674a8-c8da-4b5e-8265-5ebc21926459
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:19 GMT
+      - Mon, 12 Mar 2018 13:26:33 GMT
+      Content-Length:
+      - '166'
     body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb2\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2\",\r\n
-        \ \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"e2e30a77-f81b-43fc-9693-08303e43deed\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/backendAddressPools/rspec-lb2-pool\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\r\n
-        \       }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\": [],\r\n    \"probes\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-probe\",\r\n        \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/probes/rspec-lb2-probe\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\": [],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
+      encoding: UTF-8
+      string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Network/loadBalancers/non_existent_lb''
+        under resource group ''miq-azure-test1'' was not found."}}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:25 GMT
+  recorded_at: Mon, 12 Mar 2018 13:26:34 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed?api-version=2017-12-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2531,7 +2621,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA4ODQsIm5iZiI6MTUyMDg2MDg4NCwiZXhwIjoxNTIwODY0Nzg0LCJhaW8iOiJZMk5nWUdpOG0rOTQycGVadmNIdTZwZnE0d1VkQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRF82dGEzWTc3ME82Y1dwVHFtSW1BQSIsInZlciI6IjEuMCJ9.l5OoUZ1ance2A6NMV32h79ED9Z63ArZd2W_71bGMy-pIkzcdMx-tO5cOs9TOPFdwa4W_-zN0G-r7GEmtFaz54OLS_nk-AvX7UCVIXeBomHZCsAgsjwm1IagK55Cr3i87H4xyxwCN4axso-LvHDPKySu21zE1MqJcQhjXsbNX0WocZK6rFCGIDE2qzIjmiBfSGDqHe1zXA3mzZnfA07iyubU2yeNAPpKL6yni69dhNYGlZUgfhq6K8K5IYAKe8Il9XG9_cg3brFbrWlw71YlkAFLksW-xvr85_KLnZCZrU0Pv-qSjjWXPjqwsYWzvC5XEWFxVZ4QBwlPwgWsuL9G2zQ
   response:
     status:
       code: 200
@@ -2547,43 +2637,56 @@ http_interactions:
       - application/json; charset=utf-8
       Expires:
       - "-1"
-      Etag:
-      - W/"a38434c8-7b23-4092-b7c6-402238eac0dc"
       Vary:
       - Accept-Encoding
-      X-Ms-Request-Id:
-      - 0fd15240-6a1c-4b39-a4f6-aa53fd8591c2
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/LowCostGet3Min;4797,Microsoft.Compute/LowCostGet30Min;38362
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      X-Ms-Request-Id:
+      - c1ffac23-fd97-438b-912e-cb3ef7468dca
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
+      - '14999'
       X-Ms-Correlation-Request-Id:
-      - 5cc03163-922e-41a1-9601-dba2d7cf2a81
+      - '04205482-f2c2-4296-bed4-f37b951aed64'
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102421Z:5cc03163-922e-41a1-9601-dba2d7cf2a81
+      - WESTEUROPE:20180312T132635Z:04205482-f2c2-4296-bed4-f37b951aed64
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:20 GMT
+      - Mon, 12 Mar 2018 13:26:35 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb1-LoadBalancerFrontEnd\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\",\r\n
-        \ \"etag\": \"W/\\\"a38434c8-7b23-4092-b7c6-402238eac0dc\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"f28e0f25-b372-4edf-97d9-13a9e3b4ba2d\",\r\n    \"ipAddress\":
-        \"40.71.82.83\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\":
-        \"Static\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipTags\": [],\r\n
-        \   \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
-        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
+      string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"61b7c052-1d09-4898-b995-cce5676aaab0\",\r\n
+        \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Basic_A0\"\r\n    },\r\n
+        \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
+        \"RedHat\",\r\n        \"offer\": \"RHEL\",\r\n        \"sku\": \"7.3\",\r\n
+        \       \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
+        \"Linux\",\r\n        \"name\": \"miqazure-linux-managed_OsDisk_1_7b2bdf790a7d4379ace2846d307730cd\",\r\n
+        \       \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n
+        \       \"managedDisk\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/disks/miqazure-linux-managed_OsDisk_1_7b2bdf790a7d4379ace2846d307730cd\"\r\n
+        \       }\r\n      },\r\n      \"dataDisks\": [\r\n        {\r\n          \"lun\":
+        0,\r\n          \"name\": \"miqazure-linux-managed-data-disk\",\r\n          \"createOption\":
+        \"Attach\",\r\n          \"caching\": \"None\",\r\n          \"managedDisk\":
+        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/disks/miqazure-linux-managed-data-disk\"\r\n
+        \         }\r\n        }\r\n      ]\r\n    },\r\n    \"osProfile\": {\r\n
+        \     \"computerName\": \"miqazure-linux-managed\",\r\n      \"adminUsername\":
+        \"dberger\",\r\n      \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\":
+        false\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\":
+        {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944\"}]},\r\n
+        \   \"provisioningState\": \"Succeeded\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n
+        \ \"location\": \"eastus\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed\",\r\n
+        \ \"name\": \"miqazure-linux-managed\"\r\n}"
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:25 GMT
+  recorded_at: Mon, 12 Mar 2018 13:26:35 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1?api-version=2017-12-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2597,7 +2700,232 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA4ODQsIm5iZiI6MTUyMDg2MDg4NCwiZXhwIjoxNTIwODY0Nzg0LCJhaW8iOiJZMk5nWUdpOG0rOTQycGVadmNIdTZwZnE0d1VkQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRF82dGEzWTc3ME82Y1dwVHFtSW1BQSIsInZlciI6IjEuMCJ9.l5OoUZ1ance2A6NMV32h79ED9Z63ArZd2W_71bGMy-pIkzcdMx-tO5cOs9TOPFdwa4W_-zN0G-r7GEmtFaz54OLS_nk-AvX7UCVIXeBomHZCsAgsjwm1IagK55Cr3i87H4xyxwCN4axso-LvHDPKySu21zE1MqJcQhjXsbNX0WocZK6rFCGIDE2qzIjmiBfSGDqHe1zXA3mzZnfA07iyubU2yeNAPpKL6yni69dhNYGlZUgfhq6K8K5IYAKe8Il9XG9_cg3brFbrWlw71YlkAFLksW-xvr85_KLnZCZrU0Pv-qSjjWXPjqwsYWzvC5XEWFxVZ4QBwlPwgWsuL9G2zQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/LowCostGet3Min;4796,Microsoft.Compute/LowCostGet30Min;38361
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      X-Ms-Request-Id:
+      - f638363b-2cc3-40a6-afb5-dcb3f2e7b4f8
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14999'
+      X-Ms-Correlation-Request-Id:
+      - c0550b2c-777c-4c09-851e-e7c8b51695d8
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T132636Z:c0550b2c-777c-4c09-851e-e7c8b51695d8
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:26:36 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"03e8467b-baab-4867-9cc4-157336b7e2e4\",\r\n
+        \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Basic_A0\"\r\n    },\r\n
+        \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
+        \"RedHat\",\r\n        \"offer\": \"RHEL\",\r\n        \"sku\": \"7.2\",\r\n
+        \       \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
+        \"Linux\",\r\n        \"name\": \"miq-test-rhel1\",\r\n        \"createOption\":
+        \"FromImage\",\r\n        \"vhd\": {\r\n          \"uri\": \"https://miqazuretest18686.blob.core.windows.net/vhds/miq-test-rhel12016218112243.vhd\"\r\n
+        \       },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n      \"dataDisks\":
+        []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"miq-test-rhel1\",\r\n
+        \     \"adminUsername\": \"dberger\",\r\n      \"linuxConfiguration\": {\r\n
+        \       \"disablePasswordAuthentication\": false\r\n      },\r\n      \"secrets\":
+        []\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390\"}]},\r\n
+        \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
+        true,\r\n        \"storageUri\": \"https://miqazuretest18686.blob.core.windows.net/\"\r\n
+        \     }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n
+        \ \"resources\": [\r\n    {\r\n      \"properties\": {\r\n        \"publisher\":
+        \"Microsoft.OSTCExtensions\",\r\n        \"type\": \"LinuxDiagnostic\",\r\n
+        \       \"typeHandlerVersion\": \"2.0\",\r\n        \"autoUpgradeMinorVersion\":
+        true,\r\n        \"settings\": {\"xmlCfg\":\"PFdhZENmZz48RGlhZ25vc3RpY01vbml0b3JDb25maWd1cmF0aW9uIG92ZXJhbGxRdW90YUluTUI9IjQwOTYiPjxEaWFnbm9zdGljSW5mcmFzdHJ1Y3R1cmVMb2dzIHNjaGVkdWxlZFRyYW5zZmVyUGVyaW9kPSJQVDFNIiBzY2hlZHVsZWRUcmFuc2ZlckxvZ0xldmVsRmlsdGVyPSJXYXJuaW5nIi8+PFBlcmZvcm1hbmNlQ291bnRlcnMgc2NoZWR1bGVkVHJhbnNmZXJQZXJpb2Q9IlBUMU0iPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlTWVtb3J5IiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQnl0ZXMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcUGVyY2VudEF2YWlsYWJsZU1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iTWVtb3J5IHVzZWQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50VXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgcGVyY2VudGFnZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkQnlDYWNoZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHVzZWQgYnkgY2FjaGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1BlclNlYyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50UGVyU2Vjb25kIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFnZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1JlYWRQZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2UgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1dyaXR0ZW5QZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2Ugd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iU3dhcCBhdmFpbGFibGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50QXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZFN3YXAiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlN3YXAgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRJZGxlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgaWRsZSB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFVzZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iUGVyY2VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkNQVSB1c2VyIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50TmljZVRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIG5pY2UgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRQcml2aWxlZ2VkVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgcHJpdmlsZWdlZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudEludGVycnVwdFRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIGludGVycnVwdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudERQQ1RpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIERQQyB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFByb2Nlc3NvclRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIHBlcmNlbnRhZ2UgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50SU9XYWl0VGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgSU8gd2FpdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xSZWFkQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCBndWVzdCBPUyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXFdyaXRlQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGUgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xUcmFuc2ZlcnNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXJzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcUmVhZHNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xXcml0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVJlYWRUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVdyaXRlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlNlY29uZHMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJEaXNrIHdyaXRlIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xBdmVyYWdlVHJhbnNmZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXIgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXEF2ZXJhZ2VEaXNrUXVldWVMZW5ndGgiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcXVldWUgbGVuZ3RoIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVHJhbnNtaXR0ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgb3V0IGd1ZXN0IE9TIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzUmVjZWl2ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgaW4gZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1RyYW5zbWl0dGVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHNlbnQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1JlY2VpdmVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHJlY2VpdmVkIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVG90YWwiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxSeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyByZWNlaXZlZCBlcnJvcnMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxUeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyBzZW50IGVycm9ycyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTmV0d29ya0ludGVyZmFjZVxUb3RhbENvbGxpc2lvbnMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgY29sbGlzaW9ucyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48L1BlcmZvcm1hbmNlQ291bnRlcnM+PE1ldHJpY3MgcmVzb3VyY2VJZD0iL3N1YnNjcmlwdGlvbnMvMjU4NmM2NGItMzhiNC00NTI3LWExNDAtMDEyZDQ5ZGZjMDJjL3Jlc291cmNlR3JvdXBzL21pcS1henVyZS10ZXN0MS9wcm92aWRlcnMvTWljcm9zb2Z0LkNvbXB1dGUvdmlydHVhbE1hY2hpbmVzL21pcS10ZXN0LXJoZWwxIj48TWV0cmljQWdncmVnYXRpb24gc2NoZWR1bGVkVHJhbnNmZXJQZXJpb2Q9IlBUMUgiLz48TWV0cmljQWdncmVnYXRpb24gc2NoZWR1bGVkVHJhbnNmZXJQZXJpb2Q9IlBUMU0iLz48L01ldHJpY3M+PC9EaWFnbm9zdGljTW9uaXRvckNvbmZpZ3VyYXRpb24+PC9XYWRDZmc+\",\"StorageAccount\":\"miqazuretest18686\"},\r\n
+        \       \"provisioningState\": \"Succeeded\"\r\n      },\r\n      \"type\":
+        \"Microsoft.Compute/virtualMachines/extensions\",\r\n      \"location\": \"eastus\",\r\n
+        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/extensions/Microsoft.Insights.VMDiagnosticsSettings\",\r\n
+        \     \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n    }\r\n
+        \ ],\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\":
+        \"eastus\",\r\n  \"tags\": {\r\n    \"Shutdown\": \"true\"\r\n  },\r\n  \"id\":
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1\",\r\n
+        \ \"name\": \"miq-test-rhel1\"\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:26:36 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1?api-version=2017-12-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA4ODQsIm5iZiI6MTUyMDg2MDg4NCwiZXhwIjoxNTIwODY0Nzg0LCJhaW8iOiJZMk5nWUdpOG0rOTQycGVadmNIdTZwZnE0d1VkQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRF82dGEzWTc3ME82Y1dwVHFtSW1BQSIsInZlciI6IjEuMCJ9.l5OoUZ1ance2A6NMV32h79ED9Z63ArZd2W_71bGMy-pIkzcdMx-tO5cOs9TOPFdwa4W_-zN0G-r7GEmtFaz54OLS_nk-AvX7UCVIXeBomHZCsAgsjwm1IagK55Cr3i87H4xyxwCN4axso-LvHDPKySu21zE1MqJcQhjXsbNX0WocZK6rFCGIDE2qzIjmiBfSGDqHe1zXA3mzZnfA07iyubU2yeNAPpKL6yni69dhNYGlZUgfhq6K8K5IYAKe8Il9XG9_cg3brFbrWlw71YlkAFLksW-xvr85_KLnZCZrU0Pv-qSjjWXPjqwsYWzvC5XEWFxVZ4QBwlPwgWsuL9G2zQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/LowCostGet3Min;4795,Microsoft.Compute/LowCostGet30Min;38360
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      X-Ms-Request-Id:
+      - 963cfe97-fbc4-4879-8d8a-b46abec8cbfc
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14999'
+      X-Ms-Correlation-Request-Id:
+      - 6000e5a8-7d4a-4356-a3e2-a29ed53a1a22
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T132637Z:6000e5a8-7d4a-4356-a3e2-a29ed53a1a22
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:26:36 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"796c5bcc-338a-448d-b61c-165279a7fb3e\",\r\n
+        \   \"availabilitySet\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/MIQAZURE-AVAILSET-EAST\"\r\n
+        \   },\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Basic_A0\"\r\n
+        \   },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
+        \"OpenLogic\",\r\n        \"offer\": \"CentOS\",\r\n        \"sku\": \"7.1\",\r\n
+        \       \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
+        \"Linux\",\r\n        \"name\": \"miqazure-centos1\",\r\n        \"createOption\":
+        \"FromImage\",\r\n        \"vhd\": {\r\n          \"uri\": \"https://miqazuretest14047.blob.core.windows.net/vhds/miqazure-centos12016221104946.vhd\"\r\n
+        \       },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n      \"dataDisks\":
+        []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"miqazure-centos1\",\r\n
+        \     \"adminUsername\": \"dberger\",\r\n      \"linuxConfiguration\": {\r\n
+        \       \"disablePasswordAuthentication\": false\r\n      },\r\n      \"secrets\":
+        []\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611\"}]},\r\n
+        \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
+        true,\r\n        \"storageUri\": \"https://miqazuretest14047.blob.core.windows.net/\"\r\n
+        \     }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n
+        \ \"resources\": [\r\n    {\r\n      \"properties\": {\r\n        \"publisher\":
+        \"Microsoft.OSTCExtensions\",\r\n        \"type\": \"LinuxDiagnostic\",\r\n
+        \       \"typeHandlerVersion\": \"2.0\",\r\n        \"autoUpgradeMinorVersion\":
+        true,\r\n        \"settings\": {\"xmlCfg\":\"PFdhZENmZz48RGlhZ25vc3RpY01vbml0b3JDb25maWd1cmF0aW9uIG92ZXJhbGxRdW90YUluTUI9IjQwOTYiPjxEaWFnbm9zdGljSW5mcmFzdHJ1Y3R1cmVMb2dzIHNjaGVkdWxlZFRyYW5zZmVyUGVyaW9kPSJQVDFNIiBzY2hlZHVsZWRUcmFuc2ZlckxvZ0xldmVsRmlsdGVyPSJXYXJuaW5nIi8+PFBlcmZvcm1hbmNlQ291bnRlcnMgc2NoZWR1bGVkVHJhbnNmZXJQZXJpb2Q9IlBUMU0iPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlTWVtb3J5IiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQnl0ZXMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcUGVyY2VudEF2YWlsYWJsZU1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iTWVtb3J5IHVzZWQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50VXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgcGVyY2VudGFnZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkQnlDYWNoZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHVzZWQgYnkgY2FjaGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1BlclNlYyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50UGVyU2Vjb25kIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFnZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1JlYWRQZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2UgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1dyaXR0ZW5QZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2Ugd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iU3dhcCBhdmFpbGFibGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50QXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZFN3YXAiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlN3YXAgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRJZGxlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgaWRsZSB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFVzZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iUGVyY2VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkNQVSB1c2VyIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50TmljZVRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIG5pY2UgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRQcml2aWxlZ2VkVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgcHJpdmlsZWdlZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudEludGVycnVwdFRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIGludGVycnVwdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudERQQ1RpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIERQQyB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFByb2Nlc3NvclRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIHBlcmNlbnRhZ2UgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50SU9XYWl0VGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgSU8gd2FpdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xSZWFkQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCBndWVzdCBPUyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXFdyaXRlQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGUgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xUcmFuc2ZlcnNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXJzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcUmVhZHNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xXcml0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVJlYWRUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVdyaXRlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlNlY29uZHMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJEaXNrIHdyaXRlIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xBdmVyYWdlVHJhbnNmZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXIgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXEF2ZXJhZ2VEaXNrUXVldWVMZW5ndGgiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcXVldWUgbGVuZ3RoIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVHJhbnNtaXR0ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgb3V0IGd1ZXN0IE9TIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzUmVjZWl2ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgaW4gZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1RyYW5zbWl0dGVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHNlbnQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1JlY2VpdmVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHJlY2VpdmVkIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVG90YWwiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxSeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyByZWNlaXZlZCBlcnJvcnMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxUeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyBzZW50IGVycm9ycyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTmV0d29ya0ludGVyZmFjZVxUb3RhbENvbGxpc2lvbnMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgY29sbGlzaW9ucyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48L1BlcmZvcm1hbmNlQ291bnRlcnM+PE1ldHJpY3MgcmVzb3VyY2VJZD0iL3N1YnNjcmlwdGlvbnMvMjU4NmM2NGItMzhiNC00NTI3LWExNDAtMDEyZDQ5ZGZjMDJjL3Jlc291cmNlR3JvdXBzL21pcS1henVyZS10ZXN0MS9wcm92aWRlcnMvTWljcm9zb2Z0LkNvbXB1dGUvdmlydHVhbE1hY2hpbmVzL21pcWF6dXJlLWNlbnRvczEiPjxNZXRyaWNBZ2dyZWdhdGlvbiBzY2hlZHVsZWRUcmFuc2ZlclBlcmlvZD0iUFQxSCIvPjxNZXRyaWNBZ2dyZWdhdGlvbiBzY2hlZHVsZWRUcmFuc2ZlclBlcmlvZD0iUFQxTSIvPjwvTWV0cmljcz48L0RpYWdub3N0aWNNb25pdG9yQ29uZmlndXJhdGlvbj48L1dhZENmZz4=\",\"StorageAccount\":\"miqazuretest14047\"},\r\n
+        \       \"provisioningState\": \"Succeeded\"\r\n      },\r\n      \"type\":
+        \"Microsoft.Compute/virtualMachines/extensions\",\r\n      \"location\": \"eastus\",\r\n
+        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1/extensions/Microsoft.Insights.VMDiagnosticsSettings\",\r\n
+        \     \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n    }\r\n
+        \ ],\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\":
+        \"eastus\",\r\n  \"tags\": {\r\n    \"Shutdown\": \"true\"\r\n  },\r\n  \"id\":
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1\",\r\n
+        \ \"name\": \"miqazure-centos1\"\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:26:37 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/non_existent_vm_that_does_not_exist?api-version=2017-12-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA4ODQsIm5iZiI6MTUyMDg2MDg4NCwiZXhwIjoxNTIwODY0Nzg0LCJhaW8iOiJZMk5nWUdpOG0rOTQycGVadmNIdTZwZnE0d1VkQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRF82dGEzWTc3ME82Y1dwVHFtSW1BQSIsInZlciI6IjEuMCJ9.l5OoUZ1ance2A6NMV32h79ED9Z63ArZd2W_71bGMy-pIkzcdMx-tO5cOs9TOPFdwa4W_-zN0G-r7GEmtFaz54OLS_nk-AvX7UCVIXeBomHZCsAgsjwm1IagK55Cr3i87H4xyxwCN4axso-LvHDPKySu21zE1MqJcQhjXsbNX0WocZK6rFCGIDE2qzIjmiBfSGDqHe1zXA3mzZnfA07iyubU2yeNAPpKL6yni69dhNYGlZUgfhq6K8K5IYAKe8Il9XG9_cg3brFbrWlw71YlkAFLksW-xvr85_KLnZCZrU0Pv-qSjjWXPjqwsYWzvC5XEWFxVZ4QBwlPwgWsuL9G2zQ
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      X-Ms-Failure-Cause:
+      - gateway
+      X-Ms-Request-Id:
+      - 26d00c6b-589e-4704-b505-77b5698bc059
+      X-Ms-Correlation-Request-Id:
+      - 26d00c6b-589e-4704-b505-77b5698bc059
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T132638Z:26d00c6b-589e-4704-b505-77b5698bc059
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:26:37 GMT
+      Content-Length:
+      - '188'
+    body:
+      encoding: UTF-8
+      string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Compute/virtualMachines/non_existent_vm_that_does_not_exist''
+        under resource group ''miq-azure-test4'' was not found."}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:26:38 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA4ODQsIm5iZiI6MTUyMDg2MDg4NCwiZXhwIjoxNTIwODY0Nzg0LCJhaW8iOiJZMk5nWUdpOG0rOTQycGVadmNIdTZwZnE0d1VkQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRF82dGEzWTc3ME82Y1dwVHFtSW1BQSIsInZlciI6IjEuMCJ9.l5OoUZ1ance2A6NMV32h79ED9Z63ArZd2W_71bGMy-pIkzcdMx-tO5cOs9TOPFdwa4W_-zN0G-r7GEmtFaz54OLS_nk-AvX7UCVIXeBomHZCsAgsjwm1IagK55Cr3i87H4xyxwCN4axso-LvHDPKySu21zE1MqJcQhjXsbNX0WocZK6rFCGIDE2qzIjmiBfSGDqHe1zXA3mzZnfA07iyubU2yeNAPpKL6yni69dhNYGlZUgfhq6K8K5IYAKe8Il9XG9_cg3brFbrWlw71YlkAFLksW-xvr85_KLnZCZrU0Pv-qSjjWXPjqwsYWzvC5XEWFxVZ4QBwlPwgWsuL9G2zQ
   response:
     status:
       code: 200
@@ -2614,36 +2942,2802 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"cddd97d1-6111-4477-8a00-3dc885237a1d"
+      - W/"b6339880-8ead-4c9e-b5c0-f38c4f8612d5"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 1403e5b6-8fa0-4cd3-89b1-76b6c4fd805b
+      - 64b77e23-5f40-4f4e-94c5-ed770f0cf448
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - '14998'
       X-Ms-Correlation-Request-Id:
-      - e4a5f369-a742-466f-bd8f-42e17eaaf9c9
+      - fa459cb5-c986-4589-bb68-9fa8313bb144
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102421Z:e4a5f369-a742-466f-bd8f-42e17eaaf9c9
+      - WESTEUROPE:20180312T132638Z:fa459cb5-c986-4589-bb68-9fa8313bb144
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:21 GMT
+      - Mon, 12 Mar 2018 13:26:38 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb2-publicip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\",\r\n
-        \ \"etag\": \"W/\\\"cddd97d1-6111-4477-8a00-3dc885237a1d\\\"\",\r\n  \"location\":
+      string: "{\r\n  \"name\": \"miqazure-linux-manag944\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944\",\r\n
+        \ \"etag\": \"W/\\\"b6339880-8ead-4c9e-b5c0-f38c4f8612d5\\\"\",\r\n  \"location\":
         \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"83e7257d-ab94-4229-8eb5-4798f37ef28d\",\r\n    \"publicIPAddressVersion\":
+        \   \"resourceGuid\": \"c5e8b90e-5a78-49b0-b224-b70ed3fb45e5\",\r\n    \"ipConfigurations\":
+        [\r\n      {\r\n        \"name\": \"ipconfig1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944/ipConfigurations/ipconfig1\",\r\n
+        \       \"etag\": \"W/\\\"b6339880-8ead-4c9e-b5c0-f38c4f8612d5\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"privateIPAddress\": \"172.25.0.4\",\r\n          \"privateIPAllocationMethod\":
+        \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqazure-linux-managed-ip\"\r\n
+        \         },\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2/subnets/default\"\r\n
+        \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
+        \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\":
+        [],\r\n      \"appliedDnsServers\": []\r\n    },\r\n    \"enableAcceleratedNetworking\":
+        false,\r\n    \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\":
+        {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg\"\r\n
+        \   },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed\"\r\n
+        \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
+        \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:26:38 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/non_existent?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA4ODQsIm5iZiI6MTUyMDg2MDg4NCwiZXhwIjoxNTIwODY0Nzg0LCJhaW8iOiJZMk5nWUdpOG0rOTQycGVadmNIdTZwZnE0d1VkQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRF82dGEzWTc3ME82Y1dwVHFtSW1BQSIsInZlciI6IjEuMCJ9.l5OoUZ1ance2A6NMV32h79ED9Z63ArZd2W_71bGMy-pIkzcdMx-tO5cOs9TOPFdwa4W_-zN0G-r7GEmtFaz54OLS_nk-AvX7UCVIXeBomHZCsAgsjwm1IagK55Cr3i87H4xyxwCN4axso-LvHDPKySu21zE1MqJcQhjXsbNX0WocZK6rFCGIDE2qzIjmiBfSGDqHe1zXA3mzZnfA07iyubU2yeNAPpKL6yni69dhNYGlZUgfhq6K8K5IYAKe8Il9XG9_cg3brFbrWlw71YlkAFLksW-xvr85_KLnZCZrU0Pv-qSjjWXPjqwsYWzvC5XEWFxVZ4QBwlPwgWsuL9G2zQ
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      X-Ms-Failure-Cause:
+      - gateway
+      X-Ms-Request-Id:
+      - dc9347cb-538a-4ac8-b4d2-471b3f0ead9c
+      X-Ms-Correlation-Request-Id:
+      - dc9347cb-538a-4ac8-b4d2-471b3f0ead9c
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T132639Z:dc9347cb-538a-4ac8-b4d2-471b3f0ead9c
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:26:39 GMT
+      Content-Length:
+      - '167'
+    body:
+      encoding: UTF-8
+      string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Network/networkInterfaces/non_existent''
+        under resource group ''miq-azure-test4'' was not found."}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:26:39 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA4ODQsIm5iZiI6MTUyMDg2MDg4NCwiZXhwIjoxNTIwODY0Nzg0LCJhaW8iOiJZMk5nWUdpOG0rOTQycGVadmNIdTZwZnE0d1VkQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRF82dGEzWTc3ME82Y1dwVHFtSW1BQSIsInZlciI6IjEuMCJ9.l5OoUZ1ance2A6NMV32h79ED9Z63ArZd2W_71bGMy-pIkzcdMx-tO5cOs9TOPFdwa4W_-zN0G-r7GEmtFaz54OLS_nk-AvX7UCVIXeBomHZCsAgsjwm1IagK55Cr3i87H4xyxwCN4axso-LvHDPKySu21zE1MqJcQhjXsbNX0WocZK6rFCGIDE2qzIjmiBfSGDqHe1zXA3mzZnfA07iyubU2yeNAPpKL6yni69dhNYGlZUgfhq6K8K5IYAKe8Il9XG9_cg3brFbrWlw71YlkAFLksW-xvr85_KLnZCZrU0Pv-qSjjWXPjqwsYWzvC5XEWFxVZ4QBwlPwgWsuL9G2zQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"f006e6f9-0292-42cd-99fc-f72f194553c1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - b975ec6e-bf62-4f5f-969f-91eb8280b856
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Correlation-Request-Id:
+      - 7cb7c838-9941-430c-a694-de099a9dc0be
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T132641Z:7cb7c838-9941-430c-a694-de099a9dc0be
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:26:40 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"miq-test-rhel1390\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390\",\r\n
+        \ \"etag\": \"W/\\\"f006e6f9-0292-42cd-99fc-f72f194553c1\\\"\",\r\n  \"location\":
+        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"98853f48-2806-4065-be57-cf9159550440\",\r\n    \"ipConfigurations\":
+        [\r\n      {\r\n        \"name\": \"ipconfig1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1\",\r\n
+        \       \"etag\": \"W/\\\"f006e6f9-0292-42cd-99fc-f72f194553c1\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"privateIPAddress\": \"10.16.0.4\",\r\n          \"privateIPAllocationMethod\":
+        \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1\"\r\n
+        \         },\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\"\r\n
+        \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
+        \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\":
+        [],\r\n      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\":
+        \"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net\"\r\n    },\r\n    \"macAddress\":
+        \"00-0D-3A-10-EB-AB\",\r\n    \"enableAcceleratedNetworking\": false,\r\n
+        \   \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\": {\r\n
+        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1\"\r\n
+        \   },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1\"\r\n
+        \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
+        \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:26:41 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA4ODQsIm5iZiI6MTUyMDg2MDg4NCwiZXhwIjoxNTIwODY0Nzg0LCJhaW8iOiJZMk5nWUdpOG0rOTQycGVadmNIdTZwZnE0d1VkQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRF82dGEzWTc3ME82Y1dwVHFtSW1BQSIsInZlciI6IjEuMCJ9.l5OoUZ1ance2A6NMV32h79ED9Z63ArZd2W_71bGMy-pIkzcdMx-tO5cOs9TOPFdwa4W_-zN0G-r7GEmtFaz54OLS_nk-AvX7UCVIXeBomHZCsAgsjwm1IagK55Cr3i87H4xyxwCN4axso-LvHDPKySu21zE1MqJcQhjXsbNX0WocZK6rFCGIDE2qzIjmiBfSGDqHe1zXA3mzZnfA07iyubU2yeNAPpKL6yni69dhNYGlZUgfhq6K8K5IYAKe8Il9XG9_cg3brFbrWlw71YlkAFLksW-xvr85_KLnZCZrU0Pv-qSjjWXPjqwsYWzvC5XEWFxVZ4QBwlPwgWsuL9G2zQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"26031ef6-bb55-4019-8185-2dd1edcb207c"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 30bf1a91-3282-480c-94fb-ac343b8767b4
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14997'
+      X-Ms-Correlation-Request-Id:
+      - fd9b0dcd-66bf-4f2a-b77b-5cc6eca96686
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T132642Z:fd9b0dcd-66bf-4f2a-b77b-5cc6eca96686
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:26:41 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"miqazure-centos1611\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611\",\r\n
+        \ \"etag\": \"W/\\\"26031ef6-bb55-4019-8185-2dd1edcb207c\\\"\",\r\n  \"location\":
+        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"f1760e49-9853-4fdc-acfc-4ea232b9ed76\",\r\n    \"ipConfigurations\":
+        [\r\n      {\r\n        \"name\": \"ipconfig1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1\",\r\n
+        \       \"etag\": \"W/\\\"26031ef6-bb55-4019-8185-2dd1edcb207c\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"privateIPAddress\": \"10.16.0.5\",\r\n          \"privateIPAllocationMethod\":
+        \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1\"\r\n
+        \         },\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\"\r\n
+        \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
+        \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\":
+        [],\r\n      \"appliedDnsServers\": []\r\n    },\r\n    \"enableAcceleratedNetworking\":
+        false,\r\n    \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\":
+        {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1\"\r\n
+        \   },\r\n    \"virtualMachine\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1\"\r\n
+        \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
+        \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:26:42 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed/instanceView?api-version=2017-12-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA4ODQsIm5iZiI6MTUyMDg2MDg4NCwiZXhwIjoxNTIwODY0Nzg0LCJhaW8iOiJZMk5nWUdpOG0rOTQycGVadmNIdTZwZnE0d1VkQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRF82dGEzWTc3ME82Y1dwVHFtSW1BQSIsInZlciI6IjEuMCJ9.l5OoUZ1ance2A6NMV32h79ED9Z63ArZd2W_71bGMy-pIkzcdMx-tO5cOs9TOPFdwa4W_-zN0G-r7GEmtFaz54OLS_nk-AvX7UCVIXeBomHZCsAgsjwm1IagK55Cr3i87H4xyxwCN4axso-LvHDPKySu21zE1MqJcQhjXsbNX0WocZK6rFCGIDE2qzIjmiBfSGDqHe1zXA3mzZnfA07iyubU2yeNAPpKL6yni69dhNYGlZUgfhq6K8K5IYAKe8Il9XG9_cg3brFbrWlw71YlkAFLksW-xvr85_KLnZCZrU0Pv-qSjjWXPjqwsYWzvC5XEWFxVZ4QBwlPwgWsuL9G2zQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/GetInstanceView3Min;4799,Microsoft.Compute/GetInstanceView30Min;23849
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      X-Ms-Request-Id:
+      - cf7863be-50c5-417a-8931-a4457f0d9bec
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14999'
+      X-Ms-Correlation-Request-Id:
+      - 5f318ed7-c077-486c-8b61-f1e4dd93ed95
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T132649Z:5f318ed7-c077-486c-8b61-f1e4dd93ed95
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:26:48 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"miqazure-linux-managed_OsDisk_1_7b2bdf790a7d4379ace2846d307730cd\",\r\n
+        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
+        succeeded\",\r\n          \"time\": \"2018-01-23T20:06:17.9818931+00:00\"\r\n
+        \       }\r\n      ]\r\n    },\r\n    {\r\n      \"name\": \"miqazure-linux-managed-data-disk\",\r\n
+        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
+        succeeded\",\r\n          \"time\": \"2018-01-23T20:06:17.9818931+00:00\"\r\n
+        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\":
+        \"ProvisioningState/succeeded\",\r\n      \"level\": \"Info\",\r\n      \"displayStatus\":
+        \"Provisioning succeeded\",\r\n      \"time\": \"2018-01-23T20:06:17.9975145+00:00\"\r\n
+        \   },\r\n    {\r\n      \"code\": \"PowerState/deallocated\",\r\n      \"level\":
+        \"Info\",\r\n      \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:26:49 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/instanceView?api-version=2017-12-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA4ODQsIm5iZiI6MTUyMDg2MDg4NCwiZXhwIjoxNTIwODY0Nzg0LCJhaW8iOiJZMk5nWUdpOG0rOTQycGVadmNIdTZwZnE0d1VkQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRF82dGEzWTc3ME82Y1dwVHFtSW1BQSIsInZlciI6IjEuMCJ9.l5OoUZ1ance2A6NMV32h79ED9Z63ArZd2W_71bGMy-pIkzcdMx-tO5cOs9TOPFdwa4W_-zN0G-r7GEmtFaz54OLS_nk-AvX7UCVIXeBomHZCsAgsjwm1IagK55Cr3i87H4xyxwCN4axso-LvHDPKySu21zE1MqJcQhjXsbNX0WocZK6rFCGIDE2qzIjmiBfSGDqHe1zXA3mzZnfA07iyubU2yeNAPpKL6yni69dhNYGlZUgfhq6K8K5IYAKe8Il9XG9_cg3brFbrWlw71YlkAFLksW-xvr85_KLnZCZrU0Pv-qSjjWXPjqwsYWzvC5XEWFxVZ4QBwlPwgWsuL9G2zQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/GetInstanceView3Min;4798,Microsoft.Compute/GetInstanceView30Min;23848
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      X-Ms-Request-Id:
+      - f853dccb-36fa-4830-bb0c-066bf490287e
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14998'
+      X-Ms-Correlation-Request-Id:
+      - 302f242f-47d9-427a-a1da-37fdbc261125
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T132649Z:302f242f-47d9-427a-a1da-37fdbc261125
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:26:49 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"vmAgent\": {\r\n    \"vmAgentVersion\": \"WALinuxAgent-2.0.16\",\r\n
+        \   \"statuses\": [\r\n      {\r\n        \"code\": \"ProvisioningState/succeeded\",\r\n
+        \       \"level\": \"Info\",\r\n        \"displayStatus\": \"Ready\",\r\n
+        \       \"message\": \"GuestAgent is running and accepting new configurations.\",\r\n
+        \       \"time\": \"2018-03-12T13:26:44+00:00\"\r\n      }\r\n    ],\r\n    \"extensionHandlers\":
+        [\r\n      {\r\n        \"type\": \"Microsoft.OSTCExtensions.LinuxDiagnostic\",\r\n
+        \       \"typeHandlerVersion\": \"2.3.9027\",\r\n        \"status\": {\r\n
+        \         \"code\": \"ProvisioningState/succeeded\",\r\n          \"level\":
+        \"Info\",\r\n          \"displayStatus\": \"Ready\"\r\n        }\r\n      }\r\n
+        \   ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"miq-test-rhel1\",\r\n
+        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
+        succeeded\",\r\n          \"time\": \"2018-01-17T18:00:29.9011002+00:00\"\r\n
+        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
+        \"https://miqazuretest18686.blob.core.windows.net/bootdiagnostics-miqtestrh-03e8467b-baab-4867-9cc4-157336b7e2e4/miq-test-rhel1.03e8467b-baab-4867-9cc4-157336b7e2e4.screenshot.bmp\",\r\n
+        \   \"serialConsoleLogBlobUri\": \"https://miqazuretest18686.blob.core.windows.net/bootdiagnostics-miqtestrh-03e8467b-baab-4867-9cc4-157336b7e2e4/miq-test-rhel1.03e8467b-baab-4867-9cc4-157336b7e2e4.serialconsole.log\"\r\n
+        \ },\r\n  \"extensions\": [\r\n    {\r\n      \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\",\r\n
+        \     \"type\": \"Microsoft.OSTCExtensions.LinuxDiagnostic\",\r\n      \"typeHandlerVersion\":
+        \"2.3.9027\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\":
+        \"ProvisioningState/succeeded\",\r\n          \"level\": \"Info\",\r\n          \"displayStatus\":
+        \"Provisioning succeeded\",\r\n          \"message\": \"Enable succeeded\"\r\n
+        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\":
+        \"ProvisioningState/succeeded\",\r\n      \"level\": \"Info\",\r\n      \"displayStatus\":
+        \"Provisioning succeeded\",\r\n      \"time\": \"2018-01-17T18:02:26.9167163+00:00\"\r\n
+        \   },\r\n    {\r\n      \"code\": \"PowerState/running\",\r\n      \"level\":
+        \"Info\",\r\n      \"displayStatus\": \"VM running\"\r\n    }\r\n  ]\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:26:49 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1/instanceView?api-version=2017-12-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA4ODQsIm5iZiI6MTUyMDg2MDg4NCwiZXhwIjoxNTIwODY0Nzg0LCJhaW8iOiJZMk5nWUdpOG0rOTQycGVadmNIdTZwZnE0d1VkQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRF82dGEzWTc3ME82Y1dwVHFtSW1BQSIsInZlciI6IjEuMCJ9.l5OoUZ1ance2A6NMV32h79ED9Z63ArZd2W_71bGMy-pIkzcdMx-tO5cOs9TOPFdwa4W_-zN0G-r7GEmtFaz54OLS_nk-AvX7UCVIXeBomHZCsAgsjwm1IagK55Cr3i87H4xyxwCN4axso-LvHDPKySu21zE1MqJcQhjXsbNX0WocZK6rFCGIDE2qzIjmiBfSGDqHe1zXA3mzZnfA07iyubU2yeNAPpKL6yni69dhNYGlZUgfhq6K8K5IYAKe8Il9XG9_cg3brFbrWlw71YlkAFLksW-xvr85_KLnZCZrU0Pv-qSjjWXPjqwsYWzvC5XEWFxVZ4QBwlPwgWsuL9G2zQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/GetInstanceView3Min;4797,Microsoft.Compute/GetInstanceView30Min;23847
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      X-Ms-Request-Id:
+      - 670f9bdb-8a83-4c2b-932d-f22db7752e9c
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Correlation-Request-Id:
+      - 2cb26990-53c1-4ea9-8661-606d2223e454
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T132650Z:2cb26990-53c1-4ea9-8661-606d2223e454
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:26:49 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"platformUpdateDomain\": 0,\r\n  \"platformFaultDomain\": 0,\r\n
+        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
+        [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
+        \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
+        \"Failed to fetch the VM status.\",\r\n        \"time\": \"2018-03-12T13:26:50+00:00\"\r\n
+        \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"miqazure-centos1\",\r\n
+        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
+        succeeded\",\r\n          \"time\": \"2016-06-22T21:18:47.2011229+00:00\"\r\n
+        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
+        \"https://miqazuretest14047.blob.core.windows.net/bootdiagnostics-miqazurec-796c5bcc-338a-448d-b61c-165279a7fb3e/miqazure-centos1.796c5bcc-338a-448d-b61c-165279a7fb3e.screenshot.bmp\",\r\n
+        \   \"serialConsoleLogBlobUri\": \"https://miqazuretest14047.blob.core.windows.net/bootdiagnostics-miqazurec-796c5bcc-338a-448d-b61c-165279a7fb3e/miqazure-centos1.796c5bcc-338a-448d-b61c-165279a7fb3e.serialconsole.log\"\r\n
+        \ },\r\n  \"extensions\": [\r\n    {\r\n      \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n
+        \   }\r\n  ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n
+        \     \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n
+        \     \"time\": \"2016-06-22T21:18:47.2636196+00:00\"\r\n    },\r\n    {\r\n
+        \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
+        \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:26:50 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups/miq-azure-test4?api-version=2017-08-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA4ODQsIm5iZiI6MTUyMDg2MDg4NCwiZXhwIjoxNTIwODY0Nzg0LCJhaW8iOiJZMk5nWUdpOG0rOTQycGVadmNIdTZwZnE0d1VkQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRF82dGEzWTc3ME82Y1dwVHFtSW1BQSIsInZlciI6IjEuMCJ9.l5OoUZ1ance2A6NMV32h79ED9Z63ArZd2W_71bGMy-pIkzcdMx-tO5cOs9TOPFdwa4W_-zN0G-r7GEmtFaz54OLS_nk-AvX7UCVIXeBomHZCsAgsjwm1IagK55Cr3i87H4xyxwCN4axso-LvHDPKySu21zE1MqJcQhjXsbNX0WocZK6rFCGIDE2qzIjmiBfSGDqHe1zXA3mzZnfA07iyubU2yeNAPpKL6yni69dhNYGlZUgfhq6K8K5IYAKe8Il9XG9_cg3brFbrWlw71YlkAFLksW-xvr85_KLnZCZrU0Pv-qSjjWXPjqwsYWzvC5XEWFxVZ4QBwlPwgWsuL9G2zQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14998'
+      X-Ms-Request-Id:
+      - 0343f81b-4181-4635-83ec-870be4cf3e02
+      X-Ms-Correlation-Request-Id:
+      - 0343f81b-4181-4635-83ec-870be4cf3e02
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T132652Z:0343f81b-4181-4635-83ec-870be4cf3e02
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:26:52 GMT
+      Content-Length:
+      - '183'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4","name":"miq-azure-test4","location":"eastus","properties":{"provisioningState":"Succeeded"}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:26:52 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups/miq-azure-test1?api-version=2017-08-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA4ODQsIm5iZiI6MTUyMDg2MDg4NCwiZXhwIjoxNTIwODY0Nzg0LCJhaW8iOiJZMk5nWUdpOG0rOTQycGVadmNIdTZwZnE0d1VkQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRF82dGEzWTc3ME82Y1dwVHFtSW1BQSIsInZlciI6IjEuMCJ9.l5OoUZ1ance2A6NMV32h79ED9Z63ArZd2W_71bGMy-pIkzcdMx-tO5cOs9TOPFdwa4W_-zN0G-r7GEmtFaz54OLS_nk-AvX7UCVIXeBomHZCsAgsjwm1IagK55Cr3i87H4xyxwCN4axso-LvHDPKySu21zE1MqJcQhjXsbNX0WocZK6rFCGIDE2qzIjmiBfSGDqHe1zXA3mzZnfA07iyubU2yeNAPpKL6yni69dhNYGlZUgfhq6K8K5IYAKe8Il9XG9_cg3brFbrWlw71YlkAFLksW-xvr85_KLnZCZrU0Pv-qSjjWXPjqwsYWzvC5XEWFxVZ4QBwlPwgWsuL9G2zQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14998'
+      X-Ms-Request-Id:
+      - 04a55e42-45be-45d0-be2b-f2e87e163cd8
+      X-Ms-Correlation-Request-Id:
+      - 04a55e42-45be-45d0-be2b-f2e87e163cd8
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T132654Z:04a55e42-45be-45d0-be2b-f2e87e163cd8
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:26:53 GMT
+      Content-Length:
+      - '183'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1","name":"miq-azure-test1","location":"eastus","properties":{"provisioningState":"Succeeded"}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:26:54 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups/miq-azure-test4?api-version=2017-08-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA4ODQsIm5iZiI6MTUyMDg2MDg4NCwiZXhwIjoxNTIwODY0Nzg0LCJhaW8iOiJZMk5nWUdpOG0rOTQycGVadmNIdTZwZnE0d1VkQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRF82dGEzWTc3ME82Y1dwVHFtSW1BQSIsInZlciI6IjEuMCJ9.l5OoUZ1ance2A6NMV32h79ED9Z63ArZd2W_71bGMy-pIkzcdMx-tO5cOs9TOPFdwa4W_-zN0G-r7GEmtFaz54OLS_nk-AvX7UCVIXeBomHZCsAgsjwm1IagK55Cr3i87H4xyxwCN4axso-LvHDPKySu21zE1MqJcQhjXsbNX0WocZK6rFCGIDE2qzIjmiBfSGDqHe1zXA3mzZnfA07iyubU2yeNAPpKL6yni69dhNYGlZUgfhq6K8K5IYAKe8Il9XG9_cg3brFbrWlw71YlkAFLksW-xvr85_KLnZCZrU0Pv-qSjjWXPjqwsYWzvC5XEWFxVZ4QBwlPwgWsuL9G2zQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14998'
+      X-Ms-Request-Id:
+      - 5414d52a-059c-4634-a03e-b2c9c783919d
+      X-Ms-Correlation-Request-Id:
+      - 5414d52a-059c-4634-a03e-b2c9c783919d
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T132654Z:5414d52a-059c-4634-a03e-b2c9c783919d
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:26:54 GMT
+      Content-Length:
+      - '183'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4","name":"miq-azure-test4","location":"eastus","properties":{"provisioningState":"Succeeded"}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:26:54 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute/locations/eastus/vmSizes?api-version=2017-12-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA4ODQsIm5iZiI6MTUyMDg2MDg4NCwiZXhwIjoxNTIwODY0Nzg0LCJhaW8iOiJZMk5nWUdpOG0rOTQycGVadmNIdTZwZnE0d1VkQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRF82dGEzWTc3ME82Y1dwVHFtSW1BQSIsInZlciI6IjEuMCJ9.l5OoUZ1ance2A6NMV32h79ED9Z63ArZd2W_71bGMy-pIkzcdMx-tO5cOs9TOPFdwa4W_-zN0G-r7GEmtFaz54OLS_nk-AvX7UCVIXeBomHZCsAgsjwm1IagK55Cr3i87H4xyxwCN4axso-LvHDPKySu21zE1MqJcQhjXsbNX0WocZK6rFCGIDE2qzIjmiBfSGDqHe1zXA3mzZnfA07iyubU2yeNAPpKL6yni69dhNYGlZUgfhq6K8K5IYAKe8Il9XG9_cg3brFbrWlw71YlkAFLksW-xvr85_KLnZCZrU0Pv-qSjjWXPjqwsYWzvC5XEWFxVZ4QBwlPwgWsuL9G2zQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/LowCostGet3Min;4792,Microsoft.Compute/LowCostGet30Min;38357
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      X-Ms-Request-Id:
+      - 14446383-9d5e-4bfe-a97d-0cac892082e6
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14998'
+      X-Ms-Correlation-Request-Id:
+      - eb4da180-684f-4eed-a688-3b5f917ed8fb
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T132655Z:eb4da180-684f-4eed-a688-3b5f917ed8fb
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:26:55 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"Standard_B1ms\",\r\n
+        \     \"numberOfCores\": 1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        4096,\r\n      \"memoryInMB\": 2048,\r\n      \"maxDataDiskCount\": 2\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_B1s\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        2048,\r\n      \"memoryInMB\": 1024,\r\n      \"maxDataDiskCount\": 2\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_B2ms\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        16384,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_B2s\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        8192,\r\n      \"memoryInMB\": 4096,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_B4ms\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        32768,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_B8ms\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS1_v2\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        7168,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS2_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        14336,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS3_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS4_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS5_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS11-1_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS11_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS12-1_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS12-2_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS12_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS13-2_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS13-4_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS13_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS14-4_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        229376,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS14-8_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        229376,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS14_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        229376,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS15_v2\",\r\n      \"numberOfCores\":
+        20,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        286720,\r\n      \"memoryInMB\": 143360,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS2_v2_Promo\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        14336,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS3_v2_Promo\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS4_v2_Promo\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS5_v2_Promo\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS11_v2_Promo\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS12_v2_Promo\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS13_v2_Promo\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS14_v2_Promo\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        229376,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F1s\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        4096,\r\n      \"memoryInMB\": 2048,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F2s\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        8192,\r\n      \"memoryInMB\": 4096,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F4s\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        16384,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F8s\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        32768,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F16s\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D2s_v3\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        16384,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D4s_v3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        32768,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D8s_v3\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D16s_v3\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        131072,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D32s_v3\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        262144,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A0\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        20480,\r\n      \"memoryInMB\": 768,\r\n      \"maxDataDiskCount\": 1\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A1\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        71680,\r\n      \"memoryInMB\": 1792,\r\n      \"maxDataDiskCount\": 2\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        138240,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        291840,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A5\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        138240,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A4\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        619520,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A6\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        291840,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A7\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        619520,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Basic_A0\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        20480,\r\n      \"memoryInMB\": 768,\r\n      \"maxDataDiskCount\": 1\r\n
+        \   },\r\n    {\r\n      \"name\": \"Basic_A1\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        40960,\r\n      \"memoryInMB\": 1792,\r\n      \"maxDataDiskCount\": 2\r\n
+        \   },\r\n    {\r\n      \"name\": \"Basic_A2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        61440,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Basic_A3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        122880,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Basic_A4\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        245760,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D1_v2\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        51200,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D2_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D3_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D4_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D5_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D11_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D12_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D13_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D14_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D15_v2\",\r\n      \"numberOfCores\":
+        20,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        286720,\r\n      \"memoryInMB\": 143360,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D2_v2_Promo\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D3_v2_Promo\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D4_v2_Promo\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D5_v2_Promo\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D11_v2_Promo\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D12_v2_Promo\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D13_v2_Promo\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D14_v2_Promo\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F1\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        16384,\r\n      \"memoryInMB\": 2048,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        32768,\r\n      \"memoryInMB\": 4096,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F4\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F8\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        131072,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F16\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        262144,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A1_v2\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        10240,\r\n      \"memoryInMB\": 2048,\r\n      \"maxDataDiskCount\": 2\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A2m_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        20480,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A2_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        20480,\r\n      \"memoryInMB\": 4096,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A4m_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        40960,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A4_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        40960,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A8m_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        81920,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A8_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        81920,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D2_v3\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        51200,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D4_v3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D8_v3\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D16_v3\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 65636,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D32_v3\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_H8\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1024000,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_H16\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        2048000,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_H8m\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1024000,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_H16m\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        2048000,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_H16r\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        2048000,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_H16mr\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        2048000,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D1\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        51200,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D4\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D11\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D12\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D13\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D14\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NV6\",\r\n      \"numberOfCores\":
+        6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        389120,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 24\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NV12\",\r\n      \"numberOfCores\":
+        12,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        696320,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 48\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NV24\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1474560,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC6s_v2\",\r\n      \"numberOfCores\":
+        6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        344064,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 12\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC12s_v2\",\r\n      \"numberOfCores\":
+        12,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        688128,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 24\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC24rs_v2\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1376256,\r\n      \"memoryInMB\": 458752,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC24s_v2\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1376256,\r\n      \"memoryInMB\": 458752,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC6\",\r\n      \"numberOfCores\":
+        6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        389120,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 24\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC12\",\r\n      \"numberOfCores\":
+        12,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        696320,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 48\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC24\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1474560,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC24r\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1474560,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS1\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        7168,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        14336,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS4\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS11\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS12\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS13\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS14\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        229376,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC6s_v3\",\r\n      \"numberOfCores\":
+        6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        344064,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 12\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC12s_v3\",\r\n      \"numberOfCores\":
+        12,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        688128,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 24\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC24rs_v3\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1376256,\r\n      \"memoryInMB\": 458752,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC24s_v3\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1376256,\r\n      \"memoryInMB\": 458752,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D64_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1638400,\r\n      \"memoryInMB\": 262144,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D64s_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        524288,\r\n      \"memoryInMB\": 262144,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E2_v3\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        51200,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E4_v3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E8_v3\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E16_v3\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E32_v3\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 262144,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E64i_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1638400,\r\n      \"memoryInMB\": 442368,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E64_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1638400,\r\n      \"memoryInMB\": 442368,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E2s_v3\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        32768,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E4-2s_v3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E4s_v3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E8-2s_v3\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        131072,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E8-4s_v3\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        131072,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E8s_v3\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        131072,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E16-4s_v3\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        262144,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E16-8s_v3\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        262144,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E16s_v3\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        262144,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E32-8s_v3\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        524288,\r\n      \"memoryInMB\": 262144,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E32-16s_v3\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        524288,\r\n      \"memoryInMB\": 262144,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E32s_v3\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        524288,\r\n      \"memoryInMB\": 262144,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E64-16s_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        884736,\r\n      \"memoryInMB\": 442368,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E64-32s_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        884736,\r\n      \"memoryInMB\": 442368,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E64is_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        884736,\r\n      \"memoryInMB\": 442368,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E64s_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        884736,\r\n      \"memoryInMB\": 442368,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F2s_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        16384,\r\n      \"memoryInMB\": 4096,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F4s_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        32768,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F8s_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F16s_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        131072,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F32s_v2\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        262144,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F64s_v2\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        524288,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F72s_v2\",\r\n      \"numberOfCores\":
+        72,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        589824,\r\n      \"memoryInMB\": 147456,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_L8s_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1811981,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_L16s_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        3623962,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_ND6s\",\r\n      \"numberOfCores\":
+        6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        344064,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 12\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_ND12s\",\r\n      \"numberOfCores\":
+        12,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        688128,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 24\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_ND24rs\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1376256,\r\n      \"memoryInMB\": 458752,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_ND24s\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1376256,\r\n      \"memoryInMB\": 458752,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A8\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        391168,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A9\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        391168,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A10\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        391168,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A11\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        391168,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   }\r\n  ]\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:26:55 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/non_existent?api-version=2017-08-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA4ODQsIm5iZiI6MTUyMDg2MDg4NCwiZXhwIjoxNTIwODY0Nzg0LCJhaW8iOiJZMk5nWUdpOG0rOTQycGVadmNIdTZwZnE0d1VkQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRF82dGEzWTc3ME82Y1dwVHFtSW1BQSIsInZlciI6IjEuMCJ9.l5OoUZ1ance2A6NMV32h79ED9Z63ArZd2W_71bGMy-pIkzcdMx-tO5cOs9TOPFdwa4W_-zN0G-r7GEmtFaz54OLS_nk-AvX7UCVIXeBomHZCsAgsjwm1IagK55Cr3i87H4xyxwCN4axso-LvHDPKySu21zE1MqJcQhjXsbNX0WocZK6rFCGIDE2qzIjmiBfSGDqHe1zXA3mzZnfA07iyubU2yeNAPpKL6yni69dhNYGlZUgfhq6K8K5IYAKe8Il9XG9_cg3brFbrWlw71YlkAFLksW-xvr85_KLnZCZrU0Pv-qSjjWXPjqwsYWzvC5XEWFxVZ4QBwlPwgWsuL9G2zQ
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      X-Ms-Failure-Cause:
+      - gateway
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14998'
+      X-Ms-Request-Id:
+      - bcd9a1a8-1bed-4b35-900c-9a4a51c01315
+      X-Ms-Correlation-Request-Id:
+      - bcd9a1a8-1bed-4b35-900c-9a4a51c01315
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T132656Z:bcd9a1a8-1bed-4b35-900c-9a4a51c01315
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:26:55 GMT
+      Content-Length:
+      - '97'
+    body:
+      encoding: UTF-8
+      string: '{"error":{"code":"DeploymentNotFound","message":"Deployment ''non_existent''
+        could not be found."}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:26:56 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/non_existent?api-version=2017-08-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA4ODQsIm5iZiI6MTUyMDg2MDg4NCwiZXhwIjoxNTIwODY0Nzg0LCJhaW8iOiJZMk5nWUdpOG0rOTQycGVadmNIdTZwZnE0d1VkQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRF82dGEzWTc3ME82Y1dwVHFtSW1BQSIsInZlciI6IjEuMCJ9.l5OoUZ1ance2A6NMV32h79ED9Z63ArZd2W_71bGMy-pIkzcdMx-tO5cOs9TOPFdwa4W_-zN0G-r7GEmtFaz54OLS_nk-AvX7UCVIXeBomHZCsAgsjwm1IagK55Cr3i87H4xyxwCN4axso-LvHDPKySu21zE1MqJcQhjXsbNX0WocZK6rFCGIDE2qzIjmiBfSGDqHe1zXA3mzZnfA07iyubU2yeNAPpKL6yni69dhNYGlZUgfhq6K8K5IYAKe8Il9XG9_cg3brFbrWlw71YlkAFLksW-xvr85_KLnZCZrU0Pv-qSjjWXPjqwsYWzvC5XEWFxVZ4QBwlPwgWsuL9G2zQ
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      X-Ms-Failure-Cause:
+      - gateway
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14997'
+      X-Ms-Request-Id:
+      - 041d79cc-74d1-4f3a-8ce7-d7c2d1b59af2
+      X-Ms-Correlation-Request-Id:
+      - 041d79cc-74d1-4f3a-8ce7-d7c2d1b59af2
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T132657Z:041d79cc-74d1-4f3a-8ce7-d7c2d1b59af2
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:26:56 GMT
+      Content-Length:
+      - '97'
+    body:
+      encoding: UTF-8
+      string: '{"error":{"code":"DeploymentNotFound","message":"Deployment ''non_existent''
+        could not be found."}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:26:57 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA4ODQsIm5iZiI6MTUyMDg2MDg4NCwiZXhwIjoxNTIwODY0Nzg0LCJhaW8iOiJZMk5nWUdpOG0rOTQycGVadmNIdTZwZnE0d1VkQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRF82dGEzWTc3ME82Y1dwVHFtSW1BQSIsInZlciI6IjEuMCJ9.l5OoUZ1ance2A6NMV32h79ED9Z63ArZd2W_71bGMy-pIkzcdMx-tO5cOs9TOPFdwa4W_-zN0G-r7GEmtFaz54OLS_nk-AvX7UCVIXeBomHZCsAgsjwm1IagK55Cr3i87H4xyxwCN4axso-LvHDPKySu21zE1MqJcQhjXsbNX0WocZK6rFCGIDE2qzIjmiBfSGDqHe1zXA3mzZnfA07iyubU2yeNAPpKL6yni69dhNYGlZUgfhq6K8K5IYAKe8Il9XG9_cg3brFbrWlw71YlkAFLksW-xvr85_KLnZCZrU0Pv-qSjjWXPjqwsYWzvC5XEWFxVZ4QBwlPwgWsuL9G2zQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"2080997a-38a6-420d-ba86-e9582e1331c7"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - dd161717-73bd-4135-b29b-8e86349ff061
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14998'
+      X-Ms-Correlation-Request-Id:
+      - 16eca241-4a19-4649-a5ab-551fb82a74b4
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T132657Z:16eca241-4a19-4649-a5ab-551fb82a74b4
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:26:57 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"spec0deply1ip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip\",\r\n
+        \ \"etag\": \"W/\\\"2080997a-38a6-420d-ba86-e9582e1331c7\\\"\",\r\n  \"location\":
+        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"a08b891e-e45a-4970-aefc-f6c996989490\",\r\n    \"publicIPAddressVersion\":
         \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
-        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
+        4,\r\n    \"dnsSettings\": {\r\n      \"domainNameLabel\": \"spec0deply1dns\",\r\n
+        \     \"fqdn\": \"spec0deply1dns.eastus.cloudapp.azure.com\"\r\n    },\r\n
+        \   \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
         \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
         \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:26 GMT
+  recorded_at: Mon, 12 Mar 2018 13:26:57 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqazure-linux-managed-ip?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA4ODQsIm5iZiI6MTUyMDg2MDg4NCwiZXhwIjoxNTIwODY0Nzg0LCJhaW8iOiJZMk5nWUdpOG0rOTQycGVadmNIdTZwZnE0d1VkQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRF82dGEzWTc3ME82Y1dwVHFtSW1BQSIsInZlciI6IjEuMCJ9.l5OoUZ1ance2A6NMV32h79ED9Z63ArZd2W_71bGMy-pIkzcdMx-tO5cOs9TOPFdwa4W_-zN0G-r7GEmtFaz54OLS_nk-AvX7UCVIXeBomHZCsAgsjwm1IagK55Cr3i87H4xyxwCN4axso-LvHDPKySu21zE1MqJcQhjXsbNX0WocZK6rFCGIDE2qzIjmiBfSGDqHe1zXA3mzZnfA07iyubU2yeNAPpKL6yni69dhNYGlZUgfhq6K8K5IYAKe8Il9XG9_cg3brFbrWlw71YlkAFLksW-xvr85_KLnZCZrU0Pv-qSjjWXPjqwsYWzvC5XEWFxVZ4QBwlPwgWsuL9G2zQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"0efc9684-fb7d-4fb7-b9b9-f33dbac04a28"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 40ea39be-dfc6-45bf-a064-a3e292c2260b
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Correlation-Request-Id:
+      - f2ad72fe-2d1b-4e73-82ce-2c7a20693308
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T132658Z:f2ad72fe-2d1b-4e73-82ce-2c7a20693308
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:26:58 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"miqazure-linux-managed-ip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqazure-linux-managed-ip\",\r\n
+        \ \"etag\": \"W/\\\"0efc9684-fb7d-4fb7-b9b9-f33dbac04a28\\\"\",\r\n  \"location\":
+        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"6a2a9142-26e8-45cd-93bf-7318192f3528\",\r\n    \"publicIPAddressVersion\":
+        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
+        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944/ipConfigurations/ipconfig1\"\r\n
+        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
+        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:26:58 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA4ODQsIm5iZiI6MTUyMDg2MDg4NCwiZXhwIjoxNTIwODY0Nzg0LCJhaW8iOiJZMk5nWUdpOG0rOTQycGVadmNIdTZwZnE0d1VkQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRF82dGEzWTc3ME82Y1dwVHFtSW1BQSIsInZlciI6IjEuMCJ9.l5OoUZ1ance2A6NMV32h79ED9Z63ArZd2W_71bGMy-pIkzcdMx-tO5cOs9TOPFdwa4W_-zN0G-r7GEmtFaz54OLS_nk-AvX7UCVIXeBomHZCsAgsjwm1IagK55Cr3i87H4xyxwCN4axso-LvHDPKySu21zE1MqJcQhjXsbNX0WocZK6rFCGIDE2qzIjmiBfSGDqHe1zXA3mzZnfA07iyubU2yeNAPpKL6yni69dhNYGlZUgfhq6K8K5IYAKe8Il9XG9_cg3brFbrWlw71YlkAFLksW-xvr85_KLnZCZrU0Pv-qSjjWXPjqwsYWzvC5XEWFxVZ4QBwlPwgWsuL9G2zQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"054052bb-11ff-4f6e-ac1a-3427c2fd17aa"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - a6d4a1ed-f398-4575-b508-3e3efaa84627
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Correlation-Request-Id:
+      - f5d6ec9b-ecf2-42db-9e7b-3ef7ffeaf7d0
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T132658Z:f5d6ec9b-ecf2-42db-9e7b-3ef7ffeaf7d0
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:26:58 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"miq-test-rhel1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1\",\r\n
+        \ \"etag\": \"W/\\\"054052bb-11ff-4f6e-ac1a-3427c2fd17aa\\\"\",\r\n  \"location\":
+        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"f6cfc635-411e-48ce-a627-39a2fc0d3168\",\r\n    \"ipAddress\":
+        \"52.224.165.15\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\":
+        \"Dynamic\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipTags\": [],\r\n
+        \   \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1\"\r\n
+        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
+        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:26:58 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA4ODQsIm5iZiI6MTUyMDg2MDg4NCwiZXhwIjoxNTIwODY0Nzg0LCJhaW8iOiJZMk5nWUdpOG0rOTQycGVadmNIdTZwZnE0d1VkQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRF82dGEzWTc3ME82Y1dwVHFtSW1BQSIsInZlciI6IjEuMCJ9.l5OoUZ1ance2A6NMV32h79ED9Z63ArZd2W_71bGMy-pIkzcdMx-tO5cOs9TOPFdwa4W_-zN0G-r7GEmtFaz54OLS_nk-AvX7UCVIXeBomHZCsAgsjwm1IagK55Cr3i87H4xyxwCN4axso-LvHDPKySu21zE1MqJcQhjXsbNX0WocZK6rFCGIDE2qzIjmiBfSGDqHe1zXA3mzZnfA07iyubU2yeNAPpKL6yni69dhNYGlZUgfhq6K8K5IYAKe8Il9XG9_cg3brFbrWlw71YlkAFLksW-xvr85_KLnZCZrU0Pv-qSjjWXPjqwsYWzvC5XEWFxVZ4QBwlPwgWsuL9G2zQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"734a3944-a880-444c-8c92-cace6e28e303"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - a7dbbc9e-8e69-4da5-b94e-8935a9bbfcf5
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14998'
+      X-Ms-Correlation-Request-Id:
+      - 34272a66-77eb-4382-bbc1-48c36e4bd9d6
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T132659Z:34272a66-77eb-4382-bbc1-48c36e4bd9d6
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:26:58 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"miqazure-centos1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1\",\r\n
+        \ \"etag\": \"W/\\\"734a3944-a880-444c-8c92-cace6e28e303\\\"\",\r\n  \"location\":
+        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"475a66f0-9e89-4226-a9f0-9baaaf31d619\",\r\n    \"publicIPAddressVersion\":
+        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
+        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1\"\r\n
+        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
+        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:26:59 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/disks/miqazure-linux-managed-data-disk?api-version=2017-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA4ODQsIm5iZiI6MTUyMDg2MDg4NCwiZXhwIjoxNTIwODY0Nzg0LCJhaW8iOiJZMk5nWUdpOG0rOTQycGVadmNIdTZwZnE0d1VkQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRF82dGEzWTc3ME82Y1dwVHFtSW1BQSIsInZlciI6IjEuMCJ9.l5OoUZ1ance2A6NMV32h79ED9Z63ArZd2W_71bGMy-pIkzcdMx-tO5cOs9TOPFdwa4W_-zN0G-r7GEmtFaz54OLS_nk-AvX7UCVIXeBomHZCsAgsjwm1IagK55Cr3i87H4xyxwCN4axso-LvHDPKySu21zE1MqJcQhjXsbNX0WocZK6rFCGIDE2qzIjmiBfSGDqHe1zXA3mzZnfA07iyubU2yeNAPpKL6yni69dhNYGlZUgfhq6K8K5IYAKe8Il9XG9_cg3brFbrWlw71YlkAFLksW-xvr85_KLnZCZrU0Pv-qSjjWXPjqwsYWzvC5XEWFxVZ4QBwlPwgWsuL9G2zQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/LowCostGet3Min;4999,Microsoft.Compute/LowCostGet30Min;19999
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131626781321631045
+      X-Ms-Request-Id:
+      - 99c7a43d-5eb0-4c44-9625-050f5bae1556
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Correlation-Request-Id:
+      - 163f2268-9021-4410-a608-84d6b7ef5de7
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T132700Z:163f2268-9021-4410-a608-84d6b7ef5de7
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:27:00 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"managedBy\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed\",\r\n
+        \ \"sku\": {\r\n    \"name\": \"Standard_LRS\",\r\n    \"tier\": \"Standard\"\r\n
+        \ },\r\n  \"properties\": {\r\n    \"creationData\": {\r\n      \"createOption\":
+        \"Empty\"\r\n    },\r\n    \"diskSizeGB\": 1,\r\n    \"timeCreated\": \"2017-10-23T17:34:14.7022771+00:00\",\r\n
+        \   \"provisioningState\": \"Succeeded\",\r\n    \"diskState\": \"Reserved\"\r\n
+        \ },\r\n  \"type\": \"Microsoft.Compute/disks\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/disks/miqazure-linux-managed-data-disk\",\r\n
+        \ \"name\": \"miqazure-linux-managed-data-disk\"\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:27:00 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/disks/miqazure-linux-managed_OsDisk_1_7b2bdf790a7d4379ace2846d307730cd?api-version=2017-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA4ODQsIm5iZiI6MTUyMDg2MDg4NCwiZXhwIjoxNTIwODY0Nzg0LCJhaW8iOiJZMk5nWUdpOG0rOTQycGVadmNIdTZwZnE0d1VkQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRF82dGEzWTc3ME82Y1dwVHFtSW1BQSIsInZlciI6IjEuMCJ9.l5OoUZ1ance2A6NMV32h79ED9Z63ArZd2W_71bGMy-pIkzcdMx-tO5cOs9TOPFdwa4W_-zN0G-r7GEmtFaz54OLS_nk-AvX7UCVIXeBomHZCsAgsjwm1IagK55Cr3i87H4xyxwCN4axso-LvHDPKySu21zE1MqJcQhjXsbNX0WocZK6rFCGIDE2qzIjmiBfSGDqHe1zXA3mzZnfA07iyubU2yeNAPpKL6yni69dhNYGlZUgfhq6K8K5IYAKe8Il9XG9_cg3brFbrWlw71YlkAFLksW-xvr85_KLnZCZrU0Pv-qSjjWXPjqwsYWzvC5XEWFxVZ4QBwlPwgWsuL9G2zQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/LowCostGet3Min;4998,Microsoft.Compute/LowCostGet30Min;19998
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131626781321631045
+      X-Ms-Request-Id:
+      - 9004e910-a091-4531-bc96-f6a520b4c06c
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14997'
+      X-Ms-Correlation-Request-Id:
+      - 7aa8ea28-a6be-4ecb-8869-f6f96e92c409
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T132701Z:7aa8ea28-a6be-4ecb-8869-f6f96e92c409
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:27:01 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"managedBy\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed\",\r\n
+        \ \"sku\": {\r\n    \"name\": \"Standard_LRS\",\r\n    \"tier\": \"Standard\"\r\n
+        \ },\r\n  \"properties\": {\r\n    \"osType\": \"Linux\",\r\n    \"creationData\":
+        {\r\n      \"createOption\": \"FromImage\",\r\n      \"imageReference\": {\r\n
+        \       \"id\": \"/Subscriptions/AZURE_SUBSCRIPTION_ID/Providers/Microsoft.Compute/Locations/eastus/Publishers/RedHat/ArtifactTypes/VMImage/Offers/RHEL/Skus/7.3/Versions/latest\"\r\n
+        \     }\r\n    },\r\n    \"diskSizeGB\": 32,\r\n    \"timeCreated\": \"2017-05-04T21:21:55.7801928+00:00\",\r\n
+        \   \"provisioningState\": \"Succeeded\",\r\n    \"diskState\": \"Reserved\"\r\n
+        \ },\r\n  \"type\": \"Microsoft.Compute/disks\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"tags\": {\r\n    \"delete\": \"false\"\r\n  },\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/disks/miqazure-linux-managed_OsDisk_1_7b2bdf790a7d4379ace2846d307730cd\",\r\n
+        \ \"name\": \"miqazure-linux-managed_OsDisk_1_7b2bdf790a7d4379ace2846d307730cd\"\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:27:01 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686?api-version=2017-10-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA4ODQsIm5iZiI6MTUyMDg2MDg4NCwiZXhwIjoxNTIwODY0Nzg0LCJhaW8iOiJZMk5nWUdpOG0rOTQycGVadmNIdTZwZnE0d1VkQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRF82dGEzWTc3ME82Y1dwVHFtSW1BQSIsInZlciI6IjEuMCJ9.l5OoUZ1ance2A6NMV32h79ED9Z63ArZd2W_71bGMy-pIkzcdMx-tO5cOs9TOPFdwa4W_-zN0G-r7GEmtFaz54OLS_nk-AvX7UCVIXeBomHZCsAgsjwm1IagK55Cr3i87H4xyxwCN4axso-LvHDPKySu21zE1MqJcQhjXsbNX0WocZK6rFCGIDE2qzIjmiBfSGDqHe1zXA3mzZnfA07iyubU2yeNAPpKL6yni69dhNYGlZUgfhq6K8K5IYAKe8Il9XG9_cg3brFbrWlw71YlkAFLksW-xvr85_KLnZCZrU0Pv-qSjjWXPjqwsYWzvC5XEWFxVZ4QBwlPwgWsuL9G2zQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 7e045d89-4140-4f43-93a2-03888d640e62
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Correlation-Request-Id:
+      - bd57582b-8fef-4940-8bef-10b47c9ff522
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T132701Z:bd57582b-8fef-4940-8bef-10b47c9ff522
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:27:01 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","name":"miqazuretest18686","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T17:22:54.7808677Z","primaryEndpoints":{"blob":"https://miqazuretest18686.blob.core.windows.net/","queue":"https://miqazuretest18686.queue.core.windows.net/","table":"https://miqazuretest18686.table.core.windows.net/","file":"https://miqazuretest18686.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:27:01 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047?api-version=2017-10-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA4ODQsIm5iZiI6MTUyMDg2MDg4NCwiZXhwIjoxNTIwODY0Nzg0LCJhaW8iOiJZMk5nWUdpOG0rOTQycGVadmNIdTZwZnE0d1VkQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRF82dGEzWTc3ME82Y1dwVHFtSW1BQSIsInZlciI6IjEuMCJ9.l5OoUZ1ance2A6NMV32h79ED9Z63ArZd2W_71bGMy-pIkzcdMx-tO5cOs9TOPFdwa4W_-zN0G-r7GEmtFaz54OLS_nk-AvX7UCVIXeBomHZCsAgsjwm1IagK55Cr3i87H4xyxwCN4axso-LvHDPKySu21zE1MqJcQhjXsbNX0WocZK6rFCGIDE2qzIjmiBfSGDqHe1zXA3mzZnfA07iyubU2yeNAPpKL6yni69dhNYGlZUgfhq6K8K5IYAKe8Il9XG9_cg3brFbrWlw71YlkAFLksW-xvr85_KLnZCZrU0Pv-qSjjWXPjqwsYWzvC5XEWFxVZ4QBwlPwgWsuL9G2zQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - dd171fc9-af35-4402-803c-81dd1c425d67
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14997'
+      X-Ms-Correlation-Request-Id:
+      - f4f979a8-c490-4972-95e0-40424afbb526
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T132702Z:f4f979a8-c490-4972-95e0-40424afbb526
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:27:02 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","name":"miqazuretest14047","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T17:30:25.7028008Z","primaryEndpoints":{"blob":"https://miqazuretest14047.blob.core.windows.net/","queue":"https://miqazuretest14047.queue.core.windows.net/","table":"https://miqazuretest14047.table.core.windows.net/","file":"https://miqazuretest14047.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:27:02 GMT
+- request:
+    method: post
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686/listKeys?api-version=2017-10-01
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA4ODQsIm5iZiI6MTUyMDg2MDg4NCwiZXhwIjoxNTIwODY0Nzg0LCJhaW8iOiJZMk5nWUdpOG0rOTQycGVadmNIdTZwZnE0d1VkQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRF82dGEzWTc3ME82Y1dwVHFtSW1BQSIsInZlciI6IjEuMCJ9.l5OoUZ1ance2A6NMV32h79ED9Z63ArZd2W_71bGMy-pIkzcdMx-tO5cOs9TOPFdwa4W_-zN0G-r7GEmtFaz54OLS_nk-AvX7UCVIXeBomHZCsAgsjwm1IagK55Cr3i87H4xyxwCN4axso-LvHDPKySu21zE1MqJcQhjXsbNX0WocZK6rFCGIDE2qzIjmiBfSGDqHe1zXA3mzZnfA07iyubU2yeNAPpKL6yni69dhNYGlZUgfhq6K8K5IYAKe8Il9XG9_cg3brFbrWlw71YlkAFLksW-xvr85_KLnZCZrU0Pv-qSjjWXPjqwsYWzvC5XEWFxVZ4QBwlPwgWsuL9G2zQ
+      Content-Length:
+      - '0'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 1973e2f6-39ac-48a4-9246-2250aced42ae
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Writes:
+      - '1199'
+      X-Ms-Correlation-Request-Id:
+      - 0ae250dd-a2d3-44a4-aae5-72fb597185f6
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T132702Z:0ae250dd-a2d3-44a4-aae5-72fb597185f6
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:27:02 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"keys":[{"keyName":"key1","value":"32PV5jeBt8nw1XvFbZokY26SXchbD6H2tw/YrteEYVE0kpMLKrZ74VrwaIjDyucdi/RxDaAlf7dJIilLS7muNw==","permissions":"Full"},{"keyName":"key2","value":"Eo5x9CQJL1/wl6Tkj5N7M5eEdw6Hym6AeyTt3xjcDl30sV8Iadro6ywZzOHQwNDlmrDaBF6x2a9ZFL7zswxQ7w==","permissions":"Full"}]}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:27:03 GMT
+- request:
+    method: post
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047/listKeys?api-version=2017-10-01
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA4ODQsIm5iZiI6MTUyMDg2MDg4NCwiZXhwIjoxNTIwODY0Nzg0LCJhaW8iOiJZMk5nWUdpOG0rOTQycGVadmNIdTZwZnE0d1VkQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRF82dGEzWTc3ME82Y1dwVHFtSW1BQSIsInZlciI6IjEuMCJ9.l5OoUZ1ance2A6NMV32h79ED9Z63ArZd2W_71bGMy-pIkzcdMx-tO5cOs9TOPFdwa4W_-zN0G-r7GEmtFaz54OLS_nk-AvX7UCVIXeBomHZCsAgsjwm1IagK55Cr3i87H4xyxwCN4axso-LvHDPKySu21zE1MqJcQhjXsbNX0WocZK6rFCGIDE2qzIjmiBfSGDqHe1zXA3mzZnfA07iyubU2yeNAPpKL6yni69dhNYGlZUgfhq6K8K5IYAKe8Il9XG9_cg3brFbrWlw71YlkAFLksW-xvr85_KLnZCZrU0Pv-qSjjWXPjqwsYWzvC5XEWFxVZ4QBwlPwgWsuL9G2zQ
+      Content-Length:
+      - '0'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 265414ad-f744-48c5-a491-7351c0edf27f
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Writes:
+      - '1199'
+      X-Ms-Correlation-Request-Id:
+      - f9b731b9-78b6-4b9b-a743-dc1888a1b271
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T132703Z:f9b731b9-78b6-4b9b-a743-dc1888a1b271
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:27:02 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"keys":[{"keyName":"key1","value":"9hGLwV9mjvAc1ARzeGwpsS9oZPLqOBzHCCHjeixyt1wpPYVn32cXmm3Gs9ogFPXZhDH61PAXxud0Dg/qwOnJ1w==","permissions":"Full"},{"keyName":"key2","value":"FfW8btVjJE2LkKHvN8Prr3FDX71BrS4SnMkONq2fLVPPm6x7vqqjeDSWDh17aI4CBLYf3Y1pc6njkbz53HdMYg==","permissions":"Full"}]}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:27:03 GMT
+- request:
+    method: head
+    uri: https://miqazuretest18686.blob.core.windows.net/vhds/miq-test-rhel12016218112243.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 13:27:03 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey miqazuretest18686:E96D8EBGl8uY4fB7Eg9m4WJqWKZXsn6r8vgxMlvbQsY=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '32212255232'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - dQL+XHjFNPdoMEweI63fwQ==
+      Last-Modified:
+      - Mon, 12 Mar 2018 13:22:59 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D5881C60249D9B"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 1f4aa9bc-001e-0042-1e05-ba0d6b000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Meta-Microsoftazurecompute-Resourcegroupname:
+      - miq-azure-test1
+      X-Ms-Meta-Microsoftazurecompute-Vmname:
+      - miq-test-rhel1
+      X-Ms-Meta-Microsoftazurecompute-Diskid:
+      - 0ea91415-9058-46c6-9792-3afcb4da976f
+      X-Ms-Meta-Microsoftazurecompute-Diskname:
+      - miq-test-rhel1
+      X-Ms-Meta-Microsoftazurecompute-Disktype:
+      - OSDisk
+      X-Ms-Lease-Status:
+      - locked
+      X-Ms-Lease-State:
+      - leased
+      X-Ms-Lease-Duration:
+      - infinite
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '372'
+      X-Ms-Copy-Id:
+      - b967ea05-82a2-405a-8df9-4615d59df4eb
+      X-Ms-Copy-Source:
+      - https://ardfepirv2bl5prdstr06.blob.core.windows.net/a879bbefc56a43abb0ce65052aac09f3/rhel-72-20160302?sv=2014-02-14&sr=b&si=PirCacheAccountPublisherContainerPolicy&sig=2TQ3SKHqVnqe4jVKB4qMCBOphv2nYelKworI7pfckrs%3D
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 32212255232/32212255232
+      X-Ms-Copy-Completion-Time:
+      - Fri, 18 Mar 2016 17:23:28 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Mon, 12 Mar 2018 13:27:03 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:27:04 GMT
+- request:
+    method: head
+    uri: https://miqazuretest14047.blob.core.windows.net/vhds/miqazure-centos12016221104946.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 13:27:04 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey miqazuretest14047:YhADAbjXAJPepEFhTnha8f45mCSRI2ZkQmNNSQc6LYI=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '32212255232'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - bLK7rgT7IgMNX2YxL9BCyg==
+      Last-Modified:
+      - Fri, 22 Apr 2016 19:05:58 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D36AE123954B35"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - ee31831b-001e-000a-7e05-ba3ff6000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Meta-Microsoftazurecompute-Resourcegroupname:
+      - miq-azure-test1
+      X-Ms-Meta-Microsoftazurecompute-Vmname:
+      - miqazure-centos1
+      X-Ms-Meta-Microsoftazurecompute-Diskid:
+      - 66656abf-e460-45ac-a6f0-851d0a50b23a
+      X-Ms-Meta-Microsoftazurecompute-Diskname:
+      - miqazure-centos1
+      X-Ms-Meta-Microsoftazurecompute-Disktype:
+      - OSDisk
+      X-Ms-Lease-Status:
+      - locked
+      X-Ms-Lease-State:
+      - leased
+      X-Ms-Lease-Duration:
+      - infinite
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '1'
+      X-Ms-Copy-Id:
+      - 549dd428-4055-4337-a425-05293b903858
+      X-Ms-Copy-Source:
+      - https://ardfepirv2bl5prdstr06.blob.core.windows.net/5112500ae3b842c8b9c604889f8753c3/OpenLogic-CentOS-71-20160308?sv=2014-02-14&sr=b&si=PirCacheAccountPublisherContainerPolicy&sig=fxe20jiCl%2Foys9OSvljXlookVPi76KM8FYlTr%2BSY4IQ%3D
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 32212255232/32212255232
+      X-Ms-Copy-Completion-Time:
+      - Mon, 21 Mar 2016 16:50:14 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Mon, 12 Mar 2018 13:27:04 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:27:05 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA4ODQsIm5iZiI6MTUyMDg2MDg4NCwiZXhwIjoxNTIwODY0Nzg0LCJhaW8iOiJZMk5nWUdpOG0rOTQycGVadmNIdTZwZnE0d1VkQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRF82dGEzWTc3ME82Y1dwVHFtSW1BQSIsInZlciI6IjEuMCJ9.l5OoUZ1ance2A6NMV32h79ED9Z63ArZd2W_71bGMy-pIkzcdMx-tO5cOs9TOPFdwa4W_-zN0G-r7GEmtFaz54OLS_nk-AvX7UCVIXeBomHZCsAgsjwm1IagK55Cr3i87H4xyxwCN4axso-LvHDPKySu21zE1MqJcQhjXsbNX0WocZK6rFCGIDE2qzIjmiBfSGDqHe1zXA3mzZnfA07iyubU2yeNAPpKL6yni69dhNYGlZUgfhq6K8K5IYAKe8Il9XG9_cg3brFbrWlw71YlkAFLksW-xvr85_KLnZCZrU0Pv-qSjjWXPjqwsYWzvC5XEWFxVZ4QBwlPwgWsuL9G2zQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 962c83a6-220e-4dc5-8434-2be7a88c4d0c
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Correlation-Request-Id:
+      - 03547a1e-704a-4f22-acbd-adc9428c3251
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T132705Z:03547a1e-704a-4f22-acbd-adc9428c3251
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:27:04 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"miqazure-linux-managed-nsg\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg\",\r\n
+        \ \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/networkSecurityGroups\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
+        \"b4611f96-94a8-4486-94c5-16bb6c7a5c84\",\r\n    \"securityRules\": [\r\n
+        \     {\r\n        \"name\": \"default-allow-ssh\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/securityRules/default-allow-ssh\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"protocol\": \"TCP\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"22\",\r\n          \"sourceAddressPrefix\":
+        \"*\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n          \"access\":
+        \"Allow\",\r\n          \"priority\": 1000,\r\n          \"direction\": \"Inbound\",\r\n
+        \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      }\r\n    ],\r\n    \"defaultSecurityRules\": [\r\n
+        \     {\r\n        \"name\": \"AllowVnetInBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/AllowVnetInBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow inbound traffic from all VMs in VNET\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"VirtualNetwork\",\r\n          \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n          \"direction\":
+        \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowAzureLoadBalancerInBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/AllowAzureLoadBalancerInBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow inbound traffic from azure load balancer\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"AzureLoadBalancer\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65001,\r\n          \"direction\":
+        \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllInBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/DenyAllInBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Deny all inbound traffic\",\r\n          \"protocol\":
+        \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\":
+        \"*\",\r\n          \"sourceAddressPrefix\": \"*\",\r\n          \"destinationAddressPrefix\":
+        \"*\",\r\n          \"access\": \"Deny\",\r\n          \"priority\": 65500,\r\n
+        \         \"direction\": \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n
+        \         \"destinationPortRanges\": [],\r\n          \"sourceAddressPrefixes\":
+        [],\r\n          \"destinationAddressPrefixes\": []\r\n        }\r\n      },\r\n
+        \     {\r\n        \"name\": \"AllowVnetOutBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/AllowVnetOutBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow outbound traffic from all VMs to all VMs
+        in VNET\",\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\":
+        \"*\",\r\n          \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"VirtualNetwork\",\r\n          \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n          \"direction\":
+        \"Outbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowInternetOutBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/AllowInternetOutBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow outbound traffic from all VMs to Internet\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"*\",\r\n          \"destinationAddressPrefix\": \"Internet\",\r\n          \"access\":
+        \"Allow\",\r\n          \"priority\": 65001,\r\n          \"direction\": \"Outbound\",\r\n
+        \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllOutBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/DenyAllOutBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Deny all outbound traffic\",\r\n          \"protocol\":
+        \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\":
+        \"*\",\r\n          \"sourceAddressPrefix\": \"*\",\r\n          \"destinationAddressPrefix\":
+        \"*\",\r\n          \"access\": \"Deny\",\r\n          \"priority\": 65500,\r\n
+        \         \"direction\": \"Outbound\",\r\n          \"sourcePortRanges\":
+        [],\r\n          \"destinationPortRanges\": [],\r\n          \"sourceAddressPrefixes\":
+        [],\r\n          \"destinationAddressPrefixes\": []\r\n        }\r\n      }\r\n
+        \   ],\r\n    \"networkInterfaces\": [\r\n      {\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944\"\r\n
+        \     }\r\n    ]\r\n  }\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:27:05 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/non_existent?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA4ODQsIm5iZiI6MTUyMDg2MDg4NCwiZXhwIjoxNTIwODY0Nzg0LCJhaW8iOiJZMk5nWUdpOG0rOTQycGVadmNIdTZwZnE0d1VkQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRF82dGEzWTc3ME82Y1dwVHFtSW1BQSIsInZlciI6IjEuMCJ9.l5OoUZ1ance2A6NMV32h79ED9Z63ArZd2W_71bGMy-pIkzcdMx-tO5cOs9TOPFdwa4W_-zN0G-r7GEmtFaz54OLS_nk-AvX7UCVIXeBomHZCsAgsjwm1IagK55Cr3i87H4xyxwCN4axso-LvHDPKySu21zE1MqJcQhjXsbNX0WocZK6rFCGIDE2qzIjmiBfSGDqHe1zXA3mzZnfA07iyubU2yeNAPpKL6yni69dhNYGlZUgfhq6K8K5IYAKe8Il9XG9_cg3brFbrWlw71YlkAFLksW-xvr85_KLnZCZrU0Pv-qSjjWXPjqwsYWzvC5XEWFxVZ4QBwlPwgWsuL9G2zQ
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      X-Ms-Failure-Cause:
+      - gateway
+      X-Ms-Request-Id:
+      - f51e2012-8528-4af2-8c51-4d6b189de473
+      X-Ms-Correlation-Request-Id:
+      - f51e2012-8528-4af2-8c51-4d6b189de473
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T132705Z:f51e2012-8528-4af2-8c51-4d6b189de473
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:27:05 GMT
+      Content-Length:
+      - '171'
+    body:
+      encoding: UTF-8
+      string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Network/networkSecurityGroups/non_existent''
+        under resource group ''miq-azure-test4'' was not found."}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:27:05 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA4ODQsIm5iZiI6MTUyMDg2MDg4NCwiZXhwIjoxNTIwODY0Nzg0LCJhaW8iOiJZMk5nWUdpOG0rOTQycGVadmNIdTZwZnE0d1VkQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRF82dGEzWTc3ME82Y1dwVHFtSW1BQSIsInZlciI6IjEuMCJ9.l5OoUZ1ance2A6NMV32h79ED9Z63ArZd2W_71bGMy-pIkzcdMx-tO5cOs9TOPFdwa4W_-zN0G-r7GEmtFaz54OLS_nk-AvX7UCVIXeBomHZCsAgsjwm1IagK55Cr3i87H4xyxwCN4axso-LvHDPKySu21zE1MqJcQhjXsbNX0WocZK6rFCGIDE2qzIjmiBfSGDqHe1zXA3mzZnfA07iyubU2yeNAPpKL6yni69dhNYGlZUgfhq6K8K5IYAKe8Il9XG9_cg3brFbrWlw71YlkAFLksW-xvr85_KLnZCZrU0Pv-qSjjWXPjqwsYWzvC5XEWFxVZ4QBwlPwgWsuL9G2zQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"5ad0e691-263e-42ca-8a93-833bd4dbf13f"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 201ce840-6f15-4b66-a85c-4564d7648408
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Correlation-Request-Id:
+      - 6413b846-ec54-49cf-bcd9-2378b16eefc3
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T132706Z:6413b846-ec54-49cf-bcd9-2378b16eefc3
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:27:06 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"miq-test-rhel1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1\",\r\n
+        \ \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/networkSecurityGroups\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"f4a4a6a5-e2e8-47bd-b46f-00592f8fce53\",\r\n    \"securityRules\":
+        [\r\n      {\r\n        \"name\": \"default-allow-ssh\",\r\n        \"id\":
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/securityRules/default-allow-ssh\",\r\n
+        \       \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"protocol\": \"Tcp\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"22\",\r\n          \"sourceAddressPrefix\":
+        \"*\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n          \"access\":
+        \"Allow\",\r\n          \"priority\": 1000,\r\n          \"direction\": \"Inbound\",\r\n
+        \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"rhel1-inbound1\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/securityRules/rhel1-inbound1\",\r\n
+        \       \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"protocol\": \"Tcp\",\r\n          \"sourcePortRange\": \"80\",\r\n
+        \         \"destinationPortRange\": \"80\",\r\n          \"sourceAddressPrefix\":
+        \"*\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n          \"access\":
+        \"Allow\",\r\n          \"priority\": 100,\r\n          \"direction\": \"Inbound\",\r\n
+        \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"rhel1-inbound2\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/securityRules/rhel1-inbound2\",\r\n
+        \       \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"protocol\": \"Tcp\",\r\n          \"sourcePortRange\": \"443\",\r\n
+        \         \"destinationPortRange\": \"443\",\r\n          \"sourceAddressPrefix\":
+        \"*\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n          \"access\":
+        \"Allow\",\r\n          \"priority\": 200,\r\n          \"direction\": \"Inbound\",\r\n
+        \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      }\r\n    ],\r\n    \"defaultSecurityRules\": [\r\n
+        \     {\r\n        \"name\": \"AllowVnetInBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/defaultSecurityRules/AllowVnetInBound\",\r\n
+        \       \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow inbound traffic from all VMs in VNET\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"VirtualNetwork\",\r\n          \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n          \"direction\":
+        \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowAzureLoadBalancerInBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/defaultSecurityRules/AllowAzureLoadBalancerInBound\",\r\n
+        \       \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow inbound traffic from azure load balancer\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"AzureLoadBalancer\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65001,\r\n          \"direction\":
+        \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllInBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/defaultSecurityRules/DenyAllInBound\",\r\n
+        \       \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Deny all inbound traffic\",\r\n          \"protocol\":
+        \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\":
+        \"*\",\r\n          \"sourceAddressPrefix\": \"*\",\r\n          \"destinationAddressPrefix\":
+        \"*\",\r\n          \"access\": \"Deny\",\r\n          \"priority\": 65500,\r\n
+        \         \"direction\": \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n
+        \         \"destinationPortRanges\": [],\r\n          \"sourceAddressPrefixes\":
+        [],\r\n          \"destinationAddressPrefixes\": []\r\n        }\r\n      },\r\n
+        \     {\r\n        \"name\": \"AllowVnetOutBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/defaultSecurityRules/AllowVnetOutBound\",\r\n
+        \       \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow outbound traffic from all VMs to all VMs
+        in VNET\",\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\":
+        \"*\",\r\n          \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"VirtualNetwork\",\r\n          \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n          \"direction\":
+        \"Outbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowInternetOutBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/defaultSecurityRules/AllowInternetOutBound\",\r\n
+        \       \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow outbound traffic from all VMs to Internet\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"*\",\r\n          \"destinationAddressPrefix\": \"Internet\",\r\n          \"access\":
+        \"Allow\",\r\n          \"priority\": 65001,\r\n          \"direction\": \"Outbound\",\r\n
+        \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllOutBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/defaultSecurityRules/DenyAllOutBound\",\r\n
+        \       \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Deny all outbound traffic\",\r\n          \"protocol\":
+        \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\":
+        \"*\",\r\n          \"sourceAddressPrefix\": \"*\",\r\n          \"destinationAddressPrefix\":
+        \"*\",\r\n          \"access\": \"Deny\",\r\n          \"priority\": 65500,\r\n
+        \         \"direction\": \"Outbound\",\r\n          \"sourcePortRanges\":
+        [],\r\n          \"destinationPortRanges\": [],\r\n          \"sourceAddressPrefixes\":
+        [],\r\n          \"destinationAddressPrefixes\": []\r\n        }\r\n      }\r\n
+        \   ],\r\n    \"networkInterfaces\": [\r\n      {\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390\"\r\n
+        \     }\r\n    ]\r\n  }\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:27:06 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA4ODQsIm5iZiI6MTUyMDg2MDg4NCwiZXhwIjoxNTIwODY0Nzg0LCJhaW8iOiJZMk5nWUdpOG0rOTQycGVadmNIdTZwZnE0d1VkQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRF82dGEzWTc3ME82Y1dwVHFtSW1BQSIsInZlciI6IjEuMCJ9.l5OoUZ1ance2A6NMV32h79ED9Z63ArZd2W_71bGMy-pIkzcdMx-tO5cOs9TOPFdwa4W_-zN0G-r7GEmtFaz54OLS_nk-AvX7UCVIXeBomHZCsAgsjwm1IagK55Cr3i87H4xyxwCN4axso-LvHDPKySu21zE1MqJcQhjXsbNX0WocZK6rFCGIDE2qzIjmiBfSGDqHe1zXA3mzZnfA07iyubU2yeNAPpKL6yni69dhNYGlZUgfhq6K8K5IYAKe8Il9XG9_cg3brFbrWlw71YlkAFLksW-xvr85_KLnZCZrU0Pv-qSjjWXPjqwsYWzvC5XEWFxVZ4QBwlPwgWsuL9G2zQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"f1907e14-fcad-4f75-8faa-ab325bf879d9"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 2794273d-a95c-4199-b6dd-17b5d89576ae
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Correlation-Request-Id:
+      - f8a3a605-c994-42b3-9fbd-551b2ff41e42
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T132706Z:f8a3a605-c994-42b3-9fbd-551b2ff41e42
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:27:06 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"miqazure-centos1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1\",\r\n
+        \ \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/networkSecurityGroups\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
+        \"9ca49a93-6f7d-464c-b23d-e61e847ce2d6\",\r\n    \"securityRules\": [\r\n
+        \     {\r\n        \"name\": \"default-allow-ssh\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/securityRules/default-allow-ssh\",\r\n
+        \       \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"protocol\": \"Tcp\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"22\",\r\n          \"sourceAddressPrefix\":
+        \"*\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n          \"access\":
+        \"Allow\",\r\n          \"priority\": 1000,\r\n          \"direction\": \"Inbound\",\r\n
+        \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      }\r\n    ],\r\n    \"defaultSecurityRules\": [\r\n
+        \     {\r\n        \"name\": \"AllowVnetInBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/defaultSecurityRules/AllowVnetInBound\",\r\n
+        \       \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow inbound traffic from all VMs in VNET\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"VirtualNetwork\",\r\n          \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n          \"direction\":
+        \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowAzureLoadBalancerInBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/defaultSecurityRules/AllowAzureLoadBalancerInBound\",\r\n
+        \       \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow inbound traffic from azure load balancer\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"AzureLoadBalancer\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65001,\r\n          \"direction\":
+        \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllInBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/defaultSecurityRules/DenyAllInBound\",\r\n
+        \       \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Deny all inbound traffic\",\r\n          \"protocol\":
+        \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\":
+        \"*\",\r\n          \"sourceAddressPrefix\": \"*\",\r\n          \"destinationAddressPrefix\":
+        \"*\",\r\n          \"access\": \"Deny\",\r\n          \"priority\": 65500,\r\n
+        \         \"direction\": \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n
+        \         \"destinationPortRanges\": [],\r\n          \"sourceAddressPrefixes\":
+        [],\r\n          \"destinationAddressPrefixes\": []\r\n        }\r\n      },\r\n
+        \     {\r\n        \"name\": \"AllowVnetOutBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/defaultSecurityRules/AllowVnetOutBound\",\r\n
+        \       \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow outbound traffic from all VMs to all VMs
+        in VNET\",\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\":
+        \"*\",\r\n          \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"VirtualNetwork\",\r\n          \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n          \"direction\":
+        \"Outbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowInternetOutBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/defaultSecurityRules/AllowInternetOutBound\",\r\n
+        \       \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow outbound traffic from all VMs to Internet\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"*\",\r\n          \"destinationAddressPrefix\": \"Internet\",\r\n          \"access\":
+        \"Allow\",\r\n          \"priority\": 65001,\r\n          \"direction\": \"Outbound\",\r\n
+        \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllOutBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/defaultSecurityRules/DenyAllOutBound\",\r\n
+        \       \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Deny all outbound traffic\",\r\n          \"protocol\":
+        \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\":
+        \"*\",\r\n          \"sourceAddressPrefix\": \"*\",\r\n          \"destinationAddressPrefix\":
+        \"*\",\r\n          \"access\": \"Deny\",\r\n          \"priority\": 65500,\r\n
+        \         \"direction\": \"Outbound\",\r\n          \"sourcePortRanges\":
+        [],\r\n          \"destinationPortRanges\": [],\r\n          \"sourceAddressPrefixes\":
+        [],\r\n          \"destinationAddressPrefixes\": []\r\n        }\r\n      }\r\n
+        \   ],\r\n    \"networkInterfaces\": [\r\n      {\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611\"\r\n
+        \     }\r\n    ]\r\n  }\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:27:06 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA4ODQsIm5iZiI6MTUyMDg2MDg4NCwiZXhwIjoxNTIwODY0Nzg0LCJhaW8iOiJZMk5nWUdpOG0rOTQycGVadmNIdTZwZnE0d1VkQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRF82dGEzWTc3ME82Y1dwVHFtSW1BQSIsInZlciI6IjEuMCJ9.l5OoUZ1ance2A6NMV32h79ED9Z63ArZd2W_71bGMy-pIkzcdMx-tO5cOs9TOPFdwa4W_-zN0G-r7GEmtFaz54OLS_nk-AvX7UCVIXeBomHZCsAgsjwm1IagK55Cr3i87H4xyxwCN4axso-LvHDPKySu21zE1MqJcQhjXsbNX0WocZK6rFCGIDE2qzIjmiBfSGDqHe1zXA3mzZnfA07iyubU2yeNAPpKL6yni69dhNYGlZUgfhq6K8K5IYAKe8Il9XG9_cg3brFbrWlw71YlkAFLksW-xvr85_KLnZCZrU0Pv-qSjjWXPjqwsYWzvC5XEWFxVZ4QBwlPwgWsuL9G2zQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"f5bbd20f-7ae4-4b6d-89c8-eb3481fcbe05"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 7b4f089a-a5f1-4190-856a-5c48242b56b5
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14997'
+      X-Ms-Correlation-Request-Id:
+      - 8a5d0f98-bedc-4c78-9222-5b3db96d7d9d
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T132707Z:8a5d0f98-bedc-4c78-9222-5b3db96d7d9d
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:27:06 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"miq-azure-test2\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2\",\r\n
+        \ \"etag\": \"W/\\\"f5bbd20f-7ae4-4b6d-89c8-eb3481fcbe05\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
+        \"f950a3cf-749a-49d5-a7fb-33a400b0e93c\",\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\":
+        [\r\n        \"172.25.0.0/16\"\r\n      ]\r\n    },\r\n    \"subnets\": [\r\n
+        \     {\r\n        \"name\": \"default\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2/subnets/default\",\r\n
+        \       \"etag\": \"W/\\\"f5bbd20f-7ae4-4b6d-89c8-eb3481fcbe05\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"addressPrefix\": \"172.25.0.0/24\",\r\n          \"ipConfigurations\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944/ipConfigurations/ipconfig1\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"virtualNetworkPeerings\":
+        [],\r\n    \"enableDdosProtection\": false,\r\n    \"enableVmProtection\":
+        false\r\n  }\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:27:07 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/non_existent?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA4ODQsIm5iZiI6MTUyMDg2MDg4NCwiZXhwIjoxNTIwODY0Nzg0LCJhaW8iOiJZMk5nWUdpOG0rOTQycGVadmNIdTZwZnE0d1VkQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRF82dGEzWTc3ME82Y1dwVHFtSW1BQSIsInZlciI6IjEuMCJ9.l5OoUZ1ance2A6NMV32h79ED9Z63ArZd2W_71bGMy-pIkzcdMx-tO5cOs9TOPFdwa4W_-zN0G-r7GEmtFaz54OLS_nk-AvX7UCVIXeBomHZCsAgsjwm1IagK55Cr3i87H4xyxwCN4axso-LvHDPKySu21zE1MqJcQhjXsbNX0WocZK6rFCGIDE2qzIjmiBfSGDqHe1zXA3mzZnfA07iyubU2yeNAPpKL6yni69dhNYGlZUgfhq6K8K5IYAKe8Il9XG9_cg3brFbrWlw71YlkAFLksW-xvr85_KLnZCZrU0Pv-qSjjWXPjqwsYWzvC5XEWFxVZ4QBwlPwgWsuL9G2zQ
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      X-Ms-Failure-Cause:
+      - gateway
+      X-Ms-Request-Id:
+      - 6ccf4147-c786-46ef-b7ca-62a8ada10ce3
+      X-Ms-Correlation-Request-Id:
+      - 6ccf4147-c786-46ef-b7ca-62a8ada10ce3
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T132708Z:6ccf4147-c786-46ef-b7ca-62a8ada10ce3
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:27:07 GMT
+      Content-Length:
+      - '165'
+    body:
+      encoding: UTF-8
+      string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Network/virtualNetworks/non_existent''
+        under resource group ''miq-azure-test2'' was not found."}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:27:08 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjA4ODQsIm5iZiI6MTUyMDg2MDg4NCwiZXhwIjoxNTIwODY0Nzg0LCJhaW8iOiJZMk5nWUdpOG0rOTQycGVadmNIdTZwZnE0d1VkQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRF82dGEzWTc3ME82Y1dwVHFtSW1BQSIsInZlciI6IjEuMCJ9.l5OoUZ1ance2A6NMV32h79ED9Z63ArZd2W_71bGMy-pIkzcdMx-tO5cOs9TOPFdwa4W_-zN0G-r7GEmtFaz54OLS_nk-AvX7UCVIXeBomHZCsAgsjwm1IagK55Cr3i87H4xyxwCN4axso-LvHDPKySu21zE1MqJcQhjXsbNX0WocZK6rFCGIDE2qzIjmiBfSGDqHe1zXA3mzZnfA07iyubU2yeNAPpKL6yni69dhNYGlZUgfhq6K8K5IYAKe8Il9XG9_cg3brFbrWlw71YlkAFLksW-xvr85_KLnZCZrU0Pv-qSjjWXPjqwsYWzvC5XEWFxVZ4QBwlPwgWsuL9G2zQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"a8b09238-30fc-4b36-a58d-e3cc69e267c5"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 4ccba150-37f6-41dd-93a4-9611fc6a8ae8
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Correlation-Request-Id:
+      - fe092357-f303-4b66-bbd5-4cc43909a06a
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T132708Z:fe092357-f303-4b66-bbd5-4cc43909a06a
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:27:08 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"miq-azure-test1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1\",\r\n
+        \ \"etag\": \"W/\\\"a8b09238-30fc-4b36-a58d-e3cc69e267c5\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
+        \"d74c1e5f-50e4-4c8a-a7fe-78eaddc6b915\",\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\":
+        [\r\n        \"10.16.0.0/16\"\r\n      ]\r\n    },\r\n    \"subnets\": [\r\n
+        \     {\r\n        \"name\": \"default\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\",\r\n
+        \       \"etag\": \"W/\\\"a8b09238-30fc-4b36-a58d-e3cc69e267c5\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"addressPrefix\": \"10.16.0.0/24\",\r\n          \"ipConfigurations\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241/ipConfigurations/ipconfig1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1/ipConfigurations/miqmismatch1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/dbergerprov1/ipConfigurations/dbergerprov1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/ladas_test_1/ipConfigurations/ladas_test_1\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"virtualNetworkPeerings\":
+        [],\r\n    \"enableDdosProtection\": false,\r\n    \"enableVmProtection\":
+        false\r\n  }\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:27:08 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_500/network_port_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_500/network_port_refresh.yml
@@ -1,6 +1,62 @@
 ---
 http_interactions:
 - request:
+    method: post
+    uri: https://login.microsoftonline.com/AZURE_TENANT_ID/oauth2/token
+    body:
+      encoding: UTF-8
+      string: grant_type=client_credentials&client_id=AZURE_CLIENT_ID&client_secret=AZURE_CLIENT_SECRET&resource=https%3A%2F%2Fmanagement.azure.com%2F
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Server:
+      - Microsoft-IIS/10.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Request-Id:
+      - d5dc8274-9b06-478e-a789-1b1ccf4c2100
+      P3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Set-Cookie:
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHz3ofaajT5ZLhLaL7Z7MLnSRUIyPp9XsZ-oArJ628yb92zXbkuWvIQ9Mac8-eo3Rr3o5LrdIV2HbBIYogll2PAJo28ADjicl61hnjuOPdtua28MSUHhadxbEFSM0MyodRucL3nXmYZ9T7fUfak3v-y6AXk4VSazI5jKh-dDFeGLd8gAA;
+        domain=.login.microsoftonline.com; path=/; secure; HttpOnly
+      - stsservicecookie=ests; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=002; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Tue, 13 Mar 2018 09:00:48 GMT
+      Content-Length:
+      - '1505'
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"Bearer","expires_in":"3600","ext_expires_in":"0","expires_on":"1520935249","not_before":"1520931349","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA5MzEzNDksIm5iZiI6MTUyMDkzMTM0OSwiZXhwIjoxNTIwOTM1MjQ5LCJhaW8iOiJZMk5nWURBTjFDdDJkcHEzYjE1K2V1Lys2UnRMQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZElMYzFRYWJqa2VuaVJzY3owd2hBQSIsInZlciI6IjEuMCJ9.LrEXUjZiTyG_nyq5Il4b_ZTjjRnxBkm0u5WFOnnBAZNpz8LWO5F1s6mdjgVNPNOFuzUShc_EYAZUqZn_XLvKMMcvSeHz5t68yWYr7CJlq7IW1lP2jic9JfCeuqfMa0-fwrhNijdKM1AnpBpV1hwizWngb4tkMASxfEpKj9wZDeGJlQqlDtVXja8xGUehwHw6tWirlE4YJbxTzube0pxcOPxlHoHJC82UpYY6ychn740ZLKrD4M5w8KcNmdvjmZO4oLC7q29rk49tx2BamoEvfkZl4ZZW2Cx-YmDGFwepbBEg4bVn8CMKENiLNyo16Yw_c9qryS0T83InFG1HFAVcTw"}'
+    http_version: 
+  recorded_at: Tue, 13 Mar 2018 09:00:49 GMT
+- request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
     body:
@@ -16,7 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA5MzEzNDksIm5iZiI6MTUyMDkzMTM0OSwiZXhwIjoxNTIwOTM1MjQ5LCJhaW8iOiJZMk5nWURBTjFDdDJkcHEzYjE1K2V1Lys2UnRMQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZElMYzFRYWJqa2VuaVJzY3owd2hBQSIsInZlciI6IjEuMCJ9.LrEXUjZiTyG_nyq5Il4b_ZTjjRnxBkm0u5WFOnnBAZNpz8LWO5F1s6mdjgVNPNOFuzUShc_EYAZUqZn_XLvKMMcvSeHz5t68yWYr7CJlq7IW1lP2jic9JfCeuqfMa0-fwrhNijdKM1AnpBpV1hwizWngb4tkMASxfEpKj9wZDeGJlQqlDtVXja8xGUehwHw6tWirlE4YJbxTzube0pxcOPxlHoHJC82UpYY6ychn740ZLKrD4M5w8KcNmdvjmZO4oLC7q29rk49tx2BamoEvfkZl4ZZW2Cx-YmDGFwepbBEg4bVn8CMKENiLNyo16Yw_c9qryS0T83InFG1HFAVcTw
   response:
     status:
       code: 200
@@ -35,26 +91,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14997'
+      - '14999'
       X-Ms-Request-Id:
-      - cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - f9a4287f-ef38-4feb-b24b-fb1f6a3986de
       X-Ms-Correlation-Request-Id:
-      - cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - f9a4287f-ef38-4feb-b24b-fb1f6a3986de
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102417Z:cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - WESTEUROPE:20180313T090052Z:f9a4287f-ef38-4feb-b24b-fb1f6a3986de
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:17 GMT
+      - Tue, 13 Mar 2018 09:00:51 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID","subscriptionId":"AZURE_SUBSCRIPTION_ID","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:22 GMT
+  recorded_at: Tue, 13 Mar 2018 09:00:52 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers?api-version=2015-01-01
@@ -71,7 +127,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA5MzEzNDksIm5iZiI6MTUyMDkzMTM0OSwiZXhwIjoxNTIwOTM1MjQ5LCJhaW8iOiJZMk5nWURBTjFDdDJkcHEzYjE1K2V1Lys2UnRMQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZElMYzFRYWJqa2VuaVJzY3owd2hBQSIsInZlciI6IjEuMCJ9.LrEXUjZiTyG_nyq5Il4b_ZTjjRnxBkm0u5WFOnnBAZNpz8LWO5F1s6mdjgVNPNOFuzUShc_EYAZUqZn_XLvKMMcvSeHz5t68yWYr7CJlq7IW1lP2jic9JfCeuqfMa0-fwrhNijdKM1AnpBpV1hwizWngb4tkMASxfEpKj9wZDeGJlQqlDtVXja8xGUehwHw6tWirlE4YJbxTzube0pxcOPxlHoHJC82UpYY6ychn740ZLKrD4M5w8KcNmdvjmZO4oLC7q29rk49tx2BamoEvfkZl4ZZW2Cx-YmDGFwepbBEg4bVn8CMKENiLNyo16Yw_c9qryS0T83InFG1HFAVcTw
   response:
     status:
       code: 200
@@ -88,21 +144,21 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - '14929'
       X-Ms-Request-Id:
-      - fe3532ca-59a2-474e-9094-8a3697b82bef
+      - 34079127-54ed-4411-a078-20c51272a015
       X-Ms-Correlation-Request-Id:
-      - fe3532ca-59a2-474e-9094-8a3697b82bef
+      - 34079127-54ed-4411-a078-20c51272a015
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102419Z:fe3532ca-59a2-474e-9094-8a3697b82bef
+      - WESTEUROPE:20180313T090054Z:34079127-54ed-4411-a078-20c51272a015
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:18 GMT
+      - Tue, 13 Mar 2018 09:00:54 GMT
       Content-Length:
-      - '320853'
+      - '322992'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"},{"applicationId":"d87dcbc6-a371-462e-88e3-28ad15ec4e64","roleDefinitionId":"861776c5-e0df-4f95-be4f-ac1eec193323"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["East
@@ -442,7 +498,10 @@ http_interactions:
         Central US","West Europe","North Europe","East US","UK West","UK South","West
         Central US","West US 2","South India","Central India","West India","Canada
         East","Canada Central","Korea South","Korea Central"],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"managedClusters","locations":["East
-        US","West Europe","Central US","Canada Central","Canada East"],"apiVersions":["2017-08-31"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
+        US","West Europe","Central US","Canada Central","Canada East"],"apiVersions":["2017-08-31"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operationresults","locations":["East
+        US","West Europe","Central US","UK West","UK South","West Central US","West
+        US 2","South India","Central India","West India","Canada East","Canada Central","Korea
+        South","Korea Central"],"apiVersions":["2017-08-31","2016-03-30"]},{"resourceType":"locations/operations","locations":["Japan
         East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
@@ -510,7 +569,7 @@ http_interactions:
         US","South Central US","North Europe","West Europe","Southeast Asia","West
         US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"listMigrationdate","locations":["East
         US","South Central US","North Europe","West Europe","Southeast Asia","West
-        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2018-03-01","2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
@@ -612,47 +671,47 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"networkWatchers/lenses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"networkWatchers/lenses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -662,47 +721,52 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2018-02-01","2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"ddosProtectionPlans","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","West
         US 2","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
@@ -1438,57 +1502,57 @@ http_interactions:
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/asyncoperations","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/asyncoperations","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/listAccountSas","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/listAccountSas","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/listServiceSas","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/listServiceSas","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/blobServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/blobServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/tableServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/tableServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/queueServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/queueServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/fileServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/fileServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01","2016-01-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01","2016-01-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
         US","West US","West Europe","North Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":["East
         US","West US","West Europe","North Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.visualstudio","namespace":"microsoft.visualstudio","authorization":{"applicationId":"499b84ac-1321-427f-aa17-267ca6975798","roleDefinitionId":"6a18f445-86f0-4e2e-b8a9-6b9b5677e3d8"},"resourceTypes":[{"resourceType":"account","locations":["North
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.visualstudio","namespace":"microsoft.visualstudio","authorization":{"applicationId":"499b84ac-1321-427f-aa17-267ca6975798","roleDefinitionId":"6a18f445-86f0-4e2e-b8a9-6b9b5677e3d8"},"resourceTypes":[{"resourceType":"account","locations":["North
         Central US","South Central US","East US","West US","Central US","North Europe","West
         Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
         East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/project","locations":["North
@@ -2173,7 +2237,8 @@ http_interactions:
         US","West US 2","East US","East US 2","North Europe","West Europe","Southeast
         Asia","East Asia","North Central US","South Central US","Japan West","Australia
         East","Brazil South","Central India","West Central US","Canada Central","UK
-        South"],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ServiceBus","namespace":"Microsoft.ServiceBus","authorization":{"applicationId":"80a10ef9-8168-493d-abf9-3297c4ef6e3c","roleDefinitionId":"2b7763f7-bbe2-4e19-befe-28c79f1cf7f7"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        South"],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.SecurityGraph","namespace":"Microsoft.SecurityGraph","resourceTypes":[{"resourceType":"operations","locations":["West
+        US"],"apiVersions":["2017-04-01-preview"]},{"resourceType":"diagnosticSettings","locations":[],"apiVersions":["2017-04-01-preview"]},{"resourceType":"diagnosticSettingsCategories","locations":[],"apiVersions":["2017-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ServiceBus","namespace":"Microsoft.ServiceBus","authorization":{"applicationId":"80a10ef9-8168-493d-abf9-3297c4ef6e3c","roleDefinitionId":"2b7763f7-bbe2-4e19-befe-28c79f1cf7f7"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US 2","West
         US","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
@@ -2322,10 +2387,10 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:23 GMT
+  recorded_at: Tue, 13 Mar 2018 09:00:54 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944?api-version=2018-03-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2339,7 +2404,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA5MzEzNDksIm5iZiI6MTUyMDkzMTM0OSwiZXhwIjoxNTIwOTM1MjQ5LCJhaW8iOiJZMk5nWURBTjFDdDJkcHEzYjE1K2V1Lys2UnRMQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZElMYzFRYWJqa2VuaVJzY3owd2hBQSIsInZlciI6IjEuMCJ9.LrEXUjZiTyG_nyq5Il4b_ZTjjRnxBkm0u5WFOnnBAZNpz8LWO5F1s6mdjgVNPNOFuzUShc_EYAZUqZn_XLvKMMcvSeHz5t68yWYr7CJlq7IW1lP2jic9JfCeuqfMa0-fwrhNijdKM1AnpBpV1hwizWngb4tkMASxfEpKj9wZDeGJlQqlDtVXja8xGUehwHw6tWirlE4YJbxTzube0pxcOPxlHoHJC82UpYY6ychn740ZLKrD4M5w8KcNmdvjmZO4oLC7q29rk49tx2BamoEvfkZl4ZZW2Cx-YmDGFwepbBEg4bVn8CMKENiLNyo16Yw_c9qryS0T83InFG1HFAVcTw
   response:
     status:
       code: 200
@@ -2356,234 +2421,52 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67"
+      - W/"b6339880-8ead-4c9e-b5c0-f38c4f8612d5"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - '080de667-081e-4d58-9e94-9e7243d4200e'
+      - 1f8024cc-a3a5-49c6-b8e4-35794367a681
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
+      - '14924'
       X-Ms-Correlation-Request-Id:
-      - '093d49ac-c85f-440e-956b-955b6698dd19'
+      - 632d99cd-43e3-486c-8aeb-872601e20e26
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102419Z:093d49ac-c85f-440e-956b-955b6698dd19
+      - WESTEUROPE:20180313T090055Z:632d99cd-43e3-486c-8aeb-872601e20e26
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:19 GMT
+      - Tue, 13 Mar 2018 09:00:55 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1\",\r\n
-        \ \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"7ab88756-810f-4083-95db-8b05d50e38f2\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ],\r\n          \"inboundNatRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"backendIPConfigurations\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\"\r\n
-        \           }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-rule\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\":
-        80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\"\r\n
-        \         },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n
-        \       \"name\": \"rspec-lb-probe\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-NAT\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 3441,\r\n          \"backendPort\":
-        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:24 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"7a8e5fe7-f777-4435-992b-a54f28c2f28c"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - bd22ca22-a01f-4ecf-9230-a4558fb66931
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Correlation-Request-Id:
-      - 19c674a8-c8da-4b5e-8265-5ebc21926459
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102420Z:19c674a8-c8da-4b5e-8265-5ebc21926459
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Mon, 12 Mar 2018 10:24:19 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb2\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2\",\r\n
-        \ \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"e2e30a77-f81b-43fc-9693-08303e43deed\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/backendAddressPools/rspec-lb2-pool\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\r\n
-        \       }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\": [],\r\n    \"probes\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-probe\",\r\n        \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/probes/rspec-lb2-probe\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\": [],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:25 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"a38434c8-7b23-4092-b7c6-402238eac0dc"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 0fd15240-6a1c-4b39-a4f6-aa53fd8591c2
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Correlation-Request-Id:
-      - 5cc03163-922e-41a1-9601-dba2d7cf2a81
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102421Z:5cc03163-922e-41a1-9601-dba2d7cf2a81
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Mon, 12 Mar 2018 10:24:20 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb1-LoadBalancerFrontEnd\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\",\r\n
-        \ \"etag\": \"W/\\\"a38434c8-7b23-4092-b7c6-402238eac0dc\\\"\",\r\n  \"location\":
+      string: "{\r\n  \"name\": \"miqazure-linux-manag944\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944\",\r\n
+        \ \"etag\": \"W/\\\"b6339880-8ead-4c9e-b5c0-f38c4f8612d5\\\"\",\r\n  \"location\":
         \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"f28e0f25-b372-4edf-97d9-13a9e3b4ba2d\",\r\n    \"ipAddress\":
-        \"40.71.82.83\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\":
-        \"Static\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipTags\": [],\r\n
-        \   \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
-        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
+        \   \"resourceGuid\": \"c5e8b90e-5a78-49b0-b224-b70ed3fb45e5\",\r\n    \"ipConfigurations\":
+        [\r\n      {\r\n        \"name\": \"ipconfig1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944/ipConfigurations/ipconfig1\",\r\n
+        \       \"etag\": \"W/\\\"b6339880-8ead-4c9e-b5c0-f38c4f8612d5\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"privateIPAddress\": \"172.25.0.4\",\r\n          \"privateIPAllocationMethod\":
+        \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqazure-linux-managed-ip\"\r\n
+        \         },\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2/subnets/default\"\r\n
+        \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
+        \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\":
+        [],\r\n      \"appliedDnsServers\": []\r\n    },\r\n    \"enableAcceleratedNetworking\":
+        false,\r\n    \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\":
+        {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg\"\r\n
+        \   },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed\"\r\n
+        \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
+        \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:25 GMT
+  recorded_at: Tue, 13 Mar 2018 09:00:55 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg?api-version=2018-03-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2597,7 +2480,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA5MzEzNDksIm5iZiI6MTUyMDkzMTM0OSwiZXhwIjoxNTIwOTM1MjQ5LCJhaW8iOiJZMk5nWURBTjFDdDJkcHEzYjE1K2V1Lys2UnRMQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZElMYzFRYWJqa2VuaVJzY3owd2hBQSIsInZlciI6IjEuMCJ9.LrEXUjZiTyG_nyq5Il4b_ZTjjRnxBkm0u5WFOnnBAZNpz8LWO5F1s6mdjgVNPNOFuzUShc_EYAZUqZn_XLvKMMcvSeHz5t68yWYr7CJlq7IW1lP2jic9JfCeuqfMa0-fwrhNijdKM1AnpBpV1hwizWngb4tkMASxfEpKj9wZDeGJlQqlDtVXja8xGUehwHw6tWirlE4YJbxTzube0pxcOPxlHoHJC82UpYY6ychn740ZLKrD4M5w8KcNmdvjmZO4oLC7q29rk49tx2BamoEvfkZl4ZZW2Cx-YmDGFwepbBEg4bVn8CMKENiLNyo16Yw_c9qryS0T83InFG1HFAVcTw
   response:
     status:
       code: 200
@@ -2614,36 +2497,245 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"cddd97d1-6111-4477-8a00-3dc885237a1d"
+      - W/"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 1403e5b6-8fa0-4cd3-89b1-76b6c4fd805b
+      - b553b0e4-e69f-4af7-87d2-6c1e5dcc015f
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - '14923'
       X-Ms-Correlation-Request-Id:
-      - e4a5f369-a742-466f-bd8f-42e17eaaf9c9
+      - 1d90d9ae-65f8-4125-a3ff-0bf5c8653686
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102421Z:e4a5f369-a742-466f-bd8f-42e17eaaf9c9
+      - WESTEUROPE:20180313T090101Z:1d90d9ae-65f8-4125-a3ff-0bf5c8653686
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:21 GMT
+      - Tue, 13 Mar 2018 09:01:01 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb2-publicip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\",\r\n
-        \ \"etag\": \"W/\\\"cddd97d1-6111-4477-8a00-3dc885237a1d\\\"\",\r\n  \"location\":
+      string: "{\r\n  \"name\": \"miqazure-linux-managed-nsg\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg\",\r\n
+        \ \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/networkSecurityGroups\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
+        \"b4611f96-94a8-4486-94c5-16bb6c7a5c84\",\r\n    \"securityRules\": [\r\n
+        \     {\r\n        \"name\": \"default-allow-ssh\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/securityRules/default-allow-ssh\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"protocol\": \"TCP\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"22\",\r\n          \"sourceAddressPrefix\":
+        \"*\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n          \"access\":
+        \"Allow\",\r\n          \"priority\": 1000,\r\n          \"direction\": \"Inbound\",\r\n
+        \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      }\r\n    ],\r\n    \"defaultSecurityRules\": [\r\n
+        \     {\r\n        \"name\": \"AllowVnetInBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/AllowVnetInBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow inbound traffic from all VMs in VNET\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"VirtualNetwork\",\r\n          \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n          \"direction\":
+        \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowAzureLoadBalancerInBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/AllowAzureLoadBalancerInBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow inbound traffic from azure load balancer\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"AzureLoadBalancer\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65001,\r\n          \"direction\":
+        \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllInBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/DenyAllInBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Deny all inbound traffic\",\r\n          \"protocol\":
+        \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\":
+        \"*\",\r\n          \"sourceAddressPrefix\": \"*\",\r\n          \"destinationAddressPrefix\":
+        \"*\",\r\n          \"access\": \"Deny\",\r\n          \"priority\": 65500,\r\n
+        \         \"direction\": \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n
+        \         \"destinationPortRanges\": [],\r\n          \"sourceAddressPrefixes\":
+        [],\r\n          \"destinationAddressPrefixes\": []\r\n        }\r\n      },\r\n
+        \     {\r\n        \"name\": \"AllowVnetOutBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/AllowVnetOutBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow outbound traffic from all VMs to all VMs
+        in VNET\",\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\":
+        \"*\",\r\n          \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"VirtualNetwork\",\r\n          \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n          \"direction\":
+        \"Outbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowInternetOutBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/AllowInternetOutBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow outbound traffic from all VMs to Internet\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"*\",\r\n          \"destinationAddressPrefix\": \"Internet\",\r\n          \"access\":
+        \"Allow\",\r\n          \"priority\": 65001,\r\n          \"direction\": \"Outbound\",\r\n
+        \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllOutBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/DenyAllOutBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Deny all outbound traffic\",\r\n          \"protocol\":
+        \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\":
+        \"*\",\r\n          \"sourceAddressPrefix\": \"*\",\r\n          \"destinationAddressPrefix\":
+        \"*\",\r\n          \"access\": \"Deny\",\r\n          \"priority\": 65500,\r\n
+        \         \"direction\": \"Outbound\",\r\n          \"sourcePortRanges\":
+        [],\r\n          \"destinationPortRanges\": [],\r\n          \"sourceAddressPrefixes\":
+        [],\r\n          \"destinationAddressPrefixes\": []\r\n        }\r\n      }\r\n
+        \   ],\r\n    \"networkInterfaces\": [\r\n      {\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944\"\r\n
+        \     }\r\n    ]\r\n  }\r\n}"
+    http_version: 
+  recorded_at: Tue, 13 Mar 2018 09:01:01 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2?api-version=2018-03-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA5MzEzNDksIm5iZiI6MTUyMDkzMTM0OSwiZXhwIjoxNTIwOTM1MjQ5LCJhaW8iOiJZMk5nWURBTjFDdDJkcHEzYjE1K2V1Lys2UnRMQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZElMYzFRYWJqa2VuaVJzY3owd2hBQSIsInZlciI6IjEuMCJ9.LrEXUjZiTyG_nyq5Il4b_ZTjjRnxBkm0u5WFOnnBAZNpz8LWO5F1s6mdjgVNPNOFuzUShc_EYAZUqZn_XLvKMMcvSeHz5t68yWYr7CJlq7IW1lP2jic9JfCeuqfMa0-fwrhNijdKM1AnpBpV1hwizWngb4tkMASxfEpKj9wZDeGJlQqlDtVXja8xGUehwHw6tWirlE4YJbxTzube0pxcOPxlHoHJC82UpYY6ychn740ZLKrD4M5w8KcNmdvjmZO4oLC7q29rk49tx2BamoEvfkZl4ZZW2Cx-YmDGFwepbBEg4bVn8CMKENiLNyo16Yw_c9qryS0T83InFG1HFAVcTw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"f5bbd20f-7ae4-4b6d-89c8-eb3481fcbe05"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 50b428a1-6bd8-4b2e-ac3b-2aad43964f90
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14918'
+      X-Ms-Correlation-Request-Id:
+      - ca61aa0d-76da-45ba-a528-a0ae495f9fec
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180313T090102Z:ca61aa0d-76da-45ba-a528-a0ae495f9fec
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Tue, 13 Mar 2018 09:01:01 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"miq-azure-test2\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2\",\r\n
+        \ \"etag\": \"W/\\\"f5bbd20f-7ae4-4b6d-89c8-eb3481fcbe05\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
+        \"f950a3cf-749a-49d5-a7fb-33a400b0e93c\",\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\":
+        [\r\n        \"172.25.0.0/16\"\r\n      ]\r\n    },\r\n    \"subnets\": [\r\n
+        \     {\r\n        \"name\": \"default\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2/subnets/default\",\r\n
+        \       \"etag\": \"W/\\\"f5bbd20f-7ae4-4b6d-89c8-eb3481fcbe05\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"addressPrefix\": \"172.25.0.0/24\",\r\n          \"ipConfigurations\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944/ipConfigurations/ipconfig1\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"virtualNetworkPeerings\":
+        [],\r\n    \"enableDdosProtection\": false,\r\n    \"enableVmProtection\":
+        false\r\n  }\r\n}"
+    http_version: 
+  recorded_at: Tue, 13 Mar 2018 09:01:02 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqazure-linux-managed-ip?api-version=2018-03-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA5MzEzNDksIm5iZiI6MTUyMDkzMTM0OSwiZXhwIjoxNTIwOTM1MjQ5LCJhaW8iOiJZMk5nWURBTjFDdDJkcHEzYjE1K2V1Lys2UnRMQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZElMYzFRYWJqa2VuaVJzY3owd2hBQSIsInZlciI6IjEuMCJ9.LrEXUjZiTyG_nyq5Il4b_ZTjjRnxBkm0u5WFOnnBAZNpz8LWO5F1s6mdjgVNPNOFuzUShc_EYAZUqZn_XLvKMMcvSeHz5t68yWYr7CJlq7IW1lP2jic9JfCeuqfMa0-fwrhNijdKM1AnpBpV1hwizWngb4tkMASxfEpKj9wZDeGJlQqlDtVXja8xGUehwHw6tWirlE4YJbxTzube0pxcOPxlHoHJC82UpYY6ychn740ZLKrD4M5w8KcNmdvjmZO4oLC7q29rk49tx2BamoEvfkZl4ZZW2Cx-YmDGFwepbBEg4bVn8CMKENiLNyo16Yw_c9qryS0T83InFG1HFAVcTw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"0efc9684-fb7d-4fb7-b9b9-f33dbac04a28"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 709fb748-6b21-4b60-b592-f653e26db2c8
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14917'
+      X-Ms-Correlation-Request-Id:
+      - 984ef2c3-d7d4-415c-9282-019cc0cd27af
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180313T090102Z:984ef2c3-d7d4-415c-9282-019cc0cd27af
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Tue, 13 Mar 2018 09:01:02 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"miqazure-linux-managed-ip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqazure-linux-managed-ip\",\r\n
+        \ \"etag\": \"W/\\\"0efc9684-fb7d-4fb7-b9b9-f33dbac04a28\\\"\",\r\n  \"location\":
         \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"83e7257d-ab94-4229-8eb5-4798f37ef28d\",\r\n    \"publicIPAddressVersion\":
+        \   \"resourceGuid\": \"6a2a9142-26e8-45cd-93bf-7318192f3528\",\r\n    \"publicIPAddressVersion\":
         \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
-        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
+        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944/ipConfigurations/ipconfig1\"\r\n
         \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
         \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:26 GMT
+  recorded_at: Tue, 13 Mar 2018 09:01:02 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_500/orchestration_stack_lb_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_500/orchestration_stack_lb_refresh.yml
@@ -16,7 +16,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDc0MDIsIm5iZiI6MTUyMDg0NzQwMiwiZXhwIjoxNTIwODUxMzAyLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYldDZVJlZzBva0tOM1V5STRIMGpBQSIsInZlciI6IjEuMCJ9.eQcibNRit9UpZReJbHfEsmiPLie_5JJmntSSqIl_3JhpZUk5RiY9C5-tpvcqgzi4T2gBYIWpCTaJATTECFPv8N6WD5grp4DvR8jTIAd6GymPo3g-NXmQkBj_SOQ30wf3FsCZgKP9lQpEJAW7fPQ2F8qhmSX_mPeeP2y7FPVL8WIkCw0KEMo8L1JgQDrW_oKLo6xG2BCl3XSHjezamVAYqafAg7_nHcOAPsKtYAeozxPnuEMfnLLpHwXsWoI_6SeHzTIeU00orNnTk71_yDFh6KcGqQ98uruMTawbXy8YiqUQznf9OfjqdCA2Qg7YybfSLBw6gY1eBGp27n13wOQAog
   response:
     status:
       code: 200
@@ -35,26 +35,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14997'
+      - '14999'
       X-Ms-Request-Id:
-      - cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - 223d49ab-9259-4995-bbec-48c8b0dec2dd
       X-Ms-Correlation-Request-Id:
-      - cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - 223d49ab-9259-4995-bbec-48c8b0dec2dd
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102417Z:cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - WESTEUROPE:20180312T094320Z:223d49ab-9259-4995-bbec-48c8b0dec2dd
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:17 GMT
+      - Mon, 12 Mar 2018 09:43:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID","subscriptionId":"AZURE_SUBSCRIPTION_ID","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:22 GMT
+  recorded_at: Mon, 12 Mar 2018 09:43:25 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers?api-version=2015-01-01
@@ -71,7 +71,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDc0MDIsIm5iZiI6MTUyMDg0NzQwMiwiZXhwIjoxNTIwODUxMzAyLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYldDZVJlZzBva0tOM1V5STRIMGpBQSIsInZlciI6IjEuMCJ9.eQcibNRit9UpZReJbHfEsmiPLie_5JJmntSSqIl_3JhpZUk5RiY9C5-tpvcqgzi4T2gBYIWpCTaJATTECFPv8N6WD5grp4DvR8jTIAd6GymPo3g-NXmQkBj_SOQ30wf3FsCZgKP9lQpEJAW7fPQ2F8qhmSX_mPeeP2y7FPVL8WIkCw0KEMo8L1JgQDrW_oKLo6xG2BCl3XSHjezamVAYqafAg7_nHcOAPsKtYAeozxPnuEMfnLLpHwXsWoI_6SeHzTIeU00orNnTk71_yDFh6KcGqQ98uruMTawbXy8YiqUQznf9OfjqdCA2Qg7YybfSLBw6gY1eBGp27n13wOQAog
   response:
     status:
       code: 200
@@ -88,19 +88,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - '14983'
       X-Ms-Request-Id:
-      - fe3532ca-59a2-474e-9094-8a3697b82bef
+      - c11535ad-9b1a-4173-80bf-b6381fdd0551
       X-Ms-Correlation-Request-Id:
-      - fe3532ca-59a2-474e-9094-8a3697b82bef
+      - c11535ad-9b1a-4173-80bf-b6381fdd0551
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102419Z:fe3532ca-59a2-474e-9094-8a3697b82bef
+      - WESTEUROPE:20180312T094322Z:c11535ad-9b1a-4173-80bf-b6381fdd0551
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:18 GMT
+      - Mon, 12 Mar 2018 09:43:21 GMT
       Content-Length:
       - '320853'
     body:
@@ -2322,10 +2322,10 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:23 GMT
+  recorded_at: Mon, 12 Mar 2018 09:43:27 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb?api-version=2018-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2339,7 +2339,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDc0MDIsIm5iZiI6MTUyMDg0NzQwMiwiZXhwIjoxNTIwODUxMzAyLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYldDZVJlZzBva0tOM1V5STRIMGpBQSIsInZlciI6IjEuMCJ9.eQcibNRit9UpZReJbHfEsmiPLie_5JJmntSSqIl_3JhpZUk5RiY9C5-tpvcqgzi4T2gBYIWpCTaJATTECFPv8N6WD5grp4DvR8jTIAd6GymPo3g-NXmQkBj_SOQ30wf3FsCZgKP9lQpEJAW7fPQ2F8qhmSX_mPeeP2y7FPVL8WIkCw0KEMo8L1JgQDrW_oKLo6xG2BCl3XSHjezamVAYqafAg7_nHcOAPsKtYAeozxPnuEMfnLLpHwXsWoI_6SeHzTIeU00orNnTk71_yDFh6KcGqQ98uruMTawbXy8YiqUQznf9OfjqdCA2Qg7YybfSLBw6gY1eBGp27n13wOQAog
   response:
     status:
       code: 200
@@ -2356,269 +2356,11 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67"
+      - W/"92982330-0f29-406e-bba9-ad19198579a5"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - '080de667-081e-4d58-9e94-9e7243d4200e'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Correlation-Request-Id:
-      - '093d49ac-c85f-440e-956b-955b6698dd19'
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102419Z:093d49ac-c85f-440e-956b-955b6698dd19
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Mon, 12 Mar 2018 10:24:19 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1\",\r\n
-        \ \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"7ab88756-810f-4083-95db-8b05d50e38f2\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ],\r\n          \"inboundNatRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"backendIPConfigurations\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\"\r\n
-        \           }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-rule\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\":
-        80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\"\r\n
-        \         },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n
-        \       \"name\": \"rspec-lb-probe\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-NAT\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 3441,\r\n          \"backendPort\":
-        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:24 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"7a8e5fe7-f777-4435-992b-a54f28c2f28c"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - bd22ca22-a01f-4ecf-9230-a4558fb66931
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Correlation-Request-Id:
-      - 19c674a8-c8da-4b5e-8265-5ebc21926459
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102420Z:19c674a8-c8da-4b5e-8265-5ebc21926459
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Mon, 12 Mar 2018 10:24:19 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb2\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2\",\r\n
-        \ \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"e2e30a77-f81b-43fc-9693-08303e43deed\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/backendAddressPools/rspec-lb2-pool\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\r\n
-        \       }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\": [],\r\n    \"probes\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-probe\",\r\n        \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/probes/rspec-lb2-probe\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\": [],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:25 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"a38434c8-7b23-4092-b7c6-402238eac0dc"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 0fd15240-6a1c-4b39-a4f6-aa53fd8591c2
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Correlation-Request-Id:
-      - 5cc03163-922e-41a1-9601-dba2d7cf2a81
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102421Z:5cc03163-922e-41a1-9601-dba2d7cf2a81
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Mon, 12 Mar 2018 10:24:20 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb1-LoadBalancerFrontEnd\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\",\r\n
-        \ \"etag\": \"W/\\\"a38434c8-7b23-4092-b7c6-402238eac0dc\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"f28e0f25-b372-4edf-97d9-13a9e3b4ba2d\",\r\n    \"ipAddress\":
-        \"40.71.82.83\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\":
-        \"Static\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipTags\": [],\r\n
-        \   \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
-        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:25 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"cddd97d1-6111-4477-8a00-3dc885237a1d"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 1403e5b6-8fa0-4cd3-89b1-76b6c4fd805b
+      - aaa56bc2-8221-4775-a64a-4ec2bd00ad4d
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
@@ -2627,23 +2369,145 @@ http_interactions:
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
       - '14988'
       X-Ms-Correlation-Request-Id:
-      - e4a5f369-a742-466f-bd8f-42e17eaaf9c9
+      - eb8a3ac3-3679-416a-a61d-4cb3c5aabec2
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102421Z:e4a5f369-a742-466f-bd8f-42e17eaaf9c9
+      - WESTEUROPE:20180312T094323Z:eb8a3ac3-3679-416a-a61d-4cb3c5aabec2
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:21 GMT
+      - Mon, 12 Mar 2018 09:43:23 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb2-publicip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\",\r\n
-        \ \"etag\": \"W/\\\"cddd97d1-6111-4477-8a00-3dc885237a1d\\\"\",\r\n  \"location\":
+      string: "{\r\n  \"name\": \"spec0deply1lb\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb\",\r\n
+        \ \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"8cd72f7c-03bd-4584-abc6-d9ce77ae6202\",\r\n
+        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
+        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
+        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip\"\r\n
+        \         },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
+        \           }\r\n          ],\r\n          \"inboundNatRules\": [\r\n            {\r\n
+        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
+        [\r\n      {\r\n        \"name\": \"BackendPool1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\",\r\n
+        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"backendIPConfigurations\": [\r\n            {\r\n              \"id\":
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1\"\r\n
+        \           }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n
+        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\":
+        [\r\n      {\r\n        \"name\": \"LBRule\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\",\r\n
+        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
+        \         },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\":
+        80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
+        5,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
+        false,\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\":
+        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\"\r\n
+        \         },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/probes/tcpProbe\"\r\n
+        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n
+        \       \"name\": \"tcpProbe\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/probes/tcpProbe\",\r\n
+        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"protocol\": \"Tcp\",\r\n          \"port\": 80,\r\n          \"intervalInSeconds\":
+        5,\r\n          \"numberOfProbes\": 2,\r\n          \"loadBalancingRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\":
+        [\r\n      {\r\n        \"name\": \"RDP-VM0\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0\",\r\n
+        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
+        \         },\r\n          \"frontendPort\": 50001,\r\n          \"backendPort\":
+        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
+        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
+        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1\"\r\n
+        \         }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"RDP-VM1\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1\",\r\n
+        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
+        \         },\r\n          \"frontendPort\": 50002,\r\n          \"backendPort\":
+        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
+        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
+        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1\"\r\n
+        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"outboundNatRules\":
+        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
+        \"Basic\"\r\n  }\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:43:27 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDc0MDIsIm5iZiI6MTUyMDg0NzQwMiwiZXhwIjoxNTIwODUxMzAyLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYldDZVJlZzBva0tOM1V5STRIMGpBQSIsInZlciI6IjEuMCJ9.eQcibNRit9UpZReJbHfEsmiPLie_5JJmntSSqIl_3JhpZUk5RiY9C5-tpvcqgzi4T2gBYIWpCTaJATTECFPv8N6WD5grp4DvR8jTIAd6GymPo3g-NXmQkBj_SOQ30wf3FsCZgKP9lQpEJAW7fPQ2F8qhmSX_mPeeP2y7FPVL8WIkCw0KEMo8L1JgQDrW_oKLo6xG2BCl3XSHjezamVAYqafAg7_nHcOAPsKtYAeozxPnuEMfnLLpHwXsWoI_6SeHzTIeU00orNnTk71_yDFh6KcGqQ98uruMTawbXy8YiqUQznf9OfjqdCA2Qg7YybfSLBw6gY1eBGp27n13wOQAog
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"2080997a-38a6-420d-ba86-e9582e1331c7"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - a7234871-6caf-46b5-ba7c-2ce525f171d6
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14982'
+      X-Ms-Correlation-Request-Id:
+      - 4401132d-a277-499d-94aa-a209aded5be5
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T094323Z:4401132d-a277-499d-94aa-a209aded5be5
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:43:23 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"spec0deply1ip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip\",\r\n
+        \ \"etag\": \"W/\\\"2080997a-38a6-420d-ba86-e9582e1331c7\\\"\",\r\n  \"location\":
         \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"83e7257d-ab94-4229-8eb5-4798f37ef28d\",\r\n    \"publicIPAddressVersion\":
+        \   \"resourceGuid\": \"a08b891e-e45a-4970-aefc-f6c996989490\",\r\n    \"publicIPAddressVersion\":
         \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
-        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
+        4,\r\n    \"dnsSettings\": {\r\n      \"domainNameLabel\": \"spec0deply1dns\",\r\n
+        \     \"fqdn\": \"spec0deply1dns.eastus.cloudapp.azure.com\"\r\n    },\r\n
+        \   \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
         \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
         \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:26 GMT
+  recorded_at: Mon, 12 Mar 2018 09:43:28 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_500/orchestration_stack_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_500/orchestration_stack_refresh.yml
@@ -1,6 +1,62 @@
 ---
 http_interactions:
 - request:
+    method: post
+    uri: https://login.microsoftonline.com/AZURE_TENANT_ID/oauth2/token
+    body:
+      encoding: UTF-8
+      string: grant_type=client_credentials&client_id=AZURE_CLIENT_ID&client_secret=AZURE_CLIENT_SECRET&resource=https%3A%2F%2Fmanagement.azure.com%2F
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Server:
+      - Microsoft-IIS/10.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Request-Id:
+      - 459e606d-34e8-42a2-8ddd-4c88e07d2300
+      P3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Set-Cookie:
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzbBD4OGhxdJloieuva3v_V-HtuHXtnQts5P3CCzyBalrHKSTH74WDAvYB_VpVuw58-hZI9wcfnPXOYGflDEyGNF43aFSyHfV6GFL_yge3_68N-0gKCzEaGUXU_d5-4ORfnZadniserjye7bKZ2PbB99xzmQUBJUYdbCiwVX4NFGMgAA;
+        domain=.login.microsoftonline.com; path=/; secure; HttpOnly
+      - stsservicecookie=ests; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=005; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 12 Mar 2018 09:41:41 GMT
+      Content-Length:
+      - '1505'
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1520851302","not_before":"1520847402","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDc0MDIsIm5iZiI6MTUyMDg0NzQwMiwiZXhwIjoxNTIwODUxMzAyLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYldDZVJlZzBva0tOM1V5STRIMGpBQSIsInZlciI6IjEuMCJ9.eQcibNRit9UpZReJbHfEsmiPLie_5JJmntSSqIl_3JhpZUk5RiY9C5-tpvcqgzi4T2gBYIWpCTaJATTECFPv8N6WD5grp4DvR8jTIAd6GymPo3g-NXmQkBj_SOQ30wf3FsCZgKP9lQpEJAW7fPQ2F8qhmSX_mPeeP2y7FPVL8WIkCw0KEMo8L1JgQDrW_oKLo6xG2BCl3XSHjezamVAYqafAg7_nHcOAPsKtYAeozxPnuEMfnLLpHwXsWoI_6SeHzTIeU00orNnTk71_yDFh6KcGqQ98uruMTawbXy8YiqUQznf9OfjqdCA2Qg7YybfSLBw6gY1eBGp27n13wOQAog"}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:41:46 GMT
+- request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
     body:
@@ -16,7 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDc0MDIsIm5iZiI6MTUyMDg0NzQwMiwiZXhwIjoxNTIwODUxMzAyLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYldDZVJlZzBva0tOM1V5STRIMGpBQSIsInZlciI6IjEuMCJ9.eQcibNRit9UpZReJbHfEsmiPLie_5JJmntSSqIl_3JhpZUk5RiY9C5-tpvcqgzi4T2gBYIWpCTaJATTECFPv8N6WD5grp4DvR8jTIAd6GymPo3g-NXmQkBj_SOQ30wf3FsCZgKP9lQpEJAW7fPQ2F8qhmSX_mPeeP2y7FPVL8WIkCw0KEMo8L1JgQDrW_oKLo6xG2BCl3XSHjezamVAYqafAg7_nHcOAPsKtYAeozxPnuEMfnLLpHwXsWoI_6SeHzTIeU00orNnTk71_yDFh6KcGqQ98uruMTawbXy8YiqUQznf9OfjqdCA2Qg7YybfSLBw6gY1eBGp27n13wOQAog
   response:
     status:
       code: 200
@@ -35,26 +91,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14997'
+      - '14998'
       X-Ms-Request-Id:
-      - cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - b17d15fe-c8ec-4fb5-a92b-1d9ae34378a2
       X-Ms-Correlation-Request-Id:
-      - cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - b17d15fe-c8ec-4fb5-a92b-1d9ae34378a2
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102417Z:cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - WESTEUROPE:20180312T094142Z:b17d15fe-c8ec-4fb5-a92b-1d9ae34378a2
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:17 GMT
+      - Mon, 12 Mar 2018 09:41:42 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID","subscriptionId":"AZURE_SUBSCRIPTION_ID","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:22 GMT
+  recorded_at: Mon, 12 Mar 2018 09:41:47 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers?api-version=2015-01-01
@@ -71,7 +127,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDc0MDIsIm5iZiI6MTUyMDg0NzQwMiwiZXhwIjoxNTIwODUxMzAyLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYldDZVJlZzBva0tOM1V5STRIMGpBQSIsInZlciI6IjEuMCJ9.eQcibNRit9UpZReJbHfEsmiPLie_5JJmntSSqIl_3JhpZUk5RiY9C5-tpvcqgzi4T2gBYIWpCTaJATTECFPv8N6WD5grp4DvR8jTIAd6GymPo3g-NXmQkBj_SOQ30wf3FsCZgKP9lQpEJAW7fPQ2F8qhmSX_mPeeP2y7FPVL8WIkCw0KEMo8L1JgQDrW_oKLo6xG2BCl3XSHjezamVAYqafAg7_nHcOAPsKtYAeozxPnuEMfnLLpHwXsWoI_6SeHzTIeU00orNnTk71_yDFh6KcGqQ98uruMTawbXy8YiqUQznf9OfjqdCA2Qg7YybfSLBw6gY1eBGp27n13wOQAog
   response:
     status:
       code: 200
@@ -88,19 +144,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - '14989'
       X-Ms-Request-Id:
-      - fe3532ca-59a2-474e-9094-8a3697b82bef
+      - 96fa8b0a-1cce-4cdc-b2f3-cda6ccad9876
       X-Ms-Correlation-Request-Id:
-      - fe3532ca-59a2-474e-9094-8a3697b82bef
+      - 96fa8b0a-1cce-4cdc-b2f3-cda6ccad9876
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102419Z:fe3532ca-59a2-474e-9094-8a3697b82bef
+      - WESTEUROPE:20180312T094143Z:96fa8b0a-1cce-4cdc-b2f3-cda6ccad9876
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:18 GMT
+      - Mon, 12 Mar 2018 09:41:43 GMT
       Content-Length:
       - '320853'
     body:
@@ -2322,10 +2378,10 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:23 GMT
+  recorded_at: Mon, 12 Mar 2018 09:41:48 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-deployment-dont-delete?api-version=2017-08-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2339,7 +2395,220 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDc0MDIsIm5iZiI6MTUyMDg0NzQwMiwiZXhwIjoxNTIwODUxMzAyLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYldDZVJlZzBva0tOM1V5STRIMGpBQSIsInZlciI6IjEuMCJ9.eQcibNRit9UpZReJbHfEsmiPLie_5JJmntSSqIl_3JhpZUk5RiY9C5-tpvcqgzi4T2gBYIWpCTaJATTECFPv8N6WD5grp4DvR8jTIAd6GymPo3g-NXmQkBj_SOQ30wf3FsCZgKP9lQpEJAW7fPQ2F8qhmSX_mPeeP2y7FPVL8WIkCw0KEMo8L1JgQDrW_oKLo6xG2BCl3XSHjezamVAYqafAg7_nHcOAPsKtYAeozxPnuEMfnLLpHwXsWoI_6SeHzTIeU00orNnTk71_yDFh6KcGqQ98uruMTawbXy8YiqUQznf9OfjqdCA2Qg7YybfSLBw6gY1eBGp27n13wOQAog
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14991'
+      X-Ms-Request-Id:
+      - 3f1c63c0-b48d-4ba8-9138-67c284b4d88c
+      X-Ms-Correlation-Request-Id:
+      - 3f1c63c0-b48d-4ba8-9138-67c284b4d88c
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T094144Z:3f1c63c0-b48d-4ba8-9138-67c284b4d88c
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:41:44 GMT
+      Content-Length:
+      - '3083'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-deployment-dont-delete","name":"spec-deployment-dont-delete","properties":{"templateLink":{"uri":"https://gist.githubusercontent.com/bzwei/e6ccc4d641d6afab8e26ef55c37c498e/raw/769505e37256e926a9b581a100c90bb657ff45ff/azure-parent-spec.json","contentVersion":"1.0.0.0"},"parameters":{"childDeployName":{"type":"String","value":"spec-nested-deployment-dont-delete"},"storageAccountName":{"type":"String","value":"spec0deply1stor"},"availabilitySetName":{"type":"String","value":"spec0deply1as"},"adminUsername":{"type":"String","value":"deploy1admin"},"adminPassword":{"type":"SecureString"},"dnsNameforLBIP":{"type":"String","value":"spec0deply1dns"},"vmNamePrefix":{"type":"String","value":"spec0deply1vm"},"imagePublisher":{"type":"String","value":"MicrosoftWindowsServer"},"imageOffer":{"type":"String","value":"WindowsServer"},"imageSKU":{"type":"String","value":"2012-R2-Datacenter"},"lbName":{"type":"String","value":"spec0deply1lb"},"nicNamePrefix":{"type":"String","value":"spec0deply1nic"},"publicIPAddressName":{"type":"String","value":"spec0deply1ip"},"vnetName":{"type":"String","value":"spec0deply1vnet"},"vmSize":{"type":"String","value":"Standard_D1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-04-04T23:29:05.0043846Z","duration":"PT24M6.1512983S","correlationId":"3a55e6b5-4a3b-431e-8144-53698bf6f1dc","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[],"outputs":{"siteUri":{"type":"String","value":"hard-coded
+        output for test"}},"outputResources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor"}]}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:41:49 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-deployment-dont-delete/operations?api-version=2017-08-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDc0MDIsIm5iZiI6MTUyMDg0NzQwMiwiZXhwIjoxNTIwODUxMzAyLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYldDZVJlZzBva0tOM1V5STRIMGpBQSIsInZlciI6IjEuMCJ9.eQcibNRit9UpZReJbHfEsmiPLie_5JJmntSSqIl_3JhpZUk5RiY9C5-tpvcqgzi4T2gBYIWpCTaJATTECFPv8N6WD5grp4DvR8jTIAd6GymPo3g-NXmQkBj_SOQ30wf3FsCZgKP9lQpEJAW7fPQ2F8qhmSX_mPeeP2y7FPVL8WIkCw0KEMo8L1JgQDrW_oKLo6xG2BCl3XSHjezamVAYqafAg7_nHcOAPsKtYAeozxPnuEMfnLLpHwXsWoI_6SeHzTIeU00orNnTk71_yDFh6KcGqQ98uruMTawbXy8YiqUQznf9OfjqdCA2Qg7YybfSLBw6gY1eBGp27n13wOQAog
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14987'
+      X-Ms-Request-Id:
+      - a9fb4189-d1d3-4ecd-9a69-8d71d0d13248
+      X-Ms-Correlation-Request-Id:
+      - a9fb4189-d1d3-4ecd-9a69-8d71d0d13248
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T094148Z:a9fb4189-d1d3-4ecd-9a69-8d71d0d13248
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:41:48 GMT
+      Content-Length:
+      - '801'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-deployment-dont-delete/operations/6AF613CA61ABB553","operationId":"6AF613CA61ABB553","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:29:04.6934934Z","duration":"PT24M3.4746371S","trackingId":"a0997dbb-9578-4dd9-bad6-1286c02855c8","serviceRequestId":"08b8faec-0f0f-4cb2-8453-fabbd3448cb9","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete","resourceType":"Microsoft.Resources/deployments","resourceName":"spec-nested-deployment-dont-delete"}}}]}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:41:54 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete?api-version=2017-08-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDc0MDIsIm5iZiI6MTUyMDg0NzQwMiwiZXhwIjoxNTIwODUxMzAyLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYldDZVJlZzBva0tOM1V5STRIMGpBQSIsInZlciI6IjEuMCJ9.eQcibNRit9UpZReJbHfEsmiPLie_5JJmntSSqIl_3JhpZUk5RiY9C5-tpvcqgzi4T2gBYIWpCTaJATTECFPv8N6WD5grp4DvR8jTIAd6GymPo3g-NXmQkBj_SOQ30wf3FsCZgKP9lQpEJAW7fPQ2F8qhmSX_mPeeP2y7FPVL8WIkCw0KEMo8L1JgQDrW_oKLo6xG2BCl3XSHjezamVAYqafAg7_nHcOAPsKtYAeozxPnuEMfnLLpHwXsWoI_6SeHzTIeU00orNnTk71_yDFh6KcGqQ98uruMTawbXy8YiqUQznf9OfjqdCA2Qg7YybfSLBw6gY1eBGp27n13wOQAog
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Request-Id:
+      - 38582b98-2029-4e2c-b16c-6f49a919e59c
+      X-Ms-Correlation-Request-Id:
+      - 38582b98-2029-4e2c-b16c-6f49a919e59c
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T094151Z:38582b98-2029-4e2c-b16c-6f49a919e59c
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:41:51 GMT
+      Content-Length:
+      - '7230'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete","name":"spec-nested-deployment-dont-delete","properties":{"templateLink":{"uri":"https://gist.githubusercontent.com/bzwei/c09f906306399d238762bce711781200/raw/3558b735da03c1c030023d70b78ec3451dab5689/azure-loadbalancer.json","contentVersion":"1.0.0.0"},"parameters":{"storageAccountName":{"type":"String","value":"spec0deply1stor"},"availabilitySetName":{"type":"String","value":"spec0deply1as"},"adminUsername":{"type":"String","value":"deploy1admin"},"adminPassword":{"type":"SecureString"},"dnsNameforLBIP":{"type":"String","value":"spec0deply1dns"},"vmNamePrefix":{"type":"String","value":"spec0deply1vm"},"imagePublisher":{"type":"String","value":"MicrosoftWindowsServer"},"imageOffer":{"type":"String","value":"WindowsServer"},"imageSKU":{"type":"String","value":"2012-R2-Datacenter"},"lbName":{"type":"String","value":"spec0deply1lb"},"nicNamePrefix":{"type":"String","value":"spec0deply1nic"},"publicIPAddressName":{"type":"String","value":"spec0deply1ip"},"vnetName":{"type":"String","value":"spec0deply1vnet"},"vmSize":{"type":"String","value":"Standard_D1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-04-04T23:28:59.2682474Z","duration":"PT23M55.442141S","correlationId":"3a55e6b5-4a3b-431e-8144-53698bf6f1dc","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["eastus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"availabilitySets","locations":["eastus"]},{"resourceType":"virtualMachines","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"publicIPAddresses","locations":["eastus"]},{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"loadBalancers","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"spec0deply1ip"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic0"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic1"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"spec0deply1stor"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"spec0deply1as"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"spec0deply1vm0"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"spec0deply1stor"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"spec0deply1as"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"spec0deply1vm1"}],"outputResources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor"}]}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:41:56 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations?api-version=2017-08-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDc0MDIsIm5iZiI6MTUyMDg0NzQwMiwiZXhwIjoxNTIwODUxMzAyLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYldDZVJlZzBva0tOM1V5STRIMGpBQSIsInZlciI6IjEuMCJ9.eQcibNRit9UpZReJbHfEsmiPLie_5JJmntSSqIl_3JhpZUk5RiY9C5-tpvcqgzi4T2gBYIWpCTaJATTECFPv8N6WD5grp4DvR8jTIAd6GymPo3g-NXmQkBj_SOQ30wf3FsCZgKP9lQpEJAW7fPQ2F8qhmSX_mPeeP2y7FPVL8WIkCw0KEMo8L1JgQDrW_oKLo6xG2BCl3XSHjezamVAYqafAg7_nHcOAPsKtYAeozxPnuEMfnLLpHwXsWoI_6SeHzTIeU00orNnTk71_yDFh6KcGqQ98uruMTawbXy8YiqUQznf9OfjqdCA2Qg7YybfSLBw6gY1eBGp27n13wOQAog
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Request-Id:
+      - 55a291c6-d817-41bb-ace4-f7912b377145
+      X-Ms-Correlation-Request-Id:
+      - 55a291c6-d817-41bb-ace4-f7912b377145
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T094152Z:55a291c6-d817-41bb-ace4-f7912b377145
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:41:52 GMT
+      Content-Length:
+      - '6866'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/2A5D9DB48CB9B87D","operationId":"2A5D9DB48CB9B87D","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:28:58.871396Z","duration":"PT4M5.2351465S","trackingId":"413c1acd-4a86-42aa-8371-2f7fe7760fba","serviceRequestId":"520c4ff7-a725-4e8f-946e-d203617aa3f9","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"spec0deply1vm1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/F59DBCC8F57674DA","operationId":"F59DBCC8F57674DA","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:28:57.3638022Z","duration":"PT4M3.6342685S","trackingId":"a7e62d93-ed67-4f9f-93bc-d7ca4451f6f9","serviceRequestId":"5b58ce6a-8aa5-45a1-b7a3-9c82b6150bd7","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"spec0deply1vm0"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/727DE014666F097A","operationId":"727DE014666F097A","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:28.2942519Z","duration":"PT3.4353223S","trackingId":"dda58292-47ab-4139-8d67-8c99aae9c93c","serviceRequestId":"7b1ba585-6ce8-4e35-83cf-27d7a344ff40","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/8984B6C47B4DBB63","operationId":"8984B6C47B4DBB63","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:26.6945925Z","duration":"PT1.75149S","trackingId":"cf689996-82e8-4740-87f0-8f820b4d153a","serviceRequestId":"831312e5-eaf1-417d-9fdb-5723d493b396","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic0"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/5BB7F6FEF271DCC5","operationId":"5BB7F6FEF271DCC5","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:24.7522379Z","duration":"PT1.8393589S","trackingId":"f42ecee0-2ab0-44d0-9748-44249046b29e","serviceRequestId":"2c6c9788-7fc1-4e6b-928f-241a44e192ea","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/ACBE290D4E246F6C","operationId":"ACBE290D4E246F6C","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:22.8224458Z","duration":"PT16.8373612S","trackingId":"a7759f29-cf9e-4892-bb7b-3e08f64e4ff7","serviceRequestId":"25c16d1d-b611-4fc3-ad7c-eedb21574599","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"spec0deply1ip"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/CDA31B5D53DE7D18","operationId":"CDA31B5D53DE7D18","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:24:53.5717985Z","duration":"PT19M47.4658028S","trackingId":"1ce6f839-7da9-4e40-97d4-2693cfbbc796","serviceRequestId":"3a55e6b5-4a3b-431e-8144-53698bf6f1dc","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"spec0deply1stor"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/07A1436712650187","operationId":"07A1436712650187","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:22.0339723Z","duration":"PT16.0077667S","trackingId":"89200282-9510-4328-ac23-a73df06aea3e","serviceRequestId":"86d89b1a-900e-4719-8d9b-7f18bc963ec7","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"spec0deply1vnet"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/C35E071B1E2FC92A","operationId":"C35E071B1E2FC92A","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:08.170721Z","duration":"PT2.1819157S","trackingId":"a2495990-63ae-4ea3-8904-866b7e01ec18","serviceRequestId":"97334c1c-6e32-4bc5-b96c-25314a5fef57","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"spec0deply1as"}}}]}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:41:57 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDc0MDIsIm5iZiI6MTUyMDg0NzQwMiwiZXhwIjoxNTIwODUxMzAyLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYldDZVJlZzBva0tOM1V5STRIMGpBQSIsInZlciI6IjEuMCJ9.eQcibNRit9UpZReJbHfEsmiPLie_5JJmntSSqIl_3JhpZUk5RiY9C5-tpvcqgzi4T2gBYIWpCTaJATTECFPv8N6WD5grp4DvR8jTIAd6GymPo3g-NXmQkBj_SOQ30wf3FsCZgKP9lQpEJAW7fPQ2F8qhmSX_mPeeP2y7FPVL8WIkCw0KEMo8L1JgQDrW_oKLo6xG2BCl3XSHjezamVAYqafAg7_nHcOAPsKtYAeozxPnuEMfnLLpHwXsWoI_6SeHzTIeU00orNnTk71_yDFh6KcGqQ98uruMTawbXy8YiqUQznf9OfjqdCA2Qg7YybfSLBw6gY1eBGp27n13wOQAog
   response:
     status:
       code: 200
@@ -2356,11 +2625,11 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67"
+      - W/"92982330-0f29-406e-bba9-ad19198579a5"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - '080de667-081e-4d58-9e94-9e7243d4200e'
+      - 5e6719b7-4c04-4e05-8082-4a46927a6cfb
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
@@ -2369,74 +2638,83 @@ http_interactions:
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
       - '14986'
       X-Ms-Correlation-Request-Id:
-      - '093d49ac-c85f-440e-956b-955b6698dd19'
+      - 5836d460-51cc-4a2a-b6f3-80537e3df1d8
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102419Z:093d49ac-c85f-440e-956b-955b6698dd19
+      - WESTEUROPE:20180312T094156Z:5836d460-51cc-4a2a-b6f3-80537e3df1d8
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:19 GMT
+      - Mon, 12 Mar 2018 09:41:56 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1\",\r\n
-        \ \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n  \"type\":
+      string: "{\r\n  \"name\": \"spec0deply1lb\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb\",\r\n
+        \ \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n  \"type\":
         \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"7ab88756-810f-4083-95db-8b05d50e38f2\",\r\n
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"8cd72f7c-03bd-4584-abc6-d9ce77ae6202\",\r\n
         \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
+        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\"\r\n
+        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip\"\r\n
         \         },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
         \           }\r\n          ],\r\n          \"inboundNatRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\"\r\n
+        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1\"\r\n
         \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
+        [\r\n      {\r\n        \"name\": \"BackendPool1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\",\r\n
+        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"backendIPConfigurations\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\"\r\n
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1\"\r\n
         \           }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
+        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
         \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-rule\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
+        [\r\n      {\r\n        \"name\": \"LBRule\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\",\r\n
+        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
+        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
         \         },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\":
         80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
+        5,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
         false,\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\"\r\n
-        \         },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\"\r\n
+        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\"\r\n
+        \         },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/probes/tcpProbe\"\r\n
         \         }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n
-        \       \"name\": \"rspec-lb-probe\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
+        \       \"name\": \"tcpProbe\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/probes/tcpProbe\",\r\n
+        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
+        \         \"protocol\": \"Tcp\",\r\n          \"port\": 80,\r\n          \"intervalInSeconds\":
+        5,\r\n          \"numberOfProbes\": 2,\r\n          \"loadBalancingRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
         \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-NAT\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
+        [\r\n      {\r\n        \"name\": \"RDP-VM0\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0\",\r\n
+        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 3441,\r\n          \"backendPort\":
+        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
+        \         },\r\n          \"frontendPort\": 50001,\r\n          \"backendPort\":
         3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
         4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
+        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1\"\r\n
+        \         }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"RDP-VM1\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1\",\r\n
+        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
+        \         },\r\n          \"frontendPort\": 50002,\r\n          \"backendPort\":
+        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
+        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
+        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1\"\r\n
         \         }\r\n        }\r\n      }\r\n    ],\r\n    \"outboundNatRules\":
         [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
         \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:24 GMT
+  recorded_at: Mon, 12 Mar 2018 09:42:01 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1?api-version=2017-12-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2450,7 +2728,167 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDc0MDIsIm5iZiI6MTUyMDg0NzQwMiwiZXhwIjoxNTIwODUxMzAyLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYldDZVJlZzBva0tOM1V5STRIMGpBQSIsInZlciI6IjEuMCJ9.eQcibNRit9UpZReJbHfEsmiPLie_5JJmntSSqIl_3JhpZUk5RiY9C5-tpvcqgzi4T2gBYIWpCTaJATTECFPv8N6WD5grp4DvR8jTIAd6GymPo3g-NXmQkBj_SOQ30wf3FsCZgKP9lQpEJAW7fPQ2F8qhmSX_mPeeP2y7FPVL8WIkCw0KEMo8L1JgQDrW_oKLo6xG2BCl3XSHjezamVAYqafAg7_nHcOAPsKtYAeozxPnuEMfnLLpHwXsWoI_6SeHzTIeU00orNnTk71_yDFh6KcGqQ98uruMTawbXy8YiqUQznf9OfjqdCA2Qg7YybfSLBw6gY1eBGp27n13wOQAog
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/LowCostGet3Min;4767,Microsoft.Compute/LowCostGet30Min;38367
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344652126238
+      X-Ms-Request-Id:
+      - 5c0d12fe-0aac-40ef-8b1c-a710bfa100f6
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14987'
+      X-Ms-Correlation-Request-Id:
+      - 6b4e6709-4114-44f4-b81c-26b184e1368f
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T094157Z:6b4e6709-4114-44f4-b81c-26b184e1368f
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:41:56 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"4d1502d5-351a-42f4-8569-22284f906d68\",\r\n
+        \   \"availabilitySet\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/SPEC0DEPLY1AS\"\r\n
+        \   },\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_D1\"\r\n
+        \   },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
+        \"MicrosoftWindowsServer\",\r\n        \"offer\": \"WindowsServer\",\r\n        \"sku\":
+        \"2012-R2-Datacenter\",\r\n        \"version\": \"latest\"\r\n      },\r\n
+        \     \"osDisk\": {\r\n        \"osType\": \"Windows\",\r\n        \"name\":
+        \"osdisk\",\r\n        \"createOption\": \"FromImage\",\r\n        \"vhd\":
+        {\r\n          \"uri\": \"http://spec0deply1stor.blob.core.windows.net/vhds/osdisk1.vhd\"\r\n
+        \       },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n      \"dataDisks\":
+        []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"spec0deply1vm1\",\r\n
+        \     \"adminUsername\": \"deploy1admin\",\r\n      \"windowsConfiguration\":
+        {\r\n        \"provisionVMAgent\": true,\r\n        \"enableAutomaticUpdates\":
+        true\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\":
+        {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1\"}]},\r\n
+        \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
+        true,\r\n        \"storageUri\": \"http://spec0deply1stor.blob.core.windows.net\"\r\n
+        \     }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n
+        \ \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"tags\": {\r\n    \"Shutdown\": \"true\"\r\n  },\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1\",\r\n
+        \ \"name\": \"spec0deply1vm1\"\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:42:02 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0?api-version=2017-12-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDc0MDIsIm5iZiI6MTUyMDg0NzQwMiwiZXhwIjoxNTIwODUxMzAyLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYldDZVJlZzBva0tOM1V5STRIMGpBQSIsInZlciI6IjEuMCJ9.eQcibNRit9UpZReJbHfEsmiPLie_5JJmntSSqIl_3JhpZUk5RiY9C5-tpvcqgzi4T2gBYIWpCTaJATTECFPv8N6WD5grp4DvR8jTIAd6GymPo3g-NXmQkBj_SOQ30wf3FsCZgKP9lQpEJAW7fPQ2F8qhmSX_mPeeP2y7FPVL8WIkCw0KEMo8L1JgQDrW_oKLo6xG2BCl3XSHjezamVAYqafAg7_nHcOAPsKtYAeozxPnuEMfnLLpHwXsWoI_6SeHzTIeU00orNnTk71_yDFh6KcGqQ98uruMTawbXy8YiqUQznf9OfjqdCA2Qg7YybfSLBw6gY1eBGp27n13wOQAog
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/LowCostGet3Min;4766,Microsoft.Compute/LowCostGet30Min;38366
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344652126238
+      X-Ms-Request-Id:
+      - 24017360-08e0-4dd7-bd4c-87982759c98e
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Correlation-Request-Id:
+      - 45686aa8-51fc-41d1-b977-6346671611ba
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T094159Z:45686aa8-51fc-41d1-b977-6346671611ba
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:41:59 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"d7022008-f6b1-4f4c-8be8-e2d677ef3261\",\r\n
+        \   \"availabilitySet\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/SPEC0DEPLY1AS\"\r\n
+        \   },\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_D1\"\r\n
+        \   },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
+        \"MicrosoftWindowsServer\",\r\n        \"offer\": \"WindowsServer\",\r\n        \"sku\":
+        \"2012-R2-Datacenter\",\r\n        \"version\": \"latest\"\r\n      },\r\n
+        \     \"osDisk\": {\r\n        \"osType\": \"Windows\",\r\n        \"name\":
+        \"osdisk\",\r\n        \"createOption\": \"FromImage\",\r\n        \"vhd\":
+        {\r\n          \"uri\": \"http://spec0deply1stor.blob.core.windows.net/vhds/osdisk0.vhd\"\r\n
+        \       },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n      \"dataDisks\":
+        []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"spec0deply1vm0\",\r\n
+        \     \"adminUsername\": \"deploy1admin\",\r\n      \"windowsConfiguration\":
+        {\r\n        \"provisionVMAgent\": true,\r\n        \"enableAutomaticUpdates\":
+        true\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\":
+        {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0\"}]},\r\n
+        \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
+        true,\r\n        \"storageUri\": \"http://spec0deply1stor.blob.core.windows.net\"\r\n
+        \     }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n
+        \ \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"tags\": {\r\n    \"Shutdown\": \"true\"\r\n  },\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0\",\r\n
+        \ \"name\": \"spec0deply1vm0\"\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:42:04 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDc0MDIsIm5iZiI6MTUyMDg0NzQwMiwiZXhwIjoxNTIwODUxMzAyLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYldDZVJlZzBva0tOM1V5STRIMGpBQSIsInZlciI6IjEuMCJ9.eQcibNRit9UpZReJbHfEsmiPLie_5JJmntSSqIl_3JhpZUk5RiY9C5-tpvcqgzi4T2gBYIWpCTaJATTECFPv8N6WD5grp4DvR8jTIAd6GymPo3g-NXmQkBj_SOQ30wf3FsCZgKP9lQpEJAW7fPQ2F8qhmSX_mPeeP2y7FPVL8WIkCw0KEMo8L1JgQDrW_oKLo6xG2BCl3XSHjezamVAYqafAg7_nHcOAPsKtYAeozxPnuEMfnLLpHwXsWoI_6SeHzTIeU00orNnTk71_yDFh6KcGqQ98uruMTawbXy8YiqUQznf9OfjqdCA2Qg7YybfSLBw6gY1eBGp27n13wOQAog
   response:
     status:
       code: 200
@@ -2467,57 +2905,1053 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"7a8e5fe7-f777-4435-992b-a54f28c2f28c"
+      - W/"2ec58a0b-4c03-4d0a-b788-9daffd54e7b2"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - bd22ca22-a01f-4ecf-9230-a4558fb66931
+      - 263a2a38-45dc-40bc-9ea2-6160331c51d9
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14985'
+      X-Ms-Correlation-Request-Id:
+      - ba7d7ffd-34cc-4cb4-9a2d-ad82e85fec6a
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T094200Z:ba7d7ffd-34cc-4cb4-9a2d-ad82e85fec6a
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:41:59 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"spec0deply1nic1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1\",\r\n
+        \ \"etag\": \"W/\\\"2ec58a0b-4c03-4d0a-b788-9daffd54e7b2\\\"\",\r\n  \"location\":
+        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"57bbf7aa-d6c4-4f56-8f6a-089d15334221\",\r\n    \"ipConfigurations\":
+        [\r\n      {\r\n        \"name\": \"ipconfig1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1\",\r\n
+        \       \"etag\": \"W/\\\"2ec58a0b-4c03-4d0a-b788-9daffd54e7b2\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"privateIPAddress\": \"10.0.0.5\",\r\n          \"privateIPAllocationMethod\":
+        \"Dynamic\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1\"\r\n
+        \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
+        \"IPv4\",\r\n          \"loadBalancerBackendAddressPools\": [\r\n            {\r\n
+        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\"\r\n
+        \           }\r\n          ],\r\n          \"loadBalancerInboundNatRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\":
+        {\r\n      \"dnsServers\": [],\r\n      \"appliedDnsServers\": []\r\n    },\r\n
+        \   \"enableAcceleratedNetworking\": false,\r\n    \"enableIPForwarding\":
+        false,\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1\"\r\n
+        \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
+        \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:42:04 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDc0MDIsIm5iZiI6MTUyMDg0NzQwMiwiZXhwIjoxNTIwODUxMzAyLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYldDZVJlZzBva0tOM1V5STRIMGpBQSIsInZlciI6IjEuMCJ9.eQcibNRit9UpZReJbHfEsmiPLie_5JJmntSSqIl_3JhpZUk5RiY9C5-tpvcqgzi4T2gBYIWpCTaJATTECFPv8N6WD5grp4DvR8jTIAd6GymPo3g-NXmQkBj_SOQ30wf3FsCZgKP9lQpEJAW7fPQ2F8qhmSX_mPeeP2y7FPVL8WIkCw0KEMo8L1JgQDrW_oKLo6xG2BCl3XSHjezamVAYqafAg7_nHcOAPsKtYAeozxPnuEMfnLLpHwXsWoI_6SeHzTIeU00orNnTk71_yDFh6KcGqQ98uruMTawbXy8YiqUQznf9OfjqdCA2Qg7YybfSLBw6gY1eBGp27n13wOQAog
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"b817491c-aab8-4aab-b41d-b07bfffa5639"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 61e28512-d691-49c2-9753-23ce3749622f
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14985'
+      X-Ms-Correlation-Request-Id:
+      - f193c8bf-e51e-40e5-87cd-a0eb600031c7
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T094205Z:f193c8bf-e51e-40e5-87cd-a0eb600031c7
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:42:05 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"spec0deply1nic0\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0\",\r\n
+        \ \"etag\": \"W/\\\"b817491c-aab8-4aab-b41d-b07bfffa5639\\\"\",\r\n  \"location\":
+        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"80ad9866-071d-4e3f-91d0-d47954eccee0\",\r\n    \"ipConfigurations\":
+        [\r\n      {\r\n        \"name\": \"ipconfig1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1\",\r\n
+        \       \"etag\": \"W/\\\"b817491c-aab8-4aab-b41d-b07bfffa5639\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"privateIPAddress\": \"10.0.0.4\",\r\n          \"privateIPAllocationMethod\":
+        \"Dynamic\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1\"\r\n
+        \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
+        \"IPv4\",\r\n          \"loadBalancerBackendAddressPools\": [\r\n            {\r\n
+        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\"\r\n
+        \           }\r\n          ],\r\n          \"loadBalancerInboundNatRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\":
+        {\r\n      \"dnsServers\": [],\r\n      \"appliedDnsServers\": []\r\n    },\r\n
+        \   \"enableAcceleratedNetworking\": false,\r\n    \"enableIPForwarding\":
+        false,\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0\"\r\n
+        \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
+        \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:42:10 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1/instanceView?api-version=2017-12-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDc0MDIsIm5iZiI6MTUyMDg0NzQwMiwiZXhwIjoxNTIwODUxMzAyLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYldDZVJlZzBva0tOM1V5STRIMGpBQSIsInZlciI6IjEuMCJ9.eQcibNRit9UpZReJbHfEsmiPLie_5JJmntSSqIl_3JhpZUk5RiY9C5-tpvcqgzi4T2gBYIWpCTaJATTECFPv8N6WD5grp4DvR8jTIAd6GymPo3g-NXmQkBj_SOQ30wf3FsCZgKP9lQpEJAW7fPQ2F8qhmSX_mPeeP2y7FPVL8WIkCw0KEMo8L1JgQDrW_oKLo6xG2BCl3XSHjezamVAYqafAg7_nHcOAPsKtYAeozxPnuEMfnLLpHwXsWoI_6SeHzTIeU00orNnTk71_yDFh6KcGqQ98uruMTawbXy8YiqUQznf9OfjqdCA2Qg7YybfSLBw6gY1eBGp27n13wOQAog
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/GetInstanceView3Min;4797,Microsoft.Compute/GetInstanceView30Min;23997
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344652126238
+      X-Ms-Request-Id:
+      - de5ea90d-b7b4-459c-89e9-103ecedf9ea0
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14983'
+      X-Ms-Correlation-Request-Id:
+      - d534b2cb-95eb-4a3b-9144-69fb450aeccc
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T094210Z:d534b2cb-95eb-4a3b-9144-69fb450aeccc
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:42:10 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"platformUpdateDomain\": 0,\r\n  \"platformFaultDomain\": 0,\r\n
+        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
+        [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
+        \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
+        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2018-03-12T09:42:06+00:00\"\r\n
+        \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"osdisk\",\r\n
+        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
+        succeeded\",\r\n          \"time\": \"2016-09-03T02:09:09.3853413+00:00\"\r\n
+        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
+        \"https://spec0deply1stor.blob.core.windows.net/bootdiagnostics-spec0depl-4d1502d5-351a-42f4-8569-22284f906d68/spec0deply1vm1.4d1502d5-351a-42f4-8569-22284f906d68.screenshot.bmp\",\r\n
+        \   \"serialConsoleLogBlobUri\": \"https://spec0deply1stor.blob.core.windows.net/bootdiagnostics-spec0depl-4d1502d5-351a-42f4-8569-22284f906d68/spec0deply1vm1.4d1502d5-351a-42f4-8569-22284f906d68.serialconsole.log\"\r\n
+        \ },\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n
+        \     \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n
+        \     \"time\": \"2016-09-03T02:09:09.4478672+00:00\"\r\n    },\r\n    {\r\n
+        \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
+        \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:42:15 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0/instanceView?api-version=2017-12-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDc0MDIsIm5iZiI6MTUyMDg0NzQwMiwiZXhwIjoxNTIwODUxMzAyLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYldDZVJlZzBva0tOM1V5STRIMGpBQSIsInZlciI6IjEuMCJ9.eQcibNRit9UpZReJbHfEsmiPLie_5JJmntSSqIl_3JhpZUk5RiY9C5-tpvcqgzi4T2gBYIWpCTaJATTECFPv8N6WD5grp4DvR8jTIAd6GymPo3g-NXmQkBj_SOQ30wf3FsCZgKP9lQpEJAW7fPQ2F8qhmSX_mPeeP2y7FPVL8WIkCw0KEMo8L1JgQDrW_oKLo6xG2BCl3XSHjezamVAYqafAg7_nHcOAPsKtYAeozxPnuEMfnLLpHwXsWoI_6SeHzTIeU00orNnTk71_yDFh6KcGqQ98uruMTawbXy8YiqUQznf9OfjqdCA2Qg7YybfSLBw6gY1eBGp27n13wOQAog
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/GetInstanceView3Min;4796,Microsoft.Compute/GetInstanceView30Min;23996
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344652126238
+      X-Ms-Request-Id:
+      - 11c6f277-ed2b-44ef-b5a6-798aad06a47e
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14987'
+      X-Ms-Correlation-Request-Id:
+      - ca307bb5-d12e-4de1-9c07-01a976803109
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T094211Z:ca307bb5-d12e-4de1-9c07-01a976803109
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:42:10 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"platformUpdateDomain\": 1,\r\n  \"platformFaultDomain\": 1,\r\n
+        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
+        [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
+        \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
+        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2018-03-12T09:42:11+00:00\"\r\n
+        \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"osdisk\",\r\n
+        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
+        succeeded\",\r\n          \"time\": \"2016-09-03T02:05:35.0977796+00:00\"\r\n
+        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
+        \"https://spec0deply1stor.blob.core.windows.net/bootdiagnostics-spec0depl-d7022008-f6b1-4f4c-8be8-e2d677ef3261/spec0deply1vm0.d7022008-f6b1-4f4c-8be8-e2d677ef3261.screenshot.bmp\",\r\n
+        \   \"serialConsoleLogBlobUri\": \"https://spec0deply1stor.blob.core.windows.net/bootdiagnostics-spec0depl-d7022008-f6b1-4f4c-8be8-e2d677ef3261/spec0deply1vm0.d7022008-f6b1-4f4c-8be8-e2d677ef3261.serialconsole.log\"\r\n
+        \ },\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n
+        \     \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n
+        \     \"time\": \"2016-09-03T02:05:35.1602741+00:00\"\r\n    },\r\n    {\r\n
+        \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
+        \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:42:16 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups/miq-azure-test1?api-version=2017-08-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDc0MDIsIm5iZiI6MTUyMDg0NzQwMiwiZXhwIjoxNTIwODUxMzAyLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYldDZVJlZzBva0tOM1V5STRIMGpBQSIsInZlciI6IjEuMCJ9.eQcibNRit9UpZReJbHfEsmiPLie_5JJmntSSqIl_3JhpZUk5RiY9C5-tpvcqgzi4T2gBYIWpCTaJATTECFPv8N6WD5grp4DvR8jTIAd6GymPo3g-NXmQkBj_SOQ30wf3FsCZgKP9lQpEJAW7fPQ2F8qhmSX_mPeeP2y7FPVL8WIkCw0KEMo8L1JgQDrW_oKLo6xG2BCl3XSHjezamVAYqafAg7_nHcOAPsKtYAeozxPnuEMfnLLpHwXsWoI_6SeHzTIeU00orNnTk71_yDFh6KcGqQ98uruMTawbXy8YiqUQznf9OfjqdCA2Qg7YybfSLBw6gY1eBGp27n13wOQAog
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14987'
+      X-Ms-Request-Id:
+      - d4d0745d-edbe-4fda-89a4-649eeb652b22
+      X-Ms-Correlation-Request-Id:
+      - d4d0745d-edbe-4fda-89a4-649eeb652b22
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T094211Z:d4d0745d-edbe-4fda-89a4-649eeb652b22
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:42:11 GMT
+      Content-Length:
+      - '183'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1","name":"miq-azure-test1","location":"eastus","properties":{"provisioningState":"Succeeded"}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:42:16 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute/locations/eastus/vmSizes?api-version=2017-12-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDc0MDIsIm5iZiI6MTUyMDg0NzQwMiwiZXhwIjoxNTIwODUxMzAyLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYldDZVJlZzBva0tOM1V5STRIMGpBQSIsInZlciI6IjEuMCJ9.eQcibNRit9UpZReJbHfEsmiPLie_5JJmntSSqIl_3JhpZUk5RiY9C5-tpvcqgzi4T2gBYIWpCTaJATTECFPv8N6WD5grp4DvR8jTIAd6GymPo3g-NXmQkBj_SOQ30wf3FsCZgKP9lQpEJAW7fPQ2F8qhmSX_mPeeP2y7FPVL8WIkCw0KEMo8L1JgQDrW_oKLo6xG2BCl3XSHjezamVAYqafAg7_nHcOAPsKtYAeozxPnuEMfnLLpHwXsWoI_6SeHzTIeU00orNnTk71_yDFh6KcGqQ98uruMTawbXy8YiqUQznf9OfjqdCA2Qg7YybfSLBw6gY1eBGp27n13wOQAog
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/LowCostGet3Min;4762,Microsoft.Compute/LowCostGet30Min;38362
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344652126238
+      X-Ms-Request-Id:
+      - 7a5bcd5f-ec95-472d-9224-a6a98f11cea7
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
       - '14986'
       X-Ms-Correlation-Request-Id:
-      - 19c674a8-c8da-4b5e-8265-5ebc21926459
+      - 01371d76-a39e-45d2-b445-75bde1fb09d5
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102420Z:19c674a8-c8da-4b5e-8265-5ebc21926459
+      - WESTEUROPE:20180312T094212Z:01371d76-a39e-45d2-b445-75bde1fb09d5
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:19 GMT
+      - Mon, 12 Mar 2018 09:42:11 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb2\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2\",\r\n
-        \ \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"e2e30a77-f81b-43fc-9693-08303e43deed\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/backendAddressPools/rspec-lb2-pool\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\r\n
-        \       }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\": [],\r\n    \"probes\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-probe\",\r\n        \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/probes/rspec-lb2-probe\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\": [],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
+      string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"Standard_B1ms\",\r\n
+        \     \"numberOfCores\": 1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        4096,\r\n      \"memoryInMB\": 2048,\r\n      \"maxDataDiskCount\": 2\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_B1s\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        2048,\r\n      \"memoryInMB\": 1024,\r\n      \"maxDataDiskCount\": 2\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_B2ms\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        16384,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_B2s\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        8192,\r\n      \"memoryInMB\": 4096,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_B4ms\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        32768,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_B8ms\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS1_v2\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        7168,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS2_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        14336,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS3_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS4_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS5_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS11-1_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS11_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS12-1_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS12-2_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS12_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS13-2_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS13-4_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS13_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS14-4_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        229376,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS14-8_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        229376,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS14_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        229376,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS15_v2\",\r\n      \"numberOfCores\":
+        20,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        286720,\r\n      \"memoryInMB\": 143360,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS2_v2_Promo\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        14336,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS3_v2_Promo\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS4_v2_Promo\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS5_v2_Promo\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS11_v2_Promo\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS12_v2_Promo\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS13_v2_Promo\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS14_v2_Promo\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        229376,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F1s\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        4096,\r\n      \"memoryInMB\": 2048,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F2s\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        8192,\r\n      \"memoryInMB\": 4096,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F4s\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        16384,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F8s\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        32768,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F16s\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D2s_v3\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        16384,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D4s_v3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        32768,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D8s_v3\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D16s_v3\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        131072,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D32s_v3\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        262144,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A0\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        20480,\r\n      \"memoryInMB\": 768,\r\n      \"maxDataDiskCount\": 1\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A1\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        71680,\r\n      \"memoryInMB\": 1792,\r\n      \"maxDataDiskCount\": 2\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        138240,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        291840,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A5\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        138240,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A4\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        619520,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A6\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        291840,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A7\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        619520,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Basic_A0\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        20480,\r\n      \"memoryInMB\": 768,\r\n      \"maxDataDiskCount\": 1\r\n
+        \   },\r\n    {\r\n      \"name\": \"Basic_A1\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        40960,\r\n      \"memoryInMB\": 1792,\r\n      \"maxDataDiskCount\": 2\r\n
+        \   },\r\n    {\r\n      \"name\": \"Basic_A2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        61440,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Basic_A3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        122880,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Basic_A4\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        245760,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D1_v2\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        51200,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D2_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D3_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D4_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D5_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D11_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D12_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D13_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D14_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D15_v2\",\r\n      \"numberOfCores\":
+        20,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        286720,\r\n      \"memoryInMB\": 143360,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D2_v2_Promo\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D3_v2_Promo\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D4_v2_Promo\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D5_v2_Promo\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D11_v2_Promo\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D12_v2_Promo\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D13_v2_Promo\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D14_v2_Promo\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F1\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        16384,\r\n      \"memoryInMB\": 2048,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        32768,\r\n      \"memoryInMB\": 4096,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F4\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F8\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        131072,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F16\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        262144,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A1_v2\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        10240,\r\n      \"memoryInMB\": 2048,\r\n      \"maxDataDiskCount\": 2\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A2m_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        20480,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A2_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        20480,\r\n      \"memoryInMB\": 4096,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A4m_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        40960,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A4_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        40960,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A8m_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        81920,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A8_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        81920,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D2_v3\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        51200,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D4_v3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D8_v3\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D16_v3\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 65636,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D32_v3\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_H8\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1024000,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_H16\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        2048000,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_H8m\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1024000,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_H16m\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        2048000,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_H16r\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        2048000,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_H16mr\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        2048000,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D1\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        51200,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D4\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D11\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D12\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D13\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D14\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NV6\",\r\n      \"numberOfCores\":
+        6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        389120,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 24\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NV12\",\r\n      \"numberOfCores\":
+        12,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        696320,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 48\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NV24\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1474560,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC6s_v2\",\r\n      \"numberOfCores\":
+        6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        344064,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 12\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC12s_v2\",\r\n      \"numberOfCores\":
+        12,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        688128,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 24\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC24rs_v2\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1376256,\r\n      \"memoryInMB\": 458752,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC24s_v2\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1376256,\r\n      \"memoryInMB\": 458752,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC6\",\r\n      \"numberOfCores\":
+        6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        389120,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 24\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC12\",\r\n      \"numberOfCores\":
+        12,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        696320,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 48\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC24\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1474560,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC24r\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1474560,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS1\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        7168,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        14336,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS4\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS11\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS12\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS13\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS14\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        229376,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC6s_v3\",\r\n      \"numberOfCores\":
+        6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        344064,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 12\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC12s_v3\",\r\n      \"numberOfCores\":
+        12,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        688128,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 24\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC24rs_v3\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1376256,\r\n      \"memoryInMB\": 458752,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC24s_v3\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1376256,\r\n      \"memoryInMB\": 458752,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D64_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1638400,\r\n      \"memoryInMB\": 262144,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D64s_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        524288,\r\n      \"memoryInMB\": 262144,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E2_v3\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        51200,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E4_v3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E8_v3\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E16_v3\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E32_v3\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 262144,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E64i_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1638400,\r\n      \"memoryInMB\": 442368,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E64_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1638400,\r\n      \"memoryInMB\": 442368,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E2s_v3\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        32768,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E4-2s_v3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E4s_v3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E8-2s_v3\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        131072,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E8-4s_v3\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        131072,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E8s_v3\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        131072,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E16-4s_v3\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        262144,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E16-8s_v3\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        262144,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E16s_v3\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        262144,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E32-8s_v3\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        524288,\r\n      \"memoryInMB\": 262144,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E32-16s_v3\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        524288,\r\n      \"memoryInMB\": 262144,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E32s_v3\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        524288,\r\n      \"memoryInMB\": 262144,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E64-16s_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        884736,\r\n      \"memoryInMB\": 442368,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E64-32s_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        884736,\r\n      \"memoryInMB\": 442368,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E64is_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        884736,\r\n      \"memoryInMB\": 442368,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E64s_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        884736,\r\n      \"memoryInMB\": 442368,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F2s_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        16384,\r\n      \"memoryInMB\": 4096,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F4s_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        32768,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F8s_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F16s_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        131072,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F32s_v2\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        262144,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F64s_v2\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        524288,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F72s_v2\",\r\n      \"numberOfCores\":
+        72,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        589824,\r\n      \"memoryInMB\": 147456,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_L8s_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1811981,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_L16s_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        3623962,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_ND6s\",\r\n      \"numberOfCores\":
+        6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        344064,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 12\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_ND12s\",\r\n      \"numberOfCores\":
+        12,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        688128,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 24\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_ND24rs\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1376256,\r\n      \"memoryInMB\": 458752,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_ND24s\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1376256,\r\n      \"memoryInMB\": 458752,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A8\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        391168,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A9\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        391168,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A10\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        391168,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A11\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        391168,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:25 GMT
+  recorded_at: Mon, 12 Mar 2018 09:42:16 GMT
+- request:
+    method: post
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-deployment-dont-delete/exportTemplate?api-version=2017-08-01
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDc0MDIsIm5iZiI6MTUyMDg0NzQwMiwiZXhwIjoxNTIwODUxMzAyLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYldDZVJlZzBva0tOM1V5STRIMGpBQSIsInZlciI6IjEuMCJ9.eQcibNRit9UpZReJbHfEsmiPLie_5JJmntSSqIl_3JhpZUk5RiY9C5-tpvcqgzi4T2gBYIWpCTaJATTECFPv8N6WD5grp4DvR8jTIAd6GymPo3g-NXmQkBj_SOQ30wf3FsCZgKP9lQpEJAW7fPQ2F8qhmSX_mPeeP2y7FPVL8WIkCw0KEMo8L1JgQDrW_oKLo6xG2BCl3XSHjezamVAYqafAg7_nHcOAPsKtYAeozxPnuEMfnLLpHwXsWoI_6SeHzTIeU00orNnTk71_yDFh6KcGqQ98uruMTawbXy8YiqUQznf9OfjqdCA2Qg7YybfSLBw6gY1eBGp27n13wOQAog
+      Content-Length:
+      - '0'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Writes:
+      - '1196'
+      X-Ms-Request-Id:
+      - 2ae5698b-4f09-4236-8832-bc69f02c91c4
+      X-Ms-Correlation-Request-Id:
+      - 2ae5698b-4f09-4236-8832-bc69f02c91c4
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T094213Z:2ae5698b-4f09-4236-8832-bc69f02c91c4
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:42:12 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"template":{"$schema":"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#","contentVersion":"1.0.0.0","parameters":{"childDeployName":{"type":"String"},"storageAccountName":{"type":"String","metadata":{"description":"Name
+        of storage account"}},"availabilitySetName":{"type":"String","metadata":{"description":"Name
+        of availability set"}},"adminUsername":{"type":"String","metadata":{"description":"Admin
+        username"}},"adminPassword":{"type":"SecureString","metadata":{"description":"Admin
+        password"}},"dnsNameforLBIP":{"type":"String","metadata":{"description":"DNS
+        for Load Balancer IP"}},"vmNamePrefix":{"defaultValue":"myVM","type":"String","metadata":{"description":"Prefix
+        to use for VM names"}},"imagePublisher":{"defaultValue":"MicrosoftWindowsServer","type":"String","metadata":{"description":"Image
+        Publisher"}},"imageOffer":{"defaultValue":"WindowsServer","type":"String","metadata":{"description":"Image
+        Offer"}},"imageSKU":{"defaultValue":"2012-R2-Datacenter","type":"String","metadata":{"description":"Image
+        SKU"}},"lbName":{"defaultValue":"myLB","type":"String","metadata":{"description":"Load
+        Balancer name"}},"nicNamePrefix":{"defaultValue":"nic","type":"String","metadata":{"description":"Network
+        Interface name prefix"}},"publicIPAddressName":{"defaultValue":"myPublicIP","type":"String","metadata":{"description":"Public
+        IP Name"}},"vnetName":{"defaultValue":"myVNET","type":"String","metadata":{"description":"VNET
+        name"}},"vmSize":{"defaultValue":"Standard_D1","type":"String","metadata":{"description":"Size
+        of the VM"}}},"resources":[{"type":"Microsoft.Resources/deployments","name":"[parameters(''childDeployName'')]","apiVersion":"2015-01-01","properties":{"mode":"Incremental","templateLink":{"uri":"https://gist.githubusercontent.com/bzwei/c09f906306399d238762bce711781200/raw/3558b735da03c1c030023d70b78ec3451dab5689/azure-loadbalancer.json","contentVersion":"1.0.0.0"},"parameters":{"storageAccountName":{"value":"[parameters(''storageAccountName'')]"},"availabilitySetName":{"value":"[parameters(''availabilitySetName'')]"},"adminUsername":{"value":"[parameters(''adminUsername'')]"},"adminPassword":{"value":"[parameters(''adminPassword'')]"},"dnsNameforLBIP":{"value":"[parameters(''dnsNameforLBIP'')]"},"vmNamePrefix":{"value":"[parameters(''vmNamePrefix'')]"},"imagePublisher":{"value":"[parameters(''imagePublisher'')]"},"imageOffer":{"value":"[parameters(''imageOffer'')]"},"imageSKU":{"value":"[parameters(''imageSKU'')]"},"lbName":{"value":"[parameters(''lbName'')]"},"nicNamePrefix":{"value":"[parameters(''nicNamePrefix'')]"},"publicIPAddressName":{"value":"[parameters(''publicIPAddressName'')]"},"vnetName":{"value":"[parameters(''vnetName'')]"},"vmSize":{"value":"[parameters(''vmSize'')]"}}}}],"outputs":{"siteUri":{"type":"String","value":"hard-coded
+        output for test"}}}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:42:18 GMT
+- request:
+    method: post
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/exportTemplate?api-version=2017-08-01
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDc0MDIsIm5iZiI6MTUyMDg0NzQwMiwiZXhwIjoxNTIwODUxMzAyLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYldDZVJlZzBva0tOM1V5STRIMGpBQSIsInZlciI6IjEuMCJ9.eQcibNRit9UpZReJbHfEsmiPLie_5JJmntSSqIl_3JhpZUk5RiY9C5-tpvcqgzi4T2gBYIWpCTaJATTECFPv8N6WD5grp4DvR8jTIAd6GymPo3g-NXmQkBj_SOQ30wf3FsCZgKP9lQpEJAW7fPQ2F8qhmSX_mPeeP2y7FPVL8WIkCw0KEMo8L1JgQDrW_oKLo6xG2BCl3XSHjezamVAYqafAg7_nHcOAPsKtYAeozxPnuEMfnLLpHwXsWoI_6SeHzTIeU00orNnTk71_yDFh6KcGqQ98uruMTawbXy8YiqUQznf9OfjqdCA2Qg7YybfSLBw6gY1eBGp27n13wOQAog
+      Content-Length:
+      - '0'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Writes:
+      - '1199'
+      X-Ms-Request-Id:
+      - b084944a-c0df-42c5-9878-0dbd6165d59d
+      X-Ms-Correlation-Request-Id:
+      - b084944a-c0df-42c5-9878-0dbd6165d59d
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T094214Z:b084944a-c0df-42c5-9878-0dbd6165d59d
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:42:13 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"template":{"$schema":"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json","contentVersion":"1.0.0.0","parameters":{"storageAccountName":{"type":"String","metadata":{"description":"Name
+        of storage account"}},"availabilitySetName":{"type":"String","metadata":{"description":"Name
+        of availability set"}},"adminUsername":{"type":"String","metadata":{"description":"Admin
+        username"}},"adminPassword":{"type":"SecureString","metadata":{"description":"Admin
+        password"}},"dnsNameforLBIP":{"type":"String","metadata":{"description":"DNS
+        for Load Balancer IP"}},"vmNamePrefix":{"defaultValue":"myVM","type":"String","metadata":{"description":"Prefix
+        to use for VM names"}},"imagePublisher":{"defaultValue":"MicrosoftWindowsServer","type":"String","metadata":{"description":"Image
+        Publisher"}},"imageOffer":{"defaultValue":"WindowsServer","type":"String","metadata":{"description":"Image
+        Offer"}},"imageSKU":{"defaultValue":"2012-R2-Datacenter","type":"String","metadata":{"description":"Image
+        SKU"}},"lbName":{"defaultValue":"myLB","type":"String","metadata":{"description":"Load
+        Balancer name"}},"nicNamePrefix":{"defaultValue":"nic","type":"String","metadata":{"description":"Network
+        Interface name prefix"}},"publicIPAddressName":{"defaultValue":"myPublicIP","type":"String","metadata":{"description":"Public
+        IP Name"}},"vnetName":{"defaultValue":"myVNET","type":"String","metadata":{"description":"VNET
+        name"}},"vmSize":{"defaultValue":"Standard_D1","type":"String","metadata":{"description":"Size
+        of the VM"}}},"variables":{"storageAccountType":"Standard_LRS","addressPrefix":"10.0.0.0/16","subnetName":"Subnet-1","subnetPrefix":"10.0.0.0/24","publicIPAddressType":"Dynamic","vnetID":"[resourceId(''Microsoft.Network/virtualNetworks'',parameters(''vnetName''))]","subnetRef":"[concat(variables(''vnetID''),''/subnets/'',variables
+        (''subnetName''))]","publicIPAddressID":"[resourceId(''Microsoft.Network/publicIPAddresses'',parameters(''publicIPAddressName''))]","numberOfInstances":2,"lbID":"[resourceId(''Microsoft.Network/loadBalancers'',parameters(''lbName''))]","frontEndIPConfigID":"[concat(variables(''lbID''),''/frontendIPConfigurations/LoadBalancerFrontEnd'')]","lbPoolID":"[concat(variables(''lbID''),''/backendAddressPools/BackendPool1'')]","lbProbeID":"[concat(variables(''lbID''),''/probes/tcpProbe'')]"},"resources":[{"type":"Microsoft.Storage/storageAccounts","name":"[parameters(''storageAccountName'')]","apiVersion":"2015-05-01-preview","location":"[resourceGroup().location]","properties":{"accountType":"[variables(''storageAccountType'')]"}},{"type":"Microsoft.Compute/availabilitySets","name":"[parameters(''availabilitySetName'')]","apiVersion":"2015-05-01-preview","location":"[resourceGroup().location]","properties":{}},{"type":"Microsoft.Network/publicIPAddresses","name":"[parameters(''publicIPAddressName'')]","apiVersion":"2015-05-01-preview","location":"[resourceGroup().location]","properties":{"publicIPAllocationMethod":"[variables(''publicIPAddressType'')]","dnsSettings":{"domainNameLabel":"[parameters(''dnsNameforLBIP'')]"}}},{"type":"Microsoft.Network/virtualNetworks","name":"[parameters(''vnetName'')]","apiVersion":"2015-05-01-preview","location":"[resourceGroup().location]","properties":{"addressSpace":{"addressPrefixes":["[variables(''addressPrefix'')]"]},"subnets":[{"name":"[variables(''subnetName'')]","properties":{"addressPrefix":"[variables(''subnetPrefix'')]"}}]}},{"type":"Microsoft.Network/networkInterfaces","name":"[concat(parameters(''nicNamePrefix''),
+        copyindex())]","apiVersion":"2015-05-01-preview","location":"[resourceGroup().location]","copy":{"name":"nicLoop","count":"[variables(''numberOfInstances'')]"},"properties":{"ipConfigurations":[{"name":"ipconfig1","properties":{"privateIPAllocationMethod":"Dynamic","subnet":{"id":"[variables(''subnetRef'')]"},"loadBalancerBackendAddressPools":[{"id":"[concat(variables(''lbID''),
+        ''/backendAddressPools/BackendPool1'')]"}],"loadBalancerInboundNatRules":[{"id":"[concat(variables(''lbID''),''/inboundNatRules/RDP-VM'',
+        copyindex())]"}]}}]},"dependsOn":["[concat(''Microsoft.Network/virtualNetworks/'',
+        parameters(''vnetName''))]","[concat(''Microsoft.Network/loadBalancers/'',
+        parameters(''lbName''))]"]},{"type":"Microsoft.Network/loadBalancers","name":"[parameters(''lbName'')]","apiVersion":"2015-05-01-preview","location":"[resourceGroup().location]","properties":{"frontendIPConfigurations":[{"name":"LoadBalancerFrontEnd","properties":{"publicIPAddress":{"id":"[variables(''publicIPAddressID'')]"}}}],"backendAddressPools":[{"name":"BackendPool1"}],"inboundNatRules":[{"name":"RDP-VM0","properties":{"frontendIPConfiguration":{"id":"[variables(''frontEndIPConfigID'')]"},"protocol":"tcp","frontendPort":50001,"backendPort":3389,"enableFloatingIP":false}},{"name":"RDP-VM1","properties":{"frontendIPConfiguration":{"id":"[variables(''frontEndIPConfigID'')]"},"protocol":"tcp","frontendPort":50002,"backendPort":3389,"enableFloatingIP":false}}],"loadBalancingRules":[{"name":"LBRule","properties":{"frontendIPConfiguration":{"id":"[variables(''frontEndIPConfigID'')]"},"backendAddressPool":{"id":"[variables(''lbPoolID'')]"},"protocol":"tcp","frontendPort":80,"backendPort":80,"enableFloatingIP":false,"idleTimeoutInMinutes":5,"probe":{"id":"[variables(''lbProbeID'')]"}}}],"probes":[{"name":"tcpProbe","properties":{"protocol":"tcp","port":80,"intervalInSeconds":5,"numberOfProbes":2}}]},"dependsOn":["[concat(''Microsoft.Network/publicIPAddresses/'',
+        parameters(''publicIPAddressName''))]"]},{"type":"Microsoft.Compute/virtualMachines","name":"[concat(parameters(''vmNamePrefix''),
+        copyindex())]","apiVersion":"2015-06-15","location":"[resourceGroup().location]","copy":{"name":"virtualMachineLoop","count":"[variables(''numberOfInstances'')]"},"properties":{"availabilitySet":{"id":"[resourceId(''Microsoft.Compute/availabilitySets'',parameters(''availabilitySetName''))]"},"hardwareProfile":{"vmSize":"[parameters(''vmSize'')]"},"osProfile":{"computerName":"[concat(parameters(''vmNamePrefix''),
+        copyIndex())]","adminUsername":"[parameters(''adminUsername'')]","adminPassword":"[parameters(''adminPassword'')]"},"storageProfile":{"imageReference":{"publisher":"[parameters(''imagePublisher'')]","offer":"[parameters(''imageOffer'')]","sku":"[parameters(''imageSKU'')]","version":"latest"},"osDisk":{"name":"osdisk","vhd":{"uri":"[concat(''http://'',parameters(''storageAccountName''),''.blob.core.windows.net/vhds/'',''osdisk'',
+        copyindex(), ''.vhd'')]"},"caching":"ReadWrite","createOption":"FromImage"}},"networkProfile":{"networkInterfaces":[{"id":"[resourceId(''Microsoft.Network/networkInterfaces'',concat(parameters(''nicNamePrefix''),copyindex()))]"}]},"diagnosticsProfile":{"bootDiagnostics":{"enabled":"true","storageUri":"[concat(''http://'',parameters(''storageAccountName''),''.blob.core.windows.net'')]"}}},"dependsOn":["[concat(''Microsoft.Storage/storageAccounts/'',
+        parameters(''storageAccountName''))]","[concat(''Microsoft.Network/networkInterfaces/'',
+        parameters(''nicNamePrefix''), copyindex())]","[concat(''Microsoft.Compute/availabilitySets/'',
+        parameters(''availabilitySetName''))]"]}]}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:42:18 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor?api-version=2017-10-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2531,7 +3965,293 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDc0MDIsIm5iZiI6MTUyMDg0NzQwMiwiZXhwIjoxNTIwODUxMzAyLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYldDZVJlZzBva0tOM1V5STRIMGpBQSIsInZlciI6IjEuMCJ9.eQcibNRit9UpZReJbHfEsmiPLie_5JJmntSSqIl_3JhpZUk5RiY9C5-tpvcqgzi4T2gBYIWpCTaJATTECFPv8N6WD5grp4DvR8jTIAd6GymPo3g-NXmQkBj_SOQ30wf3FsCZgKP9lQpEJAW7fPQ2F8qhmSX_mPeeP2y7FPVL8WIkCw0KEMo8L1JgQDrW_oKLo6xG2BCl3XSHjezamVAYqafAg7_nHcOAPsKtYAeozxPnuEMfnLLpHwXsWoI_6SeHzTIeU00orNnTk71_yDFh6KcGqQ98uruMTawbXy8YiqUQznf9OfjqdCA2Qg7YybfSLBw6gY1eBGp27n13wOQAog
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 2ccca415-5a83-40a7-9785-4a9e6776d807
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14985'
+      X-Ms-Correlation-Request-Id:
+      - df03dd1f-51ff-4091-8184-0c0ce3bd2317
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T094214Z:df03dd1f-51ff-4091-8184-0c0ce3bd2317
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:42:14 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","name":"spec0deply1stor","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-04-04T23:05:07.8274794Z","primaryEndpoints":{"blob":"https://spec0deply1stor.blob.core.windows.net/","queue":"https://spec0deply1stor.queue.core.windows.net/","table":"https://spec0deply1stor.table.core.windows.net/","file":"https://spec0deply1stor.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:42:19 GMT
+- request:
+    method: post
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor/listKeys?api-version=2017-10-01
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDc0MDIsIm5iZiI6MTUyMDg0NzQwMiwiZXhwIjoxNTIwODUxMzAyLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYldDZVJlZzBva0tOM1V5STRIMGpBQSIsInZlciI6IjEuMCJ9.eQcibNRit9UpZReJbHfEsmiPLie_5JJmntSSqIl_3JhpZUk5RiY9C5-tpvcqgzi4T2gBYIWpCTaJATTECFPv8N6WD5grp4DvR8jTIAd6GymPo3g-NXmQkBj_SOQ30wf3FsCZgKP9lQpEJAW7fPQ2F8qhmSX_mPeeP2y7FPVL8WIkCw0KEMo8L1JgQDrW_oKLo6xG2BCl3XSHjezamVAYqafAg7_nHcOAPsKtYAeozxPnuEMfnLLpHwXsWoI_6SeHzTIeU00orNnTk71_yDFh6KcGqQ98uruMTawbXy8YiqUQznf9OfjqdCA2Qg7YybfSLBw6gY1eBGp27n13wOQAog
+      Content-Length:
+      - '0'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - f6e1127d-d555-44cf-8fb7-ce9539de8790
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Writes:
+      - '1197'
+      X-Ms-Correlation-Request-Id:
+      - c3ca0c91-5852-4ba3-8191-85401bc75173
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T094215Z:c3ca0c91-5852-4ba3-8191-85401bc75173
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:42:14 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"keys":[{"keyName":"key1","value":"68JHlwL/JgyPmvNCqop65JbepxzK0RGKJ4uD6EKszcgv1nRUJKkxO6u4OoyW/6YPT+FMJxvzEBrCGD/bduFGJQ==","permissions":"Full"},{"keyName":"key2","value":"NCT/sPC/+mrVRzXq/V5IwjN2SPaWRF4kY2coPHzJ8f+IkWMUIyfUgYTAN//h4KnxeWuX9OkY1CPyssDhDs91fw==","permissions":"Full"}]}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:42:19 GMT
+- request:
+    method: head
+    uri: https://spec0deply1stor.blob.core.windows.net/vhds/osdisk1.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:42:19 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey spec0deply1stor:bFe2Qmg/AX3PoZqb/onLlapGs6jdDC1v8b8aeX3N8OM=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - VbYhW9/6NOXzQVK/vQkdvg==
+      Last-Modified:
+      - Sat, 03 Sep 2016 02:06:37 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D3D39EF02E16B7"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - ae38ac65-001e-0118-0ce6-b94dbf000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Meta-Microsoftazurecompute-Resourcegroupname:
+      - miq-azure-test1
+      X-Ms-Meta-Microsoftazurecompute-Vmname:
+      - spec0deply1vm1
+      X-Ms-Meta-Microsoftazurecompute-Diskid:
+      - 3ce1f79e-7ba1-43e5-a97d-5a49a1a1a02e
+      X-Ms-Meta-Microsoftazurecompute-Diskname:
+      - osdisk
+      X-Ms-Meta-Microsoftazurecompute-Disktype:
+      - OSDisk
+      X-Ms-Lease-Status:
+      - locked
+      X-Ms-Lease-State:
+      - leased
+      X-Ms-Lease-Duration:
+      - infinite
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '53'
+      X-Ms-Copy-Id:
+      - 36fd9dad-148c-4f34-b2af-561feb937d76
+      X-Ms-Copy-Source:
+      - https://ardfepirv2bl5prdstr06.blob.core.windows.net/a699494373c04fc0bc8f2bb1389d6106/Windows-Server-2012-R2-20160229-en.us-127GB.vhd?sv=2014-02-14&sr=b&si=PirCacheAccountPublisherContainerPolicy&sig=ipib%2Bgp2Sh4hS%2BBx5OUKgXSymDC0Tu0Ge60PGFuy5uk%3D
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Mon, 04 Apr 2016 23:24:57 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Mon, 12 Mar 2018 09:42:15 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:42:20 GMT
+- request:
+    method: head
+    uri: https://spec0deply1stor.blob.core.windows.net/vhds/osdisk0.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:42:20 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey spec0deply1stor:q4k0z0Bzh0R/99lnrq2Y8H9Ali39YYdxzbjfh37FiQs=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - VbYhW9/6NOXzQVK/vQkdvg==
+      Last-Modified:
+      - Sat, 03 Sep 2016 02:04:38 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D3D39EA8F71715"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 627e85ec-001e-0130-42e6-b93a00000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Meta-Microsoftazurecompute-Resourcegroupname:
+      - miq-azure-test1
+      X-Ms-Meta-Microsoftazurecompute-Vmname:
+      - spec0deply1vm0
+      X-Ms-Meta-Microsoftazurecompute-Diskid:
+      - b059fe2a-4ccb-4a50-a235-ea3b7b089730
+      X-Ms-Meta-Microsoftazurecompute-Diskname:
+      - osdisk
+      X-Ms-Meta-Microsoftazurecompute-Disktype:
+      - OSDisk
+      X-Ms-Lease-Status:
+      - locked
+      X-Ms-Lease-State:
+      - leased
+      X-Ms-Lease-Duration:
+      - infinite
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '43'
+      X-Ms-Copy-Id:
+      - 27fb6a34-f422-4f0a-afcb-528942d6012f
+      X-Ms-Copy-Source:
+      - https://ardfepirv2bl5prdstr06.blob.core.windows.net/a699494373c04fc0bc8f2bb1389d6106/Windows-Server-2012-R2-20160229-en.us-127GB.vhd?sv=2014-02-14&sr=b&si=PirCacheAccountPublisherContainerPolicy&sig=ipib%2Bgp2Sh4hS%2BBx5OUKgXSymDC0Tu0Ge60PGFuy5uk%3D
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Mon, 04 Apr 2016 23:24:57 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Mon, 12 Mar 2018 09:42:16 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:42:21 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDc0MDIsIm5iZiI6MTUyMDg0NzQwMiwiZXhwIjoxNTIwODUxMzAyLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYldDZVJlZzBva0tOM1V5STRIMGpBQSIsInZlciI6IjEuMCJ9.eQcibNRit9UpZReJbHfEsmiPLie_5JJmntSSqIl_3JhpZUk5RiY9C5-tpvcqgzi4T2gBYIWpCTaJATTECFPv8N6WD5grp4DvR8jTIAd6GymPo3g-NXmQkBj_SOQ30wf3FsCZgKP9lQpEJAW7fPQ2F8qhmSX_mPeeP2y7FPVL8WIkCw0KEMo8L1JgQDrW_oKLo6xG2BCl3XSHjezamVAYqafAg7_nHcOAPsKtYAeozxPnuEMfnLLpHwXsWoI_6SeHzTIeU00orNnTk71_yDFh6KcGqQ98uruMTawbXy8YiqUQznf9OfjqdCA2Qg7YybfSLBw6gY1eBGp27n13wOQAog
   response:
     status:
       code: 200
@@ -2548,42 +4268,48 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"a38434c8-7b23-4092-b7c6-402238eac0dc"
+      - W/"be3510b0-35c7-48ea-874b-49ac343ba8c9"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 0fd15240-6a1c-4b39-a4f6-aa53fd8591c2
+      - b55680e1-f970-4457-a5bb-def8b536a5ab
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
+      - '14991'
       X-Ms-Correlation-Request-Id:
-      - 5cc03163-922e-41a1-9601-dba2d7cf2a81
+      - f783b5e5-d514-43e9-bb9a-a16fba25e87d
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102421Z:5cc03163-922e-41a1-9601-dba2d7cf2a81
+      - WESTEUROPE:20180312T094216Z:f783b5e5-d514-43e9-bb9a-a16fba25e87d
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:20 GMT
+      - Mon, 12 Mar 2018 09:42:16 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb1-LoadBalancerFrontEnd\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\",\r\n
-        \ \"etag\": \"W/\\\"a38434c8-7b23-4092-b7c6-402238eac0dc\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"f28e0f25-b372-4edf-97d9-13a9e3b4ba2d\",\r\n    \"ipAddress\":
-        \"40.71.82.83\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\":
-        \"Static\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipTags\": [],\r\n
-        \   \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
-        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
+      string: "{\r\n  \"name\": \"spec0deply1vnet\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet\",\r\n
+        \ \"etag\": \"W/\\\"be3510b0-35c7-48ea-874b-49ac343ba8c9\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
+        \"0bb1f005-1af2-4d4b-966a-89aaf6daefca\",\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\":
+        [\r\n        \"10.0.0.0/16\"\r\n      ]\r\n    },\r\n    \"subnets\": [\r\n
+        \     {\r\n        \"name\": \"Subnet-1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1\",\r\n
+        \       \"etag\": \"W/\\\"be3510b0-35c7-48ea-874b-49ac343ba8c9\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"addressPrefix\": \"10.0.0.0/24\",\r\n          \"ipConfigurations\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"virtualNetworkPeerings\":
+        [],\r\n    \"enableDdosProtection\": false,\r\n    \"enableVmProtection\":
+        false\r\n  }\r\n}"
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:25 GMT
+  recorded_at: Mon, 12 Mar 2018 09:42:21 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip?api-version=2018-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2597,7 +4323,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDc0MDIsIm5iZiI6MTUyMDg0NzQwMiwiZXhwIjoxNTIwODUxMzAyLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYldDZVJlZzBva0tOM1V5STRIMGpBQSIsInZlciI6IjEuMCJ9.eQcibNRit9UpZReJbHfEsmiPLie_5JJmntSSqIl_3JhpZUk5RiY9C5-tpvcqgzi4T2gBYIWpCTaJATTECFPv8N6WD5grp4DvR8jTIAd6GymPo3g-NXmQkBj_SOQ30wf3FsCZgKP9lQpEJAW7fPQ2F8qhmSX_mPeeP2y7FPVL8WIkCw0KEMo8L1JgQDrW_oKLo6xG2BCl3XSHjezamVAYqafAg7_nHcOAPsKtYAeozxPnuEMfnLLpHwXsWoI_6SeHzTIeU00orNnTk71_yDFh6KcGqQ98uruMTawbXy8YiqUQznf9OfjqdCA2Qg7YybfSLBw6gY1eBGp27n13wOQAog
   response:
     status:
       code: 200
@@ -2614,36 +4340,38 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"cddd97d1-6111-4477-8a00-3dc885237a1d"
+      - W/"2080997a-38a6-420d-ba86-e9582e1331c7"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 1403e5b6-8fa0-4cd3-89b1-76b6c4fd805b
+      - e8df49b0-3bc1-414d-b426-152d27d30d17
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - '14984'
       X-Ms-Correlation-Request-Id:
-      - e4a5f369-a742-466f-bd8f-42e17eaaf9c9
+      - d001df4d-481b-4618-95c1-0cef384e8950
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102421Z:e4a5f369-a742-466f-bd8f-42e17eaaf9c9
+      - WESTEUROPE:20180312T094217Z:d001df4d-481b-4618-95c1-0cef384e8950
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:21 GMT
+      - Mon, 12 Mar 2018 09:42:16 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb2-publicip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\",\r\n
-        \ \"etag\": \"W/\\\"cddd97d1-6111-4477-8a00-3dc885237a1d\\\"\",\r\n  \"location\":
+      string: "{\r\n  \"name\": \"spec0deply1ip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip\",\r\n
+        \ \"etag\": \"W/\\\"2080997a-38a6-420d-ba86-e9582e1331c7\\\"\",\r\n  \"location\":
         \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"83e7257d-ab94-4229-8eb5-4798f37ef28d\",\r\n    \"publicIPAddressVersion\":
+        \   \"resourceGuid\": \"a08b891e-e45a-4970-aefc-f6c996989490\",\r\n    \"publicIPAddressVersion\":
         \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
-        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
+        4,\r\n    \"dnsSettings\": {\r\n      \"domainNameLabel\": \"spec0deply1dns\",\r\n
+        \     \"fqdn\": \"spec0deply1dns.eastus.cloudapp.azure.com\"\r\n    },\r\n
+        \   \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
         \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
         \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:26 GMT
+  recorded_at: Mon, 12 Mar 2018 09:42:22 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_500/orchestration_stack_vm_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_500/orchestration_stack_vm_refresh.yml
@@ -1,62 +1,6 @@
 ---
 http_interactions:
 - request:
-    method: post
-    uri: https://login.microsoftonline.com/AZURE_TENANT_ID/oauth2/token
-    body:
-      encoding: UTF-8
-      string: grant_type=client_credentials&client_id=AZURE_CLIENT_ID&client_secret=AZURE_CLIENT_SECRET&resource=https%3A%2F%2Fmanagement.azure.com%2F
-    headers:
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Length:
-      - '186'
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache, no-store
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Server:
-      - Microsoft-IIS/10.0
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Ms-Request-Id:
-      - 8b09d999-d3c1-473e-95c3-7c6bf7750000
-      P3p:
-      - CP="DSP CUR OTPi IND OTRi ONL FIN"
-      Set-Cookie:
-      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzkIj2QwY5QFK43_GwiIr50TJTG7GMUiTwh0coQKPvNdRekVOmsIO-6YC8blwrsqdL6WdWxj9-iRF7-9Eo1dsy0h-ZJRhQEujzigLVY8Vc__DOncwquR5NT_SjfnAlWFU0wGX7ldSCnego314gmfyUOWGNbG6uK3bJYIH8zAP0MFUgAA;
-        domain=.login.microsoftonline.com; path=/; secure; HttpOnly
-      - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=004; path=/; secure; HttpOnly
-      X-Powered-By:
-      - ASP.NET
-      Date:
-      - Wed, 07 Mar 2018 20:18:57 GMT
-      Content-Length:
-      - '1505'
-    body:
-      encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3600","ext_expires_in":"0","expires_on":"1520457537","not_before":"1520453637","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2MzcsIm5iZiI6MTUyMDQ1MzYzNywiZXhwIjoxNTIwNDU3NTM3LCJhaW8iOiJZMk5nWUVndU5CSXl1MXFVeEdEM2ZsSFpieWtHQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibWRrSmk4SFRQa2VWdzN4cjkzVUFBQSIsInZlciI6IjEuMCJ9.J3fkRceBnuqHzbCWXI9FkZKmAqJH5NA_gajQkr41F04fYdtfIyuU_a80xJSZKU2PZiEAhPHjiXBTfsopP7FDQMHwTuQahlI1yEZWwmRRfs7PX_DQZ7rYY3zhil8dAogBXtPdWNCQBFWNfIG3pAVaxRDnEWbxohb-k2hoDecrqFj-72Nn-hXs4y_2QF6wyQqblR6oQoIC27dHQCWor4XZmCAljrPGWmerUaYj0LCCj6LQDd6w_tRZHhe7KX-xbqH3qBtv6CKc2I3rfKcpV-Yw5-w5RWkqzcLelOqwajr0gBu1W_aKG6Mo-0IRUE-r1AYEjJnyhUcQ3QVpL3SXtUfbKg"}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:57 GMT
-- request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
     body:
@@ -72,7 +16,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2MzcsIm5iZiI6MTUyMDQ1MzYzNywiZXhwIjoxNTIwNDU3NTM3LCJhaW8iOiJZMk5nWUVndU5CSXl1MXFVeEdEM2ZsSFpieWtHQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibWRrSmk4SFRQa2VWdzN4cjkzVUFBQSIsInZlciI6IjEuMCJ9.J3fkRceBnuqHzbCWXI9FkZKmAqJH5NA_gajQkr41F04fYdtfIyuU_a80xJSZKU2PZiEAhPHjiXBTfsopP7FDQMHwTuQahlI1yEZWwmRRfs7PX_DQZ7rYY3zhil8dAogBXtPdWNCQBFWNfIG3pAVaxRDnEWbxohb-k2hoDecrqFj-72Nn-hXs4y_2QF6wyQqblR6oQoIC27dHQCWor4XZmCAljrPGWmerUaYj0LCCj6LQDd6w_tRZHhe7KX-xbqH3qBtv6CKc2I3rfKcpV-Yw5-w5RWkqzcLelOqwajr0gBu1W_aKG6Mo-0IRUE-r1AYEjJnyhUcQ3QVpL3SXtUfbKg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDc0MDIsIm5iZiI6MTUyMDg0NzQwMiwiZXhwIjoxNTIwODUxMzAyLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYldDZVJlZzBva0tOM1V5STRIMGpBQSIsInZlciI6IjEuMCJ9.eQcibNRit9UpZReJbHfEsmiPLie_5JJmntSSqIl_3JhpZUk5RiY9C5-tpvcqgzi4T2gBYIWpCTaJATTECFPv8N6WD5grp4DvR8jTIAd6GymPo3g-NXmQkBj_SOQ30wf3FsCZgKP9lQpEJAW7fPQ2F8qhmSX_mPeeP2y7FPVL8WIkCw0KEMo8L1JgQDrW_oKLo6xG2BCl3XSHjezamVAYqafAg7_nHcOAPsKtYAeozxPnuEMfnLLpHwXsWoI_6SeHzTIeU00orNnTk71_yDFh6KcGqQ98uruMTawbXy8YiqUQznf9OfjqdCA2Qg7YybfSLBw6gY1eBGp27n13wOQAog
   response:
     status:
       code: 200
@@ -91,26 +35,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14994'
+      - '14996'
       X-Ms-Request-Id:
-      - 464c8d90-1607-4678-a203-e620a1ae3ecc
+      - 473b3e6f-8eb7-466b-8f85-7b1c621a8f91
       X-Ms-Correlation-Request-Id:
-      - 464c8d90-1607-4678-a203-e620a1ae3ecc
+      - 473b3e6f-8eb7-466b-8f85-7b1c621a8f91
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201857Z:464c8d90-1607-4678-a203-e620a1ae3ecc
+      - WESTEUROPE:20180312T094256Z:473b3e6f-8eb7-466b-8f85-7b1c621a8f91
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:18:57 GMT
+      - Mon, 12 Mar 2018 09:42:56 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID","subscriptionId":"AZURE_SUBSCRIPTION_ID","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:58 GMT
+  recorded_at: Mon, 12 Mar 2018 09:43:01 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers?api-version=2015-01-01
@@ -127,7 +71,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2MzcsIm5iZiI6MTUyMDQ1MzYzNywiZXhwIjoxNTIwNDU3NTM3LCJhaW8iOiJZMk5nWUVndU5CSXl1MXFVeEdEM2ZsSFpieWtHQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibWRrSmk4SFRQa2VWdzN4cjkzVUFBQSIsInZlciI6IjEuMCJ9.J3fkRceBnuqHzbCWXI9FkZKmAqJH5NA_gajQkr41F04fYdtfIyuU_a80xJSZKU2PZiEAhPHjiXBTfsopP7FDQMHwTuQahlI1yEZWwmRRfs7PX_DQZ7rYY3zhil8dAogBXtPdWNCQBFWNfIG3pAVaxRDnEWbxohb-k2hoDecrqFj-72Nn-hXs4y_2QF6wyQqblR6oQoIC27dHQCWor4XZmCAljrPGWmerUaYj0LCCj6LQDd6w_tRZHhe7KX-xbqH3qBtv6CKc2I3rfKcpV-Yw5-w5RWkqzcLelOqwajr0gBu1W_aKG6Mo-0IRUE-r1AYEjJnyhUcQ3QVpL3SXtUfbKg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDc0MDIsIm5iZiI6MTUyMDg0NzQwMiwiZXhwIjoxNTIwODUxMzAyLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYldDZVJlZzBva0tOM1V5STRIMGpBQSIsInZlciI6IjEuMCJ9.eQcibNRit9UpZReJbHfEsmiPLie_5JJmntSSqIl_3JhpZUk5RiY9C5-tpvcqgzi4T2gBYIWpCTaJATTECFPv8N6WD5grp4DvR8jTIAd6GymPo3g-NXmQkBj_SOQ30wf3FsCZgKP9lQpEJAW7fPQ2F8qhmSX_mPeeP2y7FPVL8WIkCw0KEMo8L1JgQDrW_oKLo6xG2BCl3XSHjezamVAYqafAg7_nHcOAPsKtYAeozxPnuEMfnLLpHwXsWoI_6SeHzTIeU00orNnTk71_yDFh6KcGqQ98uruMTawbXy8YiqUQznf9OfjqdCA2Qg7YybfSLBw6gY1eBGp27n13wOQAog
   response:
     status:
       code: 200
@@ -144,39 +88,37 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14970'
+      - '14985'
       X-Ms-Request-Id:
-      - 54283848-972e-416a-8c64-b204a34935bd
+      - 49bc7574-f8be-4613-b1b4-eea2e1408449
       X-Ms-Correlation-Request-Id:
-      - 54283848-972e-416a-8c64-b204a34935bd
+      - 49bc7574-f8be-4613-b1b4-eea2e1408449
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201858Z:54283848-972e-416a-8c64-b204a34935bd
+      - WESTEUROPE:20180312T094257Z:49bc7574-f8be-4613-b1b4-eea2e1408449
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:18:57 GMT
+      - Mon, 12 Mar 2018 09:42:56 GMT
       Content-Length:
-      - '310505'
+      - '320853'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"},{"applicationId":"d87dcbc6-a371-462e-88e3-28ad15ec4e64","roleDefinitionId":"861776c5-e0df-4f95-be4f-ac1eec193323"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
+      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"},{"applicationId":"d87dcbc6-a371-462e-88e3-28ad15ec4e64","roleDefinitionId":"861776c5-e0df-4f95-be4f-ac1eec193323"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["East
+        Asia","Southeast Asia","Australia East","Australia Southeast","Japan East","Japan
+        West","Central India","South India","West India","West Europe","North Europe","Canada
+        Central","Canada East","Brazil South","West US","Central US","East US","South
+        Central US","East US 2","West Central US","North Central US","West US 2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
         US","Central US","East US","South Central US","West Europe","North Europe","East
         Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
         Central US","North Central US","Japan East","Japan West","Brazil South","Central
         India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"operations","locations":["West
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["East
+        Asia","Southeast Asia","Australia East","Australia Southeast","Japan East","Japan
+        West","Central India","South India","West India","West Europe","North Europe","Canada
+        Central","Canada East","Brazil South","West US","Central US","East US","South
+        Central US","East US 2","West Central US","North Central US","West US 2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"operations","locations":["West
         US","Central US","East US","South Central US","West Europe","North Europe","East
         Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
         Central US","North Central US","Japan East","Japan West","Brazil South","Central
@@ -232,177 +174,177 @@ http_interactions:
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/internalLoadBalancers","locations":[],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"domainNames/slots/roles/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"domainNames/slots/roles/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"domainNames/capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"domainNames/serviceCertificates","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
         US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
         Central","Canada East","UK South","UK West","West US","Central US","South
         Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
-        East","Australia Southeast","West US 2","West Central US","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        East","Australia Southeast","West US 2","West Central US","France Central","South
+        India","Central India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
         US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
         Central","Canada East","UK South","UK West","West US","Central US","South
         Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
-        East","Australia Southeast","West US 2","West Central US","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metrics","locations":["North
+        East","Australia Southeast","West US 2","West Central US","France Central","South
+        India","Central India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metrics","locations":["North
         Central US","South Central US","East US","East US 2","Canada Central","Canada
         East","West US","West US 2","West Central US","Central US","East Asia","Southeast
         Asia","North Europe","West Europe","UK South","UK West","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"resourceTypes","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"moveSubscriptionResources","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"validateSubscriptionMoveAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operationStatuses","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operatingSystems","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"operatingSystemFamilies","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicNetwork","namespace":"Microsoft.ClassicNetwork","resourceTypes":[{"resourceType":"virtualNetworks","locations":["East
+        India","West India","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"resourceTypes","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"moveSubscriptionResources","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"validateSubscriptionMoveAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operationStatuses","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operatingSystems","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"operatingSystemFamilies","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicNetwork","namespace":"Microsoft.ClassicNetwork","resourceTypes":[{"resourceType":"virtualNetworks","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"virtualNetworks/remoteVirtualNetworkPeeringProxies","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01"]},{"resourceType":"virtualNetworks/remoteVirtualNetworkPeeringProxies","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"reservedIps","locations":["East
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01"]},{"resourceType":"reservedIps","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"gatewaySupportedDevices","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"networkSecurityGroups","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"gatewaySupportedDevices","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"networkSecurityGroups","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicStorage","namespace":"Microsoft.ClassicStorage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"expressRouteCrossConnections","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"expressRouteCrossConnections/peerings","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicStorage","namespace":"Microsoft.ClassicStorage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkStorageAccountAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"storageAccounts/services","locations":["West
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkStorageAccountAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"storageAccounts/services","locations":["West
         US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
         Asia","Australia East","Australia Southeast","South India","Central India","West
         India","West US 2","West Central US","East US","East US 2","North Central
         US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
-        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/diagnosticSettings","locations":["West
+        South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/diagnosticSettings","locations":["West
         US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
         Asia","Australia East","Australia Southeast","South India","Central India","West
         India","West US 2","West Central US","East US","East US 2","North Central
         US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
-        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"disks","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"images","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"vmImages","locations":[],"apiVersions":["2016-11-01"]},{"resourceType":"publicImages","locations":[],"apiVersions":["2016-11-01","2016-04-01"]},{"resourceType":"osImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"osPlatformImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute","namespace":"Microsoft.Compute","authorizations":[{"applicationId":"60e6cd67-9c8c-4951-9b3c-23c25a2169af","roleDefinitionId":"e4770acb-272e-4dc8-87f3-12f44a612224"},{"applicationId":"a303894e-f1d8-4a37-bf10-67aa654a0596","roleDefinitionId":"903ac751-8ad5-4e5a-bfc2-5e49f450a241"},{"applicationId":"a8b6bf88-1d1a-4626-b040-9a729ea93c65","roleDefinitionId":"45c8267c-80ba-4b96-9a43-115b8f49fccd"}],"resourceTypes":[{"resourceType":"availabilitySets","locations":["East
+        South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"disks","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"images","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"vmImages","locations":[],"apiVersions":["2016-11-01"]},{"resourceType":"storageAccounts/vmImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"publicImages","locations":[],"apiVersions":["2016-11-01","2016-04-01"]},{"resourceType":"osImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"osPlatformImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute","namespace":"Microsoft.Compute","authorizations":[{"applicationId":"60e6cd67-9c8c-4951-9b3c-23c25a2169af","roleDefinitionId":"e4770acb-272e-4dc8-87f3-12f44a612224"},{"applicationId":"a303894e-f1d8-4a37-bf10-67aa654a0596","roleDefinitionId":"903ac751-8ad5-4e5a-bfc2-5e49f450a241"},{"applicationId":"a8b6bf88-1d1a-4626-b040-9a729ea93c65","roleDefinitionId":"45c8267c-80ba-4b96-9a43-115b8f49fccd"}],"resourceTypes":[{"resourceType":"availabilitySets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations/usages","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations/usages","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"sharedVMImages","locations":["West
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"sharedVMImages","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"sharedVMImages/versions","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"locations/capsoperations","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"disks","locations":["Southeast
@@ -410,27 +352,27 @@ http_interactions:
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"snapshots","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"snapshots","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"locations/diskoperations","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"locations/diskoperations","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"images","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"images","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"]},{"resourceType":"locations/logAnalytics","locations":["East
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"]},{"resourceType":"locations/logAnalytics","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
         US","East US","South Central US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
@@ -547,7 +489,12 @@ http_interactions:
         US","East Asia","East US","East US 2","Japan East","Japan West","North Central
         US","North Europe","South Central US","South India","Southeast Asia","West
         Central US","West Europe","West India","West US","West US 2","UK West","UK
-        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"},{"applicationId":"f5c26e74-f226-4ae8-85f0-b4af0080ac9e","roleDefinitionId":"529d7ae6-e892-4d43-809d-8547aeb90643"}],"resourceTypes":[{"resourceType":"components","locations":["East
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/consumergroups","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/disasterrecoveryconfigs","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"},{"applicationId":"f5c26e74-f226-4ae8-85f0-b4af0080ac9e","roleDefinitionId":"529d7ae6-e892-4d43-809d-8547aeb90643"}],"resourceTypes":[{"resourceType":"components","locations":["East
         US","South Central US","North Europe","West Europe","Southeast Asia","West
         US 2"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
         US","South Central US","North Europe","West Europe","Southeast Asia","West
@@ -614,32 +561,32 @@ http_interactions:
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/accessPolicies","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"vaults/accessPolicies","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-10-01","2015-06-01","2014-12-19-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"deletedVaults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01","2014-12-19-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"deletedVaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-10-01"]},{"resourceType":"locations/deletedVaults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations/deletedVaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
         Central US","West Europe","Southeast Asia","Japan East","West Central US"],"apiVersions":["2016-04-01"]},{"resourceType":"webServices","locations":["South
         Central US","West Europe","Southeast Asia","Japan East","East US 2","West
         Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"operations","locations":["South
@@ -665,97 +612,97 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"networkWatchers/lenses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"networkWatchers/lenses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","West
         US 2","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
@@ -846,7 +793,7 @@ http_interactions:
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
         West","Korea Central","Korea South"],"apiVersions":["2017-07-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ResourceHealth","namespace":"Microsoft.ResourceHealth","authorizations":[{"applicationId":"8bdebf23-c0fe-4187-a378-717ad86f6a53","roleDefinitionId":"cc026344-c8b1-4561-83ba-59eba84b27cc"}],"resourceTypes":[{"resourceType":"availabilityStatuses","locations":[],"apiVersions":["2017-07-01","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"notifications","locations":["Australia
-        Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Security","namespace":"Microsoft.Security","authorization":{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
+        Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Security","namespace":"Microsoft.Security","authorizations":[{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},{"applicationId":"fc780465-2017-40d4-a0c5-307022471b92"}],"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatuses","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/virtualMachines","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/endpoints","locations":["Central
@@ -898,565 +845,595 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Central India","South
         India"],"apiVersions":["2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Sql","namespace":"Microsoft.Sql","authorizations":[{"applicationId":"e4ab13ed-33cb-41b4-9140-6e264582cf85","roleDefinitionId":"ec3ddc95-44dc-47a2-9926-5e9f5ffd44ec"},{"applicationId":"0130cc9f-7ac5-4026-bd5f-80a08a54e6d9","roleDefinitionId":"45e8abf8-0ec4-44f3-9c37-cff4f7779302"},{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},{"applicationId":"76c7f279-7959-468f-8943-3954880e0d8c","roleDefinitionId":"7f7513a8-73f9-4c5f-97a2-c41f0ea783ef"}],"resourceTypes":[{"resourceType":"operations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/capabilities","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/databaseAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/databaseOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverKeyOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/keys","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/encryptionProtector","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/usages","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01","2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/communicationLinks","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administrators","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administratorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/restorableDroppedDatabases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recoverableDatabases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/geoBackupPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/importExportOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/operationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/backupLongTermRetentionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/automaticTuning","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/automaticTuning","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/databases/transparentDataEncryption","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recommendedElasticPools","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/auditingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/connectionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/connectionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies/rules","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/securityAlertPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/securityAlertPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/auditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/extendedAuditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/elasticpools","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-09-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/jobAgentOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/jobAgentAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/disasterRecoveryConfiguration","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/dnsAliases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/failoverGroups","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/virtualNetworkRules","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/virtualNetworkRulesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/virtualNetworkRulesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/databaseRestoreAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metricDefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/aggregatedDatabaseMetrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metricdefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries/queryText","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPools/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/extensions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPoolEstimates","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditRecords","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentScans","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/vulnerabilityAssessments","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessment","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/syncGroups","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups/syncMembers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/syncAgents","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"managedInstances/administrators","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/databases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metricDefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/administratorAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/administratorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncMemberOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncAgentOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncDatabaseIds","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorizations":[{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},{"applicationId":"e406a681-f3d4-42a8-90b6-c2b029497af1"}],"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/capabilities","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/databaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"locations/databaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverKeyOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/keys","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/encryptionProtector","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01","2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/communicationLinks","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/restorableDroppedDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recoverableDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/geoBackupPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/importExportOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/operationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/backupLongTermRetentionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/databases/transparentDataEncryption","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recommendedElasticPools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies/rules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/extendedAuditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/elasticPoolAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/elasticPoolOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/elasticpools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-09-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/jobAgentOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/jobAgentAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/disasterRecoveryConfiguration","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/dnsAliases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/failoverGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/virtualNetworkRules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/virtualNetworkRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/virtualNetworkRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/databaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/aggregatedDatabaseMetrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metricdefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries/queryText","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPools/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/extensions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPoolEstimates","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditRecords","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentScans","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/vulnerabilityAssessments","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessment","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/syncGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups/syncMembers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/syncAgents","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"managedInstances/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/administratorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncMemberOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncAgentOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncDatabaseIds","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/longTermRetentionPolicyOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionPolicyAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionBackupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionBackupAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorizations":[{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},{"applicationId":"e406a681-f3d4-42a8-90b6-c2b029497af1"}],"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
@@ -1795,12 +1772,12 @@ http_interactions:
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","Canada Central","Canada East","UK South","UK West","West US 2","West
-        Central US","South India","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","South India","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","South India","Canada Central","Canada East","UK South","UK West","West
-        US 2","West Central US","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Capacity","namespace":"Microsoft.Capacity","authorization":{"applicationId":"4d0ad6c7-f6c3-46d8-ab0d-1406d5e6c86b","roleDefinitionId":"FD9C0A9A-4DB9-4F41-8A61-98385DEB6E2D"},"resourceTypes":[{"resourceType":"resources","locations":["South
+        US 2","West Central US","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Capacity","namespace":"Microsoft.Capacity","authorization":{"applicationId":"4d0ad6c7-f6c3-46d8-ab0d-1406d5e6c86b","roleDefinitionId":"FD9C0A9A-4DB9-4F41-8A61-98385DEB6E2D"},"resourceTypes":[{"resourceType":"resources","locations":["South
         Central US"],"apiVersions":["2017-11-01"]},{"resourceType":"reservationOrders","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/reservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/reservations/revisions","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"catalogs","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"appliedReservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"checkOffers","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"checkScopes","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"calculatePrice","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/calculateRefund","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/return","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/split","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/merge","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"validateReservationOrder","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/availableScopes","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Cdn","namespace":"Microsoft.Cdn","resourceTypes":[{"resourceType":"profiles","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
@@ -1876,9 +1853,9 @@ http_interactions:
         2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/updateAccountsCreationSettings","locations":["West
         US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/accountsCreationSettings","locations":["West
         US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2016-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Commerce","namespace":"Microsoft.Commerce","resourceTypes":[{"resourceType":"UsageAggregates","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]},{"resourceType":"RateCard","locations":[],"apiVersions":["2016-08-31-preview","2015-06-01-preview","2015-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Consumption","namespace":"Microsoft.Consumption","resourceTypes":[{"resourceType":"ReservationSummaries","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationTransactions","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Balances","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Marketplaces","locations":[],"apiVersions":["2018-01-31"]},{"resourceType":"Pricesheets","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationDetails","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Budgets","locations":[],"apiVersions":["2018-01-31","2017-12-30-preview"]},{"resourceType":"Terms","locations":[],"apiVersions":["2018-01-31","2017-12-30-preview"]},{"resourceType":"UsageDetails","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview","2017-04-24-preview"]},{"resourceType":"Operations","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview","2017-04-24-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerInstance","namespace":"Microsoft.ContainerInstance","resourceTypes":[{"resourceType":"containerGroups","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/usages","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/operations","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/operations","locations":["West
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
         US"],"apiVersions":["2016-04-08"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.CustomerInsights","namespace":"Microsoft.CustomerInsights","authorization":{"applicationId":"38c77d00-5fcb-4cce-9d93-af4738258e3c","roleDefinitionId":"E006F9C7-F333-477C-8AD6-1F3A9FE87F55"},"resourceTypes":[{"resourceType":"hubs","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/profiles","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/interactions","locations":["East
@@ -1895,7 +1872,9 @@ http_interactions:
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"operations","locations":["East
         US 2"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Databricks","namespace":"Microsoft.Databricks","authorizations":[{"applicationId":"d9327919-6775-4843-9037-3fb0fb0473cb","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},{"applicationId":"2ff814a6-3304-4ab8-85cb-cd0e6f879c1d","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"}],"resourceTypes":[{"resourceType":"workspaces","locations":["West
         US","East US 2","West Europe","East US","North Europe","Southeast Asia","East
-        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]},{"resourceType":"locations","locations":["West
+        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2017-09-01-preview"]},{"resourceType":"workspaces/virtualNetworkPeerings","locations":["West
+        US","East US 2","West Europe","North Europe","East US","Southeast Asia","East
+        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01"]},{"resourceType":"locations","locations":["West
         US","East US 2","West Europe","North Europe","East US","Southeast Asia"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
         US","East US 2","West Europe","East US","North Europe","Southeast Asia","East
         Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataCatalog","namespace":"Microsoft.DataCatalog","resourceTypes":[{"resourceType":"catalogs","locations":["East
@@ -1919,23 +1898,26 @@ http_interactions:
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers/listSasTokens","locations":["East
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataLakeStore","namespace":"Microsoft.DataLakeStore","authorization":{"applicationId":"e9f49c6b-5ce5-44c8-925d-015017e9f7ad","roleDefinitionId":"17eb9cca-f08a-4499-b2d3-852d175f614f"},"resourceTypes":[{"resourceType":"accounts","locations":["East
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/firewallRules","locations":["East
-        US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataMigration","namespace":"Microsoft.DataMigration","authorization":{"applicationId":"a4bad4aa-bf02-4631-9f78-a64ffdba8150","roleDefinitionId":"b831a21d-db98-4760-89cb-bef871952df1","managedByRoleDefinitionId":"6256fb55-9e59-4018-a9e1-76b11c0a4c89"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services/projects","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationStatuses","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
+        US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataMigration","namespace":"Microsoft.DataMigration","authorization":{"applicationId":"a4bad4aa-bf02-4631-9f78-a64ffdba8150","roleDefinitionId":"b831a21d-db98-4760-89cb-bef871952df1","managedByRoleDefinitionId":"6256fb55-9e59-4018-a9e1-76b11c0a4c89"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services/projects","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationStatuses","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
-        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/recoverableServers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
@@ -1959,7 +1941,10 @@ http_interactions:
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
-        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/recoverableServers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
@@ -2015,12 +2000,7 @@ http_interactions:
         US 2","East US","West US","Central US","East US 2","West Central US","West
         Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
         US 2","East US","West US","Central US","East US 2","West Central US","West
-        Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","West
-        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
-        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
-        India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/consumergroups","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/disasterrecoveryconfigs","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
         US 2","South Central US","Central US","Australia Southeast","Central India","West
         Central US","West US 2","Canada East","Canada Central","Brazil South","UK
         South","UK West","East Asia","Australia East","Japan East","Japan West","North
@@ -2131,7 +2111,7 @@ http_interactions:
         West","Japan East","East Asia","Southeast Asia","West Europe","North Europe","East
         US","West US","Australia East","Australia Southeast","Central US","Brazil
         South","Central India","West India","South India","South Central US","Canada
-        Central","Canada East","West Central US","West US 2"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
+        Central","Canada East","West Central US","West US 2"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-05","2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
         Central US","East US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"operations","locations":["West
         Central US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
         Central US","East US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.PolicyInsights","namespace":"Microsoft.PolicyInsights","authorization":{"applicationId":"1d78a85d-813d-46f0-b496-dd72f50a3ec0","roleDefinitionId":"63d2b225-4c34-4641-8768-21a1f7c68ce8"},"resourceTypes":[{"resourceType":"policyEvents","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"policyStates","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
@@ -2163,12 +2143,12 @@ http_interactions:
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
         Central US","South Central US","North Europe","West Europe","East Asia","Southeast
         Asia","West US","East US","Japan West","Japan East","Brazil South","Central
         US","East US 2","Australia East","Australia Southeast","South India","Central
@@ -2208,52 +2188,62 @@ http_interactions:
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/clusterVersions","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"clusters/applications","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operations","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/clusterVersions","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/environments","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operations","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
         Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applianceDefinitions","locations":["West
         Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applications","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
-        Central US"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
+        Central US"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
-        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
-        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups","locations":["West
-        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
-        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups/cloudEndpoints","locations":["West
-        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
-        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups/serverEndpoints","locations":["West
-        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
-        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/registeredServers","locations":["West
-        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
-        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/workflows","locations":["West
-        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
-        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
+        US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
+        US","Canada Central","Canada East","Central US","East US 2","UK South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups","locations":["West
+        US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
+        US","Canada Central","Canada East","Central US","East US 2","UK South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups/cloudEndpoints","locations":["West
+        US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
+        US","Canada Central","Canada East","Central US","East US 2","UK South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups/serverEndpoints","locations":["West
+        US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
+        US","Canada Central","Canada East","Central US","East US 2","UK South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/registeredServers","locations":["West
+        US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
+        US","Canada Central","Canada East","Central US","East US 2","UK South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/workflows","locations":["West
+        US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
+        US","Canada Central","Canada East","Central US","East US 2","UK South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","West Central US","Japan East","Japan West","Australia East","Australia
         Southeast"],"apiVersions":["2017-06-01","2017-05-15","2017-01-01","2016-10-01","2016-06-01","2015-03-15","2014-09-01"]},{"resourceType":"operations","locations":["West
@@ -2332,10 +2322,10 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:59 GMT
+  recorded_at: Mon, 12 Mar 2018 09:43:02 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0?api-version=2017-12-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2349,7 +2339,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2MzcsIm5iZiI6MTUyMDQ1MzYzNywiZXhwIjoxNTIwNDU3NTM3LCJhaW8iOiJZMk5nWUVndU5CSXl1MXFVeEdEM2ZsSFpieWtHQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibWRrSmk4SFRQa2VWdzN4cjkzVUFBQSIsInZlciI6IjEuMCJ9.J3fkRceBnuqHzbCWXI9FkZKmAqJH5NA_gajQkr41F04fYdtfIyuU_a80xJSZKU2PZiEAhPHjiXBTfsopP7FDQMHwTuQahlI1yEZWwmRRfs7PX_DQZ7rYY3zhil8dAogBXtPdWNCQBFWNfIG3pAVaxRDnEWbxohb-k2hoDecrqFj-72Nn-hXs4y_2QF6wyQqblR6oQoIC27dHQCWor4XZmCAljrPGWmerUaYj0LCCj6LQDd6w_tRZHhe7KX-xbqH3qBtv6CKc2I3rfKcpV-Yw5-w5RWkqzcLelOqwajr0gBu1W_aKG6Mo-0IRUE-r1AYEjJnyhUcQ3QVpL3SXtUfbKg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDc0MDIsIm5iZiI6MTUyMDg0NzQwMiwiZXhwIjoxNTIwODUxMzAyLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYldDZVJlZzBva0tOM1V5STRIMGpBQSIsInZlciI6IjEuMCJ9.eQcibNRit9UpZReJbHfEsmiPLie_5JJmntSSqIl_3JhpZUk5RiY9C5-tpvcqgzi4T2gBYIWpCTaJATTECFPv8N6WD5grp4DvR8jTIAd6GymPo3g-NXmQkBj_SOQ30wf3FsCZgKP9lQpEJAW7fPQ2F8qhmSX_mPeeP2y7FPVL8WIkCw0KEMo8L1JgQDrW_oKLo6xG2BCl3XSHjezamVAYqafAg7_nHcOAPsKtYAeozxPnuEMfnLLpHwXsWoI_6SeHzTIeU00orNnTk71_yDFh6KcGqQ98uruMTawbXy8YiqUQznf9OfjqdCA2Qg7YybfSLBw6gY1eBGp27n13wOQAog
   response:
     status:
       code: 200
@@ -2368,60 +2358,54 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/LowCostGet3Min;4725,Microsoft.Compute/LowCostGet30Min;37859
+      - Microsoft.Compute/LowCostGet3Min;4741,Microsoft.Compute/LowCostGet30Min;38341
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344652126238
       X-Ms-Request-Id:
-      - b7984e60-3723-4ff6-b909-5ae4285d075e
+      - 5936b961-d60e-478a-9ce0-f7dbe7867dee
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14969'
+      - '14984'
       X-Ms-Correlation-Request-Id:
-      - 105c74f3-1a05-4faf-a7cd-c29dfe16b17d
+      - 708e2020-4eb1-48c6-8709-69044246d205
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201859Z:105c74f3-1a05-4faf-a7cd-c29dfe16b17d
+      - WESTEUROPE:20180312T094258Z:708e2020-4eb1-48c6-8709-69044246d205
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:18:59 GMT
+      - Mon, 12 Mar 2018 09:42:57 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"03e8467b-baab-4867-9cc4-157336b7e2e4\",\r\n
-        \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Basic_A0\"\r\n    },\r\n
-        \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
-        \"RedHat\",\r\n        \"offer\": \"RHEL\",\r\n        \"sku\": \"7.2\",\r\n
-        \       \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
-        \"Linux\",\r\n        \"name\": \"miq-test-rhel1\",\r\n        \"createOption\":
-        \"FromImage\",\r\n        \"vhd\": {\r\n          \"uri\": \"https://miqazuretest18686.blob.core.windows.net/vhds/miq-test-rhel12016218112243.vhd\"\r\n
+      string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"d7022008-f6b1-4f4c-8be8-e2d677ef3261\",\r\n
+        \   \"availabilitySet\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/SPEC0DEPLY1AS\"\r\n
+        \   },\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_D1\"\r\n
+        \   },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
+        \"MicrosoftWindowsServer\",\r\n        \"offer\": \"WindowsServer\",\r\n        \"sku\":
+        \"2012-R2-Datacenter\",\r\n        \"version\": \"latest\"\r\n      },\r\n
+        \     \"osDisk\": {\r\n        \"osType\": \"Windows\",\r\n        \"name\":
+        \"osdisk\",\r\n        \"createOption\": \"FromImage\",\r\n        \"vhd\":
+        {\r\n          \"uri\": \"http://spec0deply1stor.blob.core.windows.net/vhds/osdisk0.vhd\"\r\n
         \       },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n      \"dataDisks\":
-        []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"miq-test-rhel1\",\r\n
-        \     \"adminUsername\": \"dberger\",\r\n      \"linuxConfiguration\": {\r\n
-        \       \"disablePasswordAuthentication\": false\r\n      },\r\n      \"secrets\":
-        []\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390\"}]},\r\n
+        []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"spec0deply1vm0\",\r\n
+        \     \"adminUsername\": \"deploy1admin\",\r\n      \"windowsConfiguration\":
+        {\r\n        \"provisionVMAgent\": true,\r\n        \"enableAutomaticUpdates\":
+        true\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\":
+        {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0\"}]},\r\n
         \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
-        true,\r\n        \"storageUri\": \"https://miqazuretest18686.blob.core.windows.net/\"\r\n
+        true,\r\n        \"storageUri\": \"http://spec0deply1stor.blob.core.windows.net\"\r\n
         \     }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n
-        \ \"resources\": [\r\n    {\r\n      \"properties\": {\r\n        \"publisher\":
-        \"Microsoft.OSTCExtensions\",\r\n        \"type\": \"LinuxDiagnostic\",\r\n
-        \       \"typeHandlerVersion\": \"2.0\",\r\n        \"autoUpgradeMinorVersion\":
-        true,\r\n        \"settings\": {\"xmlCfg\":\"PFdhZENmZz48RGlhZ25vc3RpY01vbml0b3JDb25maWd1cmF0aW9uIG92ZXJhbGxRdW90YUluTUI9IjQwOTYiPjxEaWFnbm9zdGljSW5mcmFzdHJ1Y3R1cmVMb2dzIHNjaGVkdWxlZFRyYW5zZmVyUGVyaW9kPSJQVDFNIiBzY2hlZHVsZWRUcmFuc2ZlckxvZ0xldmVsRmlsdGVyPSJXYXJuaW5nIi8+PFBlcmZvcm1hbmNlQ291bnRlcnMgc2NoZWR1bGVkVHJhbnNmZXJQZXJpb2Q9IlBUMU0iPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlTWVtb3J5IiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQnl0ZXMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcUGVyY2VudEF2YWlsYWJsZU1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iTWVtb3J5IHVzZWQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50VXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgcGVyY2VudGFnZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkQnlDYWNoZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHVzZWQgYnkgY2FjaGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1BlclNlYyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50UGVyU2Vjb25kIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFnZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1JlYWRQZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2UgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1dyaXR0ZW5QZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2Ugd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iU3dhcCBhdmFpbGFibGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50QXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZFN3YXAiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlN3YXAgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRJZGxlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgaWRsZSB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFVzZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iUGVyY2VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkNQVSB1c2VyIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50TmljZVRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIG5pY2UgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRQcml2aWxlZ2VkVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgcHJpdmlsZWdlZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudEludGVycnVwdFRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIGludGVycnVwdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudERQQ1RpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIERQQyB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFByb2Nlc3NvclRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIHBlcmNlbnRhZ2UgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50SU9XYWl0VGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgSU8gd2FpdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xSZWFkQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCBndWVzdCBPUyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXFdyaXRlQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGUgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xUcmFuc2ZlcnNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXJzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcUmVhZHNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xXcml0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVJlYWRUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVdyaXRlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlNlY29uZHMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJEaXNrIHdyaXRlIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xBdmVyYWdlVHJhbnNmZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXIgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXEF2ZXJhZ2VEaXNrUXVldWVMZW5ndGgiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcXVldWUgbGVuZ3RoIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVHJhbnNtaXR0ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgb3V0IGd1ZXN0IE9TIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzUmVjZWl2ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgaW4gZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1RyYW5zbWl0dGVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHNlbnQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1JlY2VpdmVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHJlY2VpdmVkIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVG90YWwiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxSeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyByZWNlaXZlZCBlcnJvcnMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxUeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyBzZW50IGVycm9ycyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTmV0d29ya0ludGVyZmFjZVxUb3RhbENvbGxpc2lvbnMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgY29sbGlzaW9ucyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48L1BlcmZvcm1hbmNlQ291bnRlcnM+PE1ldHJpY3MgcmVzb3VyY2VJZD0iL3N1YnNjcmlwdGlvbnMvMjU4NmM2NGItMzhiNC00NTI3LWExNDAtMDEyZDQ5ZGZjMDJjL3Jlc291cmNlR3JvdXBzL21pcS1henVyZS10ZXN0MS9wcm92aWRlcnMvTWljcm9zb2Z0LkNvbXB1dGUvdmlydHVhbE1hY2hpbmVzL21pcS10ZXN0LXJoZWwxIj48TWV0cmljQWdncmVnYXRpb24gc2NoZWR1bGVkVHJhbnNmZXJQZXJpb2Q9IlBUMUgiLz48TWV0cmljQWdncmVnYXRpb24gc2NoZWR1bGVkVHJhbnNmZXJQZXJpb2Q9IlBUMU0iLz48L01ldHJpY3M+PC9EaWFnbm9zdGljTW9uaXRvckNvbmZpZ3VyYXRpb24+PC9XYWRDZmc+\",\"StorageAccount\":\"miqazuretest18686\"},\r\n
-        \       \"provisioningState\": \"Succeeded\"\r\n      },\r\n      \"type\":
-        \"Microsoft.Compute/virtualMachines/extensions\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/extensions/Microsoft.Insights.VMDiagnosticsSettings\",\r\n
-        \     \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n    }\r\n
-        \ ],\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\":
-        \"eastus\",\r\n  \"tags\": {\r\n    \"Shutdown\": \"true\"\r\n  },\r\n  \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1\",\r\n
-        \ \"name\": \"miq-test-rhel1\"\r\n}"
+        \ \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"tags\": {\r\n    \"Shutdown\": \"true\"\r\n  },\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0\",\r\n
+        \ \"name\": \"spec0deply1vm0\"\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:59 GMT
+  recorded_at: Mon, 12 Mar 2018 09:43:02 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0?api-version=2018-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2435,7 +2419,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2MzcsIm5iZiI6MTUyMDQ1MzYzNywiZXhwIjoxNTIwNDU3NTM3LCJhaW8iOiJZMk5nWUVndU5CSXl1MXFVeEdEM2ZsSFpieWtHQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibWRrSmk4SFRQa2VWdzN4cjkzVUFBQSIsInZlciI6IjEuMCJ9.J3fkRceBnuqHzbCWXI9FkZKmAqJH5NA_gajQkr41F04fYdtfIyuU_a80xJSZKU2PZiEAhPHjiXBTfsopP7FDQMHwTuQahlI1yEZWwmRRfs7PX_DQZ7rYY3zhil8dAogBXtPdWNCQBFWNfIG3pAVaxRDnEWbxohb-k2hoDecrqFj-72Nn-hXs4y_2QF6wyQqblR6oQoIC27dHQCWor4XZmCAljrPGWmerUaYj0LCCj6LQDd6w_tRZHhe7KX-xbqH3qBtv6CKc2I3rfKcpV-Yw5-w5RWkqzcLelOqwajr0gBu1W_aKG6Mo-0IRUE-r1AYEjJnyhUcQ3QVpL3SXtUfbKg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDc0MDIsIm5iZiI6MTUyMDg0NzQwMiwiZXhwIjoxNTIwODUxMzAyLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYldDZVJlZzBva0tOM1V5STRIMGpBQSIsInZlciI6IjEuMCJ9.eQcibNRit9UpZReJbHfEsmiPLie_5JJmntSSqIl_3JhpZUk5RiY9C5-tpvcqgzi4T2gBYIWpCTaJATTECFPv8N6WD5grp4DvR8jTIAd6GymPo3g-NXmQkBj_SOQ30wf3FsCZgKP9lQpEJAW7fPQ2F8qhmSX_mPeeP2y7FPVL8WIkCw0KEMo8L1JgQDrW_oKLo6xG2BCl3XSHjezamVAYqafAg7_nHcOAPsKtYAeozxPnuEMfnLLpHwXsWoI_6SeHzTIeU00orNnTk71_yDFh6KcGqQ98uruMTawbXy8YiqUQznf9OfjqdCA2Qg7YybfSLBw6gY1eBGp27n13wOQAog
   response:
     status:
       code: 200
@@ -2452,54 +2436,54 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"f006e6f9-0292-42cd-99fc-f72f194553c1"
+      - W/"b817491c-aab8-4aab-b41d-b07bfffa5639"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 121e4d63-aa2a-4b4e-9a99-3004813e9284
+      - bbddec95-3961-48f1-937b-70a205e6af0c
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14979'
+      - '14989'
       X-Ms-Correlation-Request-Id:
-      - 27acb776-9121-4360-a8e3-2591bb652b83
+      - 7aa2608c-f83a-4594-b7ae-6b416ff6d480
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201900Z:27acb776-9121-4360-a8e3-2591bb652b83
+      - WESTEUROPE:20180312T094259Z:7aa2608c-f83a-4594-b7ae-6b416ff6d480
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:19:00 GMT
+      - Mon, 12 Mar 2018 09:42:59 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"miq-test-rhel1390\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390\",\r\n
-        \ \"etag\": \"W/\\\"f006e6f9-0292-42cd-99fc-f72f194553c1\\\"\",\r\n  \"location\":
+      string: "{\r\n  \"name\": \"spec0deply1nic0\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0\",\r\n
+        \ \"etag\": \"W/\\\"b817491c-aab8-4aab-b41d-b07bfffa5639\\\"\",\r\n  \"location\":
         \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"98853f48-2806-4065-be57-cf9159550440\",\r\n    \"ipConfigurations\":
-        [\r\n      {\r\n        \"name\": \"ipconfig1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1\",\r\n
-        \       \"etag\": \"W/\\\"f006e6f9-0292-42cd-99fc-f72f194553c1\\\"\",\r\n
+        \   \"resourceGuid\": \"80ad9866-071d-4e3f-91d0-d47954eccee0\",\r\n    \"ipConfigurations\":
+        [\r\n      {\r\n        \"name\": \"ipconfig1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1\",\r\n
+        \       \"etag\": \"W/\\\"b817491c-aab8-4aab-b41d-b07bfffa5639\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAddress\": \"10.16.0.4\",\r\n          \"privateIPAllocationMethod\":
-        \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1\"\r\n
-        \         },\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\"\r\n
+        \         \"privateIPAddress\": \"10.0.0.4\",\r\n          \"privateIPAllocationMethod\":
+        \"Dynamic\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1\"\r\n
         \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
-        \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\":
-        [],\r\n      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\":
-        \"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net\"\r\n    },\r\n    \"macAddress\":
-        \"00-0D-3A-10-EB-AB\",\r\n    \"enableAcceleratedNetworking\": false,\r\n
-        \   \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\": {\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1\"\r\n
-        \   },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1\"\r\n
+        \"IPv4\",\r\n          \"loadBalancerBackendAddressPools\": [\r\n            {\r\n
+        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\"\r\n
+        \           }\r\n          ],\r\n          \"loadBalancerInboundNatRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\":
+        {\r\n      \"dnsServers\": [],\r\n      \"appliedDnsServers\": []\r\n    },\r\n
+        \   \"enableAcceleratedNetworking\": false,\r\n    \"enableIPForwarding\":
+        false,\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0\"\r\n
         \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
         \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:19:00 GMT
+  recorded_at: Mon, 12 Mar 2018 09:43:04 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups/miq-azure-test1?api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0/instanceView?api-version=2017-12-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2513,60 +2497,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2MzcsIm5iZiI6MTUyMDQ1MzYzNywiZXhwIjoxNTIwNDU3NTM3LCJhaW8iOiJZMk5nWUVndU5CSXl1MXFVeEdEM2ZsSFpieWtHQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibWRrSmk4SFRQa2VWdzN4cjkzVUFBQSIsInZlciI6IjEuMCJ9.J3fkRceBnuqHzbCWXI9FkZKmAqJH5NA_gajQkr41F04fYdtfIyuU_a80xJSZKU2PZiEAhPHjiXBTfsopP7FDQMHwTuQahlI1yEZWwmRRfs7PX_DQZ7rYY3zhil8dAogBXtPdWNCQBFWNfIG3pAVaxRDnEWbxohb-k2hoDecrqFj-72Nn-hXs4y_2QF6wyQqblR6oQoIC27dHQCWor4XZmCAljrPGWmerUaYj0LCCj6LQDd6w_tRZHhe7KX-xbqH3qBtv6CKc2I3rfKcpV-Yw5-w5RWkqzcLelOqwajr0gBu1W_aKG6Mo-0IRUE-r1AYEjJnyhUcQ3QVpL3SXtUfbKg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14979'
-      X-Ms-Request-Id:
-      - 9f1e3cae-04f2-47a0-ae8d-72305bbed6e6
-      X-Ms-Correlation-Request-Id:
-      - 9f1e3cae-04f2-47a0-ae8d-72305bbed6e6
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201900Z:9f1e3cae-04f2-47a0-ae8d-72305bbed6e6
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:18:59 GMT
-      Content-Length:
-      - '183'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1","name":"miq-azure-test1","location":"eastus","properties":{"provisioningState":"Succeeded"}}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:19:00 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute/locations/eastus/vmSizes?api-version=2017-12-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2MzcsIm5iZiI6MTUyMDQ1MzYzNywiZXhwIjoxNTIwNDU3NTM3LCJhaW8iOiJZMk5nWUVndU5CSXl1MXFVeEdEM2ZsSFpieWtHQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibWRrSmk4SFRQa2VWdzN4cjkzVUFBQSIsInZlciI6IjEuMCJ9.J3fkRceBnuqHzbCWXI9FkZKmAqJH5NA_gajQkr41F04fYdtfIyuU_a80xJSZKU2PZiEAhPHjiXBTfsopP7FDQMHwTuQahlI1yEZWwmRRfs7PX_DQZ7rYY3zhil8dAogBXtPdWNCQBFWNfIG3pAVaxRDnEWbxohb-k2hoDecrqFj-72Nn-hXs4y_2QF6wyQqblR6oQoIC27dHQCWor4XZmCAljrPGWmerUaYj0LCCj6LQDd6w_tRZHhe7KX-xbqH3qBtv6CKc2I3rfKcpV-Yw5-w5RWkqzcLelOqwajr0gBu1W_aKG6Mo-0IRUE-r1AYEjJnyhUcQ3QVpL3SXtUfbKg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDc0MDIsIm5iZiI6MTUyMDg0NzQwMiwiZXhwIjoxNTIwODUxMzAyLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYldDZVJlZzBva0tOM1V5STRIMGpBQSIsInZlciI6IjEuMCJ9.eQcibNRit9UpZReJbHfEsmiPLie_5JJmntSSqIl_3JhpZUk5RiY9C5-tpvcqgzi4T2gBYIWpCTaJATTECFPv8N6WD5grp4DvR8jTIAd6GymPo3g-NXmQkBj_SOQ30wf3FsCZgKP9lQpEJAW7fPQ2F8qhmSX_mPeeP2y7FPVL8WIkCw0KEMo8L1JgQDrW_oKLo6xG2BCl3XSHjezamVAYqafAg7_nHcOAPsKtYAeozxPnuEMfnLLpHwXsWoI_6SeHzTIeU00orNnTk71_yDFh6KcGqQ98uruMTawbXy8YiqUQznf9OfjqdCA2Qg7YybfSLBw6gY1eBGp27n13wOQAog
   response:
     status:
       code: 200
@@ -2585,26 +2516,155 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/LowCostGet3Min;4736,Microsoft.Compute/LowCostGet30Min;37858
+      - Microsoft.Compute/GetInstanceView3Min;4793,Microsoft.Compute/GetInstanceView30Min;23993
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344652126238
       X-Ms-Request-Id:
-      - 8be0a4c2-3dc3-47dd-ae47-233671788ebb
+      - 9dd57b26-c7e7-4d17-b7f1-5971bb01e633
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14968'
+      - '14983'
       X-Ms-Correlation-Request-Id:
-      - f4853fd7-7b97-4d97-a19a-29179eea7b1a
+      - 920f88bf-87a1-4289-aac2-2f8951bf3375
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201901Z:f4853fd7-7b97-4d97-a19a-29179eea7b1a
+      - WESTEUROPE:20180312T094310Z:920f88bf-87a1-4289-aac2-2f8951bf3375
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:19:00 GMT
+      - Mon, 12 Mar 2018 09:43:10 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"platformUpdateDomain\": 1,\r\n  \"platformFaultDomain\": 1,\r\n
+        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
+        [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
+        \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
+        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2018-03-12T09:43:00+00:00\"\r\n
+        \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"osdisk\",\r\n
+        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
+        succeeded\",\r\n          \"time\": \"2016-09-03T02:05:35.0977796+00:00\"\r\n
+        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
+        \"https://spec0deply1stor.blob.core.windows.net/bootdiagnostics-spec0depl-d7022008-f6b1-4f4c-8be8-e2d677ef3261/spec0deply1vm0.d7022008-f6b1-4f4c-8be8-e2d677ef3261.screenshot.bmp\",\r\n
+        \   \"serialConsoleLogBlobUri\": \"https://spec0deply1stor.blob.core.windows.net/bootdiagnostics-spec0depl-d7022008-f6b1-4f4c-8be8-e2d677ef3261/spec0deply1vm0.d7022008-f6b1-4f4c-8be8-e2d677ef3261.serialconsole.log\"\r\n
+        \ },\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n
+        \     \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n
+        \     \"time\": \"2016-09-03T02:05:35.1602741+00:00\"\r\n    },\r\n    {\r\n
+        \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
+        \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:43:14 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups/miq-azure-test1?api-version=2017-08-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDc0MDIsIm5iZiI6MTUyMDg0NzQwMiwiZXhwIjoxNTIwODUxMzAyLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYldDZVJlZzBva0tOM1V5STRIMGpBQSIsInZlciI6IjEuMCJ9.eQcibNRit9UpZReJbHfEsmiPLie_5JJmntSSqIl_3JhpZUk5RiY9C5-tpvcqgzi4T2gBYIWpCTaJATTECFPv8N6WD5grp4DvR8jTIAd6GymPo3g-NXmQkBj_SOQ30wf3FsCZgKP9lQpEJAW7fPQ2F8qhmSX_mPeeP2y7FPVL8WIkCw0KEMo8L1JgQDrW_oKLo6xG2BCl3XSHjezamVAYqafAg7_nHcOAPsKtYAeozxPnuEMfnLLpHwXsWoI_6SeHzTIeU00orNnTk71_yDFh6KcGqQ98uruMTawbXy8YiqUQznf9OfjqdCA2Qg7YybfSLBw6gY1eBGp27n13wOQAog
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14982'
+      X-Ms-Request-Id:
+      - 38436fab-29b9-43ce-8625-f8228b416cd2
+      X-Ms-Correlation-Request-Id:
+      - 38436fab-29b9-43ce-8625-f8228b416cd2
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T094310Z:38436fab-29b9-43ce-8625-f8228b416cd2
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:43:10 GMT
+      Content-Length:
+      - '183'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1","name":"miq-azure-test1","location":"eastus","properties":{"provisioningState":"Succeeded"}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:43:15 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute/locations/eastus/vmSizes?api-version=2017-12-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDc0MDIsIm5iZiI6MTUyMDg0NzQwMiwiZXhwIjoxNTIwODUxMzAyLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYldDZVJlZzBva0tOM1V5STRIMGpBQSIsInZlciI6IjEuMCJ9.eQcibNRit9UpZReJbHfEsmiPLie_5JJmntSSqIl_3JhpZUk5RiY9C5-tpvcqgzi4T2gBYIWpCTaJATTECFPv8N6WD5grp4DvR8jTIAd6GymPo3g-NXmQkBj_SOQ30wf3FsCZgKP9lQpEJAW7fPQ2F8qhmSX_mPeeP2y7FPVL8WIkCw0KEMo8L1JgQDrW_oKLo6xG2BCl3XSHjezamVAYqafAg7_nHcOAPsKtYAeozxPnuEMfnLLpHwXsWoI_6SeHzTIeU00orNnTk71_yDFh6KcGqQ98uruMTawbXy8YiqUQznf9OfjqdCA2Qg7YybfSLBw6gY1eBGp27n13wOQAog
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/LowCostGet3Min;4740,Microsoft.Compute/LowCostGet30Min;38337
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344652126238
+      X-Ms-Request-Id:
+      - a701344f-1bbe-439e-a9af-47be54a1d1fa
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14986'
+      X-Ms-Correlation-Request-Id:
+      - 04326a36-8cea-41f0-910a-a8d5f9d76bb9
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T094311Z:04326a36-8cea-41f0-910a-a8d5f9d76bb9
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:43:11 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"Standard_B1ms\",\r\n
@@ -3081,6 +3141,12 @@ http_interactions:
         \   },\r\n    {\r\n      \"name\": \"Standard_F72s_v2\",\r\n      \"numberOfCores\":
         72,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
         589824,\r\n      \"memoryInMB\": 147456,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_L8s_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1811981,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_L16s_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        3623962,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
         \   },\r\n    {\r\n      \"name\": \"Standard_ND6s\",\r\n      \"numberOfCores\":
         6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
         344064,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 12\r\n
@@ -3107,10 +3173,10 @@ http_interactions:
         391168,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
         \   }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:19:01 GMT
+  recorded_at: Mon, 12 Mar 2018 09:43:15 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete?api-version=2017-08-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3124,7 +3190,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2MzcsIm5iZiI6MTUyMDQ1MzYzNywiZXhwIjoxNTIwNDU3NTM3LCJhaW8iOiJZMk5nWUVndU5CSXl1MXFVeEdEM2ZsSFpieWtHQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibWRrSmk4SFRQa2VWdzN4cjkzVUFBQSIsInZlciI6IjEuMCJ9.J3fkRceBnuqHzbCWXI9FkZKmAqJH5NA_gajQkr41F04fYdtfIyuU_a80xJSZKU2PZiEAhPHjiXBTfsopP7FDQMHwTuQahlI1yEZWwmRRfs7PX_DQZ7rYY3zhil8dAogBXtPdWNCQBFWNfIG3pAVaxRDnEWbxohb-k2hoDecrqFj-72Nn-hXs4y_2QF6wyQqblR6oQoIC27dHQCWor4XZmCAljrPGWmerUaYj0LCCj6LQDd6w_tRZHhe7KX-xbqH3qBtv6CKc2I3rfKcpV-Yw5-w5RWkqzcLelOqwajr0gBu1W_aKG6Mo-0IRUE-r1AYEjJnyhUcQ3QVpL3SXtUfbKg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDc0MDIsIm5iZiI6MTUyMDg0NzQwMiwiZXhwIjoxNTIwODUxMzAyLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYldDZVJlZzBva0tOM1V5STRIMGpBQSIsInZlciI6IjEuMCJ9.eQcibNRit9UpZReJbHfEsmiPLie_5JJmntSSqIl_3JhpZUk5RiY9C5-tpvcqgzi4T2gBYIWpCTaJATTECFPv8N6WD5grp4DvR8jTIAd6GymPo3g-NXmQkBj_SOQ30wf3FsCZgKP9lQpEJAW7fPQ2F8qhmSX_mPeeP2y7FPVL8WIkCw0KEMo8L1JgQDrW_oKLo6xG2BCl3XSHjezamVAYqafAg7_nHcOAPsKtYAeozxPnuEMfnLLpHwXsWoI_6SeHzTIeU00orNnTk71_yDFh6KcGqQ98uruMTawbXy8YiqUQznf9OfjqdCA2Qg7YybfSLBw6gY1eBGp27n13wOQAog
   response:
     status:
       code: 200
@@ -3134,69 +3200,36 @@ http_interactions:
       - no-cache
       Pragma:
       - no-cache
-      Transfer-Encoding:
-      - chunked
       Content-Type:
       - application/json; charset=utf-8
       Expires:
       - "-1"
       Vary:
       - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/LowCostGet3Min;4735,Microsoft.Compute/LowCostGet30Min;37857
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14983'
+      X-Ms-Request-Id:
+      - c9835363-0bcf-42e2-9874-a87b1cd8abe5
+      X-Ms-Correlation-Request-Id:
+      - c9835363-0bcf-42e2-9874-a87b1cd8abe5
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T094312Z:c9835363-0bcf-42e2-9874-a87b1cd8abe5
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
-      X-Ms-Request-Id:
-      - 003e9522-bb41-4428-bd73-ee61712b7804
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14971'
-      X-Ms-Correlation-Request-Id:
-      - 5100eadb-fb38-4af9-9329-dfca1ae82bf6
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201911Z:5100eadb-fb38-4af9-9329-dfca1ae82bf6
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:19:11 GMT
+      - Mon, 12 Mar 2018 09:43:11 GMT
+      Content-Length:
+      - '7230'
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"03e8467b-baab-4867-9cc4-157336b7e2e4\",\r\n
-        \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Basic_A0\"\r\n    },\r\n
-        \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
-        \"RedHat\",\r\n        \"offer\": \"RHEL\",\r\n        \"sku\": \"7.2\",\r\n
-        \       \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
-        \"Linux\",\r\n        \"name\": \"miq-test-rhel1\",\r\n        \"createOption\":
-        \"FromImage\",\r\n        \"vhd\": {\r\n          \"uri\": \"https://miqazuretest18686.blob.core.windows.net/vhds/miq-test-rhel12016218112243.vhd\"\r\n
-        \       },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n      \"dataDisks\":
-        []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"miq-test-rhel1\",\r\n
-        \     \"adminUsername\": \"dberger\",\r\n      \"linuxConfiguration\": {\r\n
-        \       \"disablePasswordAuthentication\": false\r\n      },\r\n      \"secrets\":
-        []\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390\"}]},\r\n
-        \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
-        true,\r\n        \"storageUri\": \"https://miqazuretest18686.blob.core.windows.net/\"\r\n
-        \     }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n
-        \ \"resources\": [\r\n    {\r\n      \"properties\": {\r\n        \"publisher\":
-        \"Microsoft.OSTCExtensions\",\r\n        \"type\": \"LinuxDiagnostic\",\r\n
-        \       \"typeHandlerVersion\": \"2.0\",\r\n        \"autoUpgradeMinorVersion\":
-        true,\r\n        \"settings\": {\"xmlCfg\":\"PFdhZENmZz48RGlhZ25vc3RpY01vbml0b3JDb25maWd1cmF0aW9uIG92ZXJhbGxRdW90YUluTUI9IjQwOTYiPjxEaWFnbm9zdGljSW5mcmFzdHJ1Y3R1cmVMb2dzIHNjaGVkdWxlZFRyYW5zZmVyUGVyaW9kPSJQVDFNIiBzY2hlZHVsZWRUcmFuc2ZlckxvZ0xldmVsRmlsdGVyPSJXYXJuaW5nIi8+PFBlcmZvcm1hbmNlQ291bnRlcnMgc2NoZWR1bGVkVHJhbnNmZXJQZXJpb2Q9IlBUMU0iPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlTWVtb3J5IiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQnl0ZXMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcUGVyY2VudEF2YWlsYWJsZU1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iTWVtb3J5IHVzZWQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50VXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgcGVyY2VudGFnZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkQnlDYWNoZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHVzZWQgYnkgY2FjaGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1BlclNlYyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50UGVyU2Vjb25kIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFnZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1JlYWRQZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2UgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1dyaXR0ZW5QZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2Ugd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iU3dhcCBhdmFpbGFibGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50QXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZFN3YXAiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlN3YXAgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRJZGxlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgaWRsZSB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFVzZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iUGVyY2VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkNQVSB1c2VyIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50TmljZVRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIG5pY2UgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRQcml2aWxlZ2VkVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgcHJpdmlsZWdlZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudEludGVycnVwdFRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIGludGVycnVwdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudERQQ1RpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIERQQyB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFByb2Nlc3NvclRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIHBlcmNlbnRhZ2UgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50SU9XYWl0VGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgSU8gd2FpdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xSZWFkQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCBndWVzdCBPUyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXFdyaXRlQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGUgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xUcmFuc2ZlcnNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXJzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcUmVhZHNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xXcml0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVJlYWRUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVdyaXRlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlNlY29uZHMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJEaXNrIHdyaXRlIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xBdmVyYWdlVHJhbnNmZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXIgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXEF2ZXJhZ2VEaXNrUXVldWVMZW5ndGgiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcXVldWUgbGVuZ3RoIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVHJhbnNtaXR0ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgb3V0IGd1ZXN0IE9TIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzUmVjZWl2ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgaW4gZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1RyYW5zbWl0dGVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHNlbnQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1JlY2VpdmVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHJlY2VpdmVkIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVG90YWwiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxSeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyByZWNlaXZlZCBlcnJvcnMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxUeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyBzZW50IGVycm9ycyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTmV0d29ya0ludGVyZmFjZVxUb3RhbENvbGxpc2lvbnMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgY29sbGlzaW9ucyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48L1BlcmZvcm1hbmNlQ291bnRlcnM+PE1ldHJpY3MgcmVzb3VyY2VJZD0iL3N1YnNjcmlwdGlvbnMvMjU4NmM2NGItMzhiNC00NTI3LWExNDAtMDEyZDQ5ZGZjMDJjL3Jlc291cmNlR3JvdXBzL21pcS1henVyZS10ZXN0MS9wcm92aWRlcnMvTWljcm9zb2Z0LkNvbXB1dGUvdmlydHVhbE1hY2hpbmVzL21pcS10ZXN0LXJoZWwxIj48TWV0cmljQWdncmVnYXRpb24gc2NoZWR1bGVkVHJhbnNmZXJQZXJpb2Q9IlBUMUgiLz48TWV0cmljQWdncmVnYXRpb24gc2NoZWR1bGVkVHJhbnNmZXJQZXJpb2Q9IlBUMU0iLz48L01ldHJpY3M+PC9EaWFnbm9zdGljTW9uaXRvckNvbmZpZ3VyYXRpb24+PC9XYWRDZmc+\",\"StorageAccount\":\"miqazuretest18686\"},\r\n
-        \       \"provisioningState\": \"Succeeded\"\r\n      },\r\n      \"type\":
-        \"Microsoft.Compute/virtualMachines/extensions\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/extensions/Microsoft.Insights.VMDiagnosticsSettings\",\r\n
-        \     \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n    }\r\n
-        \ ],\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\":
-        \"eastus\",\r\n  \"tags\": {\r\n    \"Shutdown\": \"true\"\r\n  },\r\n  \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1\",\r\n
-        \ \"name\": \"miq-test-rhel1\"\r\n}"
+      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete","name":"spec-nested-deployment-dont-delete","properties":{"templateLink":{"uri":"https://gist.githubusercontent.com/bzwei/c09f906306399d238762bce711781200/raw/3558b735da03c1c030023d70b78ec3451dab5689/azure-loadbalancer.json","contentVersion":"1.0.0.0"},"parameters":{"storageAccountName":{"type":"String","value":"spec0deply1stor"},"availabilitySetName":{"type":"String","value":"spec0deply1as"},"adminUsername":{"type":"String","value":"deploy1admin"},"adminPassword":{"type":"SecureString"},"dnsNameforLBIP":{"type":"String","value":"spec0deply1dns"},"vmNamePrefix":{"type":"String","value":"spec0deply1vm"},"imagePublisher":{"type":"String","value":"MicrosoftWindowsServer"},"imageOffer":{"type":"String","value":"WindowsServer"},"imageSKU":{"type":"String","value":"2012-R2-Datacenter"},"lbName":{"type":"String","value":"spec0deply1lb"},"nicNamePrefix":{"type":"String","value":"spec0deply1nic"},"publicIPAddressName":{"type":"String","value":"spec0deply1ip"},"vnetName":{"type":"String","value":"spec0deply1vnet"},"vmSize":{"type":"String","value":"Standard_D1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-04-04T23:28:59.2682474Z","duration":"PT23M55.442141S","correlationId":"3a55e6b5-4a3b-431e-8144-53698bf6f1dc","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["eastus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"availabilitySets","locations":["eastus"]},{"resourceType":"virtualMachines","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"publicIPAddresses","locations":["eastus"]},{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"loadBalancers","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"spec0deply1ip"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic0"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic1"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"spec0deply1stor"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"spec0deply1as"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"spec0deply1vm0"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"spec0deply1stor"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"spec0deply1as"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"spec0deply1vm1"}],"outputResources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor"}]}}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:19:11 GMT
+  recorded_at: Mon, 12 Mar 2018 09:43:16 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/instanceView?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-deployment-dont-delete?api-version=2017-08-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3210,7 +3243,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2MzcsIm5iZiI6MTUyMDQ1MzYzNywiZXhwIjoxNTIwNDU3NTM3LCJhaW8iOiJZMk5nWUVndU5CSXl1MXFVeEdEM2ZsSFpieWtHQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibWRrSmk4SFRQa2VWdzN4cjkzVUFBQSIsInZlciI6IjEuMCJ9.J3fkRceBnuqHzbCWXI9FkZKmAqJH5NA_gajQkr41F04fYdtfIyuU_a80xJSZKU2PZiEAhPHjiXBTfsopP7FDQMHwTuQahlI1yEZWwmRRfs7PX_DQZ7rYY3zhil8dAogBXtPdWNCQBFWNfIG3pAVaxRDnEWbxohb-k2hoDecrqFj-72Nn-hXs4y_2QF6wyQqblR6oQoIC27dHQCWor4XZmCAljrPGWmerUaYj0LCCj6LQDd6w_tRZHhe7KX-xbqH3qBtv6CKc2I3rfKcpV-Yw5-w5RWkqzcLelOqwajr0gBu1W_aKG6Mo-0IRUE-r1AYEjJnyhUcQ3QVpL3SXtUfbKg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDc0MDIsIm5iZiI6MTUyMDg0NzQwMiwiZXhwIjoxNTIwODUxMzAyLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYldDZVJlZzBva0tOM1V5STRIMGpBQSIsInZlciI6IjEuMCJ9.eQcibNRit9UpZReJbHfEsmiPLie_5JJmntSSqIl_3JhpZUk5RiY9C5-tpvcqgzi4T2gBYIWpCTaJATTECFPv8N6WD5grp4DvR8jTIAd6GymPo3g-NXmQkBj_SOQ30wf3FsCZgKP9lQpEJAW7fPQ2F8qhmSX_mPeeP2y7FPVL8WIkCw0KEMo8L1JgQDrW_oKLo6xG2BCl3XSHjezamVAYqafAg7_nHcOAPsKtYAeozxPnuEMfnLLpHwXsWoI_6SeHzTIeU00orNnTk71_yDFh6KcGqQ98uruMTawbXy8YiqUQznf9OfjqdCA2Qg7YybfSLBw6gY1eBGp27n13wOQAog
   response:
     status:
       code: 200
@@ -3220,68 +3253,37 @@ http_interactions:
       - no-cache
       Pragma:
       - no-cache
-      Transfer-Encoding:
-      - chunked
       Content-Type:
       - application/json; charset=utf-8
       Expires:
       - "-1"
       Vary:
       - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/GetInstanceView3Min;4791,Microsoft.Compute/GetInstanceView30Min;23918
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
-      X-Ms-Request-Id:
-      - 812aeb98-9186-437a-849a-e5c1aa31bfb6
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
       - '14984'
+      X-Ms-Request-Id:
+      - ae0d17d3-0bbf-4b96-9327-424e8f05eb7e
       X-Ms-Correlation-Request-Id:
-      - 7a2879cf-8505-40ae-ad96-b8f4f130615e
+      - ae0d17d3-0bbf-4b96-9327-424e8f05eb7e
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201923Z:7a2879cf-8505-40ae-ad96-b8f4f130615e
+      - WESTEUROPE:20180312T094313Z:ae0d17d3-0bbf-4b96-9327-424e8f05eb7e
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:19:23 GMT
+      - Mon, 12 Mar 2018 09:43:13 GMT
+      Content-Length:
+      - '3083'
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"vmAgent\": {\r\n    \"vmAgentVersion\": \"WALinuxAgent-2.0.16\",\r\n
-        \   \"statuses\": [\r\n      {\r\n        \"code\": \"ProvisioningState/succeeded\",\r\n
-        \       \"level\": \"Info\",\r\n        \"displayStatus\": \"Ready\",\r\n
-        \       \"message\": \"GuestAgent is running and accepting new configurations.\",\r\n
-        \       \"time\": \"2018-03-07T20:19:08+00:00\"\r\n      }\r\n    ],\r\n    \"extensionHandlers\":
-        [\r\n      {\r\n        \"type\": \"Microsoft.OSTCExtensions.LinuxDiagnostic\",\r\n
-        \       \"typeHandlerVersion\": \"2.3.9027\",\r\n        \"status\": {\r\n
-        \         \"code\": \"ProvisioningState/succeeded\",\r\n          \"level\":
-        \"Info\",\r\n          \"displayStatus\": \"Ready\"\r\n        }\r\n      }\r\n
-        \   ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"miq-test-rhel1\",\r\n
-        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
-        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"time\": \"2018-01-17T18:00:29.9011002+00:00\"\r\n
-        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
-        \"https://miqazuretest18686.blob.core.windows.net/bootdiagnostics-miqtestrh-03e8467b-baab-4867-9cc4-157336b7e2e4/miq-test-rhel1.03e8467b-baab-4867-9cc4-157336b7e2e4.screenshot.bmp\",\r\n
-        \   \"serialConsoleLogBlobUri\": \"https://miqazuretest18686.blob.core.windows.net/bootdiagnostics-miqtestrh-03e8467b-baab-4867-9cc4-157336b7e2e4/miq-test-rhel1.03e8467b-baab-4867-9cc4-157336b7e2e4.serialconsole.log\"\r\n
-        \ },\r\n  \"extensions\": [\r\n    {\r\n      \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\",\r\n
-        \     \"type\": \"Microsoft.OSTCExtensions.LinuxDiagnostic\",\r\n      \"typeHandlerVersion\":
-        \"2.3.9027\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\":
-        \"ProvisioningState/succeeded\",\r\n          \"level\": \"Info\",\r\n          \"displayStatus\":
-        \"Provisioning succeeded\",\r\n          \"message\": \"Enable succeeded\"\r\n
-        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\":
-        \"ProvisioningState/succeeded\",\r\n      \"level\": \"Info\",\r\n      \"displayStatus\":
-        \"Provisioning succeeded\",\r\n      \"time\": \"2018-01-17T18:02:26.9167163+00:00\"\r\n
-        \   },\r\n    {\r\n      \"code\": \"PowerState/running\",\r\n      \"level\":
-        \"Info\",\r\n      \"displayStatus\": \"VM running\"\r\n    }\r\n  ]\r\n}"
+      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-deployment-dont-delete","name":"spec-deployment-dont-delete","properties":{"templateLink":{"uri":"https://gist.githubusercontent.com/bzwei/e6ccc4d641d6afab8e26ef55c37c498e/raw/769505e37256e926a9b581a100c90bb657ff45ff/azure-parent-spec.json","contentVersion":"1.0.0.0"},"parameters":{"childDeployName":{"type":"String","value":"spec-nested-deployment-dont-delete"},"storageAccountName":{"type":"String","value":"spec0deply1stor"},"availabilitySetName":{"type":"String","value":"spec0deply1as"},"adminUsername":{"type":"String","value":"deploy1admin"},"adminPassword":{"type":"SecureString"},"dnsNameforLBIP":{"type":"String","value":"spec0deply1dns"},"vmNamePrefix":{"type":"String","value":"spec0deply1vm"},"imagePublisher":{"type":"String","value":"MicrosoftWindowsServer"},"imageOffer":{"type":"String","value":"WindowsServer"},"imageSKU":{"type":"String","value":"2012-R2-Datacenter"},"lbName":{"type":"String","value":"spec0deply1lb"},"nicNamePrefix":{"type":"String","value":"spec0deply1nic"},"publicIPAddressName":{"type":"String","value":"spec0deply1ip"},"vnetName":{"type":"String","value":"spec0deply1vnet"},"vmSize":{"type":"String","value":"Standard_D1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-04-04T23:29:05.0043846Z","duration":"PT24M6.1512983S","correlationId":"3a55e6b5-4a3b-431e-8144-53698bf6f1dc","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[],"outputs":{"siteUri":{"type":"String","value":"hard-coded
+        output for test"}},"outputResources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor"}]}}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:19:23 GMT
+  recorded_at: Mon, 12 Mar 2018 09:43:18 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Network/networkInterfaces?api-version=2017-11-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor?api-version=2017-10-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3295,7 +3297,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2MzcsIm5iZiI6MTUyMDQ1MzYzNywiZXhwIjoxNTIwNDU3NTM3LCJhaW8iOiJZMk5nWUVndU5CSXl1MXFVeEdEM2ZsSFpieWtHQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibWRrSmk4SFRQa2VWdzN4cjkzVUFBQSIsInZlciI6IjEuMCJ9.J3fkRceBnuqHzbCWXI9FkZKmAqJH5NA_gajQkr41F04fYdtfIyuU_a80xJSZKU2PZiEAhPHjiXBTfsopP7FDQMHwTuQahlI1yEZWwmRRfs7PX_DQZ7rYY3zhil8dAogBXtPdWNCQBFWNfIG3pAVaxRDnEWbxohb-k2hoDecrqFj-72Nn-hXs4y_2QF6wyQqblR6oQoIC27dHQCWor4XZmCAljrPGWmerUaYj0LCCj6LQDd6w_tRZHhe7KX-xbqH3qBtv6CKc2I3rfKcpV-Yw5-w5RWkqzcLelOqwajr0gBu1W_aKG6Mo-0IRUE-r1AYEjJnyhUcQ3QVpL3SXtUfbKg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDc0MDIsIm5iZiI6MTUyMDg0NzQwMiwiZXhwIjoxNTIwODUxMzAyLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYldDZVJlZzBva0tOM1V5STRIMGpBQSIsInZlciI6IjEuMCJ9.eQcibNRit9UpZReJbHfEsmiPLie_5JJmntSSqIl_3JhpZUk5RiY9C5-tpvcqgzi4T2gBYIWpCTaJATTECFPv8N6WD5grp4DvR8jTIAd6GymPo3g-NXmQkBj_SOQ30wf3FsCZgKP9lQpEJAW7fPQ2F8qhmSX_mPeeP2y7FPVL8WIkCw0KEMo8L1JgQDrW_oKLo6xG2BCl3XSHjezamVAYqafAg7_nHcOAPsKtYAeozxPnuEMfnLLpHwXsWoI_6SeHzTIeU00orNnTk71_yDFh6KcGqQ98uruMTawbXy8YiqUQznf9OfjqdCA2Qg7YybfSLBw6gY1eBGp27n13wOQAog
   response:
     status:
       code: 200
@@ -3305,136 +3307,38 @@ http_interactions:
       - no-cache
       Pragma:
       - no-cache
+      Transfer-Encoding:
+      - chunked
       Content-Type:
-      - application/json; charset=utf-8
+      - application/json
       Expires:
       - "-1"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 883ae019-5943-46de-a467-6c7ec3df9aec
-      X-Ms-Correlation-Request-Id:
-      - 883ae019-5943-46de-a467-6c7ec3df9aec
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201928Z:883ae019-5943-46de-a467-6c7ec3df9aec
+      - 58e6598e-91f3-4c19-9938-a147abb0144a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14981'
+      X-Ms-Correlation-Request-Id:
+      - b4b78c58-618b-473a-a6f2-1f7f52506cc6
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T094314Z:b4b78c58-618b-473a-a6f2-1f7f52506cc6
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:19:27 GMT
-      Content-Length:
-      - '31614'
+      - Mon, 12 Mar 2018 09:43:13 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"name":"miqazure-coreos1235","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235","etag":"W/\"4a6546ab-a4c0-4d27-bccd-f6ebf3c405a2\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"fb0a5e60-a6c2-4bb8-a2f5-0c16216a49b0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235/ipConfigurations/ipconfig1","etag":"W/\"4a6546ab-a4c0-4d27-bccd-f6ebf3c405a2\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.20.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/publicIPAddresses/miqazure-coreos1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/virtualNetworks/miq-azure-test3/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"rliadcyr3l1elbnsw4rabxqg1f.dx.internal.cloudapp.net"},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkSecurityGroups/miqazure-coreos1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Compute/virtualMachines/miqazure-coreos1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"dbergerprov1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/dbergerprov1","etag":"W/\"074dd836-918c-4e40-a118-94f0d366e175\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"ecdcd2f0-91bb-4c40-91cd-a3d76fc5e455","ipConfigurations":[{"name":"dbergerprov1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/dbergerprov1/ipConfigurations/dbergerprov1","etag":"W/\"074dd836-918c-4e40-a118-94f0d366e175\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.9","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/dbergerprov1-publicIp"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/virtualMachines/dbergerprov1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-rhel1390","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390","etag":"W/\"f006e6f9-0292-42cd-99fc-f72f194553c1\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"98853f48-2806-4065-be57-cf9159550440","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1","etag":"W/\"f006e6f9-0292-42cd-99fc-f72f194553c1\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"macAddress":"00-0D-3A-10-EB-AB","enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-ubuntu1989","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989","etag":"W/\"64e07488-15a2-4cec-b84a-6fd5ef04323c\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"134a6669-ac4a-4d08-a0db-387bc4c49537","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989/ipConfigurations/ipconfig1","etag":"W/\"64e07488-15a2-4cec-b84a-6fd5ef04323c\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.17.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-ubuntu1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest18687/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-win12610","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610","etag":"W/\"dd925ef5-33d1-402c-a0f4-18c78c2641f4\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"5c2eef2c-0b36-4277-a940-957ed4d13be0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610/ipConfigurations/ipconfig1","etag":"W/\"dd925ef5-33d1-402c-a0f4-18c78c2641f4\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.18.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-win12"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest19881/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-winimg241","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241","etag":"W/\"4a17a745-16a9-42d9-88c9-17a518959525\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"8ed2f3b0-4a4b-49ae-9f1d-ff7890dbd396","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241/ipConfigurations/ipconfig1","etag":"W/\"4a17a745-16a9-42d9-88c9-17a518959525\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.7","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqtestwinimg6202"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-centos1611","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611","etag":"W/\"26031ef6-bb55-4019-8185-2dd1edcb207c\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"f1760e49-9853-4fdc-acfc-4ea232b9ed76","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1","etag":"W/\"26031ef6-bb55-4019-8185-2dd1edcb207c\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.5","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqmismatch1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1","etag":"W/\"3a72d0c3-bfda-4da5-a61b-e8c33e43de79\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"23d804a8-b623-49e7-9c8d-1d64245bef1e","ipConfigurations":[{"name":"miqmismatch1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1/ipConfigurations/miqmismatch1","etag":"W/\"3a72d0c3-bfda-4da5-a61b-e8c33e43de79\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.8","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqmismatch1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqmismatch1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"rspec-lb-a670","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670","etag":"W/\"cf3a0b0d-d596-4f33-bc31-749f92ba4f00\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"46cb8216-786e-408e-9d86-c0855b357349","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1","etag":"W/\"cf3a0b0d-d596-4f33-bc31-749f92ba4f00\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.6","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-a-ip"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"rspec-lb-b843","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843","etag":"W/\"76aabe0c-8678-43f0-81a5-2f15784a4b99\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"3ef6fa01-ac34-43a1-8fd7-67c706b4d8ef","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1","etag":"W/\"76aabe0c-8678-43f0-81a5-2f15784a4b99\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.11","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-b-ip"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"spec0deply1nic0","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","etag":"W/\"b817491c-aab8-4aab-b41d-b07bfffa5639\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"80ad9866-071d-4e3f-91d0-d47954eccee0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1","etag":"W/\"b817491c-aab8-4aab-b41d-b07bfffa5639\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.4","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"spec0deply1nic1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","etag":"W/\"2ec58a0b-4c03-4d0a-b788-9daffd54e7b2\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"57bbf7aa-d6c4-4f56-8f6a-089d15334221","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1","etag":"W/\"2ec58a0b-4c03-4d0a-b788-9daffd54e7b2\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.5","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqmismatch2656","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqmismatch2656","etag":"W/\"fef6a836-2802-4897-90c3-b3d71f133384\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"969dde6c-73c0-4340-877d-2b5fe2060026","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqmismatch2656/ipConfigurations/ipconfig1","etag":"W/\"fef6a836-2802-4897-90c3-b3d71f133384\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"172.23.0.4","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/virtualNetworks/miqazuretest33606/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkSecurityGroups/miqmismatch2-nsg"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Compute/virtualMachines/miqmismatch2"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-linux-manag944","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944","etag":"W/\"b6339880-8ead-4c9e-b5c0-f38c4f8612d5\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"c5e8b90e-5a78-49b0-b224-b70ed3fb45e5","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944/ipConfigurations/ipconfig1","etag":"W/\"b6339880-8ead-4c9e-b5c0-f38c4f8612d5\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"172.25.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqazure-linux-managed-ip"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"jf-metrics-2751","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751","etag":"W/\"c5f6f02a-b17c-4f34-882b-11c7adef0b44\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"207a58d3-f18d-4dab-8168-919877297a52","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751/ipConfigurations/ipconfig1","etag":"W/\"c5f6f02a-b17c-4f34-882b-11c7adef0b44\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.7","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-2"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-2"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/jf-metrics-2"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"jf-metrics-3421","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421","etag":"W/\"0b6f160b-ad10-48f8-9d0c-657193bb823f\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"b8b345e8-a353-4700-992e-be48a717b4e2","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421/ipConfigurations/ipconfig1","etag":"W/\"0b6f160b-ad10-48f8-9d0c-657193bb823f\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.8","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-3"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-3"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/jf-metrics-3"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-oraclelinux310","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310","etag":"W/\"54cd4fe1-3ed5-4a8c-bc8d-527679c7a631\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"6a3fc1d7-4532-4ca0-b5c2-546cc8f7f313","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310/ipConfigurations/ipconfig1","etag":"W/\"54cd4fe1-3ed5-4a8c-bc8d-527679c7a631\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.5","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-oraclelinux993","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993","etag":"W/\"a9432274-7b40-4eb3-a64f-a04267a423ff\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"75d8ed14-e0ae-4d84-99f6-e3f43d073e76","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993/ipConfigurations/ipconfig1","etag":"W/\"a9432274-7b40-4eb3-a64f-a04267a423ff\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.6","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux2"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux2"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"}]}'
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","name":"spec0deply1stor","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-04-04T23:05:07.8274794Z","primaryEndpoints":{"blob":"https://spec0deply1stor.blob.core.windows.net/","queue":"https://spec0deply1stor.queue.core.windows.net/","table":"https://spec0deply1stor.table.core.windows.net/","file":"https://spec0deply1stor.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:19:28 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Network/publicIPAddresses?api-version=2017-11-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2MzcsIm5iZiI6MTUyMDQ1MzYzNywiZXhwIjoxNTIwNDU3NTM3LCJhaW8iOiJZMk5nWUVndU5CSXl1MXFVeEdEM2ZsSFpieWtHQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibWRrSmk4SFRQa2VWdzN4cjkzVUFBQSIsInZlciI6IjEuMCJ9.J3fkRceBnuqHzbCWXI9FkZKmAqJH5NA_gajQkr41F04fYdtfIyuU_a80xJSZKU2PZiEAhPHjiXBTfsopP7FDQMHwTuQahlI1yEZWwmRRfs7PX_DQZ7rYY3zhil8dAogBXtPdWNCQBFWNfIG3pAVaxRDnEWbxohb-k2hoDecrqFj-72Nn-hXs4y_2QF6wyQqblR6oQoIC27dHQCWor4XZmCAljrPGWmerUaYj0LCCj6LQDd6w_tRZHhe7KX-xbqH3qBtv6CKc2I3rfKcpV-Yw5-w5RWkqzcLelOqwajr0gBu1W_aKG6Mo-0IRUE-r1AYEjJnyhUcQ3QVpL3SXtUfbKg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 31ec7209-6dec-4285-941c-f12f8fd233d5
-      X-Ms-Correlation-Request-Id:
-      - 31ec7209-6dec-4285-941c-f12f8fd233d5
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201930Z:31ec7209-6dec-4285-941c-f12f8fd233d5
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:19:30 GMT
-      Content-Length:
-      - '13978'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[{"name":"miqazure-coreos1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/publicIPAddresses/miqazure-coreos1","etag":"W/\"da64b64b-a755-4389-a2f3-5cba32f18c06\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"28617ed1-0270-4b39-873a-c3b48b3deef1","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"dbergerprov1-publicIp","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/dbergerprov1-publicIp","etag":"W/\"3d984c69-3f35-41ce-bdfc-8d207053a6a9\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"eb0e8804-e169-44ac-bb47-0929370977d2","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/dbergerprov1/ipConfigurations/dbergerprov1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"ladas_test","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/ladas_test","etag":"W/\"32e21623-9a1b-4c40-80f4-6a350aa237a7\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"3daa5f66-5a01-4242-b95b-c4e0ee8f0c36","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[]},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miq-test-rhel1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1","etag":"W/\"054052bb-11ff-4f6e-ac1a-3427c2fd17aa\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"f6cfc635-411e-48ce-a627-39a2fc0d3168","ipAddress":"52.224.165.15","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miq-test-ubuntu1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-ubuntu1","etag":"W/\"bcae50c5-146f-4fcb-a461-7c1030ba7b74\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"e272bd74-f661-484f-b223-88dd128a4049","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miq-test-win12","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-win12","etag":"W/\"56ce00f4-50d7-4682-9ee8-6836bf5c0ea6\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"b9200977-8147-40a5-83c2-d5892d5ddedc","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miqazure-centos1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1","etag":"W/\"734a3944-a880-444c-8c92-cace6e28e303\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"475a66f0-9e89-4226-a9f0-9baaaf31d619","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miqtestwinimg6202","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqtestwinimg6202","etag":"W/\"b656279a-26ff-4021-94bb-263420cf494e\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"fb942169-855b-44f8-b12f-fd63e961b140","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"rspec-lb-a-ip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-a-ip","etag":"W/\"3ba30997-7d2f-470c-96f6-301158e93b7c\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"3c605f75-23c0-46ab-ba2b-6fd4430140fd","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"rspec-lb-b-ip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-b-ip","etag":"W/\"cf6012c7-3d47-438f-84d7-332ad1ef4500\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"5d1a2425-a351-4c0f-bc87-37e6500bff22","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"rspec-lb1-LoadBalancerFrontEnd","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd","etag":"W/\"a38434c8-7b23-4092-b7c6-402238eac0dc\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"f28e0f25-b372-4edf-97d9-13a9e3b4ba2d","ipAddress":"40.71.82.83","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"rspec-lb2-publicip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip","etag":"W/\"cddd97d1-6111-4477-8a00-3dc885237a1d\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"83e7257d-ab94-4229-8eb5-4798f37ef28d","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"spec0deply1ip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip","etag":"W/\"2080997a-38a6-420d-ba86-e9582e1331c7\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"a08b891e-e45a-4970-aefc-f6c996989490","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"spec0deply1dns","fqdn":"spec0deply1dns.eastus.cloudapp.azure.com"},"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miqazure-linux-managed-ip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqazure-linux-managed-ip","etag":"W/\"0efc9684-fb7d-4fb7-b9b9-f33dbac04a28\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"6a2a9142-26e8-45cd-93bf-7318192f3528","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miqmismatch1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqmismatch1","etag":"W/\"9b8b1729-21c4-4c53-94f2-15715315ad73\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"a97c71d0-6b78-4ffe-8e5c-0be1ee653f8c","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"miqmismatch1","fqdn":"miqmismatch1.eastus.cloudapp.azure.com"},"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1/ipConfigurations/miqmismatch1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"jf-metrics-2","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-2","etag":"W/\"b43ebe01-574c-4454-87eb-3401fbcf36f2\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"e446f3e4-9410-4d7f-bb04-2652096359de","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"jf-metrics-3","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-3","etag":"W/\"a6ee7100-6202-4ae2-a2db-f828abec8af9\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"de5995a4-15c1-40ba-ad78-67e70a92654b","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miqazure-oraclelinux1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux1","etag":"W/\"98bee7b4-2fcc-471d-b5ce-92850e6c3d6b\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"f2ac7c18-520b-4b42-94e7-da264a842f41","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miqazure-oraclelinux2","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux2","etag":"W/\"0865cebc-95b9-49d2-9f10-21dbafb23cac\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"2f4e1091-46f0-474c-a697-8dbcea6ba2a6","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}}]}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:19:30 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Storage/storageAccounts?api-version=2017-10-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2MzcsIm5iZiI6MTUyMDQ1MzYzNywiZXhwIjoxNTIwNDU3NTM3LCJhaW8iOiJZMk5nWUVndU5CSXl1MXFVeEdEM2ZsSFpieWtHQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibWRrSmk4SFRQa2VWdzN4cjkzVUFBQSIsInZlciI6IjEuMCJ9.J3fkRceBnuqHzbCWXI9FkZKmAqJH5NA_gajQkr41F04fYdtfIyuU_a80xJSZKU2PZiEAhPHjiXBTfsopP7FDQMHwTuQahlI1yEZWwmRRfs7PX_DQZ7rYY3zhil8dAogBXtPdWNCQBFWNfIG3pAVaxRDnEWbxohb-k2hoDecrqFj-72Nn-hXs4y_2QF6wyQqblR6oQoIC27dHQCWor4XZmCAljrPGWmerUaYj0LCCj6LQDd6w_tRZHhe7KX-xbqH3qBtv6CKc2I3rfKcpV-Yw5-w5RWkqzcLelOqwajr0gBu1W_aKG6Mo-0IRUE-r1AYEjJnyhUcQ3QVpL3SXtUfbKg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 6dc7da61-e4e5-488e-96e2-6a7243f830b9
-      X-Ms-Correlation-Request-Id:
-      - 6dc7da61-e4e5-488e-96e2-6a7243f830b9
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201932Z:6dc7da61-e4e5-488e-96e2-6a7243f830b9
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:19:31 GMT
-      Content-Length:
-      - '8649'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","name":"miqazuretest18686","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T17:22:54.7808677Z","primaryEndpoints":{"blob":"https://miqazuretest18686.blob.core.windows.net/","queue":"https://miqazuretest18686.queue.core.windows.net/","table":"https://miqazuretest18686.table.core.windows.net/","file":"https://miqazuretest18686.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","name":"miqazuretest14047","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T17:30:25.7028008Z","primaryEndpoints":{"blob":"https://miqazuretest14047.blob.core.windows.net/","queue":"https://miqazuretest14047.queue.core.windows.net/","table":"https://miqazuretest14047.table.core.windows.net/","file":"https://miqazuretest14047.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Premium_LRS","tier":"Premium"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb","name":"rspeclb","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-09-02T16:29:11.6823797Z","primaryEndpoints":{"blob":"https://rspeclb.blob.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","name":"spec0deply1stor","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-04-04T23:05:07.8274794Z","primaryEndpoints":{"blob":"https://spec0deply1stor.blob.core.windows.net/","queue":"https://spec0deply1stor.queue.core.windows.net/","table":"https://spec0deply1stor.table.core.windows.net/","file":"https://spec0deply1stor.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Storage/storageAccounts/miqazuretest26611","name":"miqazuretest26611","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2211656Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2211656Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-05-02T18:01:29.2743021Z","primaryEndpoints":{"blob":"https://miqazuretest26611.blob.core.windows.net/","queue":"https://miqazuretest26611.queue.core.windows.net/","table":"https://miqazuretest26611.table.core.windows.net/","file":"https://miqazuretest26611.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","name":"miqazuretest16487","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T17:26:55.3231669Z","primaryEndpoints":{"blob":"https://miqazuretest16487.blob.core.windows.net/","queue":"https://miqazuretest16487.queue.core.windows.net/","table":"https://miqazuretest16487.table.core.windows.net/","file":"https://miqazuretest16487.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Storage/storageAccounts/miqazuretest32946","name":"miqazuretest32946","type":"Microsoft.Storage/storageAccounts","location":"westus","tags":{"delete":"false"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.0404359Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.0404359Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T21:18:37.0793411Z","primaryEndpoints":{"blob":"https://miqazuretest32946.blob.core.windows.net/","queue":"https://miqazuretest32946.queue.core.windows.net/","table":"https://miqazuretest32946.table.core.windows.net/","file":"https://miqazuretest32946.file.core.windows.net/"},"primaryLocation":"westus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Storage/storageAccounts/miqazureshared1","name":"miqazureshared1","type":"Microsoft.Storage/storageAccounts","location":"centralus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.1935084Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.1935084Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T20:42:52.498085Z","primaryEndpoints":{"blob":"https://miqazureshared1.blob.core.windows.net/","queue":"https://miqazureshared1.queue.core.windows.net/","table":"https://miqazureshared1.table.core.windows.net/","file":"https://miqazureshared1.file.core.windows.net/"},"primaryLocation":"centralus","statusOfPrimary":"available","secondaryLocation":"eastus2","statusOfSecondary":"available","secondaryEndpoints":{"blob":"https://miqazureshared1-secondary.blob.core.windows.net/","queue":"https://miqazureshared1-secondary.queue.core.windows.net/","table":"https://miqazureshared1-secondary.table.core.windows.net/"}}}]}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:19:32 GMT
+  recorded_at: Mon, 12 Mar 2018 09:43:18 GMT
 - request:
     method: post
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686/listKeys?api-version=2017-10-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor/listKeys?api-version=2017-10-01
     body:
       encoding: ASCII-8BIT
       string: ''
@@ -3448,7 +3352,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2MzcsIm5iZiI6MTUyMDQ1MzYzNywiZXhwIjoxNTIwNDU3NTM3LCJhaW8iOiJZMk5nWUVndU5CSXl1MXFVeEdEM2ZsSFpieWtHQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibWRrSmk4SFRQa2VWdzN4cjkzVUFBQSIsInZlciI6IjEuMCJ9.J3fkRceBnuqHzbCWXI9FkZKmAqJH5NA_gajQkr41F04fYdtfIyuU_a80xJSZKU2PZiEAhPHjiXBTfsopP7FDQMHwTuQahlI1yEZWwmRRfs7PX_DQZ7rYY3zhil8dAogBXtPdWNCQBFWNfIG3pAVaxRDnEWbxohb-k2hoDecrqFj-72Nn-hXs4y_2QF6wyQqblR6oQoIC27dHQCWor4XZmCAljrPGWmerUaYj0LCCj6LQDd6w_tRZHhe7KX-xbqH3qBtv6CKc2I3rfKcpV-Yw5-w5RWkqzcLelOqwajr0gBu1W_aKG6Mo-0IRUE-r1AYEjJnyhUcQ3QVpL3SXtUfbKg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDc0MDIsIm5iZiI6MTUyMDg0NzQwMiwiZXhwIjoxNTIwODUxMzAyLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYldDZVJlZzBva0tOM1V5STRIMGpBQSIsInZlciI6IjEuMCJ9.eQcibNRit9UpZReJbHfEsmiPLie_5JJmntSSqIl_3JhpZUk5RiY9C5-tpvcqgzi4T2gBYIWpCTaJATTECFPv8N6WD5grp4DvR8jTIAd6GymPo3g-NXmQkBj_SOQ30wf3FsCZgKP9lQpEJAW7fPQ2F8qhmSX_mPeeP2y7FPVL8WIkCw0KEMo8L1JgQDrW_oKLo6xG2BCl3XSHjezamVAYqafAg7_nHcOAPsKtYAeozxPnuEMfnLLpHwXsWoI_6SeHzTIeU00orNnTk71_yDFh6KcGqQ98uruMTawbXy8YiqUQznf9OfjqdCA2Qg7YybfSLBw6gY1eBGp27n13wOQAog
       Content-Length:
       - '0'
   response:
@@ -3469,29 +3373,29 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 9d5258d5-30dc-4527-b6b3-f54b6b980e60
+      - 5055e128-7c06-4666-b7ef-25df236127ab
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1196'
+      - '1199'
       X-Ms-Correlation-Request-Id:
-      - cb8cfa3c-ba0b-449b-a927-31142438dedc
+      - 65291eab-94fb-4b67-ac5f-ba792ae4187f
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201932Z:cb8cfa3c-ba0b-449b-a927-31142438dedc
+      - WESTEUROPE:20180312T094314Z:65291eab-94fb-4b67-ac5f-ba792ae4187f
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:19:32 GMT
+      - Mon, 12 Mar 2018 09:43:14 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"keys":[{"keyName":"key1","value":"32PV5jeBt8nw1XvFbZokY26SXchbD6H2tw/YrteEYVE0kpMLKrZ74VrwaIjDyucdi/RxDaAlf7dJIilLS7muNw==","permissions":"Full"},{"keyName":"key2","value":"Eo5x9CQJL1/wl6Tkj5N7M5eEdw6Hym6AeyTt3xjcDl30sV8Iadro6ywZzOHQwNDlmrDaBF6x2a9ZFL7zswxQ7w==","permissions":"Full"}]}'
+      string: '{"keys":[{"keyName":"key1","value":"68JHlwL/JgyPmvNCqop65JbepxzK0RGKJ4uD6EKszcgv1nRUJKkxO6u4OoyW/6YPT+FMJxvzEBrCGD/bduFGJQ==","permissions":"Full"},{"keyName":"key2","value":"NCT/sPC/+mrVRzXq/V5IwjN2SPaWRF4kY2coPHzJ8f+IkWMUIyfUgYTAN//h4KnxeWuX9OkY1CPyssDhDs91fw==","permissions":"Full"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:19:33 GMT
+  recorded_at: Mon, 12 Mar 2018 09:43:19 GMT
 - request:
     method: head
-    uri: https://miqazuretest18686.blob.core.windows.net/vhds/miq-test-rhel12016218112243.vhd
+    uri: https://spec0deply1stor.blob.core.windows.net/vhds/osdisk0.vhd
     body:
       encoding: US-ASCII
       string: ''
@@ -3505,7 +3409,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:19:33 GMT
+      - Mon, 12 Mar 2018 09:43:19 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -3513,38 +3417,38 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest18686:feQo83k/cwkYxpeQPCdgyax2Si4NqsHk5Y9D70qOBYs=
+      - SharedKey spec0deply1stor:t1GCyJadeGlEqU6xz2Lz7VsjpFEAlIezNRM2tbKJSKc=
   response:
     status:
       code: 200
       message: OK
     headers:
       Content-Length:
-      - '32212255232'
+      - '136367309312'
       Content-Type:
       - application/octet-stream
       Content-Md5:
-      - dQL+XHjFNPdoMEweI63fwQ==
+      - VbYhW9/6NOXzQVK/vQkdvg==
       Last-Modified:
-      - Wed, 07 Mar 2018 20:19:33 GMT
+      - Sat, 03 Sep 2016 02:04:38 GMT
       Accept-Ranges:
       - bytes
       Etag:
-      - '"0x8D58468BD6F569B"'
+      - '"0x8D3D39EA8F71715"'
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 3b2f87eb-001e-00b7-7b51-b6297a000000
+      - b54b8b25-001e-0048-12e6-b914e2000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Microsoftazurecompute-Resourcegroupname:
       - miq-azure-test1
       X-Ms-Meta-Microsoftazurecompute-Vmname:
-      - miq-test-rhel1
+      - spec0deply1vm0
       X-Ms-Meta-Microsoftazurecompute-Diskid:
-      - 0ea91415-9058-46c6-9792-3afcb4da976f
+      - b059fe2a-4ccb-4a50-a235-ea3b7b089730
       X-Ms-Meta-Microsoftazurecompute-Diskname:
-      - miq-test-rhel1
+      - osdisk
       X-Ms-Meta-Microsoftazurecompute-Disktype:
       - OSDisk
       X-Ms-Lease-Status:
@@ -3556,29 +3460,29 @@ http_interactions:
       X-Ms-Blob-Type:
       - PageBlob
       X-Ms-Blob-Sequence-Number:
-      - '371'
+      - '43'
       X-Ms-Copy-Id:
-      - b967ea05-82a2-405a-8df9-4615d59df4eb
+      - 27fb6a34-f422-4f0a-afcb-528942d6012f
       X-Ms-Copy-Source:
-      - https://ardfepirv2bl5prdstr06.blob.core.windows.net/a879bbefc56a43abb0ce65052aac09f3/rhel-72-20160302?sv=2014-02-14&sr=b&si=PirCacheAccountPublisherContainerPolicy&sig=2TQ3SKHqVnqe4jVKB4qMCBOphv2nYelKworI7pfckrs%3D
+      - https://ardfepirv2bl5prdstr06.blob.core.windows.net/a699494373c04fc0bc8f2bb1389d6106/Windows-Server-2012-R2-20160229-en.us-127GB.vhd?sv=2014-02-14&sr=b&si=PirCacheAccountPublisherContainerPolicy&sig=ipib%2Bgp2Sh4hS%2BBx5OUKgXSymDC0Tu0Ge60PGFuy5uk%3D
       X-Ms-Copy-Status:
       - success
       X-Ms-Copy-Progress:
-      - 32212255232/32212255232
+      - 136367309312/136367309312
       X-Ms-Copy-Completion-Time:
-      - Fri, 18 Mar 2016 17:23:28 GMT
+      - Mon, 04 Apr 2016 23:24:57 GMT
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:19:33 GMT
+      - Mon, 12 Mar 2018 09:43:14 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:19:33 GMT
+  recorded_at: Mon, 12 Mar 2018 09:43:19 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet?api-version=2018-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3592,7 +3496,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2MzcsIm5iZiI6MTUyMDQ1MzYzNywiZXhwIjoxNTIwNDU3NTM3LCJhaW8iOiJZMk5nWUVndU5CSXl1MXFVeEdEM2ZsSFpieWtHQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibWRrSmk4SFRQa2VWdzN4cjkzVUFBQSIsInZlciI6IjEuMCJ9.J3fkRceBnuqHzbCWXI9FkZKmAqJH5NA_gajQkr41F04fYdtfIyuU_a80xJSZKU2PZiEAhPHjiXBTfsopP7FDQMHwTuQahlI1yEZWwmRRfs7PX_DQZ7rYY3zhil8dAogBXtPdWNCQBFWNfIG3pAVaxRDnEWbxohb-k2hoDecrqFj-72Nn-hXs4y_2QF6wyQqblR6oQoIC27dHQCWor4XZmCAljrPGWmerUaYj0LCCj6LQDd6w_tRZHhe7KX-xbqH3qBtv6CKc2I3rfKcpV-Yw5-w5RWkqzcLelOqwajr0gBu1W_aKG6Mo-0IRUE-r1AYEjJnyhUcQ3QVpL3SXtUfbKg
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDc0MDIsIm5iZiI6MTUyMDg0NzQwMiwiZXhwIjoxNTIwODUxMzAyLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYldDZVJlZzBva0tOM1V5STRIMGpBQSIsInZlciI6IjEuMCJ9.eQcibNRit9UpZReJbHfEsmiPLie_5JJmntSSqIl_3JhpZUk5RiY9C5-tpvcqgzi4T2gBYIWpCTaJATTECFPv8N6WD5grp4DvR8jTIAd6GymPo3g-NXmQkBj_SOQ30wf3FsCZgKP9lQpEJAW7fPQ2F8qhmSX_mPeeP2y7FPVL8WIkCw0KEMo8L1JgQDrW_oKLo6xG2BCl3XSHjezamVAYqafAg7_nHcOAPsKtYAeozxPnuEMfnLLpHwXsWoI_6SeHzTIeU00orNnTk71_yDFh6KcGqQ98uruMTawbXy8YiqUQznf9OfjqdCA2Qg7YybfSLBw6gY1eBGp27n13wOQAog
   response:
     status:
       code: 200
@@ -3609,351 +3513,43 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"5ad0e691-263e-42ca-8a93-833bd4dbf13f"
+      - W/"be3510b0-35c7-48ea-874b-49ac343ba8c9"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 7e8f035f-e5f7-4143-8886-49596e863679
+      - 5c15fc9c-5b2c-4970-bd8d-eae021cc595f
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14863'
+      - '14984'
       X-Ms-Correlation-Request-Id:
-      - 311ea696-eb3f-42b3-a075-8f882cdbd156
+      - 9a07fe8b-c6ac-41d0-a732-941d331e126d
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201934Z:311ea696-eb3f-42b3-a075-8f882cdbd156
+      - WESTEUROPE:20180312T094315Z:9a07fe8b-c6ac-41d0-a732-941d331e126d
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:19:33 GMT
+      - Mon, 12 Mar 2018 09:43:15 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"miq-test-rhel1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1\",\r\n
-        \ \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/networkSecurityGroups\",\r\n  \"location\": \"eastus\",\r\n
-        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"f4a4a6a5-e2e8-47bd-b46f-00592f8fce53\",\r\n    \"securityRules\":
-        [\r\n      {\r\n        \"name\": \"default-allow-ssh\",\r\n        \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/securityRules/default-allow-ssh\",\r\n
-        \       \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Tcp\",\r\n          \"sourcePortRange\": \"*\",\r\n
-        \         \"destinationPortRange\": \"22\",\r\n          \"sourceAddressPrefix\":
-        \"*\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n          \"access\":
-        \"Allow\",\r\n          \"priority\": 1000,\r\n          \"direction\": \"Inbound\",\r\n
-        \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
-        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
-        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"rhel1-inbound1\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/securityRules/rhel1-inbound1\",\r\n
-        \       \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Tcp\",\r\n          \"sourcePortRange\": \"80\",\r\n
-        \         \"destinationPortRange\": \"80\",\r\n          \"sourceAddressPrefix\":
-        \"*\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n          \"access\":
-        \"Allow\",\r\n          \"priority\": 100,\r\n          \"direction\": \"Inbound\",\r\n
-        \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
-        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
-        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"rhel1-inbound2\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/securityRules/rhel1-inbound2\",\r\n
-        \       \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Tcp\",\r\n          \"sourcePortRange\": \"443\",\r\n
-        \         \"destinationPortRange\": \"443\",\r\n          \"sourceAddressPrefix\":
-        \"*\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n          \"access\":
-        \"Allow\",\r\n          \"priority\": 200,\r\n          \"direction\": \"Inbound\",\r\n
-        \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
-        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
-        []\r\n        }\r\n      }\r\n    ],\r\n    \"defaultSecurityRules\": [\r\n
-        \     {\r\n        \"name\": \"AllowVnetInBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/defaultSecurityRules/AllowVnetInBound\",\r\n
-        \       \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"description\": \"Allow inbound traffic from all VMs in VNET\",\r\n
-        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
-        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
-        \"VirtualNetwork\",\r\n          \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
-        \         \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n          \"direction\":
-        \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
-        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
-        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowAzureLoadBalancerInBound\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/defaultSecurityRules/AllowAzureLoadBalancerInBound\",\r\n
-        \       \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"description\": \"Allow inbound traffic from azure load balancer\",\r\n
-        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
-        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
-        \"AzureLoadBalancer\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n
-        \         \"access\": \"Allow\",\r\n          \"priority\": 65001,\r\n          \"direction\":
-        \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
-        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
-        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllInBound\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/defaultSecurityRules/DenyAllInBound\",\r\n
-        \       \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"description\": \"Deny all inbound traffic\",\r\n          \"protocol\":
-        \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\":
-        \"*\",\r\n          \"sourceAddressPrefix\": \"*\",\r\n          \"destinationAddressPrefix\":
-        \"*\",\r\n          \"access\": \"Deny\",\r\n          \"priority\": 65500,\r\n
-        \         \"direction\": \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n
-        \         \"destinationPortRanges\": [],\r\n          \"sourceAddressPrefixes\":
-        [],\r\n          \"destinationAddressPrefixes\": []\r\n        }\r\n      },\r\n
-        \     {\r\n        \"name\": \"AllowVnetOutBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/defaultSecurityRules/AllowVnetOutBound\",\r\n
-        \       \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"description\": \"Allow outbound traffic from all VMs to all VMs
-        in VNET\",\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\":
-        \"*\",\r\n          \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
-        \"VirtualNetwork\",\r\n          \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
-        \         \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n          \"direction\":
-        \"Outbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
-        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
-        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowInternetOutBound\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/defaultSecurityRules/AllowInternetOutBound\",\r\n
-        \       \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"description\": \"Allow outbound traffic from all VMs to Internet\",\r\n
-        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
-        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
-        \"*\",\r\n          \"destinationAddressPrefix\": \"Internet\",\r\n          \"access\":
-        \"Allow\",\r\n          \"priority\": 65001,\r\n          \"direction\": \"Outbound\",\r\n
-        \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
-        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
-        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllOutBound\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/defaultSecurityRules/DenyAllOutBound\",\r\n
-        \       \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"description\": \"Deny all outbound traffic\",\r\n          \"protocol\":
-        \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\":
-        \"*\",\r\n          \"sourceAddressPrefix\": \"*\",\r\n          \"destinationAddressPrefix\":
-        \"*\",\r\n          \"access\": \"Deny\",\r\n          \"priority\": 65500,\r\n
-        \         \"direction\": \"Outbound\",\r\n          \"sourcePortRanges\":
-        [],\r\n          \"destinationPortRanges\": [],\r\n          \"sourceAddressPrefixes\":
-        [],\r\n          \"destinationAddressPrefixes\": []\r\n        }\r\n      }\r\n
-        \   ],\r\n    \"networkInterfaces\": [\r\n      {\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390\"\r\n
-        \     }\r\n    ]\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:19:34 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2MzcsIm5iZiI6MTUyMDQ1MzYzNywiZXhwIjoxNTIwNDU3NTM3LCJhaW8iOiJZMk5nWUVndU5CSXl1MXFVeEdEM2ZsSFpieWtHQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibWRrSmk4SFRQa2VWdzN4cjkzVUFBQSIsInZlciI6IjEuMCJ9.J3fkRceBnuqHzbCWXI9FkZKmAqJH5NA_gajQkr41F04fYdtfIyuU_a80xJSZKU2PZiEAhPHjiXBTfsopP7FDQMHwTuQahlI1yEZWwmRRfs7PX_DQZ7rYY3zhil8dAogBXtPdWNCQBFWNfIG3pAVaxRDnEWbxohb-k2hoDecrqFj-72Nn-hXs4y_2QF6wyQqblR6oQoIC27dHQCWor4XZmCAljrPGWmerUaYj0LCCj6LQDd6w_tRZHhe7KX-xbqH3qBtv6CKc2I3rfKcpV-Yw5-w5RWkqzcLelOqwajr0gBu1W_aKG6Mo-0IRUE-r1AYEjJnyhUcQ3QVpL3SXtUfbKg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"fceae1ac-4620-482a-bc6d-79c867179ae5"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 61d71fcf-53d1-4986-8d11-996844edca06
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14968'
-      X-Ms-Correlation-Request-Id:
-      - b7ca6de4-db5d-4dcd-87ca-3a4fc998946b
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201934Z:b7ca6de4-db5d-4dcd-87ca-3a4fc998946b
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:19:33 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"miq-azure-test1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1\",\r\n
-        \ \"etag\": \"W/\\\"fceae1ac-4620-482a-bc6d-79c867179ae5\\\"\",\r\n  \"type\":
+      string: "{\r\n  \"name\": \"spec0deply1vnet\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet\",\r\n
+        \ \"etag\": \"W/\\\"be3510b0-35c7-48ea-874b-49ac343ba8c9\\\"\",\r\n  \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
-        \"d74c1e5f-50e4-4c8a-a7fe-78eaddc6b915\",\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\":
-        [\r\n        \"10.16.0.0/16\"\r\n      ]\r\n    },\r\n    \"subnets\": [\r\n
-        \     {\r\n        \"name\": \"default\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\",\r\n
-        \       \"etag\": \"W/\\\"fceae1ac-4620-482a-bc6d-79c867179ae5\\\"\",\r\n
+        \"0bb1f005-1af2-4d4b-966a-89aaf6daefca\",\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\":
+        [\r\n        \"10.0.0.0/16\"\r\n      ]\r\n    },\r\n    \"subnets\": [\r\n
+        \     {\r\n        \"name\": \"Subnet-1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1\",\r\n
+        \       \"etag\": \"W/\\\"be3510b0-35c7-48ea-874b-49ac343ba8c9\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"addressPrefix\": \"10.16.0.0/24\",\r\n          \"ipConfigurations\":
-        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241/ipConfigurations/ipconfig1\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1/ipConfigurations/miqmismatch1\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/dbergerprov1/ipConfigurations/dbergerprov1\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\"\r\n
+        \         \"addressPrefix\": \"10.0.0.0/24\",\r\n          \"ipConfigurations\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1\"\r\n
         \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"virtualNetworkPeerings\":
         [],\r\n    \"enableDdosProtection\": false,\r\n    \"enableVmProtection\":
         false\r\n  }\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:19:34 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2MzcsIm5iZiI6MTUyMDQ1MzYzNywiZXhwIjoxNTIwNDU3NTM3LCJhaW8iOiJZMk5nWUVndU5CSXl1MXFVeEdEM2ZsSFpieWtHQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibWRrSmk4SFRQa2VWdzN4cjkzVUFBQSIsInZlciI6IjEuMCJ9.J3fkRceBnuqHzbCWXI9FkZKmAqJH5NA_gajQkr41F04fYdtfIyuU_a80xJSZKU2PZiEAhPHjiXBTfsopP7FDQMHwTuQahlI1yEZWwmRRfs7PX_DQZ7rYY3zhil8dAogBXtPdWNCQBFWNfIG3pAVaxRDnEWbxohb-k2hoDecrqFj-72Nn-hXs4y_2QF6wyQqblR6oQoIC27dHQCWor4XZmCAljrPGWmerUaYj0LCCj6LQDd6w_tRZHhe7KX-xbqH3qBtv6CKc2I3rfKcpV-Yw5-w5RWkqzcLelOqwajr0gBu1W_aKG6Mo-0IRUE-r1AYEjJnyhUcQ3QVpL3SXtUfbKg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"f006e6f9-0292-42cd-99fc-f72f194553c1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 9448c1e8-a171-4613-b0c0-61826c75bf2c
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14967'
-      X-Ms-Correlation-Request-Id:
-      - '092afbd8-2e8f-4bc1-a47a-34fda8dbb794'
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201935Z:092afbd8-2e8f-4bc1-a47a-34fda8dbb794
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:19:34 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"miq-test-rhel1390\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390\",\r\n
-        \ \"etag\": \"W/\\\"f006e6f9-0292-42cd-99fc-f72f194553c1\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"98853f48-2806-4065-be57-cf9159550440\",\r\n    \"ipConfigurations\":
-        [\r\n      {\r\n        \"name\": \"ipconfig1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1\",\r\n
-        \       \"etag\": \"W/\\\"f006e6f9-0292-42cd-99fc-f72f194553c1\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAddress\": \"10.16.0.4\",\r\n          \"privateIPAllocationMethod\":
-        \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1\"\r\n
-        \         },\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\"\r\n
-        \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
-        \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\":
-        [],\r\n      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\":
-        \"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net\"\r\n    },\r\n    \"macAddress\":
-        \"00-0D-3A-10-EB-AB\",\r\n    \"enableAcceleratedNetworking\": false,\r\n
-        \   \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\": {\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1\"\r\n
-        \   },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1\"\r\n
-        \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
-        \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:19:35 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2MzcsIm5iZiI6MTUyMDQ1MzYzNywiZXhwIjoxNTIwNDU3NTM3LCJhaW8iOiJZMk5nWUVndU5CSXl1MXFVeEdEM2ZsSFpieWtHQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibWRrSmk4SFRQa2VWdzN4cjkzVUFBQSIsInZlciI6IjEuMCJ9.J3fkRceBnuqHzbCWXI9FkZKmAqJH5NA_gajQkr41F04fYdtfIyuU_a80xJSZKU2PZiEAhPHjiXBTfsopP7FDQMHwTuQahlI1yEZWwmRRfs7PX_DQZ7rYY3zhil8dAogBXtPdWNCQBFWNfIG3pAVaxRDnEWbxohb-k2hoDecrqFj-72Nn-hXs4y_2QF6wyQqblR6oQoIC27dHQCWor4XZmCAljrPGWmerUaYj0LCCj6LQDd6w_tRZHhe7KX-xbqH3qBtv6CKc2I3rfKcpV-Yw5-w5RWkqzcLelOqwajr0gBu1W_aKG6Mo-0IRUE-r1AYEjJnyhUcQ3QVpL3SXtUfbKg
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"054052bb-11ff-4f6e-ac1a-3427c2fd17aa"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 5b43d47d-9d9c-4371-b435-7dd9b969aa36
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14977'
-      X-Ms-Correlation-Request-Id:
-      - dbe674f5-220b-4865-a4de-827f5638be45
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201935Z:dbe674f5-220b-4865-a4de-827f5638be45
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:19:35 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"miq-test-rhel1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1\",\r\n
-        \ \"etag\": \"W/\\\"054052bb-11ff-4f6e-ac1a-3427c2fd17aa\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"f6cfc635-411e-48ce-a627-39a2fc0d3168\",\r\n    \"ipAddress\":
-        \"52.224.165.15\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\":
-        \"Dynamic\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipTags\": [],\r\n
-        \   \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1\"\r\n
-        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
-        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:19:35 GMT
+  recorded_at: Mon, 12 Mar 2018 09:43:20 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_500/powered_off_vm_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_500/powered_off_vm_refresh.yml
@@ -1,6 +1,62 @@
 ---
 http_interactions:
 - request:
+    method: post
+    uri: https://login.microsoftonline.com/AZURE_TENANT_ID/oauth2/token
+    body:
+      encoding: UTF-8
+      string: grant_type=client_credentials&client_id=AZURE_CLIENT_ID&client_secret=AZURE_CLIENT_SECRET&resource=https%3A%2F%2Fmanagement.azure.com%2F
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Server:
+      - Microsoft-IIS/10.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Request-Id:
+      - f927ff1c-ab7c-48a0-bbbe-a41ba0f21500
+      P3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Set-Cookie:
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzMEO9NMTjN1riGDKjHDhZstcsWruxUCbnWEOq-n1OeuGnoB77jSEC-ECjoYhIZolLvAKk9ayHPFyLq55gkinkclgzYUfEongKA-3lez5SWOA8zn7wknPDBjnFpxZg_Wy8NSDnMxLuUeioebxkHrn9vyilYVsSab9UxPW8j5maRNMgAA;
+        domain=.login.microsoftonline.com; path=/; secure; HttpOnly
+      - stsservicecookie=ests; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=007; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 12 Mar 2018 09:39:31 GMT
+      Content-Length:
+      - '1505'
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1520851171","not_before":"1520847271","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcyNzEsIm5iZiI6MTUyMDg0NzI3MSwiZXhwIjoxNTIwODUxMTcxLCJhaW8iOiJZMk5nWUVpNS9kNXM5OFJ2bFJuTTE2VWQrYnc1QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSFA4bi1YeXJvRWk3dnFRYm9QSVZBQSIsInZlciI6IjEuMCJ9.cmV6jFj1RmnNMfUAqSAd6LuXcaqVd5c5CcyiJRxLck21ye7EkiYbfaNlHqF_rO-NiA88HYw9zsJZ3osPiesmsWrC4pgFwpbZxznA94d6ZAY2IQDemPO3TkzRfeRWvF55N1Ffzmch2kOI46MCHImKOXet05c5l7xlu33Ca9Z6S3lXndG8U79R_cHcheQlOokfNq2dWe433UyM8KDJ5FUdqN54Y4pkupjgITef3qDk2JT7Lq4VBAZBuaY-k7-SUblaId0Is15YrvRCfO76ycs_vPuYvUTXOCsLEQHJH1xZnb3UAixHDp08yhuYUnyZqZjxFVzrnHpL7bbl-JlkltDOlw"}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:39:36 GMT
+- request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
     body:
@@ -16,7 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcyNzEsIm5iZiI6MTUyMDg0NzI3MSwiZXhwIjoxNTIwODUxMTcxLCJhaW8iOiJZMk5nWUVpNS9kNXM5OFJ2bFJuTTE2VWQrYnc1QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSFA4bi1YeXJvRWk3dnFRYm9QSVZBQSIsInZlciI6IjEuMCJ9.cmV6jFj1RmnNMfUAqSAd6LuXcaqVd5c5CcyiJRxLck21ye7EkiYbfaNlHqF_rO-NiA88HYw9zsJZ3osPiesmsWrC4pgFwpbZxznA94d6ZAY2IQDemPO3TkzRfeRWvF55N1Ffzmch2kOI46MCHImKOXet05c5l7xlu33Ca9Z6S3lXndG8U79R_cHcheQlOokfNq2dWe433UyM8KDJ5FUdqN54Y4pkupjgITef3qDk2JT7Lq4VBAZBuaY-k7-SUblaId0Is15YrvRCfO76ycs_vPuYvUTXOCsLEQHJH1xZnb3UAixHDp08yhuYUnyZqZjxFVzrnHpL7bbl-JlkltDOlw
   response:
     status:
       code: 200
@@ -35,26 +91,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14997'
+      - '14998'
       X-Ms-Request-Id:
-      - cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - f1208297-2de9-4af3-a4b9-f4081bb4b931
       X-Ms-Correlation-Request-Id:
-      - cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - f1208297-2de9-4af3-a4b9-f4081bb4b931
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102417Z:cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - WESTEUROPE:20180312T093932Z:f1208297-2de9-4af3-a4b9-f4081bb4b931
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:17 GMT
+      - Mon, 12 Mar 2018 09:39:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID","subscriptionId":"AZURE_SUBSCRIPTION_ID","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:22 GMT
+  recorded_at: Mon, 12 Mar 2018 09:39:37 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers?api-version=2015-01-01
@@ -71,7 +127,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcyNzEsIm5iZiI6MTUyMDg0NzI3MSwiZXhwIjoxNTIwODUxMTcxLCJhaW8iOiJZMk5nWUVpNS9kNXM5OFJ2bFJuTTE2VWQrYnc1QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSFA4bi1YeXJvRWk3dnFRYm9QSVZBQSIsInZlciI6IjEuMCJ9.cmV6jFj1RmnNMfUAqSAd6LuXcaqVd5c5CcyiJRxLck21ye7EkiYbfaNlHqF_rO-NiA88HYw9zsJZ3osPiesmsWrC4pgFwpbZxznA94d6ZAY2IQDemPO3TkzRfeRWvF55N1Ffzmch2kOI46MCHImKOXet05c5l7xlu33Ca9Z6S3lXndG8U79R_cHcheQlOokfNq2dWe433UyM8KDJ5FUdqN54Y4pkupjgITef3qDk2JT7Lq4VBAZBuaY-k7-SUblaId0Is15YrvRCfO76ycs_vPuYvUTXOCsLEQHJH1xZnb3UAixHDp08yhuYUnyZqZjxFVzrnHpL7bbl-JlkltDOlw
   response:
     status:
       code: 200
@@ -88,19 +144,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - '14990'
       X-Ms-Request-Id:
-      - fe3532ca-59a2-474e-9094-8a3697b82bef
+      - 30cc2494-cb2c-44b1-b739-2ebefd752338
       X-Ms-Correlation-Request-Id:
-      - fe3532ca-59a2-474e-9094-8a3697b82bef
+      - 30cc2494-cb2c-44b1-b739-2ebefd752338
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102419Z:fe3532ca-59a2-474e-9094-8a3697b82bef
+      - WESTEUROPE:20180312T093934Z:30cc2494-cb2c-44b1-b739-2ebefd752338
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:18 GMT
+      - Mon, 12 Mar 2018 09:39:34 GMT
       Content-Length:
       - '320853'
     body:
@@ -2322,10 +2378,10 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:23 GMT
+  recorded_at: Mon, 12 Mar 2018 09:39:39 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1?api-version=2017-12-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2339,7 +2395,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcyNzEsIm5iZiI6MTUyMDg0NzI3MSwiZXhwIjoxNTIwODUxMTcxLCJhaW8iOiJZMk5nWUVpNS9kNXM5OFJ2bFJuTTE2VWQrYnc1QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSFA4bi1YeXJvRWk3dnFRYm9QSVZBQSIsInZlciI6IjEuMCJ9.cmV6jFj1RmnNMfUAqSAd6LuXcaqVd5c5CcyiJRxLck21ye7EkiYbfaNlHqF_rO-NiA88HYw9zsJZ3osPiesmsWrC4pgFwpbZxznA94d6ZAY2IQDemPO3TkzRfeRWvF55N1Ffzmch2kOI46MCHImKOXet05c5l7xlu33Ca9Z6S3lXndG8U79R_cHcheQlOokfNq2dWe433UyM8KDJ5FUdqN54Y4pkupjgITef3qDk2JT7Lq4VBAZBuaY-k7-SUblaId0Is15YrvRCfO76ycs_vPuYvUTXOCsLEQHJH1xZnb3UAixHDp08yhuYUnyZqZjxFVzrnHpL7bbl-JlkltDOlw
   response:
     status:
       code: 200
@@ -2355,88 +2411,64 @@ http_interactions:
       - application/json; charset=utf-8
       Expires:
       - "-1"
-      Etag:
-      - W/"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67"
       Vary:
       - Accept-Encoding
-      X-Ms-Request-Id:
-      - '080de667-081e-4d58-9e94-9e7243d4200e'
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/LowCostGet3Min;4741,Microsoft.Compute/LowCostGet30Min;37838
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      X-Ms-Request-Id:
+      - 2bd50802-b4d0-49be-b54c-9bbf08cc34b9
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
+      - '14997'
       X-Ms-Correlation-Request-Id:
-      - '093d49ac-c85f-440e-956b-955b6698dd19'
+      - 0e0a57cd-e31e-4aeb-aa3c-6eceeb008e73
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102419Z:093d49ac-c85f-440e-956b-955b6698dd19
+      - WESTEUROPE:20180312T093935Z:0e0a57cd-e31e-4aeb-aa3c-6eceeb008e73
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:19 GMT
+      - Mon, 12 Mar 2018 09:39:34 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1\",\r\n
-        \ \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"7ab88756-810f-4083-95db-8b05d50e38f2\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ],\r\n          \"inboundNatRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"backendIPConfigurations\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\"\r\n
-        \           }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-rule\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\":
-        80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\"\r\n
-        \         },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n
-        \       \"name\": \"rspec-lb-probe\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-NAT\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 3441,\r\n          \"backendPort\":
-        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
+      string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"796c5bcc-338a-448d-b61c-165279a7fb3e\",\r\n
+        \   \"availabilitySet\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/MIQAZURE-AVAILSET-EAST\"\r\n
+        \   },\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Basic_A0\"\r\n
+        \   },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
+        \"OpenLogic\",\r\n        \"offer\": \"CentOS\",\r\n        \"sku\": \"7.1\",\r\n
+        \       \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
+        \"Linux\",\r\n        \"name\": \"miqazure-centos1\",\r\n        \"createOption\":
+        \"FromImage\",\r\n        \"vhd\": {\r\n          \"uri\": \"https://miqazuretest14047.blob.core.windows.net/vhds/miqazure-centos12016221104946.vhd\"\r\n
+        \       },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n      \"dataDisks\":
+        []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"miqazure-centos1\",\r\n
+        \     \"adminUsername\": \"dberger\",\r\n      \"linuxConfiguration\": {\r\n
+        \       \"disablePasswordAuthentication\": false\r\n      },\r\n      \"secrets\":
+        []\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611\"}]},\r\n
+        \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
+        true,\r\n        \"storageUri\": \"https://miqazuretest14047.blob.core.windows.net/\"\r\n
+        \     }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n
+        \ \"resources\": [\r\n    {\r\n      \"properties\": {\r\n        \"publisher\":
+        \"Microsoft.OSTCExtensions\",\r\n        \"type\": \"LinuxDiagnostic\",\r\n
+        \       \"typeHandlerVersion\": \"2.0\",\r\n        \"autoUpgradeMinorVersion\":
+        true,\r\n        \"settings\": {\"xmlCfg\":\"PFdhZENmZz48RGlhZ25vc3RpY01vbml0b3JDb25maWd1cmF0aW9uIG92ZXJhbGxRdW90YUluTUI9IjQwOTYiPjxEaWFnbm9zdGljSW5mcmFzdHJ1Y3R1cmVMb2dzIHNjaGVkdWxlZFRyYW5zZmVyUGVyaW9kPSJQVDFNIiBzY2hlZHVsZWRUcmFuc2ZlckxvZ0xldmVsRmlsdGVyPSJXYXJuaW5nIi8+PFBlcmZvcm1hbmNlQ291bnRlcnMgc2NoZWR1bGVkVHJhbnNmZXJQZXJpb2Q9IlBUMU0iPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlTWVtb3J5IiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQnl0ZXMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcUGVyY2VudEF2YWlsYWJsZU1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iTWVtb3J5IHVzZWQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50VXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgcGVyY2VudGFnZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkQnlDYWNoZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHVzZWQgYnkgY2FjaGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1BlclNlYyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50UGVyU2Vjb25kIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFnZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1JlYWRQZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2UgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1dyaXR0ZW5QZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2Ugd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iU3dhcCBhdmFpbGFibGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50QXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZFN3YXAiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlN3YXAgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRJZGxlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgaWRsZSB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFVzZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iUGVyY2VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkNQVSB1c2VyIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50TmljZVRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIG5pY2UgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRQcml2aWxlZ2VkVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgcHJpdmlsZWdlZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudEludGVycnVwdFRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIGludGVycnVwdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudERQQ1RpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIERQQyB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFByb2Nlc3NvclRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIHBlcmNlbnRhZ2UgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50SU9XYWl0VGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgSU8gd2FpdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xSZWFkQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCBndWVzdCBPUyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXFdyaXRlQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGUgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xUcmFuc2ZlcnNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXJzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcUmVhZHNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xXcml0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVJlYWRUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVdyaXRlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlNlY29uZHMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJEaXNrIHdyaXRlIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xBdmVyYWdlVHJhbnNmZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXIgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXEF2ZXJhZ2VEaXNrUXVldWVMZW5ndGgiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcXVldWUgbGVuZ3RoIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVHJhbnNtaXR0ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgb3V0IGd1ZXN0IE9TIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzUmVjZWl2ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgaW4gZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1RyYW5zbWl0dGVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHNlbnQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1JlY2VpdmVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHJlY2VpdmVkIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVG90YWwiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxSeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyByZWNlaXZlZCBlcnJvcnMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxUeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyBzZW50IGVycm9ycyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTmV0d29ya0ludGVyZmFjZVxUb3RhbENvbGxpc2lvbnMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgY29sbGlzaW9ucyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48L1BlcmZvcm1hbmNlQ291bnRlcnM+PE1ldHJpY3MgcmVzb3VyY2VJZD0iL3N1YnNjcmlwdGlvbnMvMjU4NmM2NGItMzhiNC00NTI3LWExNDAtMDEyZDQ5ZGZjMDJjL3Jlc291cmNlR3JvdXBzL21pcS1henVyZS10ZXN0MS9wcm92aWRlcnMvTWljcm9zb2Z0LkNvbXB1dGUvdmlydHVhbE1hY2hpbmVzL21pcWF6dXJlLWNlbnRvczEiPjxNZXRyaWNBZ2dyZWdhdGlvbiBzY2hlZHVsZWRUcmFuc2ZlclBlcmlvZD0iUFQxSCIvPjxNZXRyaWNBZ2dyZWdhdGlvbiBzY2hlZHVsZWRUcmFuc2ZlclBlcmlvZD0iUFQxTSIvPjwvTWV0cmljcz48L0RpYWdub3N0aWNNb25pdG9yQ29uZmlndXJhdGlvbj48L1dhZENmZz4=\",\"StorageAccount\":\"miqazuretest14047\"},\r\n
+        \       \"provisioningState\": \"Succeeded\"\r\n      },\r\n      \"type\":
+        \"Microsoft.Compute/virtualMachines/extensions\",\r\n      \"location\": \"eastus\",\r\n
+        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1/extensions/Microsoft.Insights.VMDiagnosticsSettings\",\r\n
+        \     \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n    }\r\n
+        \ ],\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\":
+        \"eastus\",\r\n  \"tags\": {\r\n    \"Shutdown\": \"true\"\r\n  },\r\n  \"id\":
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1\",\r\n
+        \ \"name\": \"miqazure-centos1\"\r\n}"
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:24 GMT
+  recorded_at: Mon, 12 Mar 2018 09:39:40 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611?api-version=2018-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2450,7 +2482,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcyNzEsIm5iZiI6MTUyMDg0NzI3MSwiZXhwIjoxNTIwODUxMTcxLCJhaW8iOiJZMk5nWUVpNS9kNXM5OFJ2bFJuTTE2VWQrYnc1QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSFA4bi1YeXJvRWk3dnFRYm9QSVZBQSIsInZlciI6IjEuMCJ9.cmV6jFj1RmnNMfUAqSAd6LuXcaqVd5c5CcyiJRxLck21ye7EkiYbfaNlHqF_rO-NiA88HYw9zsJZ3osPiesmsWrC4pgFwpbZxznA94d6ZAY2IQDemPO3TkzRfeRWvF55N1Ffzmch2kOI46MCHImKOXet05c5l7xlu33Ca9Z6S3lXndG8U79R_cHcheQlOokfNq2dWe433UyM8KDJ5FUdqN54Y4pkupjgITef3qDk2JT7Lq4VBAZBuaY-k7-SUblaId0Is15YrvRCfO76ycs_vPuYvUTXOCsLEQHJH1xZnb3UAixHDp08yhuYUnyZqZjxFVzrnHpL7bbl-JlkltDOlw
   response:
     status:
       code: 200
@@ -2467,123 +2499,51 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"7a8e5fe7-f777-4435-992b-a54f28c2f28c"
+      - W/"26031ef6-bb55-4019-8185-2dd1edcb207c"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - bd22ca22-a01f-4ecf-9230-a4558fb66931
+      - be4e1972-c743-4fcf-bbae-502483e74012
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
+      - '14997'
       X-Ms-Correlation-Request-Id:
-      - 19c674a8-c8da-4b5e-8265-5ebc21926459
+      - 511d372d-cd12-4be5-acc8-8ef2b0566e03
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102420Z:19c674a8-c8da-4b5e-8265-5ebc21926459
+      - WESTEUROPE:20180312T093939Z:511d372d-cd12-4be5-acc8-8ef2b0566e03
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:19 GMT
+      - Mon, 12 Mar 2018 09:39:39 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb2\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2\",\r\n
-        \ \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"e2e30a77-f81b-43fc-9693-08303e43deed\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/backendAddressPools/rspec-lb2-pool\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\r\n
-        \       }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\": [],\r\n    \"probes\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-probe\",\r\n        \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/probes/rspec-lb2-probe\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\": [],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:25 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"a38434c8-7b23-4092-b7c6-402238eac0dc"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 0fd15240-6a1c-4b39-a4f6-aa53fd8591c2
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Correlation-Request-Id:
-      - 5cc03163-922e-41a1-9601-dba2d7cf2a81
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102421Z:5cc03163-922e-41a1-9601-dba2d7cf2a81
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Mon, 12 Mar 2018 10:24:20 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb1-LoadBalancerFrontEnd\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\",\r\n
-        \ \"etag\": \"W/\\\"a38434c8-7b23-4092-b7c6-402238eac0dc\\\"\",\r\n  \"location\":
+      string: "{\r\n  \"name\": \"miqazure-centos1611\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611\",\r\n
+        \ \"etag\": \"W/\\\"26031ef6-bb55-4019-8185-2dd1edcb207c\\\"\",\r\n  \"location\":
         \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"f28e0f25-b372-4edf-97d9-13a9e3b4ba2d\",\r\n    \"ipAddress\":
-        \"40.71.82.83\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\":
-        \"Static\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipTags\": [],\r\n
-        \   \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
-        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
+        \   \"resourceGuid\": \"f1760e49-9853-4fdc-acfc-4ea232b9ed76\",\r\n    \"ipConfigurations\":
+        [\r\n      {\r\n        \"name\": \"ipconfig1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1\",\r\n
+        \       \"etag\": \"W/\\\"26031ef6-bb55-4019-8185-2dd1edcb207c\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"privateIPAddress\": \"10.16.0.5\",\r\n          \"privateIPAllocationMethod\":
+        \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1\"\r\n
+        \         },\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\"\r\n
+        \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
+        \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\":
+        [],\r\n      \"appliedDnsServers\": []\r\n    },\r\n    \"enableAcceleratedNetworking\":
+        false,\r\n    \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\":
+        {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1\"\r\n
+        \   },\r\n    \"virtualMachine\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1\"\r\n
+        \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
+        \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:25 GMT
+  recorded_at: Mon, 12 Mar 2018 09:39:44 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1/instanceView?api-version=2017-12-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2597,7 +2557,701 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcyNzEsIm5iZiI6MTUyMDg0NzI3MSwiZXhwIjoxNTIwODUxMTcxLCJhaW8iOiJZMk5nWUVpNS9kNXM5OFJ2bFJuTTE2VWQrYnc1QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSFA4bi1YeXJvRWk3dnFRYm9QSVZBQSIsInZlciI6IjEuMCJ9.cmV6jFj1RmnNMfUAqSAd6LuXcaqVd5c5CcyiJRxLck21ye7EkiYbfaNlHqF_rO-NiA88HYw9zsJZ3osPiesmsWrC4pgFwpbZxznA94d6ZAY2IQDemPO3TkzRfeRWvF55N1Ffzmch2kOI46MCHImKOXet05c5l7xlu33Ca9Z6S3lXndG8U79R_cHcheQlOokfNq2dWe433UyM8KDJ5FUdqN54Y4pkupjgITef3qDk2JT7Lq4VBAZBuaY-k7-SUblaId0Is15YrvRCfO76ycs_vPuYvUTXOCsLEQHJH1xZnb3UAixHDp08yhuYUnyZqZjxFVzrnHpL7bbl-JlkltDOlw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/GetInstanceView3Min;4793,Microsoft.Compute/GetInstanceView30Min;23906
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      X-Ms-Request-Id:
+      - ff39fcd3-beb3-4622-8b47-6e4d82490cc8
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Correlation-Request-Id:
+      - 68a64434-701a-47e4-9d8e-55fd2351fbd8
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T093948Z:68a64434-701a-47e4-9d8e-55fd2351fbd8
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:39:47 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"platformUpdateDomain\": 0,\r\n  \"platformFaultDomain\": 0,\r\n
+        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
+        [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
+        \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
+        \"Failed to fetch the VM status.\",\r\n        \"time\": \"2018-03-12T09:39:41+00:00\"\r\n
+        \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"miqazure-centos1\",\r\n
+        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
+        succeeded\",\r\n          \"time\": \"2016-06-22T21:18:47.2011229+00:00\"\r\n
+        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
+        \"https://miqazuretest14047.blob.core.windows.net/bootdiagnostics-miqazurec-796c5bcc-338a-448d-b61c-165279a7fb3e/miqazure-centos1.796c5bcc-338a-448d-b61c-165279a7fb3e.screenshot.bmp\",\r\n
+        \   \"serialConsoleLogBlobUri\": \"https://miqazuretest14047.blob.core.windows.net/bootdiagnostics-miqazurec-796c5bcc-338a-448d-b61c-165279a7fb3e/miqazure-centos1.796c5bcc-338a-448d-b61c-165279a7fb3e.serialconsole.log\"\r\n
+        \ },\r\n  \"extensions\": [\r\n    {\r\n      \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n
+        \   }\r\n  ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n
+        \     \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n
+        \     \"time\": \"2016-06-22T21:18:47.2636196+00:00\"\r\n    },\r\n    {\r\n
+        \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
+        \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:39:52 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups/miq-azure-test1?api-version=2017-08-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcyNzEsIm5iZiI6MTUyMDg0NzI3MSwiZXhwIjoxNTIwODUxMTcxLCJhaW8iOiJZMk5nWUVpNS9kNXM5OFJ2bFJuTTE2VWQrYnc1QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSFA4bi1YeXJvRWk3dnFRYm9QSVZBQSIsInZlciI6IjEuMCJ9.cmV6jFj1RmnNMfUAqSAd6LuXcaqVd5c5CcyiJRxLck21ye7EkiYbfaNlHqF_rO-NiA88HYw9zsJZ3osPiesmsWrC4pgFwpbZxznA94d6ZAY2IQDemPO3TkzRfeRWvF55N1Ffzmch2kOI46MCHImKOXet05c5l7xlu33Ca9Z6S3lXndG8U79R_cHcheQlOokfNq2dWe433UyM8KDJ5FUdqN54Y4pkupjgITef3qDk2JT7Lq4VBAZBuaY-k7-SUblaId0Is15YrvRCfO76ycs_vPuYvUTXOCsLEQHJH1xZnb3UAixHDp08yhuYUnyZqZjxFVzrnHpL7bbl-JlkltDOlw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Request-Id:
+      - 5c6f6ecb-b9e8-4587-b3e2-6d96025e6ff9
+      X-Ms-Correlation-Request-Id:
+      - 5c6f6ecb-b9e8-4587-b3e2-6d96025e6ff9
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T093948Z:5c6f6ecb-b9e8-4587-b3e2-6d96025e6ff9
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:39:48 GMT
+      Content-Length:
+      - '183'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1","name":"miq-azure-test1","location":"eastus","properties":{"provisioningState":"Succeeded"}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:39:53 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute/locations/eastus/vmSizes?api-version=2017-12-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcyNzEsIm5iZiI6MTUyMDg0NzI3MSwiZXhwIjoxNTIwODUxMTcxLCJhaW8iOiJZMk5nWUVpNS9kNXM5OFJ2bFJuTTE2VWQrYnc1QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSFA4bi1YeXJvRWk3dnFRYm9QSVZBQSIsInZlciI6IjEuMCJ9.cmV6jFj1RmnNMfUAqSAd6LuXcaqVd5c5CcyiJRxLck21ye7EkiYbfaNlHqF_rO-NiA88HYw9zsJZ3osPiesmsWrC4pgFwpbZxznA94d6ZAY2IQDemPO3TkzRfeRWvF55N1Ffzmch2kOI46MCHImKOXet05c5l7xlu33Ca9Z6S3lXndG8U79R_cHcheQlOokfNq2dWe433UyM8KDJ5FUdqN54Y4pkupjgITef3qDk2JT7Lq4VBAZBuaY-k7-SUblaId0Is15YrvRCfO76ycs_vPuYvUTXOCsLEQHJH1xZnb3UAixHDp08yhuYUnyZqZjxFVzrnHpL7bbl-JlkltDOlw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/LowCostGet3Min;4737,Microsoft.Compute/LowCostGet30Min;37834
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      X-Ms-Request-Id:
+      - '08b4b67f-4e19-4bdd-91b7-14d017de52f9'
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Correlation-Request-Id:
+      - 8fc8a472-9d17-4571-8c74-7c23f20d3857
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T093949Z:8fc8a472-9d17-4571-8c74-7c23f20d3857
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:39:49 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"Standard_B1ms\",\r\n
+        \     \"numberOfCores\": 1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        4096,\r\n      \"memoryInMB\": 2048,\r\n      \"maxDataDiskCount\": 2\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_B1s\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        2048,\r\n      \"memoryInMB\": 1024,\r\n      \"maxDataDiskCount\": 2\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_B2ms\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        16384,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_B2s\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        8192,\r\n      \"memoryInMB\": 4096,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_B4ms\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        32768,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_B8ms\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS1_v2\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        7168,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS2_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        14336,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS3_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS4_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS5_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS11-1_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS11_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS12-1_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS12-2_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS12_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS13-2_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS13-4_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS13_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS14-4_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        229376,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS14-8_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        229376,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS14_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        229376,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS15_v2\",\r\n      \"numberOfCores\":
+        20,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        286720,\r\n      \"memoryInMB\": 143360,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS2_v2_Promo\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        14336,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS3_v2_Promo\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS4_v2_Promo\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS5_v2_Promo\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS11_v2_Promo\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS12_v2_Promo\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS13_v2_Promo\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS14_v2_Promo\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        229376,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F1s\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        4096,\r\n      \"memoryInMB\": 2048,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F2s\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        8192,\r\n      \"memoryInMB\": 4096,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F4s\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        16384,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F8s\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        32768,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F16s\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D2s_v3\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        16384,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D4s_v3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        32768,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D8s_v3\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D16s_v3\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        131072,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D32s_v3\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        262144,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A0\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        20480,\r\n      \"memoryInMB\": 768,\r\n      \"maxDataDiskCount\": 1\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A1\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        71680,\r\n      \"memoryInMB\": 1792,\r\n      \"maxDataDiskCount\": 2\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        138240,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        291840,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A5\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        138240,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A4\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        619520,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A6\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        291840,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A7\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        619520,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Basic_A0\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        20480,\r\n      \"memoryInMB\": 768,\r\n      \"maxDataDiskCount\": 1\r\n
+        \   },\r\n    {\r\n      \"name\": \"Basic_A1\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        40960,\r\n      \"memoryInMB\": 1792,\r\n      \"maxDataDiskCount\": 2\r\n
+        \   },\r\n    {\r\n      \"name\": \"Basic_A2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        61440,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Basic_A3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        122880,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Basic_A4\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        245760,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D1_v2\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        51200,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D2_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D3_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D4_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D5_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D11_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D12_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D13_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D14_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D15_v2\",\r\n      \"numberOfCores\":
+        20,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        286720,\r\n      \"memoryInMB\": 143360,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D2_v2_Promo\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D3_v2_Promo\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D4_v2_Promo\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D5_v2_Promo\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D11_v2_Promo\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D12_v2_Promo\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D13_v2_Promo\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D14_v2_Promo\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F1\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        16384,\r\n      \"memoryInMB\": 2048,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        32768,\r\n      \"memoryInMB\": 4096,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F4\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F8\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        131072,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F16\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        262144,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A1_v2\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        10240,\r\n      \"memoryInMB\": 2048,\r\n      \"maxDataDiskCount\": 2\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A2m_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        20480,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A2_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        20480,\r\n      \"memoryInMB\": 4096,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A4m_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        40960,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A4_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        40960,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A8m_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        81920,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A8_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        81920,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D2_v3\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        51200,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D4_v3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D8_v3\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D16_v3\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 65636,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D32_v3\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_H8\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1024000,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_H16\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        2048000,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_H8m\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1024000,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_H16m\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        2048000,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_H16r\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        2048000,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_H16mr\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        2048000,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D1\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        51200,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D4\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D11\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D12\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D13\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D14\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NV6\",\r\n      \"numberOfCores\":
+        6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        389120,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 24\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NV12\",\r\n      \"numberOfCores\":
+        12,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        696320,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 48\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NV24\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1474560,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC6s_v2\",\r\n      \"numberOfCores\":
+        6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        344064,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 12\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC12s_v2\",\r\n      \"numberOfCores\":
+        12,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        688128,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 24\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC24rs_v2\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1376256,\r\n      \"memoryInMB\": 458752,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC24s_v2\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1376256,\r\n      \"memoryInMB\": 458752,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC6\",\r\n      \"numberOfCores\":
+        6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        389120,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 24\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC12\",\r\n      \"numberOfCores\":
+        12,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        696320,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 48\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC24\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1474560,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC24r\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1474560,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS1\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        7168,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        14336,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS4\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS11\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS12\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS13\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS14\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        229376,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC6s_v3\",\r\n      \"numberOfCores\":
+        6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        344064,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 12\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC12s_v3\",\r\n      \"numberOfCores\":
+        12,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        688128,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 24\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC24rs_v3\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1376256,\r\n      \"memoryInMB\": 458752,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC24s_v3\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1376256,\r\n      \"memoryInMB\": 458752,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D64_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1638400,\r\n      \"memoryInMB\": 262144,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D64s_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        524288,\r\n      \"memoryInMB\": 262144,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E2_v3\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        51200,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E4_v3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E8_v3\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E16_v3\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E32_v3\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 262144,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E64i_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1638400,\r\n      \"memoryInMB\": 442368,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E64_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1638400,\r\n      \"memoryInMB\": 442368,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E2s_v3\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        32768,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E4-2s_v3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E4s_v3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E8-2s_v3\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        131072,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E8-4s_v3\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        131072,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E8s_v3\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        131072,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E16-4s_v3\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        262144,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E16-8s_v3\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        262144,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E16s_v3\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        262144,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E32-8s_v3\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        524288,\r\n      \"memoryInMB\": 262144,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E32-16s_v3\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        524288,\r\n      \"memoryInMB\": 262144,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E32s_v3\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        524288,\r\n      \"memoryInMB\": 262144,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E64-16s_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        884736,\r\n      \"memoryInMB\": 442368,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E64-32s_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        884736,\r\n      \"memoryInMB\": 442368,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E64is_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        884736,\r\n      \"memoryInMB\": 442368,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E64s_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        884736,\r\n      \"memoryInMB\": 442368,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F2s_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        16384,\r\n      \"memoryInMB\": 4096,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F4s_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        32768,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F8s_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F16s_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        131072,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F32s_v2\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        262144,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F64s_v2\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        524288,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F72s_v2\",\r\n      \"numberOfCores\":
+        72,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        589824,\r\n      \"memoryInMB\": 147456,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_L8s_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1811981,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_L16s_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        3623962,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_ND6s\",\r\n      \"numberOfCores\":
+        6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        344064,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 12\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_ND12s\",\r\n      \"numberOfCores\":
+        12,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        688128,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 24\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_ND24rs\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1376256,\r\n      \"memoryInMB\": 458752,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_ND24s\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1376256,\r\n      \"memoryInMB\": 458752,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A8\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        391168,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A9\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        391168,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A10\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        391168,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A11\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        391168,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   }\r\n  ]\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:39:54 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcyNzEsIm5iZiI6MTUyMDg0NzI3MSwiZXhwIjoxNTIwODUxMTcxLCJhaW8iOiJZMk5nWUVpNS9kNXM5OFJ2bFJuTTE2VWQrYnc1QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSFA4bi1YeXJvRWk3dnFRYm9QSVZBQSIsInZlciI6IjEuMCJ9.cmV6jFj1RmnNMfUAqSAd6LuXcaqVd5c5CcyiJRxLck21ye7EkiYbfaNlHqF_rO-NiA88HYw9zsJZ3osPiesmsWrC4pgFwpbZxznA94d6ZAY2IQDemPO3TkzRfeRWvF55N1Ffzmch2kOI46MCHImKOXet05c5l7xlu33Ca9Z6S3lXndG8U79R_cHcheQlOokfNq2dWe433UyM8KDJ5FUdqN54Y4pkupjgITef3qDk2JT7Lq4VBAZBuaY-k7-SUblaId0Is15YrvRCfO76ycs_vPuYvUTXOCsLEQHJH1xZnb3UAixHDp08yhuYUnyZqZjxFVzrnHpL7bbl-JlkltDOlw
   response:
     status:
       code: 200
@@ -2614,36 +3268,451 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"cddd97d1-6111-4477-8a00-3dc885237a1d"
+      - W/"734a3944-a880-444c-8c92-cace6e28e303"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 1403e5b6-8fa0-4cd3-89b1-76b6c4fd805b
+      - 1849f714-be40-4a91-99d6-be54f54ded41
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - '14995'
       X-Ms-Correlation-Request-Id:
-      - e4a5f369-a742-466f-bd8f-42e17eaaf9c9
+      - d64ceb16-eb86-4697-bcfe-d8b6de40d294
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102421Z:e4a5f369-a742-466f-bd8f-42e17eaaf9c9
+      - WESTEUROPE:20180312T093950Z:d64ceb16-eb86-4697-bcfe-d8b6de40d294
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:21 GMT
+      - Mon, 12 Mar 2018 09:39:49 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb2-publicip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\",\r\n
-        \ \"etag\": \"W/\\\"cddd97d1-6111-4477-8a00-3dc885237a1d\\\"\",\r\n  \"location\":
+      string: "{\r\n  \"name\": \"miqazure-centos1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1\",\r\n
+        \ \"etag\": \"W/\\\"734a3944-a880-444c-8c92-cace6e28e303\\\"\",\r\n  \"location\":
         \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"83e7257d-ab94-4229-8eb5-4798f37ef28d\",\r\n    \"publicIPAddressVersion\":
+        \   \"resourceGuid\": \"475a66f0-9e89-4226-a9f0-9baaaf31d619\",\r\n    \"publicIPAddressVersion\":
         \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
-        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
+        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1\"\r\n
         \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
         \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:26 GMT
+  recorded_at: Mon, 12 Mar 2018 09:39:54 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047?api-version=2017-10-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcyNzEsIm5iZiI6MTUyMDg0NzI3MSwiZXhwIjoxNTIwODUxMTcxLCJhaW8iOiJZMk5nWUVpNS9kNXM5OFJ2bFJuTTE2VWQrYnc1QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSFA4bi1YeXJvRWk3dnFRYm9QSVZBQSIsInZlciI6IjEuMCJ9.cmV6jFj1RmnNMfUAqSAd6LuXcaqVd5c5CcyiJRxLck21ye7EkiYbfaNlHqF_rO-NiA88HYw9zsJZ3osPiesmsWrC4pgFwpbZxznA94d6ZAY2IQDemPO3TkzRfeRWvF55N1Ffzmch2kOI46MCHImKOXet05c5l7xlu33Ca9Z6S3lXndG8U79R_cHcheQlOokfNq2dWe433UyM8KDJ5FUdqN54Y4pkupjgITef3qDk2JT7Lq4VBAZBuaY-k7-SUblaId0Is15YrvRCfO76ycs_vPuYvUTXOCsLEQHJH1xZnb3UAixHDp08yhuYUnyZqZjxFVzrnHpL7bbl-JlkltDOlw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 5749cab3-edf8-424b-9898-feb8d708788d
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Correlation-Request-Id:
+      - db536566-b6ca-4437-bed9-fcce725d8a97
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T093950Z:db536566-b6ca-4437-bed9-fcce725d8a97
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:39:50 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","name":"miqazuretest14047","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T17:30:25.7028008Z","primaryEndpoints":{"blob":"https://miqazuretest14047.blob.core.windows.net/","queue":"https://miqazuretest14047.queue.core.windows.net/","table":"https://miqazuretest14047.table.core.windows.net/","file":"https://miqazuretest14047.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:39:55 GMT
+- request:
+    method: post
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047/listKeys?api-version=2017-10-01
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcyNzEsIm5iZiI6MTUyMDg0NzI3MSwiZXhwIjoxNTIwODUxMTcxLCJhaW8iOiJZMk5nWUVpNS9kNXM5OFJ2bFJuTTE2VWQrYnc1QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSFA4bi1YeXJvRWk3dnFRYm9QSVZBQSIsInZlciI6IjEuMCJ9.cmV6jFj1RmnNMfUAqSAd6LuXcaqVd5c5CcyiJRxLck21ye7EkiYbfaNlHqF_rO-NiA88HYw9zsJZ3osPiesmsWrC4pgFwpbZxznA94d6ZAY2IQDemPO3TkzRfeRWvF55N1Ffzmch2kOI46MCHImKOXet05c5l7xlu33Ca9Z6S3lXndG8U79R_cHcheQlOokfNq2dWe433UyM8KDJ5FUdqN54Y4pkupjgITef3qDk2JT7Lq4VBAZBuaY-k7-SUblaId0Is15YrvRCfO76ycs_vPuYvUTXOCsLEQHJH1xZnb3UAixHDp08yhuYUnyZqZjxFVzrnHpL7bbl-JlkltDOlw
+      Content-Length:
+      - '0'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 73c72b43-2883-4621-8899-0d0cdd9bc2bf
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Writes:
+      - '1199'
+      X-Ms-Correlation-Request-Id:
+      - df30ad8e-8ef6-46b5-8a7a-c299ac734186
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T093951Z:df30ad8e-8ef6-46b5-8a7a-c299ac734186
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:39:51 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"keys":[{"keyName":"key1","value":"9hGLwV9mjvAc1ARzeGwpsS9oZPLqOBzHCCHjeixyt1wpPYVn32cXmm3Gs9ogFPXZhDH61PAXxud0Dg/qwOnJ1w==","permissions":"Full"},{"keyName":"key2","value":"FfW8btVjJE2LkKHvN8Prr3FDX71BrS4SnMkONq2fLVPPm6x7vqqjeDSWDh17aI4CBLYf3Y1pc6njkbz53HdMYg==","permissions":"Full"}]}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:39:56 GMT
+- request:
+    method: head
+    uri: https://miqazuretest14047.blob.core.windows.net/vhds/miqazure-centos12016221104946.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:39:56 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey miqazuretest14047:Hia9XWOU1V3+7utCZWckmNahFB89vSG028KwQiTvPwQ=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '32212255232'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - bLK7rgT7IgMNX2YxL9BCyg==
+      Last-Modified:
+      - Fri, 22 Apr 2016 19:05:58 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D36AE123954B35"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - fc9c9ed2-001e-0049-22e6-b9151f000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Meta-Microsoftazurecompute-Resourcegroupname:
+      - miq-azure-test1
+      X-Ms-Meta-Microsoftazurecompute-Vmname:
+      - miqazure-centos1
+      X-Ms-Meta-Microsoftazurecompute-Diskid:
+      - 66656abf-e460-45ac-a6f0-851d0a50b23a
+      X-Ms-Meta-Microsoftazurecompute-Diskname:
+      - miqazure-centos1
+      X-Ms-Meta-Microsoftazurecompute-Disktype:
+      - OSDisk
+      X-Ms-Lease-Status:
+      - locked
+      X-Ms-Lease-State:
+      - leased
+      X-Ms-Lease-Duration:
+      - infinite
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '1'
+      X-Ms-Copy-Id:
+      - 549dd428-4055-4337-a425-05293b903858
+      X-Ms-Copy-Source:
+      - https://ardfepirv2bl5prdstr06.blob.core.windows.net/5112500ae3b842c8b9c604889f8753c3/OpenLogic-CentOS-71-20160308?sv=2014-02-14&sr=b&si=PirCacheAccountPublisherContainerPolicy&sig=fxe20jiCl%2Foys9OSvljXlookVPi76KM8FYlTr%2BSY4IQ%3D
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 32212255232/32212255232
+      X-Ms-Copy-Completion-Time:
+      - Mon, 21 Mar 2016 16:50:14 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Mon, 12 Mar 2018 09:39:51 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:39:57 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcyNzEsIm5iZiI6MTUyMDg0NzI3MSwiZXhwIjoxNTIwODUxMTcxLCJhaW8iOiJZMk5nWUVpNS9kNXM5OFJ2bFJuTTE2VWQrYnc1QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSFA4bi1YeXJvRWk3dnFRYm9QSVZBQSIsInZlciI6IjEuMCJ9.cmV6jFj1RmnNMfUAqSAd6LuXcaqVd5c5CcyiJRxLck21ye7EkiYbfaNlHqF_rO-NiA88HYw9zsJZ3osPiesmsWrC4pgFwpbZxznA94d6ZAY2IQDemPO3TkzRfeRWvF55N1Ffzmch2kOI46MCHImKOXet05c5l7xlu33Ca9Z6S3lXndG8U79R_cHcheQlOokfNq2dWe433UyM8KDJ5FUdqN54Y4pkupjgITef3qDk2JT7Lq4VBAZBuaY-k7-SUblaId0Is15YrvRCfO76ycs_vPuYvUTXOCsLEQHJH1xZnb3UAixHDp08yhuYUnyZqZjxFVzrnHpL7bbl-JlkltDOlw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"f1907e14-fcad-4f75-8faa-ab325bf879d9"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 0a668e19-c301-46b0-ac08-ab1bfbc96c48
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Correlation-Request-Id:
+      - 00c95675-ea30-4546-9618-2ee3b015639d
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T093956Z:00c95675-ea30-4546-9618-2ee3b015639d
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:39:56 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"miqazure-centos1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1\",\r\n
+        \ \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/networkSecurityGroups\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
+        \"9ca49a93-6f7d-464c-b23d-e61e847ce2d6\",\r\n    \"securityRules\": [\r\n
+        \     {\r\n        \"name\": \"default-allow-ssh\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/securityRules/default-allow-ssh\",\r\n
+        \       \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"protocol\": \"Tcp\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"22\",\r\n          \"sourceAddressPrefix\":
+        \"*\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n          \"access\":
+        \"Allow\",\r\n          \"priority\": 1000,\r\n          \"direction\": \"Inbound\",\r\n
+        \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      }\r\n    ],\r\n    \"defaultSecurityRules\": [\r\n
+        \     {\r\n        \"name\": \"AllowVnetInBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/defaultSecurityRules/AllowVnetInBound\",\r\n
+        \       \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow inbound traffic from all VMs in VNET\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"VirtualNetwork\",\r\n          \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n          \"direction\":
+        \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowAzureLoadBalancerInBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/defaultSecurityRules/AllowAzureLoadBalancerInBound\",\r\n
+        \       \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow inbound traffic from azure load balancer\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"AzureLoadBalancer\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65001,\r\n          \"direction\":
+        \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllInBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/defaultSecurityRules/DenyAllInBound\",\r\n
+        \       \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Deny all inbound traffic\",\r\n          \"protocol\":
+        \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\":
+        \"*\",\r\n          \"sourceAddressPrefix\": \"*\",\r\n          \"destinationAddressPrefix\":
+        \"*\",\r\n          \"access\": \"Deny\",\r\n          \"priority\": 65500,\r\n
+        \         \"direction\": \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n
+        \         \"destinationPortRanges\": [],\r\n          \"sourceAddressPrefixes\":
+        [],\r\n          \"destinationAddressPrefixes\": []\r\n        }\r\n      },\r\n
+        \     {\r\n        \"name\": \"AllowVnetOutBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/defaultSecurityRules/AllowVnetOutBound\",\r\n
+        \       \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow outbound traffic from all VMs to all VMs
+        in VNET\",\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\":
+        \"*\",\r\n          \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"VirtualNetwork\",\r\n          \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n          \"direction\":
+        \"Outbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowInternetOutBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/defaultSecurityRules/AllowInternetOutBound\",\r\n
+        \       \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow outbound traffic from all VMs to Internet\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"*\",\r\n          \"destinationAddressPrefix\": \"Internet\",\r\n          \"access\":
+        \"Allow\",\r\n          \"priority\": 65001,\r\n          \"direction\": \"Outbound\",\r\n
+        \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllOutBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/defaultSecurityRules/DenyAllOutBound\",\r\n
+        \       \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Deny all outbound traffic\",\r\n          \"protocol\":
+        \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\":
+        \"*\",\r\n          \"sourceAddressPrefix\": \"*\",\r\n          \"destinationAddressPrefix\":
+        \"*\",\r\n          \"access\": \"Deny\",\r\n          \"priority\": 65500,\r\n
+        \         \"direction\": \"Outbound\",\r\n          \"sourcePortRanges\":
+        [],\r\n          \"destinationPortRanges\": [],\r\n          \"sourceAddressPrefixes\":
+        [],\r\n          \"destinationAddressPrefixes\": []\r\n        }\r\n      }\r\n
+        \   ],\r\n    \"networkInterfaces\": [\r\n      {\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611\"\r\n
+        \     }\r\n    ]\r\n  }\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:40:00 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDcyNzEsIm5iZiI6MTUyMDg0NzI3MSwiZXhwIjoxNTIwODUxMTcxLCJhaW8iOiJZMk5nWUVpNS9kNXM5OFJ2bFJuTTE2VWQrYnc1QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSFA4bi1YeXJvRWk3dnFRYm9QSVZBQSIsInZlciI6IjEuMCJ9.cmV6jFj1RmnNMfUAqSAd6LuXcaqVd5c5CcyiJRxLck21ye7EkiYbfaNlHqF_rO-NiA88HYw9zsJZ3osPiesmsWrC4pgFwpbZxznA94d6ZAY2IQDemPO3TkzRfeRWvF55N1Ffzmch2kOI46MCHImKOXet05c5l7xlu33Ca9Z6S3lXndG8U79R_cHcheQlOokfNq2dWe433UyM8KDJ5FUdqN54Y4pkupjgITef3qDk2JT7Lq4VBAZBuaY-k7-SUblaId0Is15YrvRCfO76ycs_vPuYvUTXOCsLEQHJH1xZnb3UAixHDp08yhuYUnyZqZjxFVzrnHpL7bbl-JlkltDOlw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"a8b09238-30fc-4b36-a58d-e3cc69e267c5"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 641cc6b6-64b2-4e5e-9d7c-9a7ab6e0d2d8
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Correlation-Request-Id:
+      - 15169508-ece5-4a3a-b193-e7d45da1a66d
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T093959Z:15169508-ece5-4a3a-b193-e7d45da1a66d
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:39:59 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"miq-azure-test1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1\",\r\n
+        \ \"etag\": \"W/\\\"a8b09238-30fc-4b36-a58d-e3cc69e267c5\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
+        \"d74c1e5f-50e4-4c8a-a7fe-78eaddc6b915\",\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\":
+        [\r\n        \"10.16.0.0/16\"\r\n      ]\r\n    },\r\n    \"subnets\": [\r\n
+        \     {\r\n        \"name\": \"default\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\",\r\n
+        \       \"etag\": \"W/\\\"a8b09238-30fc-4b36-a58d-e3cc69e267c5\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"addressPrefix\": \"10.16.0.0/24\",\r\n          \"ipConfigurations\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241/ipConfigurations/ipconfig1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1/ipConfigurations/miqmismatch1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/dbergerprov1/ipConfigurations/dbergerprov1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/ladas_test_1/ipConfigurations/ladas_test_1\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"virtualNetworkPeerings\":
+        [],\r\n    \"enableDdosProtection\": false,\r\n    \"enableVmProtection\":
+        false\r\n  }\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:40:04 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_500/powered_on_vm_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_500/powered_on_vm_refresh.yml
@@ -1,6 +1,62 @@
 ---
 http_interactions:
 - request:
+    method: post
+    uri: https://login.microsoftonline.com/AZURE_TENANT_ID/oauth2/token
+    body:
+      encoding: UTF-8
+      string: grant_type=client_credentials&client_id=AZURE_CLIENT_ID&client_secret=AZURE_CLIENT_SECRET&resource=https%3A%2F%2Fmanagement.azure.com%2F
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Server:
+      - Microsoft-IIS/10.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Request-Id:
+      - e15f95c6-7e0c-44ff-896a-d65e15032500
+      P3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Set-Cookie:
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzOOXfUYaLOdgNBn7nhLRjVS5LJqgtzJjLkzCG1cJCy08Ux5kyP8GQyE3mxhAWZhTK8fMx8Es5fciZgzXRY-yOeshPFm2TYrQzg-w_VIkKnz1MbWmobOMXMkIsrZXzW3cH4IKWotI7yqQ2rH0eYs55R7ZDitybeTQryqZ-_qY3u4YgAA;
+        domain=.login.microsoftonline.com; path=/; secure; HttpOnly
+      - stsservicecookie=ests; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=005; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 12 Mar 2018 09:24:58 GMT
+      Content-Length:
+      - '1505'
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"Bearer","expires_in":"3600","ext_expires_in":"0","expires_on":"1520850298","not_before":"1520846398","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDYzOTgsIm5iZiI6MTUyMDg0NjM5OCwiZXhwIjoxNTIwODUwMjk4LCJhaW8iOiJZMk5nWUREaWt2OGkzWG5nNlVUbjUxbXNxeGZsQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieHBWZjRReC1fMFNKYXRaZUZRTWxBQSIsInZlciI6IjEuMCJ9.XwasNxrTVaqKz-D9MgYSC3bmyr00gxvA0-2ZHY6Ao4d6M-8zyF3EkpgtjvJQmJyigbtLo3aYxJYaliL0Doibjzt0yACsSHn0-fXyHT7SHkg2HOUhlT2YKj6Zd0Livs6YrpkYTLfpXffETPG6mqi0Q-P06FwGkAHh7-BzxH_Gh5I6JxbYFXpqpp184d23kVbcpZd9cBSCOPtIfLo5t-HJLY71rJ_vjTYLRyI2g_8a7RIYwHlViI1_O4-qGCr7eidV9SAQOk6Qg18mVS9Xh9eqtJ7o-7KncA9DnnM_hKy_BFta_jaQK4D1UkYDDGtthSqoIQzA-TGCPYEs4uALG9JgHw"}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:25:03 GMT
+- request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
     body:
@@ -16,7 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MzgsIm5iZiI6MTUyMDQ1MzQzOCwiZXhwIjoxNTIwNDU3MzM4LCJhaW8iOiJZMk5nWUxEbUtXMDk5clB4cU9QdGorL1crV3NlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZHNPVmFSUXV2RTJjVVBpcEtWWUFBQSIsInZlciI6IjEuMCJ9.drT5CKw95WRF7LzC0WuhK-fTLpw3j61XMw_DZdrLOWP8sjjsrbn9kF7xjDSTUM0ooF5_1Y-j3dNjvI9crm_F3PMAyhYXmCsKjTJkc3DIK6URy3hqbKiRBNlrutwvILE777NY-uXK9PH-gcaVuV-mNrjrLuxxClMJ3OPpTU8Ux0fj3Nuyf3KrXC27Oks_M_RDqDaXHOTckrdz2m_LNLpi5x0nKCoxwR9r5C1m5IKZ25FSbvyRNwjwz5dReqnv5LxllQMHVWkpvO7i5438wAnnyaS2x211IBiE6_dnV2god8Sp3ZRinXc4aCimUnJl6tLa5EtT_VSmR2QcBSaq0wS_ZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDYzOTgsIm5iZiI6MTUyMDg0NjM5OCwiZXhwIjoxNTIwODUwMjk4LCJhaW8iOiJZMk5nWUREaWt2OGkzWG5nNlVUbjUxbXNxeGZsQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieHBWZjRReC1fMFNKYXRaZUZRTWxBQSIsInZlciI6IjEuMCJ9.XwasNxrTVaqKz-D9MgYSC3bmyr00gxvA0-2ZHY6Ao4d6M-8zyF3EkpgtjvJQmJyigbtLo3aYxJYaliL0Doibjzt0yACsSHn0-fXyHT7SHkg2HOUhlT2YKj6Zd0Livs6YrpkYTLfpXffETPG6mqi0Q-P06FwGkAHh7-BzxH_Gh5I6JxbYFXpqpp184d23kVbcpZd9cBSCOPtIfLo5t-HJLY71rJ_vjTYLRyI2g_8a7RIYwHlViI1_O4-qGCr7eidV9SAQOk6Qg18mVS9Xh9eqtJ7o-7KncA9DnnM_hKy_BFta_jaQK4D1UkYDDGtthSqoIQzA-TGCPYEs4uALG9JgHw
   response:
     status:
       code: 200
@@ -35,26 +91,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14995'
+      - '14999'
       X-Ms-Request-Id:
-      - e3168d2c-166d-499a-8cda-d43459ff7618
+      - 3c966f89-caab-4781-bfda-6b07f138d768
       X-Ms-Correlation-Request-Id:
-      - e3168d2c-166d-499a-8cda-d43459ff7618
+      - 3c966f89-caab-4781-bfda-6b07f138d768
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201821Z:e3168d2c-166d-499a-8cda-d43459ff7618
+      - WESTEUROPE:20180312T092459Z:3c966f89-caab-4781-bfda-6b07f138d768
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:18:20 GMT
+      - Mon, 12 Mar 2018 09:24:58 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID","subscriptionId":"AZURE_SUBSCRIPTION_ID","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:21 GMT
+  recorded_at: Mon, 12 Mar 2018 09:25:03 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers?api-version=2015-01-01
@@ -71,7 +127,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MzgsIm5iZiI6MTUyMDQ1MzQzOCwiZXhwIjoxNTIwNDU3MzM4LCJhaW8iOiJZMk5nWUxEbUtXMDk5clB4cU9QdGorL1crV3NlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZHNPVmFSUXV2RTJjVVBpcEtWWUFBQSIsInZlciI6IjEuMCJ9.drT5CKw95WRF7LzC0WuhK-fTLpw3j61XMw_DZdrLOWP8sjjsrbn9kF7xjDSTUM0ooF5_1Y-j3dNjvI9crm_F3PMAyhYXmCsKjTJkc3DIK6URy3hqbKiRBNlrutwvILE777NY-uXK9PH-gcaVuV-mNrjrLuxxClMJ3OPpTU8Ux0fj3Nuyf3KrXC27Oks_M_RDqDaXHOTckrdz2m_LNLpi5x0nKCoxwR9r5C1m5IKZ25FSbvyRNwjwz5dReqnv5LxllQMHVWkpvO7i5438wAnnyaS2x211IBiE6_dnV2god8Sp3ZRinXc4aCimUnJl6tLa5EtT_VSmR2QcBSaq0wS_ZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDYzOTgsIm5iZiI6MTUyMDg0NjM5OCwiZXhwIjoxNTIwODUwMjk4LCJhaW8iOiJZMk5nWUREaWt2OGkzWG5nNlVUbjUxbXNxeGZsQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieHBWZjRReC1fMFNKYXRaZUZRTWxBQSIsInZlciI6IjEuMCJ9.XwasNxrTVaqKz-D9MgYSC3bmyr00gxvA0-2ZHY6Ao4d6M-8zyF3EkpgtjvJQmJyigbtLo3aYxJYaliL0Doibjzt0yACsSHn0-fXyHT7SHkg2HOUhlT2YKj6Zd0Livs6YrpkYTLfpXffETPG6mqi0Q-P06FwGkAHh7-BzxH_Gh5I6JxbYFXpqpp184d23kVbcpZd9cBSCOPtIfLo5t-HJLY71rJ_vjTYLRyI2g_8a7RIYwHlViI1_O4-qGCr7eidV9SAQOk6Qg18mVS9Xh9eqtJ7o-7KncA9DnnM_hKy_BFta_jaQK4D1UkYDDGtthSqoIQzA-TGCPYEs4uALG9JgHw
   response:
     status:
       code: 200
@@ -88,39 +144,37 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14971'
+      - '14995'
       X-Ms-Request-Id:
-      - 359b97df-e5b2-461c-bbab-0a198b603571
+      - df21ef41-a6de-4338-9d4e-a5e37aed87c2
       X-Ms-Correlation-Request-Id:
-      - 359b97df-e5b2-461c-bbab-0a198b603571
+      - df21ef41-a6de-4338-9d4e-a5e37aed87c2
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201822Z:359b97df-e5b2-461c-bbab-0a198b603571
+      - WESTEUROPE:20180312T092500Z:df21ef41-a6de-4338-9d4e-a5e37aed87c2
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:18:21 GMT
+      - Mon, 12 Mar 2018 09:25:00 GMT
       Content-Length:
-      - '310505'
+      - '320853'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"},{"applicationId":"d87dcbc6-a371-462e-88e3-28ad15ec4e64","roleDefinitionId":"861776c5-e0df-4f95-be4f-ac1eec193323"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
+      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"},{"applicationId":"d87dcbc6-a371-462e-88e3-28ad15ec4e64","roleDefinitionId":"861776c5-e0df-4f95-be4f-ac1eec193323"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["East
+        Asia","Southeast Asia","Australia East","Australia Southeast","Japan East","Japan
+        West","Central India","South India","West India","West Europe","North Europe","Canada
+        Central","Canada East","Brazil South","West US","Central US","East US","South
+        Central US","East US 2","West Central US","North Central US","West US 2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
         US","Central US","East US","South Central US","West Europe","North Europe","East
         Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
         Central US","North Central US","Japan East","Japan West","Brazil South","Central
         India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"operations","locations":["West
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["East
+        Asia","Southeast Asia","Australia East","Australia Southeast","Japan East","Japan
+        West","Central India","South India","West India","West Europe","North Europe","Canada
+        Central","Canada East","Brazil South","West US","Central US","East US","South
+        Central US","East US 2","West Central US","North Central US","West US 2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"operations","locations":["West
         US","Central US","East US","South Central US","West Europe","North Europe","East
         Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
         Central US","North Central US","Japan East","Japan West","Brazil South","Central
@@ -176,177 +230,177 @@ http_interactions:
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/internalLoadBalancers","locations":[],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"domainNames/slots/roles/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"domainNames/slots/roles/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"domainNames/capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"domainNames/serviceCertificates","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
         US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
         Central","Canada East","UK South","UK West","West US","Central US","South
         Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
-        East","Australia Southeast","West US 2","West Central US","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        East","Australia Southeast","West US 2","West Central US","France Central","South
+        India","Central India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
         US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
         Central","Canada East","UK South","UK West","West US","Central US","South
         Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
-        East","Australia Southeast","West US 2","West Central US","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metrics","locations":["North
+        East","Australia Southeast","West US 2","West Central US","France Central","South
+        India","Central India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metrics","locations":["North
         Central US","South Central US","East US","East US 2","Canada Central","Canada
         East","West US","West US 2","West Central US","Central US","East Asia","Southeast
         Asia","North Europe","West Europe","UK South","UK West","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"resourceTypes","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"moveSubscriptionResources","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"validateSubscriptionMoveAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operationStatuses","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operatingSystems","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"operatingSystemFamilies","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicNetwork","namespace":"Microsoft.ClassicNetwork","resourceTypes":[{"resourceType":"virtualNetworks","locations":["East
+        India","West India","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"resourceTypes","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"moveSubscriptionResources","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"validateSubscriptionMoveAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operationStatuses","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operatingSystems","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"operatingSystemFamilies","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicNetwork","namespace":"Microsoft.ClassicNetwork","resourceTypes":[{"resourceType":"virtualNetworks","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"virtualNetworks/remoteVirtualNetworkPeeringProxies","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01"]},{"resourceType":"virtualNetworks/remoteVirtualNetworkPeeringProxies","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"reservedIps","locations":["East
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01"]},{"resourceType":"reservedIps","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"gatewaySupportedDevices","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"networkSecurityGroups","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"gatewaySupportedDevices","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"networkSecurityGroups","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicStorage","namespace":"Microsoft.ClassicStorage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"expressRouteCrossConnections","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"expressRouteCrossConnections/peerings","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicStorage","namespace":"Microsoft.ClassicStorage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkStorageAccountAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"storageAccounts/services","locations":["West
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkStorageAccountAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"storageAccounts/services","locations":["West
         US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
         Asia","Australia East","Australia Southeast","South India","Central India","West
         India","West US 2","West Central US","East US","East US 2","North Central
         US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
-        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/diagnosticSettings","locations":["West
+        South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/diagnosticSettings","locations":["West
         US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
         Asia","Australia East","Australia Southeast","South India","Central India","West
         India","West US 2","West Central US","East US","East US 2","North Central
         US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
-        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"disks","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"images","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"vmImages","locations":[],"apiVersions":["2016-11-01"]},{"resourceType":"publicImages","locations":[],"apiVersions":["2016-11-01","2016-04-01"]},{"resourceType":"osImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"osPlatformImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute","namespace":"Microsoft.Compute","authorizations":[{"applicationId":"60e6cd67-9c8c-4951-9b3c-23c25a2169af","roleDefinitionId":"e4770acb-272e-4dc8-87f3-12f44a612224"},{"applicationId":"a303894e-f1d8-4a37-bf10-67aa654a0596","roleDefinitionId":"903ac751-8ad5-4e5a-bfc2-5e49f450a241"},{"applicationId":"a8b6bf88-1d1a-4626-b040-9a729ea93c65","roleDefinitionId":"45c8267c-80ba-4b96-9a43-115b8f49fccd"}],"resourceTypes":[{"resourceType":"availabilitySets","locations":["East
+        South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"disks","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"images","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"vmImages","locations":[],"apiVersions":["2016-11-01"]},{"resourceType":"storageAccounts/vmImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"publicImages","locations":[],"apiVersions":["2016-11-01","2016-04-01"]},{"resourceType":"osImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"osPlatformImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute","namespace":"Microsoft.Compute","authorizations":[{"applicationId":"60e6cd67-9c8c-4951-9b3c-23c25a2169af","roleDefinitionId":"e4770acb-272e-4dc8-87f3-12f44a612224"},{"applicationId":"a303894e-f1d8-4a37-bf10-67aa654a0596","roleDefinitionId":"903ac751-8ad5-4e5a-bfc2-5e49f450a241"},{"applicationId":"a8b6bf88-1d1a-4626-b040-9a729ea93c65","roleDefinitionId":"45c8267c-80ba-4b96-9a43-115b8f49fccd"}],"resourceTypes":[{"resourceType":"availabilitySets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations/usages","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations/usages","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"sharedVMImages","locations":["West
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"sharedVMImages","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"sharedVMImages/versions","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"locations/capsoperations","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"disks","locations":["Southeast
@@ -354,27 +408,27 @@ http_interactions:
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"snapshots","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"snapshots","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"locations/diskoperations","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"locations/diskoperations","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"images","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"images","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"]},{"resourceType":"locations/logAnalytics","locations":["East
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"]},{"resourceType":"locations/logAnalytics","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
         US","East US","South Central US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
@@ -491,7 +545,12 @@ http_interactions:
         US","East Asia","East US","East US 2","Japan East","Japan West","North Central
         US","North Europe","South Central US","South India","Southeast Asia","West
         Central US","West Europe","West India","West US","West US 2","UK West","UK
-        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"},{"applicationId":"f5c26e74-f226-4ae8-85f0-b4af0080ac9e","roleDefinitionId":"529d7ae6-e892-4d43-809d-8547aeb90643"}],"resourceTypes":[{"resourceType":"components","locations":["East
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/consumergroups","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/disasterrecoveryconfigs","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"},{"applicationId":"f5c26e74-f226-4ae8-85f0-b4af0080ac9e","roleDefinitionId":"529d7ae6-e892-4d43-809d-8547aeb90643"}],"resourceTypes":[{"resourceType":"components","locations":["East
         US","South Central US","North Europe","West Europe","Southeast Asia","West
         US 2"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
         US","South Central US","North Europe","West Europe","Southeast Asia","West
@@ -558,32 +617,32 @@ http_interactions:
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/accessPolicies","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"vaults/accessPolicies","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-10-01","2015-06-01","2014-12-19-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"deletedVaults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01","2014-12-19-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"deletedVaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-10-01"]},{"resourceType":"locations/deletedVaults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations/deletedVaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
         Central US","West Europe","Southeast Asia","Japan East","West Central US"],"apiVersions":["2016-04-01"]},{"resourceType":"webServices","locations":["South
         Central US","West Europe","Southeast Asia","Japan East","East US 2","West
         Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"operations","locations":["South
@@ -609,97 +668,97 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"networkWatchers/lenses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"networkWatchers/lenses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","West
         US 2","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
@@ -790,7 +849,7 @@ http_interactions:
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
         West","Korea Central","Korea South"],"apiVersions":["2017-07-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ResourceHealth","namespace":"Microsoft.ResourceHealth","authorizations":[{"applicationId":"8bdebf23-c0fe-4187-a378-717ad86f6a53","roleDefinitionId":"cc026344-c8b1-4561-83ba-59eba84b27cc"}],"resourceTypes":[{"resourceType":"availabilityStatuses","locations":[],"apiVersions":["2017-07-01","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"notifications","locations":["Australia
-        Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Security","namespace":"Microsoft.Security","authorization":{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
+        Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Security","namespace":"Microsoft.Security","authorizations":[{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},{"applicationId":"fc780465-2017-40d4-a0c5-307022471b92"}],"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatuses","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/virtualMachines","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/endpoints","locations":["Central
@@ -842,565 +901,595 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Central India","South
         India"],"apiVersions":["2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Sql","namespace":"Microsoft.Sql","authorizations":[{"applicationId":"e4ab13ed-33cb-41b4-9140-6e264582cf85","roleDefinitionId":"ec3ddc95-44dc-47a2-9926-5e9f5ffd44ec"},{"applicationId":"0130cc9f-7ac5-4026-bd5f-80a08a54e6d9","roleDefinitionId":"45e8abf8-0ec4-44f3-9c37-cff4f7779302"},{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},{"applicationId":"76c7f279-7959-468f-8943-3954880e0d8c","roleDefinitionId":"7f7513a8-73f9-4c5f-97a2-c41f0ea783ef"}],"resourceTypes":[{"resourceType":"operations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/capabilities","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/databaseAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/databaseOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverKeyOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/keys","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/encryptionProtector","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/usages","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01","2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/communicationLinks","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administrators","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administratorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/restorableDroppedDatabases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recoverableDatabases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/geoBackupPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/importExportOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/operationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/backupLongTermRetentionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/automaticTuning","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/automaticTuning","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/databases/transparentDataEncryption","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recommendedElasticPools","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/auditingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/connectionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/connectionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies/rules","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/securityAlertPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/securityAlertPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/auditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/extendedAuditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/elasticpools","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-09-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/jobAgentOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/jobAgentAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/disasterRecoveryConfiguration","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/dnsAliases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/failoverGroups","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/virtualNetworkRules","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/virtualNetworkRulesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/virtualNetworkRulesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/databaseRestoreAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metricDefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/aggregatedDatabaseMetrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metricdefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries/queryText","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPools/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/extensions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPoolEstimates","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditRecords","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentScans","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/vulnerabilityAssessments","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessment","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/syncGroups","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups/syncMembers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/syncAgents","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"managedInstances/administrators","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/databases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metricDefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/administratorAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/administratorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncMemberOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncAgentOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncDatabaseIds","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorizations":[{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},{"applicationId":"e406a681-f3d4-42a8-90b6-c2b029497af1"}],"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/capabilities","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/databaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"locations/databaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverKeyOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/keys","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/encryptionProtector","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01","2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/communicationLinks","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/restorableDroppedDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recoverableDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/geoBackupPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/importExportOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/operationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/backupLongTermRetentionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/databases/transparentDataEncryption","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recommendedElasticPools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies/rules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/extendedAuditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/elasticPoolAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/elasticPoolOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/elasticpools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-09-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/jobAgentOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/jobAgentAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/disasterRecoveryConfiguration","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/dnsAliases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/failoverGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/virtualNetworkRules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/virtualNetworkRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/virtualNetworkRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/databaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/aggregatedDatabaseMetrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metricdefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries/queryText","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPools/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/extensions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPoolEstimates","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditRecords","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentScans","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/vulnerabilityAssessments","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessment","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/syncGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups/syncMembers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/syncAgents","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"managedInstances/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/administratorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncMemberOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncAgentOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncDatabaseIds","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/longTermRetentionPolicyOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionPolicyAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionBackupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionBackupAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorizations":[{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},{"applicationId":"e406a681-f3d4-42a8-90b6-c2b029497af1"}],"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
@@ -1739,12 +1828,12 @@ http_interactions:
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","Canada Central","Canada East","UK South","UK West","West US 2","West
-        Central US","South India","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","South India","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","South India","Canada Central","Canada East","UK South","UK West","West
-        US 2","West Central US","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Capacity","namespace":"Microsoft.Capacity","authorization":{"applicationId":"4d0ad6c7-f6c3-46d8-ab0d-1406d5e6c86b","roleDefinitionId":"FD9C0A9A-4DB9-4F41-8A61-98385DEB6E2D"},"resourceTypes":[{"resourceType":"resources","locations":["South
+        US 2","West Central US","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Capacity","namespace":"Microsoft.Capacity","authorization":{"applicationId":"4d0ad6c7-f6c3-46d8-ab0d-1406d5e6c86b","roleDefinitionId":"FD9C0A9A-4DB9-4F41-8A61-98385DEB6E2D"},"resourceTypes":[{"resourceType":"resources","locations":["South
         Central US"],"apiVersions":["2017-11-01"]},{"resourceType":"reservationOrders","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/reservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/reservations/revisions","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"catalogs","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"appliedReservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"checkOffers","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"checkScopes","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"calculatePrice","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/calculateRefund","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/return","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/split","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/merge","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"validateReservationOrder","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/availableScopes","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Cdn","namespace":"Microsoft.Cdn","resourceTypes":[{"resourceType":"profiles","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
@@ -1820,9 +1909,9 @@ http_interactions:
         2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/updateAccountsCreationSettings","locations":["West
         US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/accountsCreationSettings","locations":["West
         US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2016-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Commerce","namespace":"Microsoft.Commerce","resourceTypes":[{"resourceType":"UsageAggregates","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]},{"resourceType":"RateCard","locations":[],"apiVersions":["2016-08-31-preview","2015-06-01-preview","2015-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Consumption","namespace":"Microsoft.Consumption","resourceTypes":[{"resourceType":"ReservationSummaries","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationTransactions","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Balances","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Marketplaces","locations":[],"apiVersions":["2018-01-31"]},{"resourceType":"Pricesheets","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationDetails","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Budgets","locations":[],"apiVersions":["2018-01-31","2017-12-30-preview"]},{"resourceType":"Terms","locations":[],"apiVersions":["2018-01-31","2017-12-30-preview"]},{"resourceType":"UsageDetails","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview","2017-04-24-preview"]},{"resourceType":"Operations","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview","2017-04-24-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerInstance","namespace":"Microsoft.ContainerInstance","resourceTypes":[{"resourceType":"containerGroups","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/usages","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/operations","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/operations","locations":["West
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
         US"],"apiVersions":["2016-04-08"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.CustomerInsights","namespace":"Microsoft.CustomerInsights","authorization":{"applicationId":"38c77d00-5fcb-4cce-9d93-af4738258e3c","roleDefinitionId":"E006F9C7-F333-477C-8AD6-1F3A9FE87F55"},"resourceTypes":[{"resourceType":"hubs","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/profiles","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/interactions","locations":["East
@@ -1839,7 +1928,9 @@ http_interactions:
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"operations","locations":["East
         US 2"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Databricks","namespace":"Microsoft.Databricks","authorizations":[{"applicationId":"d9327919-6775-4843-9037-3fb0fb0473cb","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},{"applicationId":"2ff814a6-3304-4ab8-85cb-cd0e6f879c1d","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"}],"resourceTypes":[{"resourceType":"workspaces","locations":["West
         US","East US 2","West Europe","East US","North Europe","Southeast Asia","East
-        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]},{"resourceType":"locations","locations":["West
+        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2017-09-01-preview"]},{"resourceType":"workspaces/virtualNetworkPeerings","locations":["West
+        US","East US 2","West Europe","North Europe","East US","Southeast Asia","East
+        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01"]},{"resourceType":"locations","locations":["West
         US","East US 2","West Europe","North Europe","East US","Southeast Asia"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
         US","East US 2","West Europe","East US","North Europe","Southeast Asia","East
         Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataCatalog","namespace":"Microsoft.DataCatalog","resourceTypes":[{"resourceType":"catalogs","locations":["East
@@ -1863,23 +1954,26 @@ http_interactions:
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers/listSasTokens","locations":["East
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataLakeStore","namespace":"Microsoft.DataLakeStore","authorization":{"applicationId":"e9f49c6b-5ce5-44c8-925d-015017e9f7ad","roleDefinitionId":"17eb9cca-f08a-4499-b2d3-852d175f614f"},"resourceTypes":[{"resourceType":"accounts","locations":["East
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/firewallRules","locations":["East
-        US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataMigration","namespace":"Microsoft.DataMigration","authorization":{"applicationId":"a4bad4aa-bf02-4631-9f78-a64ffdba8150","roleDefinitionId":"b831a21d-db98-4760-89cb-bef871952df1","managedByRoleDefinitionId":"6256fb55-9e59-4018-a9e1-76b11c0a4c89"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services/projects","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationStatuses","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
+        US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataMigration","namespace":"Microsoft.DataMigration","authorization":{"applicationId":"a4bad4aa-bf02-4631-9f78-a64ffdba8150","roleDefinitionId":"b831a21d-db98-4760-89cb-bef871952df1","managedByRoleDefinitionId":"6256fb55-9e59-4018-a9e1-76b11c0a4c89"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services/projects","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationStatuses","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
-        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/recoverableServers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
@@ -1903,7 +1997,10 @@ http_interactions:
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
-        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/recoverableServers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
@@ -1959,12 +2056,7 @@ http_interactions:
         US 2","East US","West US","Central US","East US 2","West Central US","West
         Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
         US 2","East US","West US","Central US","East US 2","West Central US","West
-        Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","West
-        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
-        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
-        India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/consumergroups","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/disasterrecoveryconfigs","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
         US 2","South Central US","Central US","Australia Southeast","Central India","West
         Central US","West US 2","Canada East","Canada Central","Brazil South","UK
         South","UK West","East Asia","Australia East","Japan East","Japan West","North
@@ -2075,7 +2167,7 @@ http_interactions:
         West","Japan East","East Asia","Southeast Asia","West Europe","North Europe","East
         US","West US","Australia East","Australia Southeast","Central US","Brazil
         South","Central India","West India","South India","South Central US","Canada
-        Central","Canada East","West Central US","West US 2"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
+        Central","Canada East","West Central US","West US 2"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-05","2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
         Central US","East US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"operations","locations":["West
         Central US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
         Central US","East US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.PolicyInsights","namespace":"Microsoft.PolicyInsights","authorization":{"applicationId":"1d78a85d-813d-46f0-b496-dd72f50a3ec0","roleDefinitionId":"63d2b225-4c34-4641-8768-21a1f7c68ce8"},"resourceTypes":[{"resourceType":"policyEvents","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"policyStates","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
@@ -2107,12 +2199,12 @@ http_interactions:
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
         Central US","South Central US","North Europe","West Europe","East Asia","Southeast
         Asia","West US","East US","Japan West","Japan East","Brazil South","Central
         US","East US 2","Australia East","Australia Southeast","South India","Central
@@ -2152,52 +2244,62 @@ http_interactions:
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/clusterVersions","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"clusters/applications","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operations","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/clusterVersions","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/environments","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operations","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
         Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applianceDefinitions","locations":["West
         Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applications","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
-        Central US"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
+        Central US"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
-        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
-        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups","locations":["West
-        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
-        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups/cloudEndpoints","locations":["West
-        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
-        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups/serverEndpoints","locations":["West
-        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
-        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/registeredServers","locations":["West
-        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
-        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/workflows","locations":["West
-        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
-        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
+        US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
+        US","Canada Central","Canada East","Central US","East US 2","UK South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups","locations":["West
+        US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
+        US","Canada Central","Canada East","Central US","East US 2","UK South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups/cloudEndpoints","locations":["West
+        US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
+        US","Canada Central","Canada East","Central US","East US 2","UK South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups/serverEndpoints","locations":["West
+        US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
+        US","Canada Central","Canada East","Central US","East US 2","UK South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/registeredServers","locations":["West
+        US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
+        US","Canada Central","Canada East","Central US","East US 2","UK South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/workflows","locations":["West
+        US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
+        US","Canada Central","Canada East","Central US","East US 2","UK South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","West Central US","Japan East","Japan West","Australia East","Australia
         Southeast"],"apiVersions":["2017-06-01","2017-05-15","2017-01-01","2016-10-01","2016-06-01","2015-03-15","2014-09-01"]},{"resourceType":"operations","locations":["West
@@ -2276,10 +2378,10 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:22 GMT
+  recorded_at: Mon, 12 Mar 2018 09:25:05 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1?api-version=2017-12-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2293,7 +2395,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MzgsIm5iZiI6MTUyMDQ1MzQzOCwiZXhwIjoxNTIwNDU3MzM4LCJhaW8iOiJZMk5nWUxEbUtXMDk5clB4cU9QdGorL1crV3NlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZHNPVmFSUXV2RTJjVVBpcEtWWUFBQSIsInZlciI6IjEuMCJ9.drT5CKw95WRF7LzC0WuhK-fTLpw3j61XMw_DZdrLOWP8sjjsrbn9kF7xjDSTUM0ooF5_1Y-j3dNjvI9crm_F3PMAyhYXmCsKjTJkc3DIK6URy3hqbKiRBNlrutwvILE777NY-uXK9PH-gcaVuV-mNrjrLuxxClMJ3OPpTU8Ux0fj3Nuyf3KrXC27Oks_M_RDqDaXHOTckrdz2m_LNLpi5x0nKCoxwR9r5C1m5IKZ25FSbvyRNwjwz5dReqnv5LxllQMHVWkpvO7i5438wAnnyaS2x211IBiE6_dnV2god8Sp3ZRinXc4aCimUnJl6tLa5EtT_VSmR2QcBSaq0wS_ZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDYzOTgsIm5iZiI6MTUyMDg0NjM5OCwiZXhwIjoxNTIwODUwMjk4LCJhaW8iOiJZMk5nWUREaWt2OGkzWG5nNlVUbjUxbXNxeGZsQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieHBWZjRReC1fMFNKYXRaZUZRTWxBQSIsInZlciI6IjEuMCJ9.XwasNxrTVaqKz-D9MgYSC3bmyr00gxvA0-2ZHY6Ao4d6M-8zyF3EkpgtjvJQmJyigbtLo3aYxJYaliL0Doibjzt0yACsSHn0-fXyHT7SHkg2HOUhlT2YKj6Zd0Livs6YrpkYTLfpXffETPG6mqi0Q-P06FwGkAHh7-BzxH_Gh5I6JxbYFXpqpp184d23kVbcpZd9cBSCOPtIfLo5t-HJLY71rJ_vjTYLRyI2g_8a7RIYwHlViI1_O4-qGCr7eidV9SAQOk6Qg18mVS9Xh9eqtJ7o-7KncA9DnnM_hKy_BFta_jaQK4D1UkYDDGtthSqoIQzA-TGCPYEs4uALG9JgHw
   response:
     status:
       code: 200
@@ -2312,54 +2414,60 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/LowCostGet3Min;4726,Microsoft.Compute/LowCostGet30Min;37872
+      - Microsoft.Compute/LowCostGet3Min;4748,Microsoft.Compute/LowCostGet30Min;37931
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
       - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
       X-Ms-Request-Id:
-      - 0d7ff3f0-201b-497d-8933-56967d58f24f
+      - 89456bdb-ccbd-46bc-8c39-9dd4ef241822
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14971'
+      - '14997'
       X-Ms-Correlation-Request-Id:
-      - 8ffcfbc5-7c69-436a-841a-9d3e5e22572d
+      - a521c7e0-50dd-46ce-b948-3ad089834db7
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201822Z:8ffcfbc5-7c69-436a-841a-9d3e5e22572d
+      - WESTEUROPE:20180312T092503Z:a521c7e0-50dd-46ce-b948-3ad089834db7
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:18:22 GMT
+      - Mon, 12 Mar 2018 09:25:03 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"d7022008-f6b1-4f4c-8be8-e2d677ef3261\",\r\n
-        \   \"availabilitySet\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/SPEC0DEPLY1AS\"\r\n
-        \   },\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_D1\"\r\n
-        \   },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
-        \"MicrosoftWindowsServer\",\r\n        \"offer\": \"WindowsServer\",\r\n        \"sku\":
-        \"2012-R2-Datacenter\",\r\n        \"version\": \"latest\"\r\n      },\r\n
-        \     \"osDisk\": {\r\n        \"osType\": \"Windows\",\r\n        \"name\":
-        \"osdisk\",\r\n        \"createOption\": \"FromImage\",\r\n        \"vhd\":
-        {\r\n          \"uri\": \"http://spec0deply1stor.blob.core.windows.net/vhds/osdisk0.vhd\"\r\n
+      string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"03e8467b-baab-4867-9cc4-157336b7e2e4\",\r\n
+        \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Basic_A0\"\r\n    },\r\n
+        \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
+        \"RedHat\",\r\n        \"offer\": \"RHEL\",\r\n        \"sku\": \"7.2\",\r\n
+        \       \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
+        \"Linux\",\r\n        \"name\": \"miq-test-rhel1\",\r\n        \"createOption\":
+        \"FromImage\",\r\n        \"vhd\": {\r\n          \"uri\": \"https://miqazuretest18686.blob.core.windows.net/vhds/miq-test-rhel12016218112243.vhd\"\r\n
         \       },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n      \"dataDisks\":
-        []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"spec0deply1vm0\",\r\n
-        \     \"adminUsername\": \"deploy1admin\",\r\n      \"windowsConfiguration\":
-        {\r\n        \"provisionVMAgent\": true,\r\n        \"enableAutomaticUpdates\":
-        true\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\":
-        {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0\"}]},\r\n
+        []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"miq-test-rhel1\",\r\n
+        \     \"adminUsername\": \"dberger\",\r\n      \"linuxConfiguration\": {\r\n
+        \       \"disablePasswordAuthentication\": false\r\n      },\r\n      \"secrets\":
+        []\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390\"}]},\r\n
         \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
-        true,\r\n        \"storageUri\": \"http://spec0deply1stor.blob.core.windows.net\"\r\n
+        true,\r\n        \"storageUri\": \"https://miqazuretest18686.blob.core.windows.net/\"\r\n
         \     }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n
-        \ \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"eastus\",\r\n
-        \ \"tags\": {\r\n    \"Shutdown\": \"true\"\r\n  },\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0\",\r\n
-        \ \"name\": \"spec0deply1vm0\"\r\n}"
+        \ \"resources\": [\r\n    {\r\n      \"properties\": {\r\n        \"publisher\":
+        \"Microsoft.OSTCExtensions\",\r\n        \"type\": \"LinuxDiagnostic\",\r\n
+        \       \"typeHandlerVersion\": \"2.0\",\r\n        \"autoUpgradeMinorVersion\":
+        true,\r\n        \"settings\": {\"xmlCfg\":\"PFdhZENmZz48RGlhZ25vc3RpY01vbml0b3JDb25maWd1cmF0aW9uIG92ZXJhbGxRdW90YUluTUI9IjQwOTYiPjxEaWFnbm9zdGljSW5mcmFzdHJ1Y3R1cmVMb2dzIHNjaGVkdWxlZFRyYW5zZmVyUGVyaW9kPSJQVDFNIiBzY2hlZHVsZWRUcmFuc2ZlckxvZ0xldmVsRmlsdGVyPSJXYXJuaW5nIi8+PFBlcmZvcm1hbmNlQ291bnRlcnMgc2NoZWR1bGVkVHJhbnNmZXJQZXJpb2Q9IlBUMU0iPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlTWVtb3J5IiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQnl0ZXMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcUGVyY2VudEF2YWlsYWJsZU1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iTWVtb3J5IHVzZWQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50VXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgcGVyY2VudGFnZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkQnlDYWNoZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHVzZWQgYnkgY2FjaGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1BlclNlYyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50UGVyU2Vjb25kIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFnZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1JlYWRQZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2UgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1dyaXR0ZW5QZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2Ugd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iU3dhcCBhdmFpbGFibGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50QXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZFN3YXAiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlN3YXAgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRJZGxlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgaWRsZSB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFVzZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iUGVyY2VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkNQVSB1c2VyIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50TmljZVRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIG5pY2UgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRQcml2aWxlZ2VkVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgcHJpdmlsZWdlZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudEludGVycnVwdFRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIGludGVycnVwdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudERQQ1RpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIERQQyB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFByb2Nlc3NvclRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIHBlcmNlbnRhZ2UgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50SU9XYWl0VGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgSU8gd2FpdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xSZWFkQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCBndWVzdCBPUyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXFdyaXRlQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGUgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xUcmFuc2ZlcnNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXJzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcUmVhZHNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xXcml0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVJlYWRUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVdyaXRlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlNlY29uZHMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJEaXNrIHdyaXRlIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xBdmVyYWdlVHJhbnNmZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXIgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXEF2ZXJhZ2VEaXNrUXVldWVMZW5ndGgiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcXVldWUgbGVuZ3RoIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVHJhbnNtaXR0ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgb3V0IGd1ZXN0IE9TIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzUmVjZWl2ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgaW4gZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1RyYW5zbWl0dGVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHNlbnQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1JlY2VpdmVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHJlY2VpdmVkIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVG90YWwiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxSeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyByZWNlaXZlZCBlcnJvcnMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxUeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyBzZW50IGVycm9ycyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTmV0d29ya0ludGVyZmFjZVxUb3RhbENvbGxpc2lvbnMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgY29sbGlzaW9ucyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48L1BlcmZvcm1hbmNlQ291bnRlcnM+PE1ldHJpY3MgcmVzb3VyY2VJZD0iL3N1YnNjcmlwdGlvbnMvMjU4NmM2NGItMzhiNC00NTI3LWExNDAtMDEyZDQ5ZGZjMDJjL3Jlc291cmNlR3JvdXBzL21pcS1henVyZS10ZXN0MS9wcm92aWRlcnMvTWljcm9zb2Z0LkNvbXB1dGUvdmlydHVhbE1hY2hpbmVzL21pcS10ZXN0LXJoZWwxIj48TWV0cmljQWdncmVnYXRpb24gc2NoZWR1bGVkVHJhbnNmZXJQZXJpb2Q9IlBUMUgiLz48TWV0cmljQWdncmVnYXRpb24gc2NoZWR1bGVkVHJhbnNmZXJQZXJpb2Q9IlBUMU0iLz48L01ldHJpY3M+PC9EaWFnbm9zdGljTW9uaXRvckNvbmZpZ3VyYXRpb24+PC9XYWRDZmc+\",\"StorageAccount\":\"miqazuretest18686\"},\r\n
+        \       \"provisioningState\": \"Succeeded\"\r\n      },\r\n      \"type\":
+        \"Microsoft.Compute/virtualMachines/extensions\",\r\n      \"location\": \"eastus\",\r\n
+        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/extensions/Microsoft.Insights.VMDiagnosticsSettings\",\r\n
+        \     \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n    }\r\n
+        \ ],\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\":
+        \"eastus\",\r\n  \"tags\": {\r\n    \"Shutdown\": \"true\"\r\n  },\r\n  \"id\":
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1\",\r\n
+        \ \"name\": \"miq-test-rhel1\"\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:23 GMT
+  recorded_at: Mon, 12 Mar 2018 09:25:07 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390?api-version=2018-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2373,7 +2481,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MzgsIm5iZiI6MTUyMDQ1MzQzOCwiZXhwIjoxNTIwNDU3MzM4LCJhaW8iOiJZMk5nWUxEbUtXMDk5clB4cU9QdGorL1crV3NlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZHNPVmFSUXV2RTJjVVBpcEtWWUFBQSIsInZlciI6IjEuMCJ9.drT5CKw95WRF7LzC0WuhK-fTLpw3j61XMw_DZdrLOWP8sjjsrbn9kF7xjDSTUM0ooF5_1Y-j3dNjvI9crm_F3PMAyhYXmCsKjTJkc3DIK6URy3hqbKiRBNlrutwvILE777NY-uXK9PH-gcaVuV-mNrjrLuxxClMJ3OPpTU8Ux0fj3Nuyf3KrXC27Oks_M_RDqDaXHOTckrdz2m_LNLpi5x0nKCoxwR9r5C1m5IKZ25FSbvyRNwjwz5dReqnv5LxllQMHVWkpvO7i5438wAnnyaS2x211IBiE6_dnV2god8Sp3ZRinXc4aCimUnJl6tLa5EtT_VSmR2QcBSaq0wS_ZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDYzOTgsIm5iZiI6MTUyMDg0NjM5OCwiZXhwIjoxNTIwODUwMjk4LCJhaW8iOiJZMk5nWUREaWt2OGkzWG5nNlVUbjUxbXNxeGZsQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieHBWZjRReC1fMFNKYXRaZUZRTWxBQSIsInZlciI6IjEuMCJ9.XwasNxrTVaqKz-D9MgYSC3bmyr00gxvA0-2ZHY6Ao4d6M-8zyF3EkpgtjvJQmJyigbtLo3aYxJYaliL0Doibjzt0yACsSHn0-fXyHT7SHkg2HOUhlT2YKj6Zd0Livs6YrpkYTLfpXffETPG6mqi0Q-P06FwGkAHh7-BzxH_Gh5I6JxbYFXpqpp184d23kVbcpZd9cBSCOPtIfLo5t-HJLY71rJ_vjTYLRyI2g_8a7RIYwHlViI1_O4-qGCr7eidV9SAQOk6Qg18mVS9Xh9eqtJ7o-7KncA9DnnM_hKy_BFta_jaQK4D1UkYDDGtthSqoIQzA-TGCPYEs4uALG9JgHw
   response:
     status:
       code: 200
@@ -2390,54 +2498,54 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"b817491c-aab8-4aab-b41d-b07bfffa5639"
+      - W/"f006e6f9-0292-42cd-99fc-f72f194553c1"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 60e3c5d2-1c8d-4023-bdee-c8bb92d9b215
+      - cc673be4-31f7-4f42-bc49-c0bc04f789b5
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14982'
+      - '14996'
       X-Ms-Correlation-Request-Id:
-      - 3a96c9b8-75d1-4433-9bdc-e01b0965e50b
+      - dd56c17a-0957-4327-9f1d-e0695903c7cd
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201823Z:3a96c9b8-75d1-4433-9bdc-e01b0965e50b
+      - WESTEUROPE:20180312T092504Z:dd56c17a-0957-4327-9f1d-e0695903c7cd
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:18:22 GMT
+      - Mon, 12 Mar 2018 09:25:03 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"spec0deply1nic0\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0\",\r\n
-        \ \"etag\": \"W/\\\"b817491c-aab8-4aab-b41d-b07bfffa5639\\\"\",\r\n  \"location\":
+      string: "{\r\n  \"name\": \"miq-test-rhel1390\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390\",\r\n
+        \ \"etag\": \"W/\\\"f006e6f9-0292-42cd-99fc-f72f194553c1\\\"\",\r\n  \"location\":
         \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"80ad9866-071d-4e3f-91d0-d47954eccee0\",\r\n    \"ipConfigurations\":
-        [\r\n      {\r\n        \"name\": \"ipconfig1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1\",\r\n
-        \       \"etag\": \"W/\\\"b817491c-aab8-4aab-b41d-b07bfffa5639\\\"\",\r\n
+        \   \"resourceGuid\": \"98853f48-2806-4065-be57-cf9159550440\",\r\n    \"ipConfigurations\":
+        [\r\n      {\r\n        \"name\": \"ipconfig1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1\",\r\n
+        \       \"etag\": \"W/\\\"f006e6f9-0292-42cd-99fc-f72f194553c1\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAddress\": \"10.0.0.4\",\r\n          \"privateIPAllocationMethod\":
-        \"Dynamic\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1\"\r\n
+        \         \"privateIPAddress\": \"10.16.0.4\",\r\n          \"privateIPAllocationMethod\":
+        \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1\"\r\n
+        \         },\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\"\r\n
         \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
-        \"IPv4\",\r\n          \"loadBalancerBackendAddressPools\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\"\r\n
-        \           }\r\n          ],\r\n          \"loadBalancerInboundNatRules\":
-        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\":
-        {\r\n      \"dnsServers\": [],\r\n      \"appliedDnsServers\": []\r\n    },\r\n
-        \   \"enableAcceleratedNetworking\": false,\r\n    \"enableIPForwarding\":
-        false,\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0\"\r\n
+        \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\":
+        [],\r\n      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\":
+        \"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net\"\r\n    },\r\n    \"macAddress\":
+        \"00-0D-3A-10-EB-AB\",\r\n    \"enableAcceleratedNetworking\": false,\r\n
+        \   \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\": {\r\n
+        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1\"\r\n
+        \   },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1\"\r\n
         \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
         \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:23 GMT
+  recorded_at: Mon, 12 Mar 2018 09:25:08 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups/miq-azure-test1?api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/instanceView?api-version=2017-12-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2451,60 +2559,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MzgsIm5iZiI6MTUyMDQ1MzQzOCwiZXhwIjoxNTIwNDU3MzM4LCJhaW8iOiJZMk5nWUxEbUtXMDk5clB4cU9QdGorL1crV3NlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZHNPVmFSUXV2RTJjVVBpcEtWWUFBQSIsInZlciI6IjEuMCJ9.drT5CKw95WRF7LzC0WuhK-fTLpw3j61XMw_DZdrLOWP8sjjsrbn9kF7xjDSTUM0ooF5_1Y-j3dNjvI9crm_F3PMAyhYXmCsKjTJkc3DIK6URy3hqbKiRBNlrutwvILE777NY-uXK9PH-gcaVuV-mNrjrLuxxClMJ3OPpTU8Ux0fj3Nuyf3KrXC27Oks_M_RDqDaXHOTckrdz2m_LNLpi5x0nKCoxwR9r5C1m5IKZ25FSbvyRNwjwz5dReqnv5LxllQMHVWkpvO7i5438wAnnyaS2x211IBiE6_dnV2god8Sp3ZRinXc4aCimUnJl6tLa5EtT_VSmR2QcBSaq0wS_ZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14982'
-      X-Ms-Request-Id:
-      - f9800467-1e1b-4233-8cb4-1bcb3f6c2a01
-      X-Ms-Correlation-Request-Id:
-      - f9800467-1e1b-4233-8cb4-1bcb3f6c2a01
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201823Z:f9800467-1e1b-4233-8cb4-1bcb3f6c2a01
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:18:23 GMT
-      Content-Length:
-      - '183'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1","name":"miq-azure-test1","location":"eastus","properties":{"provisioningState":"Succeeded"}}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:23 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute/locations/eastus/vmSizes?api-version=2017-12-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MzgsIm5iZiI6MTUyMDQ1MzQzOCwiZXhwIjoxNTIwNDU3MzM4LCJhaW8iOiJZMk5nWUxEbUtXMDk5clB4cU9QdGorL1crV3NlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZHNPVmFSUXV2RTJjVVBpcEtWWUFBQSIsInZlciI6IjEuMCJ9.drT5CKw95WRF7LzC0WuhK-fTLpw3j61XMw_DZdrLOWP8sjjsrbn9kF7xjDSTUM0ooF5_1Y-j3dNjvI9crm_F3PMAyhYXmCsKjTJkc3DIK6URy3hqbKiRBNlrutwvILE777NY-uXK9PH-gcaVuV-mNrjrLuxxClMJ3OPpTU8Ux0fj3Nuyf3KrXC27Oks_M_RDqDaXHOTckrdz2m_LNLpi5x0nKCoxwR9r5C1m5IKZ25FSbvyRNwjwz5dReqnv5LxllQMHVWkpvO7i5438wAnnyaS2x211IBiE6_dnV2god8Sp3ZRinXc4aCimUnJl6tLa5EtT_VSmR2QcBSaq0wS_ZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDYzOTgsIm5iZiI6MTUyMDg0NjM5OCwiZXhwIjoxNTIwODUwMjk4LCJhaW8iOiJZMk5nWUREaWt2OGkzWG5nNlVUbjUxbXNxeGZsQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieHBWZjRReC1fMFNKYXRaZUZRTWxBQSIsInZlciI6IjEuMCJ9.XwasNxrTVaqKz-D9MgYSC3bmyr00gxvA0-2ZHY6Ao4d6M-8zyF3EkpgtjvJQmJyigbtLo3aYxJYaliL0Doibjzt0yACsSHn0-fXyHT7SHkg2HOUhlT2YKj6Zd0Livs6YrpkYTLfpXffETPG6mqi0Q-P06FwGkAHh7-BzxH_Gh5I6JxbYFXpqpp184d23kVbcpZd9cBSCOPtIfLo5t-HJLY71rJ_vjTYLRyI2g_8a7RIYwHlViI1_O4-qGCr7eidV9SAQOk6Qg18mVS9Xh9eqtJ7o-7KncA9DnnM_hKy_BFta_jaQK4D1UkYDDGtthSqoIQzA-TGCPYEs4uALG9JgHw
   response:
     status:
       code: 200
@@ -2523,26 +2578,164 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/LowCostGet3Min;4725,Microsoft.Compute/LowCostGet30Min;37871
+      - Microsoft.Compute/GetInstanceView3Min;4799,Microsoft.Compute/GetInstanceView30Min;23921
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
       - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
       X-Ms-Request-Id:
-      - c943cfdc-e48b-40ad-9d79-968660d496a6
+      - 8797579e-d15c-47ad-8002-529863f3b7df
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14971'
+      - '14992'
       X-Ms-Correlation-Request-Id:
-      - 954ffdb4-9101-46e6-bbfa-3f865fe9933c
+      - 233d497a-220c-4508-8160-9d34139bd514
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201824Z:954ffdb4-9101-46e6-bbfa-3f865fe9933c
+      - WESTEUROPE:20180312T092515Z:233d497a-220c-4508-8160-9d34139bd514
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:18:24 GMT
+      - Mon, 12 Mar 2018 09:25:15 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"vmAgent\": {\r\n    \"vmAgentVersion\": \"WALinuxAgent-2.0.16\",\r\n
+        \   \"statuses\": [\r\n      {\r\n        \"code\": \"ProvisioningState/succeeded\",\r\n
+        \       \"level\": \"Info\",\r\n        \"displayStatus\": \"Ready\",\r\n
+        \       \"message\": \"GuestAgent is running and accepting new configurations.\",\r\n
+        \       \"time\": \"2018-03-12T09:24:43+00:00\"\r\n      }\r\n    ],\r\n    \"extensionHandlers\":
+        [\r\n      {\r\n        \"type\": \"Microsoft.OSTCExtensions.LinuxDiagnostic\",\r\n
+        \       \"typeHandlerVersion\": \"2.3.9027\",\r\n        \"status\": {\r\n
+        \         \"code\": \"ProvisioningState/succeeded\",\r\n          \"level\":
+        \"Info\",\r\n          \"displayStatus\": \"Ready\"\r\n        }\r\n      }\r\n
+        \   ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"miq-test-rhel1\",\r\n
+        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
+        succeeded\",\r\n          \"time\": \"2018-01-17T18:00:29.9011002+00:00\"\r\n
+        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
+        \"https://miqazuretest18686.blob.core.windows.net/bootdiagnostics-miqtestrh-03e8467b-baab-4867-9cc4-157336b7e2e4/miq-test-rhel1.03e8467b-baab-4867-9cc4-157336b7e2e4.screenshot.bmp\",\r\n
+        \   \"serialConsoleLogBlobUri\": \"https://miqazuretest18686.blob.core.windows.net/bootdiagnostics-miqtestrh-03e8467b-baab-4867-9cc4-157336b7e2e4/miq-test-rhel1.03e8467b-baab-4867-9cc4-157336b7e2e4.serialconsole.log\"\r\n
+        \ },\r\n  \"extensions\": [\r\n    {\r\n      \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\",\r\n
+        \     \"type\": \"Microsoft.OSTCExtensions.LinuxDiagnostic\",\r\n      \"typeHandlerVersion\":
+        \"2.3.9027\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\":
+        \"ProvisioningState/succeeded\",\r\n          \"level\": \"Info\",\r\n          \"displayStatus\":
+        \"Provisioning succeeded\",\r\n          \"message\": \"Enable succeeded\"\r\n
+        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\":
+        \"ProvisioningState/succeeded\",\r\n      \"level\": \"Info\",\r\n      \"displayStatus\":
+        \"Provisioning succeeded\",\r\n      \"time\": \"2018-01-17T18:02:26.9167163+00:00\"\r\n
+        \   },\r\n    {\r\n      \"code\": \"PowerState/running\",\r\n      \"level\":
+        \"Info\",\r\n      \"displayStatus\": \"VM running\"\r\n    }\r\n  ]\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:25:19 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups/miq-azure-test1?api-version=2017-08-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDYzOTgsIm5iZiI6MTUyMDg0NjM5OCwiZXhwIjoxNTIwODUwMjk4LCJhaW8iOiJZMk5nWUREaWt2OGkzWG5nNlVUbjUxbXNxeGZsQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieHBWZjRReC1fMFNKYXRaZUZRTWxBQSIsInZlciI6IjEuMCJ9.XwasNxrTVaqKz-D9MgYSC3bmyr00gxvA0-2ZHY6Ao4d6M-8zyF3EkpgtjvJQmJyigbtLo3aYxJYaliL0Doibjzt0yACsSHn0-fXyHT7SHkg2HOUhlT2YKj6Zd0Livs6YrpkYTLfpXffETPG6mqi0Q-P06FwGkAHh7-BzxH_Gh5I6JxbYFXpqpp184d23kVbcpZd9cBSCOPtIfLo5t-HJLY71rJ_vjTYLRyI2g_8a7RIYwHlViI1_O4-qGCr7eidV9SAQOk6Qg18mVS9Xh9eqtJ7o-7KncA9DnnM_hKy_BFta_jaQK4D1UkYDDGtthSqoIQzA-TGCPYEs4uALG9JgHw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Request-Id:
+      - f67ecb24-8fa2-40b8-b6c1-2e45ba5b42ae
+      X-Ms-Correlation-Request-Id:
+      - f67ecb24-8fa2-40b8-b6c1-2e45ba5b42ae
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T092517Z:f67ecb24-8fa2-40b8-b6c1-2e45ba5b42ae
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:25:17 GMT
+      Content-Length:
+      - '183'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1","name":"miq-azure-test1","location":"eastus","properties":{"provisioningState":"Succeeded"}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:25:22 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute/locations/eastus/vmSizes?api-version=2017-12-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDYzOTgsIm5iZiI6MTUyMDg0NjM5OCwiZXhwIjoxNTIwODUwMjk4LCJhaW8iOiJZMk5nWUREaWt2OGkzWG5nNlVUbjUxbXNxeGZsQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieHBWZjRReC1fMFNKYXRaZUZRTWxBQSIsInZlciI6IjEuMCJ9.XwasNxrTVaqKz-D9MgYSC3bmyr00gxvA0-2ZHY6Ao4d6M-8zyF3EkpgtjvJQmJyigbtLo3aYxJYaliL0Doibjzt0yACsSHn0-fXyHT7SHkg2HOUhlT2YKj6Zd0Livs6YrpkYTLfpXffETPG6mqi0Q-P06FwGkAHh7-BzxH_Gh5I6JxbYFXpqpp184d23kVbcpZd9cBSCOPtIfLo5t-HJLY71rJ_vjTYLRyI2g_8a7RIYwHlViI1_O4-qGCr7eidV9SAQOk6Qg18mVS9Xh9eqtJ7o-7KncA9DnnM_hKy_BFta_jaQK4D1UkYDDGtthSqoIQzA-TGCPYEs4uALG9JgHw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/LowCostGet3Min;4744,Microsoft.Compute/LowCostGet30Min;37927
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      X-Ms-Request-Id:
+      - 9fd7a1f5-2d31-44ff-b4f7-91b6e3cde830
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Correlation-Request-Id:
+      - 1e5ff5df-3323-4c99-b0d7-29c132dfad22
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T092518Z:1e5ff5df-3323-4c99-b0d7-29c132dfad22
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:25:17 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"Standard_B1ms\",\r\n
@@ -3019,6 +3212,12 @@ http_interactions:
         \   },\r\n    {\r\n      \"name\": \"Standard_F72s_v2\",\r\n      \"numberOfCores\":
         72,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
         589824,\r\n      \"memoryInMB\": 147456,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_L8s_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1811981,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_L16s_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        3623962,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
         \   },\r\n    {\r\n      \"name\": \"Standard_ND6s\",\r\n      \"numberOfCores\":
         6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
         344064,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 12\r\n
@@ -3045,10 +3244,10 @@ http_interactions:
         391168,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
         \   }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:24 GMT
+  recorded_at: Mon, 12 Mar 2018 09:25:23 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete?api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1?api-version=2018-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3062,329 +3261,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MzgsIm5iZiI6MTUyMDQ1MzQzOCwiZXhwIjoxNTIwNDU3MzM4LCJhaW8iOiJZMk5nWUxEbUtXMDk5clB4cU9QdGorL1crV3NlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZHNPVmFSUXV2RTJjVVBpcEtWWUFBQSIsInZlciI6IjEuMCJ9.drT5CKw95WRF7LzC0WuhK-fTLpw3j61XMw_DZdrLOWP8sjjsrbn9kF7xjDSTUM0ooF5_1Y-j3dNjvI9crm_F3PMAyhYXmCsKjTJkc3DIK6URy3hqbKiRBNlrutwvILE777NY-uXK9PH-gcaVuV-mNrjrLuxxClMJ3OPpTU8Ux0fj3Nuyf3KrXC27Oks_M_RDqDaXHOTckrdz2m_LNLpi5x0nKCoxwR9r5C1m5IKZ25FSbvyRNwjwz5dReqnv5LxllQMHVWkpvO7i5438wAnnyaS2x211IBiE6_dnV2god8Sp3ZRinXc4aCimUnJl6tLa5EtT_VSmR2QcBSaq0wS_ZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14973'
-      X-Ms-Request-Id:
-      - 43d9f6f8-a2ba-4564-a5dd-5fb7f4781120
-      X-Ms-Correlation-Request-Id:
-      - 43d9f6f8-a2ba-4564-a5dd-5fb7f4781120
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201824Z:43d9f6f8-a2ba-4564-a5dd-5fb7f4781120
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:18:23 GMT
-      Content-Length:
-      - '7230'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete","name":"spec-nested-deployment-dont-delete","properties":{"templateLink":{"uri":"https://gist.githubusercontent.com/bzwei/c09f906306399d238762bce711781200/raw/3558b735da03c1c030023d70b78ec3451dab5689/azure-loadbalancer.json","contentVersion":"1.0.0.0"},"parameters":{"storageAccountName":{"type":"String","value":"spec0deply1stor"},"availabilitySetName":{"type":"String","value":"spec0deply1as"},"adminUsername":{"type":"String","value":"deploy1admin"},"adminPassword":{"type":"SecureString"},"dnsNameforLBIP":{"type":"String","value":"spec0deply1dns"},"vmNamePrefix":{"type":"String","value":"spec0deply1vm"},"imagePublisher":{"type":"String","value":"MicrosoftWindowsServer"},"imageOffer":{"type":"String","value":"WindowsServer"},"imageSKU":{"type":"String","value":"2012-R2-Datacenter"},"lbName":{"type":"String","value":"spec0deply1lb"},"nicNamePrefix":{"type":"String","value":"spec0deply1nic"},"publicIPAddressName":{"type":"String","value":"spec0deply1ip"},"vnetName":{"type":"String","value":"spec0deply1vnet"},"vmSize":{"type":"String","value":"Standard_D1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-04-04T23:28:59.2682474Z","duration":"PT23M55.442141S","correlationId":"3a55e6b5-4a3b-431e-8144-53698bf6f1dc","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["eastus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"availabilitySets","locations":["eastus"]},{"resourceType":"virtualMachines","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"publicIPAddresses","locations":["eastus"]},{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"loadBalancers","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"spec0deply1ip"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic0"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic1"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"spec0deply1stor"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"spec0deply1as"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"spec0deply1vm0"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"spec0deply1stor"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"spec0deply1as"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"spec0deply1vm1"}],"outputResources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor"}]}}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:24 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-deployment-dont-delete?api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MzgsIm5iZiI6MTUyMDQ1MzQzOCwiZXhwIjoxNTIwNDU3MzM4LCJhaW8iOiJZMk5nWUxEbUtXMDk5clB4cU9QdGorL1crV3NlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZHNPVmFSUXV2RTJjVVBpcEtWWUFBQSIsInZlciI6IjEuMCJ9.drT5CKw95WRF7LzC0WuhK-fTLpw3j61XMw_DZdrLOWP8sjjsrbn9kF7xjDSTUM0ooF5_1Y-j3dNjvI9crm_F3PMAyhYXmCsKjTJkc3DIK6URy3hqbKiRBNlrutwvILE777NY-uXK9PH-gcaVuV-mNrjrLuxxClMJ3OPpTU8Ux0fj3Nuyf3KrXC27Oks_M_RDqDaXHOTckrdz2m_LNLpi5x0nKCoxwR9r5C1m5IKZ25FSbvyRNwjwz5dReqnv5LxllQMHVWkpvO7i5438wAnnyaS2x211IBiE6_dnV2god8Sp3ZRinXc4aCimUnJl6tLa5EtT_VSmR2QcBSaq0wS_ZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14979'
-      X-Ms-Request-Id:
-      - 231d7289-8662-4b30-ae26-31eff9c3cb1a
-      X-Ms-Correlation-Request-Id:
-      - 231d7289-8662-4b30-ae26-31eff9c3cb1a
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201825Z:231d7289-8662-4b30-ae26-31eff9c3cb1a
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:18:24 GMT
-      Content-Length:
-      - '3083'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-deployment-dont-delete","name":"spec-deployment-dont-delete","properties":{"templateLink":{"uri":"https://gist.githubusercontent.com/bzwei/e6ccc4d641d6afab8e26ef55c37c498e/raw/769505e37256e926a9b581a100c90bb657ff45ff/azure-parent-spec.json","contentVersion":"1.0.0.0"},"parameters":{"childDeployName":{"type":"String","value":"spec-nested-deployment-dont-delete"},"storageAccountName":{"type":"String","value":"spec0deply1stor"},"availabilitySetName":{"type":"String","value":"spec0deply1as"},"adminUsername":{"type":"String","value":"deploy1admin"},"adminPassword":{"type":"SecureString"},"dnsNameforLBIP":{"type":"String","value":"spec0deply1dns"},"vmNamePrefix":{"type":"String","value":"spec0deply1vm"},"imagePublisher":{"type":"String","value":"MicrosoftWindowsServer"},"imageOffer":{"type":"String","value":"WindowsServer"},"imageSKU":{"type":"String","value":"2012-R2-Datacenter"},"lbName":{"type":"String","value":"spec0deply1lb"},"nicNamePrefix":{"type":"String","value":"spec0deply1nic"},"publicIPAddressName":{"type":"String","value":"spec0deply1ip"},"vnetName":{"type":"String","value":"spec0deply1vnet"},"vmSize":{"type":"String","value":"Standard_D1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-04-04T23:29:05.0043846Z","duration":"PT24M6.1512983S","correlationId":"3a55e6b5-4a3b-431e-8144-53698bf6f1dc","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[],"outputs":{"siteUri":{"type":"String","value":"hard-coded
-        output for test"}},"outputResources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor"}]}}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:25 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations?api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MzgsIm5iZiI6MTUyMDQ1MzQzOCwiZXhwIjoxNTIwNDU3MzM4LCJhaW8iOiJZMk5nWUxEbUtXMDk5clB4cU9QdGorL1crV3NlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZHNPVmFSUXV2RTJjVVBpcEtWWUFBQSIsInZlciI6IjEuMCJ9.drT5CKw95WRF7LzC0WuhK-fTLpw3j61XMw_DZdrLOWP8sjjsrbn9kF7xjDSTUM0ooF5_1Y-j3dNjvI9crm_F3PMAyhYXmCsKjTJkc3DIK6URy3hqbKiRBNlrutwvILE777NY-uXK9PH-gcaVuV-mNrjrLuxxClMJ3OPpTU8Ux0fj3Nuyf3KrXC27Oks_M_RDqDaXHOTckrdz2m_LNLpi5x0nKCoxwR9r5C1m5IKZ25FSbvyRNwjwz5dReqnv5LxllQMHVWkpvO7i5438wAnnyaS2x211IBiE6_dnV2god8Sp3ZRinXc4aCimUnJl6tLa5EtT_VSmR2QcBSaq0wS_ZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Request-Id:
-      - a551c9bb-a179-4c80-8b47-1b372f0bb784
-      X-Ms-Correlation-Request-Id:
-      - a551c9bb-a179-4c80-8b47-1b372f0bb784
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201825Z:a551c9bb-a179-4c80-8b47-1b372f0bb784
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:18:24 GMT
-      Content-Length:
-      - '6866'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/2A5D9DB48CB9B87D","operationId":"2A5D9DB48CB9B87D","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:28:58.871396Z","duration":"PT4M5.2351465S","trackingId":"413c1acd-4a86-42aa-8371-2f7fe7760fba","serviceRequestId":"520c4ff7-a725-4e8f-946e-d203617aa3f9","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"spec0deply1vm1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/F59DBCC8F57674DA","operationId":"F59DBCC8F57674DA","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:28:57.3638022Z","duration":"PT4M3.6342685S","trackingId":"a7e62d93-ed67-4f9f-93bc-d7ca4451f6f9","serviceRequestId":"5b58ce6a-8aa5-45a1-b7a3-9c82b6150bd7","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"spec0deply1vm0"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/727DE014666F097A","operationId":"727DE014666F097A","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:28.2942519Z","duration":"PT3.4353223S","trackingId":"dda58292-47ab-4139-8d67-8c99aae9c93c","serviceRequestId":"7b1ba585-6ce8-4e35-83cf-27d7a344ff40","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/8984B6C47B4DBB63","operationId":"8984B6C47B4DBB63","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:26.6945925Z","duration":"PT1.75149S","trackingId":"cf689996-82e8-4740-87f0-8f820b4d153a","serviceRequestId":"831312e5-eaf1-417d-9fdb-5723d493b396","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic0"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/5BB7F6FEF271DCC5","operationId":"5BB7F6FEF271DCC5","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:24.7522379Z","duration":"PT1.8393589S","trackingId":"f42ecee0-2ab0-44d0-9748-44249046b29e","serviceRequestId":"2c6c9788-7fc1-4e6b-928f-241a44e192ea","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/ACBE290D4E246F6C","operationId":"ACBE290D4E246F6C","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:22.8224458Z","duration":"PT16.8373612S","trackingId":"a7759f29-cf9e-4892-bb7b-3e08f64e4ff7","serviceRequestId":"25c16d1d-b611-4fc3-ad7c-eedb21574599","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"spec0deply1ip"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/CDA31B5D53DE7D18","operationId":"CDA31B5D53DE7D18","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:24:53.5717985Z","duration":"PT19M47.4658028S","trackingId":"1ce6f839-7da9-4e40-97d4-2693cfbbc796","serviceRequestId":"3a55e6b5-4a3b-431e-8144-53698bf6f1dc","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"spec0deply1stor"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/07A1436712650187","operationId":"07A1436712650187","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:22.0339723Z","duration":"PT16.0077667S","trackingId":"89200282-9510-4328-ac23-a73df06aea3e","serviceRequestId":"86d89b1a-900e-4719-8d9b-7f18bc963ec7","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"spec0deply1vnet"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/C35E071B1E2FC92A","operationId":"C35E071B1E2FC92A","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:08.170721Z","duration":"PT2.1819157S","trackingId":"a2495990-63ae-4ea3-8904-866b7e01ec18","serviceRequestId":"97334c1c-6e32-4bc5-b96c-25314a5fef57","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"spec0deply1as"}}}]}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:26 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-deployment-dont-delete/operations?api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MzgsIm5iZiI6MTUyMDQ1MzQzOCwiZXhwIjoxNTIwNDU3MzM4LCJhaW8iOiJZMk5nWUxEbUtXMDk5clB4cU9QdGorL1crV3NlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZHNPVmFSUXV2RTJjVVBpcEtWWUFBQSIsInZlciI6IjEuMCJ9.drT5CKw95WRF7LzC0WuhK-fTLpw3j61XMw_DZdrLOWP8sjjsrbn9kF7xjDSTUM0ooF5_1Y-j3dNjvI9crm_F3PMAyhYXmCsKjTJkc3DIK6URy3hqbKiRBNlrutwvILE777NY-uXK9PH-gcaVuV-mNrjrLuxxClMJ3OPpTU8Ux0fj3Nuyf3KrXC27Oks_M_RDqDaXHOTckrdz2m_LNLpi5x0nKCoxwR9r5C1m5IKZ25FSbvyRNwjwz5dReqnv5LxllQMHVWkpvO7i5438wAnnyaS2x211IBiE6_dnV2god8Sp3ZRinXc4aCimUnJl6tLa5EtT_VSmR2QcBSaq0wS_ZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14967'
-      X-Ms-Request-Id:
-      - e67d1c75-aeef-4483-a57f-2e1fa281a5d3
-      X-Ms-Correlation-Request-Id:
-      - e67d1c75-aeef-4483-a57f-2e1fa281a5d3
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201830Z:e67d1c75-aeef-4483-a57f-2e1fa281a5d3
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:18:30 GMT
-      Content-Length:
-      - '801'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-deployment-dont-delete/operations/6AF613CA61ABB553","operationId":"6AF613CA61ABB553","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:29:04.6934934Z","duration":"PT24M3.4746371S","trackingId":"a0997dbb-9578-4dd9-bad6-1286c02855c8","serviceRequestId":"08b8faec-0f0f-4cb2-8453-fabbd3448cb9","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete","resourceType":"Microsoft.Resources/deployments","resourceName":"spec-nested-deployment-dont-delete"}}}]}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:30 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete?api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MzgsIm5iZiI6MTUyMDQ1MzQzOCwiZXhwIjoxNTIwNDU3MzM4LCJhaW8iOiJZMk5nWUxEbUtXMDk5clB4cU9QdGorL1crV3NlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZHNPVmFSUXV2RTJjVVBpcEtWWUFBQSIsInZlciI6IjEuMCJ9.drT5CKw95WRF7LzC0WuhK-fTLpw3j61XMw_DZdrLOWP8sjjsrbn9kF7xjDSTUM0ooF5_1Y-j3dNjvI9crm_F3PMAyhYXmCsKjTJkc3DIK6URy3hqbKiRBNlrutwvILE777NY-uXK9PH-gcaVuV-mNrjrLuxxClMJ3OPpTU8Ux0fj3Nuyf3KrXC27Oks_M_RDqDaXHOTckrdz2m_LNLpi5x0nKCoxwR9r5C1m5IKZ25FSbvyRNwjwz5dReqnv5LxllQMHVWkpvO7i5438wAnnyaS2x211IBiE6_dnV2god8Sp3ZRinXc4aCimUnJl6tLa5EtT_VSmR2QcBSaq0wS_ZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14977'
-      X-Ms-Request-Id:
-      - efc1880a-72e4-492f-b437-fa9ace312a2f
-      X-Ms-Correlation-Request-Id:
-      - efc1880a-72e4-492f-b437-fa9ace312a2f
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201831Z:efc1880a-72e4-492f-b437-fa9ace312a2f
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:18:31 GMT
-      Content-Length:
-      - '7230'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete","name":"spec-nested-deployment-dont-delete","properties":{"templateLink":{"uri":"https://gist.githubusercontent.com/bzwei/c09f906306399d238762bce711781200/raw/3558b735da03c1c030023d70b78ec3451dab5689/azure-loadbalancer.json","contentVersion":"1.0.0.0"},"parameters":{"storageAccountName":{"type":"String","value":"spec0deply1stor"},"availabilitySetName":{"type":"String","value":"spec0deply1as"},"adminUsername":{"type":"String","value":"deploy1admin"},"adminPassword":{"type":"SecureString"},"dnsNameforLBIP":{"type":"String","value":"spec0deply1dns"},"vmNamePrefix":{"type":"String","value":"spec0deply1vm"},"imagePublisher":{"type":"String","value":"MicrosoftWindowsServer"},"imageOffer":{"type":"String","value":"WindowsServer"},"imageSKU":{"type":"String","value":"2012-R2-Datacenter"},"lbName":{"type":"String","value":"spec0deply1lb"},"nicNamePrefix":{"type":"String","value":"spec0deply1nic"},"publicIPAddressName":{"type":"String","value":"spec0deply1ip"},"vnetName":{"type":"String","value":"spec0deply1vnet"},"vmSize":{"type":"String","value":"Standard_D1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-04-04T23:28:59.2682474Z","duration":"PT23M55.442141S","correlationId":"3a55e6b5-4a3b-431e-8144-53698bf6f1dc","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["eastus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"availabilitySets","locations":["eastus"]},{"resourceType":"virtualMachines","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"publicIPAddresses","locations":["eastus"]},{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"loadBalancers","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"spec0deply1ip"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic0"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic1"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"spec0deply1stor"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"spec0deply1as"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"spec0deply1vm0"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"spec0deply1stor"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"spec0deply1as"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"spec0deply1vm1"}],"outputResources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor"}]}}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:31 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-deployment-dont-delete?api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MzgsIm5iZiI6MTUyMDQ1MzQzOCwiZXhwIjoxNTIwNDU3MzM4LCJhaW8iOiJZMk5nWUxEbUtXMDk5clB4cU9QdGorL1crV3NlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZHNPVmFSUXV2RTJjVVBpcEtWWUFBQSIsInZlciI6IjEuMCJ9.drT5CKw95WRF7LzC0WuhK-fTLpw3j61XMw_DZdrLOWP8sjjsrbn9kF7xjDSTUM0ooF5_1Y-j3dNjvI9crm_F3PMAyhYXmCsKjTJkc3DIK6URy3hqbKiRBNlrutwvILE777NY-uXK9PH-gcaVuV-mNrjrLuxxClMJ3OPpTU8Ux0fj3Nuyf3KrXC27Oks_M_RDqDaXHOTckrdz2m_LNLpi5x0nKCoxwR9r5C1m5IKZ25FSbvyRNwjwz5dReqnv5LxllQMHVWkpvO7i5438wAnnyaS2x211IBiE6_dnV2god8Sp3ZRinXc4aCimUnJl6tLa5EtT_VSmR2QcBSaq0wS_ZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14869'
-      X-Ms-Request-Id:
-      - 7d8790b1-568d-4dae-97ea-22b975f72b9d
-      X-Ms-Correlation-Request-Id:
-      - 7d8790b1-568d-4dae-97ea-22b975f72b9d
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201831Z:7d8790b1-568d-4dae-97ea-22b975f72b9d
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:18:30 GMT
-      Content-Length:
-      - '3083'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-deployment-dont-delete","name":"spec-deployment-dont-delete","properties":{"templateLink":{"uri":"https://gist.githubusercontent.com/bzwei/e6ccc4d641d6afab8e26ef55c37c498e/raw/769505e37256e926a9b581a100c90bb657ff45ff/azure-parent-spec.json","contentVersion":"1.0.0.0"},"parameters":{"childDeployName":{"type":"String","value":"spec-nested-deployment-dont-delete"},"storageAccountName":{"type":"String","value":"spec0deply1stor"},"availabilitySetName":{"type":"String","value":"spec0deply1as"},"adminUsername":{"type":"String","value":"deploy1admin"},"adminPassword":{"type":"SecureString"},"dnsNameforLBIP":{"type":"String","value":"spec0deply1dns"},"vmNamePrefix":{"type":"String","value":"spec0deply1vm"},"imagePublisher":{"type":"String","value":"MicrosoftWindowsServer"},"imageOffer":{"type":"String","value":"WindowsServer"},"imageSKU":{"type":"String","value":"2012-R2-Datacenter"},"lbName":{"type":"String","value":"spec0deply1lb"},"nicNamePrefix":{"type":"String","value":"spec0deply1nic"},"publicIPAddressName":{"type":"String","value":"spec0deply1ip"},"vnetName":{"type":"String","value":"spec0deply1vnet"},"vmSize":{"type":"String","value":"Standard_D1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-04-04T23:29:05.0043846Z","duration":"PT24M6.1512983S","correlationId":"3a55e6b5-4a3b-431e-8144-53698bf6f1dc","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[],"outputs":{"siteUri":{"type":"String","value":"hard-coded
-        output for test"}},"outputResources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor"}]}}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:31 GMT
-- request:
-    method: post
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/exportTemplate?api-version=2017-08-01
-    body:
-      encoding: ASCII-8BIT
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MzgsIm5iZiI6MTUyMDQ1MzQzOCwiZXhwIjoxNTIwNDU3MzM4LCJhaW8iOiJZMk5nWUxEbUtXMDk5clB4cU9QdGorL1crV3NlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZHNPVmFSUXV2RTJjVVBpcEtWWUFBQSIsInZlciI6IjEuMCJ9.drT5CKw95WRF7LzC0WuhK-fTLpw3j61XMw_DZdrLOWP8sjjsrbn9kF7xjDSTUM0ooF5_1Y-j3dNjvI9crm_F3PMAyhYXmCsKjTJkc3DIK6URy3hqbKiRBNlrutwvILE777NY-uXK9PH-gcaVuV-mNrjrLuxxClMJ3OPpTU8Ux0fj3Nuyf3KrXC27Oks_M_RDqDaXHOTckrdz2m_LNLpi5x0nKCoxwR9r5C1m5IKZ25FSbvyRNwjwz5dReqnv5LxllQMHVWkpvO7i5438wAnnyaS2x211IBiE6_dnV2god8Sp3ZRinXc4aCimUnJl6tLa5EtT_VSmR2QcBSaq0wS_ZQ
-      Content-Length:
-      - '0'
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDYzOTgsIm5iZiI6MTUyMDg0NjM5OCwiZXhwIjoxNTIwODUwMjk4LCJhaW8iOiJZMk5nWUREaWt2OGkzWG5nNlVUbjUxbXNxeGZsQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieHBWZjRReC1fMFNKYXRaZUZRTWxBQSIsInZlciI6IjEuMCJ9.XwasNxrTVaqKz-D9MgYSC3bmyr00gxvA0-2ZHY6Ao4d6M-8zyF3EkpgtjvJQmJyigbtLo3aYxJYaliL0Doibjzt0yACsSHn0-fXyHT7SHkg2HOUhlT2YKj6Zd0Livs6YrpkYTLfpXffETPG6mqi0Q-P06FwGkAHh7-BzxH_Gh5I6JxbYFXpqpp184d23kVbcpZd9cBSCOPtIfLo5t-HJLY71rJ_vjTYLRyI2g_8a7RIYwHlViI1_O4-qGCr7eidV9SAQOk6Qg18mVS9Xh9eqtJ7o-7KncA9DnnM_hKy_BFta_jaQK4D1UkYDDGtthSqoIQzA-TGCPYEs4uALG9JgHw
   response:
     status:
       code: 200
@@ -3400,207 +3277,43 @@ http_interactions:
       - application/json; charset=utf-8
       Expires:
       - "-1"
+      Etag:
+      - W/"054052bb-11ff-4f6e-ac1a-3427c2fd17aa"
       Vary:
       - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1197'
       X-Ms-Request-Id:
-      - bfb27219-5a09-4512-b433-5a666380e0f5
-      X-Ms-Correlation-Request-Id:
-      - bfb27219-5a09-4512-b433-5a666380e0f5
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201832Z:bfb27219-5a09-4512-b433-5a666380e0f5
+      - 4134cdbb-94d2-403c-87bd-9d3cba1ad463
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:18:31 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"template":{"$schema":"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json","contentVersion":"1.0.0.0","parameters":{"storageAccountName":{"type":"String","metadata":{"description":"Name
-        of storage account"}},"availabilitySetName":{"type":"String","metadata":{"description":"Name
-        of availability set"}},"adminUsername":{"type":"String","metadata":{"description":"Admin
-        username"}},"adminPassword":{"type":"SecureString","metadata":{"description":"Admin
-        password"}},"dnsNameforLBIP":{"type":"String","metadata":{"description":"DNS
-        for Load Balancer IP"}},"vmNamePrefix":{"defaultValue":"myVM","type":"String","metadata":{"description":"Prefix
-        to use for VM names"}},"imagePublisher":{"defaultValue":"MicrosoftWindowsServer","type":"String","metadata":{"description":"Image
-        Publisher"}},"imageOffer":{"defaultValue":"WindowsServer","type":"String","metadata":{"description":"Image
-        Offer"}},"imageSKU":{"defaultValue":"2012-R2-Datacenter","type":"String","metadata":{"description":"Image
-        SKU"}},"lbName":{"defaultValue":"myLB","type":"String","metadata":{"description":"Load
-        Balancer name"}},"nicNamePrefix":{"defaultValue":"nic","type":"String","metadata":{"description":"Network
-        Interface name prefix"}},"publicIPAddressName":{"defaultValue":"myPublicIP","type":"String","metadata":{"description":"Public
-        IP Name"}},"vnetName":{"defaultValue":"myVNET","type":"String","metadata":{"description":"VNET
-        name"}},"vmSize":{"defaultValue":"Standard_D1","type":"String","metadata":{"description":"Size
-        of the VM"}}},"variables":{"storageAccountType":"Standard_LRS","addressPrefix":"10.0.0.0/16","subnetName":"Subnet-1","subnetPrefix":"10.0.0.0/24","publicIPAddressType":"Dynamic","vnetID":"[resourceId(''Microsoft.Network/virtualNetworks'',parameters(''vnetName''))]","subnetRef":"[concat(variables(''vnetID''),''/subnets/'',variables
-        (''subnetName''))]","publicIPAddressID":"[resourceId(''Microsoft.Network/publicIPAddresses'',parameters(''publicIPAddressName''))]","numberOfInstances":2,"lbID":"[resourceId(''Microsoft.Network/loadBalancers'',parameters(''lbName''))]","frontEndIPConfigID":"[concat(variables(''lbID''),''/frontendIPConfigurations/LoadBalancerFrontEnd'')]","lbPoolID":"[concat(variables(''lbID''),''/backendAddressPools/BackendPool1'')]","lbProbeID":"[concat(variables(''lbID''),''/probes/tcpProbe'')]"},"resources":[{"type":"Microsoft.Storage/storageAccounts","name":"[parameters(''storageAccountName'')]","apiVersion":"2015-05-01-preview","location":"[resourceGroup().location]","properties":{"accountType":"[variables(''storageAccountType'')]"}},{"type":"Microsoft.Compute/availabilitySets","name":"[parameters(''availabilitySetName'')]","apiVersion":"2015-05-01-preview","location":"[resourceGroup().location]","properties":{}},{"type":"Microsoft.Network/publicIPAddresses","name":"[parameters(''publicIPAddressName'')]","apiVersion":"2015-05-01-preview","location":"[resourceGroup().location]","properties":{"publicIPAllocationMethod":"[variables(''publicIPAddressType'')]","dnsSettings":{"domainNameLabel":"[parameters(''dnsNameforLBIP'')]"}}},{"type":"Microsoft.Network/virtualNetworks","name":"[parameters(''vnetName'')]","apiVersion":"2015-05-01-preview","location":"[resourceGroup().location]","properties":{"addressSpace":{"addressPrefixes":["[variables(''addressPrefix'')]"]},"subnets":[{"name":"[variables(''subnetName'')]","properties":{"addressPrefix":"[variables(''subnetPrefix'')]"}}]}},{"type":"Microsoft.Network/networkInterfaces","name":"[concat(parameters(''nicNamePrefix''),
-        copyindex())]","apiVersion":"2015-05-01-preview","location":"[resourceGroup().location]","copy":{"name":"nicLoop","count":"[variables(''numberOfInstances'')]"},"properties":{"ipConfigurations":[{"name":"ipconfig1","properties":{"privateIPAllocationMethod":"Dynamic","subnet":{"id":"[variables(''subnetRef'')]"},"loadBalancerBackendAddressPools":[{"id":"[concat(variables(''lbID''),
-        ''/backendAddressPools/BackendPool1'')]"}],"loadBalancerInboundNatRules":[{"id":"[concat(variables(''lbID''),''/inboundNatRules/RDP-VM'',
-        copyindex())]"}]}}]},"dependsOn":["[concat(''Microsoft.Network/virtualNetworks/'',
-        parameters(''vnetName''))]","[concat(''Microsoft.Network/loadBalancers/'',
-        parameters(''lbName''))]"]},{"type":"Microsoft.Network/loadBalancers","name":"[parameters(''lbName'')]","apiVersion":"2015-05-01-preview","location":"[resourceGroup().location]","properties":{"frontendIPConfigurations":[{"name":"LoadBalancerFrontEnd","properties":{"publicIPAddress":{"id":"[variables(''publicIPAddressID'')]"}}}],"backendAddressPools":[{"name":"BackendPool1"}],"inboundNatRules":[{"name":"RDP-VM0","properties":{"frontendIPConfiguration":{"id":"[variables(''frontEndIPConfigID'')]"},"protocol":"tcp","frontendPort":50001,"backendPort":3389,"enableFloatingIP":false}},{"name":"RDP-VM1","properties":{"frontendIPConfiguration":{"id":"[variables(''frontEndIPConfigID'')]"},"protocol":"tcp","frontendPort":50002,"backendPort":3389,"enableFloatingIP":false}}],"loadBalancingRules":[{"name":"LBRule","properties":{"frontendIPConfiguration":{"id":"[variables(''frontEndIPConfigID'')]"},"backendAddressPool":{"id":"[variables(''lbPoolID'')]"},"protocol":"tcp","frontendPort":80,"backendPort":80,"enableFloatingIP":false,"idleTimeoutInMinutes":5,"probe":{"id":"[variables(''lbProbeID'')]"}}}],"probes":[{"name":"tcpProbe","properties":{"protocol":"tcp","port":80,"intervalInSeconds":5,"numberOfProbes":2}}]},"dependsOn":["[concat(''Microsoft.Network/publicIPAddresses/'',
-        parameters(''publicIPAddressName''))]"]},{"type":"Microsoft.Compute/virtualMachines","name":"[concat(parameters(''vmNamePrefix''),
-        copyindex())]","apiVersion":"2015-06-15","location":"[resourceGroup().location]","copy":{"name":"virtualMachineLoop","count":"[variables(''numberOfInstances'')]"},"properties":{"availabilitySet":{"id":"[resourceId(''Microsoft.Compute/availabilitySets'',parameters(''availabilitySetName''))]"},"hardwareProfile":{"vmSize":"[parameters(''vmSize'')]"},"osProfile":{"computerName":"[concat(parameters(''vmNamePrefix''),
-        copyIndex())]","adminUsername":"[parameters(''adminUsername'')]","adminPassword":"[parameters(''adminPassword'')]"},"storageProfile":{"imageReference":{"publisher":"[parameters(''imagePublisher'')]","offer":"[parameters(''imageOffer'')]","sku":"[parameters(''imageSKU'')]","version":"latest"},"osDisk":{"name":"osdisk","vhd":{"uri":"[concat(''http://'',parameters(''storageAccountName''),''.blob.core.windows.net/vhds/'',''osdisk'',
-        copyindex(), ''.vhd'')]"},"caching":"ReadWrite","createOption":"FromImage"}},"networkProfile":{"networkInterfaces":[{"id":"[resourceId(''Microsoft.Network/networkInterfaces'',concat(parameters(''nicNamePrefix''),copyindex()))]"}]},"diagnosticsProfile":{"bootDiagnostics":{"enabled":"true","storageUri":"[concat(''http://'',parameters(''storageAccountName''),''.blob.core.windows.net'')]"}}},"dependsOn":["[concat(''Microsoft.Storage/storageAccounts/'',
-        parameters(''storageAccountName''))]","[concat(''Microsoft.Network/networkInterfaces/'',
-        parameters(''nicNamePrefix''), copyindex())]","[concat(''Microsoft.Compute/availabilitySets/'',
-        parameters(''availabilitySetName''))]"]}]}}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:32 GMT
-- request:
-    method: post
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-deployment-dont-delete/exportTemplate?api-version=2017-08-01
-    body:
-      encoding: ASCII-8BIT
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MzgsIm5iZiI6MTUyMDQ1MzQzOCwiZXhwIjoxNTIwNDU3MzM4LCJhaW8iOiJZMk5nWUxEbUtXMDk5clB4cU9QdGorL1crV3NlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZHNPVmFSUXV2RTJjVVBpcEtWWUFBQSIsInZlciI6IjEuMCJ9.drT5CKw95WRF7LzC0WuhK-fTLpw3j61XMw_DZdrLOWP8sjjsrbn9kF7xjDSTUM0ooF5_1Y-j3dNjvI9crm_F3PMAyhYXmCsKjTJkc3DIK6URy3hqbKiRBNlrutwvILE777NY-uXK9PH-gcaVuV-mNrjrLuxxClMJ3OPpTU8Ux0fj3Nuyf3KrXC27Oks_M_RDqDaXHOTckrdz2m_LNLpi5x0nKCoxwR9r5C1m5IKZ25FSbvyRNwjwz5dReqnv5LxllQMHVWkpvO7i5438wAnnyaS2x211IBiE6_dnV2god8Sp3ZRinXc4aCimUnJl6tLa5EtT_VSmR2QcBSaq0wS_ZQ
-      Content-Length:
-      - '0'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1197'
-      X-Ms-Request-Id:
-      - 871d62ab-165d-422c-ae25-1c6b337afc40
-      X-Ms-Correlation-Request-Id:
-      - 871d62ab-165d-422c-ae25-1c6b337afc40
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201832Z:871d62ab-165d-422c-ae25-1c6b337afc40
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:18:32 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"template":{"$schema":"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#","contentVersion":"1.0.0.0","parameters":{"childDeployName":{"type":"String"},"storageAccountName":{"type":"String","metadata":{"description":"Name
-        of storage account"}},"availabilitySetName":{"type":"String","metadata":{"description":"Name
-        of availability set"}},"adminUsername":{"type":"String","metadata":{"description":"Admin
-        username"}},"adminPassword":{"type":"SecureString","metadata":{"description":"Admin
-        password"}},"dnsNameforLBIP":{"type":"String","metadata":{"description":"DNS
-        for Load Balancer IP"}},"vmNamePrefix":{"defaultValue":"myVM","type":"String","metadata":{"description":"Prefix
-        to use for VM names"}},"imagePublisher":{"defaultValue":"MicrosoftWindowsServer","type":"String","metadata":{"description":"Image
-        Publisher"}},"imageOffer":{"defaultValue":"WindowsServer","type":"String","metadata":{"description":"Image
-        Offer"}},"imageSKU":{"defaultValue":"2012-R2-Datacenter","type":"String","metadata":{"description":"Image
-        SKU"}},"lbName":{"defaultValue":"myLB","type":"String","metadata":{"description":"Load
-        Balancer name"}},"nicNamePrefix":{"defaultValue":"nic","type":"String","metadata":{"description":"Network
-        Interface name prefix"}},"publicIPAddressName":{"defaultValue":"myPublicIP","type":"String","metadata":{"description":"Public
-        IP Name"}},"vnetName":{"defaultValue":"myVNET","type":"String","metadata":{"description":"VNET
-        name"}},"vmSize":{"defaultValue":"Standard_D1","type":"String","metadata":{"description":"Size
-        of the VM"}}},"resources":[{"type":"Microsoft.Resources/deployments","name":"[parameters(''childDeployName'')]","apiVersion":"2015-01-01","properties":{"mode":"Incremental","templateLink":{"uri":"https://gist.githubusercontent.com/bzwei/c09f906306399d238762bce711781200/raw/3558b735da03c1c030023d70b78ec3451dab5689/azure-loadbalancer.json","contentVersion":"1.0.0.0"},"parameters":{"storageAccountName":{"value":"[parameters(''storageAccountName'')]"},"availabilitySetName":{"value":"[parameters(''availabilitySetName'')]"},"adminUsername":{"value":"[parameters(''adminUsername'')]"},"adminPassword":{"value":"[parameters(''adminPassword'')]"},"dnsNameforLBIP":{"value":"[parameters(''dnsNameforLBIP'')]"},"vmNamePrefix":{"value":"[parameters(''vmNamePrefix'')]"},"imagePublisher":{"value":"[parameters(''imagePublisher'')]"},"imageOffer":{"value":"[parameters(''imageOffer'')]"},"imageSKU":{"value":"[parameters(''imageSKU'')]"},"lbName":{"value":"[parameters(''lbName'')]"},"nicNamePrefix":{"value":"[parameters(''nicNamePrefix'')]"},"publicIPAddressName":{"value":"[parameters(''publicIPAddressName'')]"},"vnetName":{"value":"[parameters(''vnetName'')]"},"vmSize":{"value":"[parameters(''vmSize'')]"}}}}],"outputs":{"siteUri":{"type":"String","value":"hard-coded
-        output for test"}}}}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:32 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0?api-version=2017-12-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MzgsIm5iZiI6MTUyMDQ1MzQzOCwiZXhwIjoxNTIwNDU3MzM4LCJhaW8iOiJZMk5nWUxEbUtXMDk5clB4cU9QdGorL1crV3NlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZHNPVmFSUXV2RTJjVVBpcEtWWUFBQSIsInZlciI6IjEuMCJ9.drT5CKw95WRF7LzC0WuhK-fTLpw3j61XMw_DZdrLOWP8sjjsrbn9kF7xjDSTUM0ooF5_1Y-j3dNjvI9crm_F3PMAyhYXmCsKjTJkc3DIK6URy3hqbKiRBNlrutwvILE777NY-uXK9PH-gcaVuV-mNrjrLuxxClMJ3OPpTU8Ux0fj3Nuyf3KrXC27Oks_M_RDqDaXHOTckrdz2m_LNLpi5x0nKCoxwR9r5C1m5IKZ25FSbvyRNwjwz5dReqnv5LxllQMHVWkpvO7i5438wAnnyaS2x211IBiE6_dnV2god8Sp3ZRinXc4aCimUnJl6tLa5EtT_VSmR2QcBSaq0wS_ZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/LowCostGet3Min;4735,Microsoft.Compute/LowCostGet30Min;37869
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
-      X-Ms-Request-Id:
-      - 64c57bca-4608-4abe-9f77-0f93f99d683a
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14981'
+      - '14993'
       X-Ms-Correlation-Request-Id:
-      - 6df28d53-b452-468c-bfce-5efdbd3b8174
+      - 7d2d2df9-990b-4df4-b9bd-154768c86f04
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201834Z:6df28d53-b452-468c-bfce-5efdbd3b8174
+      - WESTEUROPE:20180312T092519Z:7d2d2df9-990b-4df4-b9bd-154768c86f04
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:18:34 GMT
+      - Mon, 12 Mar 2018 09:25:18 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"d7022008-f6b1-4f4c-8be8-e2d677ef3261\",\r\n
-        \   \"availabilitySet\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/SPEC0DEPLY1AS\"\r\n
-        \   },\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_D1\"\r\n
-        \   },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
-        \"MicrosoftWindowsServer\",\r\n        \"offer\": \"WindowsServer\",\r\n        \"sku\":
-        \"2012-R2-Datacenter\",\r\n        \"version\": \"latest\"\r\n      },\r\n
-        \     \"osDisk\": {\r\n        \"osType\": \"Windows\",\r\n        \"name\":
-        \"osdisk\",\r\n        \"createOption\": \"FromImage\",\r\n        \"vhd\":
-        {\r\n          \"uri\": \"http://spec0deply1stor.blob.core.windows.net/vhds/osdisk0.vhd\"\r\n
-        \       },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n      \"dataDisks\":
-        []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"spec0deply1vm0\",\r\n
-        \     \"adminUsername\": \"deploy1admin\",\r\n      \"windowsConfiguration\":
-        {\r\n        \"provisionVMAgent\": true,\r\n        \"enableAutomaticUpdates\":
-        true\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\":
-        {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0\"}]},\r\n
-        \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
-        true,\r\n        \"storageUri\": \"http://spec0deply1stor.blob.core.windows.net\"\r\n
-        \     }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n
-        \ \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"eastus\",\r\n
-        \ \"tags\": {\r\n    \"Shutdown\": \"true\"\r\n  },\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0\",\r\n
-        \ \"name\": \"spec0deply1vm0\"\r\n}"
+      string: "{\r\n  \"name\": \"miq-test-rhel1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1\",\r\n
+        \ \"etag\": \"W/\\\"054052bb-11ff-4f6e-ac1a-3427c2fd17aa\\\"\",\r\n  \"location\":
+        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"f6cfc635-411e-48ce-a627-39a2fc0d3168\",\r\n    \"ipAddress\":
+        \"52.224.165.15\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\":
+        \"Dynamic\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipTags\": [],\r\n
+        \   \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1\"\r\n
+        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
+        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:35 GMT
+  recorded_at: Mon, 12 Mar 2018 09:25:23 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0/instanceView?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686?api-version=2017-10-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3614,7 +3327,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MzgsIm5iZiI6MTUyMDQ1MzQzOCwiZXhwIjoxNTIwNDU3MzM4LCJhaW8iOiJZMk5nWUxEbUtXMDk5clB4cU9QdGorL1crV3NlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZHNPVmFSUXV2RTJjVVBpcEtWWUFBQSIsInZlciI6IjEuMCJ9.drT5CKw95WRF7LzC0WuhK-fTLpw3j61XMw_DZdrLOWP8sjjsrbn9kF7xjDSTUM0ooF5_1Y-j3dNjvI9crm_F3PMAyhYXmCsKjTJkc3DIK6URy3hqbKiRBNlrutwvILE777NY-uXK9PH-gcaVuV-mNrjrLuxxClMJ3OPpTU8Ux0fj3Nuyf3KrXC27Oks_M_RDqDaXHOTckrdz2m_LNLpi5x0nKCoxwR9r5C1m5IKZ25FSbvyRNwjwz5dReqnv5LxllQMHVWkpvO7i5438wAnnyaS2x211IBiE6_dnV2god8Sp3ZRinXc4aCimUnJl6tLa5EtT_VSmR2QcBSaq0wS_ZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDYzOTgsIm5iZiI6MTUyMDg0NjM5OCwiZXhwIjoxNTIwODUwMjk4LCJhaW8iOiJZMk5nWUREaWt2OGkzWG5nNlVUbjUxbXNxeGZsQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieHBWZjRReC1fMFNKYXRaZUZRTWxBQSIsInZlciI6IjEuMCJ9.XwasNxrTVaqKz-D9MgYSC3bmyr00gxvA0-2ZHY6Ao4d6M-8zyF3EkpgtjvJQmJyigbtLo3aYxJYaliL0Doibjzt0yACsSHn0-fXyHT7SHkg2HOUhlT2YKj6Zd0Livs6YrpkYTLfpXffETPG6mqi0Q-P06FwGkAHh7-BzxH_Gh5I6JxbYFXpqpp184d23kVbcpZd9cBSCOPtIfLo5t-HJLY71rJ_vjTYLRyI2g_8a7RIYwHlViI1_O4-qGCr7eidV9SAQOk6Qg18mVS9Xh9eqtJ7o-7KncA9DnnM_hKy_BFta_jaQK4D1UkYDDGtthSqoIQzA-TGCPYEs4uALG9JgHw
   response:
     status:
       code: 200
@@ -3627,158 +3340,35 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Content-Type:
-      - application/json; charset=utf-8
+      - application/json
       Expires:
       - "-1"
       Vary:
       - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/GetInstanceView3Min;4790,Microsoft.Compute/GetInstanceView30Min;23919
+      X-Ms-Request-Id:
+      - 51a58656-e9cb-4f76-ab99-8c3cdb7026f3
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
-      X-Ms-Request-Id:
-      - 5934bf2e-457e-4e0a-9f6b-17143ba3b790
       Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14970'
+      - '14994'
       X-Ms-Correlation-Request-Id:
-      - 2be4bf19-e900-4fe9-a0a2-c995ff98ec84
+      - ca3a2c55-d865-4e61-85f4-a71da93cacd0
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201847Z:2be4bf19-e900-4fe9-a0a2-c995ff98ec84
+      - WESTEUROPE:20180312T092520Z:ca3a2c55-d865-4e61-85f4-a71da93cacd0
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:18:46 GMT
+      - Mon, 12 Mar 2018 09:25:20 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"platformUpdateDomain\": 1,\r\n  \"platformFaultDomain\": 1,\r\n
-        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
-        [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
-        \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
-        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2018-03-07T20:18:35+00:00\"\r\n
-        \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"osdisk\",\r\n
-        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
-        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"time\": \"2016-09-03T02:05:35.0977796+00:00\"\r\n
-        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
-        \"https://spec0deply1stor.blob.core.windows.net/bootdiagnostics-spec0depl-d7022008-f6b1-4f4c-8be8-e2d677ef3261/spec0deply1vm0.d7022008-f6b1-4f4c-8be8-e2d677ef3261.screenshot.bmp\",\r\n
-        \   \"serialConsoleLogBlobUri\": \"https://spec0deply1stor.blob.core.windows.net/bootdiagnostics-spec0depl-d7022008-f6b1-4f4c-8be8-e2d677ef3261/spec0deply1vm0.d7022008-f6b1-4f4c-8be8-e2d677ef3261.serialconsole.log\"\r\n
-        \ },\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n
-        \     \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n
-        \     \"time\": \"2016-09-03T02:05:35.1602741+00:00\"\r\n    },\r\n    {\r\n
-        \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
-        \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","name":"miqazuretest18686","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T17:22:54.7808677Z","primaryEndpoints":{"blob":"https://miqazuretest18686.blob.core.windows.net/","queue":"https://miqazuretest18686.queue.core.windows.net/","table":"https://miqazuretest18686.table.core.windows.net/","file":"https://miqazuretest18686.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:47 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Network/networkInterfaces?api-version=2017-11-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MzgsIm5iZiI6MTUyMDQ1MzQzOCwiZXhwIjoxNTIwNDU3MzM4LCJhaW8iOiJZMk5nWUxEbUtXMDk5clB4cU9QdGorL1crV3NlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZHNPVmFSUXV2RTJjVVBpcEtWWUFBQSIsInZlciI6IjEuMCJ9.drT5CKw95WRF7LzC0WuhK-fTLpw3j61XMw_DZdrLOWP8sjjsrbn9kF7xjDSTUM0ooF5_1Y-j3dNjvI9crm_F3PMAyhYXmCsKjTJkc3DIK6URy3hqbKiRBNlrutwvILE777NY-uXK9PH-gcaVuV-mNrjrLuxxClMJ3OPpTU8Ux0fj3Nuyf3KrXC27Oks_M_RDqDaXHOTckrdz2m_LNLpi5x0nKCoxwR9r5C1m5IKZ25FSbvyRNwjwz5dReqnv5LxllQMHVWkpvO7i5438wAnnyaS2x211IBiE6_dnV2god8Sp3ZRinXc4aCimUnJl6tLa5EtT_VSmR2QcBSaq0wS_ZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 57998766-40ee-49dc-ba30-2af67b5f55fb
-      X-Ms-Correlation-Request-Id:
-      - 57998766-40ee-49dc-ba30-2af67b5f55fb
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201848Z:57998766-40ee-49dc-ba30-2af67b5f55fb
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:18:48 GMT
-      Content-Length:
-      - '31614'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[{"name":"miqazure-coreos1235","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235","etag":"W/\"4a6546ab-a4c0-4d27-bccd-f6ebf3c405a2\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"fb0a5e60-a6c2-4bb8-a2f5-0c16216a49b0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235/ipConfigurations/ipconfig1","etag":"W/\"4a6546ab-a4c0-4d27-bccd-f6ebf3c405a2\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.20.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/publicIPAddresses/miqazure-coreos1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/virtualNetworks/miq-azure-test3/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"rliadcyr3l1elbnsw4rabxqg1f.dx.internal.cloudapp.net"},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkSecurityGroups/miqazure-coreos1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Compute/virtualMachines/miqazure-coreos1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"dbergerprov1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/dbergerprov1","etag":"W/\"074dd836-918c-4e40-a118-94f0d366e175\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"ecdcd2f0-91bb-4c40-91cd-a3d76fc5e455","ipConfigurations":[{"name":"dbergerprov1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/dbergerprov1/ipConfigurations/dbergerprov1","etag":"W/\"074dd836-918c-4e40-a118-94f0d366e175\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.9","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/dbergerprov1-publicIp"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/virtualMachines/dbergerprov1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-rhel1390","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390","etag":"W/\"f006e6f9-0292-42cd-99fc-f72f194553c1\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"98853f48-2806-4065-be57-cf9159550440","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1","etag":"W/\"f006e6f9-0292-42cd-99fc-f72f194553c1\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"macAddress":"00-0D-3A-10-EB-AB","enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-ubuntu1989","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989","etag":"W/\"64e07488-15a2-4cec-b84a-6fd5ef04323c\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"134a6669-ac4a-4d08-a0db-387bc4c49537","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989/ipConfigurations/ipconfig1","etag":"W/\"64e07488-15a2-4cec-b84a-6fd5ef04323c\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.17.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-ubuntu1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest18687/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-win12610","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610","etag":"W/\"dd925ef5-33d1-402c-a0f4-18c78c2641f4\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"5c2eef2c-0b36-4277-a940-957ed4d13be0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610/ipConfigurations/ipconfig1","etag":"W/\"dd925ef5-33d1-402c-a0f4-18c78c2641f4\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.18.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-win12"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest19881/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-winimg241","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241","etag":"W/\"4a17a745-16a9-42d9-88c9-17a518959525\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"8ed2f3b0-4a4b-49ae-9f1d-ff7890dbd396","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241/ipConfigurations/ipconfig1","etag":"W/\"4a17a745-16a9-42d9-88c9-17a518959525\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.7","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqtestwinimg6202"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-centos1611","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611","etag":"W/\"26031ef6-bb55-4019-8185-2dd1edcb207c\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"f1760e49-9853-4fdc-acfc-4ea232b9ed76","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1","etag":"W/\"26031ef6-bb55-4019-8185-2dd1edcb207c\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.5","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqmismatch1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1","etag":"W/\"3a72d0c3-bfda-4da5-a61b-e8c33e43de79\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"23d804a8-b623-49e7-9c8d-1d64245bef1e","ipConfigurations":[{"name":"miqmismatch1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1/ipConfigurations/miqmismatch1","etag":"W/\"3a72d0c3-bfda-4da5-a61b-e8c33e43de79\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.8","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqmismatch1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqmismatch1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"rspec-lb-a670","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670","etag":"W/\"cf3a0b0d-d596-4f33-bc31-749f92ba4f00\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"46cb8216-786e-408e-9d86-c0855b357349","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1","etag":"W/\"cf3a0b0d-d596-4f33-bc31-749f92ba4f00\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.6","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-a-ip"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"rspec-lb-b843","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843","etag":"W/\"76aabe0c-8678-43f0-81a5-2f15784a4b99\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"3ef6fa01-ac34-43a1-8fd7-67c706b4d8ef","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1","etag":"W/\"76aabe0c-8678-43f0-81a5-2f15784a4b99\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.11","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-b-ip"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"spec0deply1nic0","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","etag":"W/\"b817491c-aab8-4aab-b41d-b07bfffa5639\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"80ad9866-071d-4e3f-91d0-d47954eccee0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1","etag":"W/\"b817491c-aab8-4aab-b41d-b07bfffa5639\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.4","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"spec0deply1nic1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","etag":"W/\"2ec58a0b-4c03-4d0a-b788-9daffd54e7b2\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"57bbf7aa-d6c4-4f56-8f6a-089d15334221","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1","etag":"W/\"2ec58a0b-4c03-4d0a-b788-9daffd54e7b2\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.5","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqmismatch2656","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqmismatch2656","etag":"W/\"fef6a836-2802-4897-90c3-b3d71f133384\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"969dde6c-73c0-4340-877d-2b5fe2060026","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqmismatch2656/ipConfigurations/ipconfig1","etag":"W/\"fef6a836-2802-4897-90c3-b3d71f133384\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"172.23.0.4","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/virtualNetworks/miqazuretest33606/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkSecurityGroups/miqmismatch2-nsg"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Compute/virtualMachines/miqmismatch2"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-linux-manag944","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944","etag":"W/\"b6339880-8ead-4c9e-b5c0-f38c4f8612d5\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"c5e8b90e-5a78-49b0-b224-b70ed3fb45e5","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944/ipConfigurations/ipconfig1","etag":"W/\"b6339880-8ead-4c9e-b5c0-f38c4f8612d5\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"172.25.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqazure-linux-managed-ip"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"jf-metrics-2751","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751","etag":"W/\"c5f6f02a-b17c-4f34-882b-11c7adef0b44\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"207a58d3-f18d-4dab-8168-919877297a52","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751/ipConfigurations/ipconfig1","etag":"W/\"c5f6f02a-b17c-4f34-882b-11c7adef0b44\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.7","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-2"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-2"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/jf-metrics-2"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"jf-metrics-3421","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421","etag":"W/\"0b6f160b-ad10-48f8-9d0c-657193bb823f\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"b8b345e8-a353-4700-992e-be48a717b4e2","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421/ipConfigurations/ipconfig1","etag":"W/\"0b6f160b-ad10-48f8-9d0c-657193bb823f\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.8","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-3"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-3"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/jf-metrics-3"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-oraclelinux310","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310","etag":"W/\"54cd4fe1-3ed5-4a8c-bc8d-527679c7a631\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"6a3fc1d7-4532-4ca0-b5c2-546cc8f7f313","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310/ipConfigurations/ipconfig1","etag":"W/\"54cd4fe1-3ed5-4a8c-bc8d-527679c7a631\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.5","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-oraclelinux993","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993","etag":"W/\"a9432274-7b40-4eb3-a64f-a04267a423ff\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"75d8ed14-e0ae-4d84-99f6-e3f43d073e76","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993/ipConfigurations/ipconfig1","etag":"W/\"a9432274-7b40-4eb3-a64f-a04267a423ff\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.6","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux2"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux2"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"}]}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:48 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Storage/storageAccounts?api-version=2017-10-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MzgsIm5iZiI6MTUyMDQ1MzQzOCwiZXhwIjoxNTIwNDU3MzM4LCJhaW8iOiJZMk5nWUxEbUtXMDk5clB4cU9QdGorL1crV3NlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZHNPVmFSUXV2RTJjVVBpcEtWWUFBQSIsInZlciI6IjEuMCJ9.drT5CKw95WRF7LzC0WuhK-fTLpw3j61XMw_DZdrLOWP8sjjsrbn9kF7xjDSTUM0ooF5_1Y-j3dNjvI9crm_F3PMAyhYXmCsKjTJkc3DIK6URy3hqbKiRBNlrutwvILE777NY-uXK9PH-gcaVuV-mNrjrLuxxClMJ3OPpTU8Ux0fj3Nuyf3KrXC27Oks_M_RDqDaXHOTckrdz2m_LNLpi5x0nKCoxwR9r5C1m5IKZ25FSbvyRNwjwz5dReqnv5LxllQMHVWkpvO7i5438wAnnyaS2x211IBiE6_dnV2god8Sp3ZRinXc4aCimUnJl6tLa5EtT_VSmR2QcBSaq0wS_ZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 22218b0e-5a47-4496-922c-4b6621e15489
-      X-Ms-Correlation-Request-Id:
-      - 22218b0e-5a47-4496-922c-4b6621e15489
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201850Z:22218b0e-5a47-4496-922c-4b6621e15489
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:18:49 GMT
-      Content-Length:
-      - '8649'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","name":"miqazuretest18686","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T17:22:54.7808677Z","primaryEndpoints":{"blob":"https://miqazuretest18686.blob.core.windows.net/","queue":"https://miqazuretest18686.queue.core.windows.net/","table":"https://miqazuretest18686.table.core.windows.net/","file":"https://miqazuretest18686.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","name":"miqazuretest14047","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T17:30:25.7028008Z","primaryEndpoints":{"blob":"https://miqazuretest14047.blob.core.windows.net/","queue":"https://miqazuretest14047.queue.core.windows.net/","table":"https://miqazuretest14047.table.core.windows.net/","file":"https://miqazuretest14047.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Premium_LRS","tier":"Premium"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb","name":"rspeclb","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-09-02T16:29:11.6823797Z","primaryEndpoints":{"blob":"https://rspeclb.blob.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","name":"spec0deply1stor","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-04-04T23:05:07.8274794Z","primaryEndpoints":{"blob":"https://spec0deply1stor.blob.core.windows.net/","queue":"https://spec0deply1stor.queue.core.windows.net/","table":"https://spec0deply1stor.table.core.windows.net/","file":"https://spec0deply1stor.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Storage/storageAccounts/miqazuretest26611","name":"miqazuretest26611","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2211656Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2211656Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-05-02T18:01:29.2743021Z","primaryEndpoints":{"blob":"https://miqazuretest26611.blob.core.windows.net/","queue":"https://miqazuretest26611.queue.core.windows.net/","table":"https://miqazuretest26611.table.core.windows.net/","file":"https://miqazuretest26611.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","name":"miqazuretest16487","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T17:26:55.3231669Z","primaryEndpoints":{"blob":"https://miqazuretest16487.blob.core.windows.net/","queue":"https://miqazuretest16487.queue.core.windows.net/","table":"https://miqazuretest16487.table.core.windows.net/","file":"https://miqazuretest16487.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Storage/storageAccounts/miqazuretest32946","name":"miqazuretest32946","type":"Microsoft.Storage/storageAccounts","location":"westus","tags":{"delete":"false"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.0404359Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.0404359Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T21:18:37.0793411Z","primaryEndpoints":{"blob":"https://miqazuretest32946.blob.core.windows.net/","queue":"https://miqazuretest32946.queue.core.windows.net/","table":"https://miqazuretest32946.table.core.windows.net/","file":"https://miqazuretest32946.file.core.windows.net/"},"primaryLocation":"westus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Storage/storageAccounts/miqazureshared1","name":"miqazureshared1","type":"Microsoft.Storage/storageAccounts","location":"centralus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.1935084Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.1935084Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T20:42:52.498085Z","primaryEndpoints":{"blob":"https://miqazureshared1.blob.core.windows.net/","queue":"https://miqazureshared1.queue.core.windows.net/","table":"https://miqazureshared1.table.core.windows.net/","file":"https://miqazureshared1.file.core.windows.net/"},"primaryLocation":"centralus","statusOfPrimary":"available","secondaryLocation":"eastus2","statusOfSecondary":"available","secondaryEndpoints":{"blob":"https://miqazureshared1-secondary.blob.core.windows.net/","queue":"https://miqazureshared1-secondary.queue.core.windows.net/","table":"https://miqazureshared1-secondary.table.core.windows.net/"}}}]}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:51 GMT
+  recorded_at: Mon, 12 Mar 2018 09:25:24 GMT
 - request:
     method: post
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor/listKeys?api-version=2017-10-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686/listKeys?api-version=2017-10-01
     body:
       encoding: ASCII-8BIT
       string: ''
@@ -3792,7 +3382,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MzgsIm5iZiI6MTUyMDQ1MzQzOCwiZXhwIjoxNTIwNDU3MzM4LCJhaW8iOiJZMk5nWUxEbUtXMDk5clB4cU9QdGorL1crV3NlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZHNPVmFSUXV2RTJjVVBpcEtWWUFBQSIsInZlciI6IjEuMCJ9.drT5CKw95WRF7LzC0WuhK-fTLpw3j61XMw_DZdrLOWP8sjjsrbn9kF7xjDSTUM0ooF5_1Y-j3dNjvI9crm_F3PMAyhYXmCsKjTJkc3DIK6URy3hqbKiRBNlrutwvILE777NY-uXK9PH-gcaVuV-mNrjrLuxxClMJ3OPpTU8Ux0fj3Nuyf3KrXC27Oks_M_RDqDaXHOTckrdz2m_LNLpi5x0nKCoxwR9r5C1m5IKZ25FSbvyRNwjwz5dReqnv5LxllQMHVWkpvO7i5438wAnnyaS2x211IBiE6_dnV2god8Sp3ZRinXc4aCimUnJl6tLa5EtT_VSmR2QcBSaq0wS_ZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDYzOTgsIm5iZiI6MTUyMDg0NjM5OCwiZXhwIjoxNTIwODUwMjk4LCJhaW8iOiJZMk5nWUREaWt2OGkzWG5nNlVUbjUxbXNxeGZsQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieHBWZjRReC1fMFNKYXRaZUZRTWxBQSIsInZlciI6IjEuMCJ9.XwasNxrTVaqKz-D9MgYSC3bmyr00gxvA0-2ZHY6Ao4d6M-8zyF3EkpgtjvJQmJyigbtLo3aYxJYaliL0Doibjzt0yACsSHn0-fXyHT7SHkg2HOUhlT2YKj6Zd0Livs6YrpkYTLfpXffETPG6mqi0Q-P06FwGkAHh7-BzxH_Gh5I6JxbYFXpqpp184d23kVbcpZd9cBSCOPtIfLo5t-HJLY71rJ_vjTYLRyI2g_8a7RIYwHlViI1_O4-qGCr7eidV9SAQOk6Qg18mVS9Xh9eqtJ7o-7KncA9DnnM_hKy_BFta_jaQK4D1UkYDDGtthSqoIQzA-TGCPYEs4uALG9JgHw
       Content-Length:
       - '0'
   response:
@@ -3813,7 +3403,7 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 9c89256a-e412-4883-a72d-8052c473e74b
+      - 1e91f165-1d71-493a-ac72-79a5cb550a52
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
@@ -3821,21 +3411,21 @@ http_interactions:
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
       - '1199'
       X-Ms-Correlation-Request-Id:
-      - edfa53cb-31e0-4802-8bfd-4dd8c7c4b1a3
+      - 57ae1377-96b9-4f08-a635-072b57841320
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201851Z:edfa53cb-31e0-4802-8bfd-4dd8c7c4b1a3
+      - WESTEUROPE:20180312T092520Z:57ae1377-96b9-4f08-a635-072b57841320
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:18:51 GMT
+      - Mon, 12 Mar 2018 09:25:20 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"keys":[{"keyName":"key1","value":"68JHlwL/JgyPmvNCqop65JbepxzK0RGKJ4uD6EKszcgv1nRUJKkxO6u4OoyW/6YPT+FMJxvzEBrCGD/bduFGJQ==","permissions":"Full"},{"keyName":"key2","value":"NCT/sPC/+mrVRzXq/V5IwjN2SPaWRF4kY2coPHzJ8f+IkWMUIyfUgYTAN//h4KnxeWuX9OkY1CPyssDhDs91fw==","permissions":"Full"}]}'
+      string: '{"keys":[{"keyName":"key1","value":"32PV5jeBt8nw1XvFbZokY26SXchbD6H2tw/YrteEYVE0kpMLKrZ74VrwaIjDyucdi/RxDaAlf7dJIilLS7muNw==","permissions":"Full"},{"keyName":"key2","value":"Eo5x9CQJL1/wl6Tkj5N7M5eEdw6Hym6AeyTt3xjcDl30sV8Iadro6ywZzOHQwNDlmrDaBF6x2a9ZFL7zswxQ7w==","permissions":"Full"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:51 GMT
+  recorded_at: Mon, 12 Mar 2018 09:25:25 GMT
 - request:
     method: head
-    uri: https://spec0deply1stor.blob.core.windows.net/vhds/osdisk0.vhd
+    uri: https://miqazuretest18686.blob.core.windows.net/vhds/miq-test-rhel12016218112243.vhd
     body:
       encoding: US-ASCII
       string: ''
@@ -3849,7 +3439,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:18:51 GMT
+      - Mon, 12 Mar 2018 09:25:54 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -3857,38 +3447,38 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey spec0deply1stor:72i/Y9x8NBWcnnJ8n/0HNvSYWbS/gOu3+rN7Cb0C2Ss=
+      - SharedKey miqazuretest18686:Lmnh4WVqNZv042WADMX/5WsAXASEMJ2igIAH1pzMbnE=
   response:
     status:
       code: 200
       message: OK
     headers:
       Content-Length:
-      - '136367309312'
+      - '32212255232'
       Content-Type:
       - application/octet-stream
       Content-Md5:
-      - VbYhW9/6NOXzQVK/vQkdvg==
+      - dQL+XHjFNPdoMEweI63fwQ==
       Last-Modified:
-      - Sat, 03 Sep 2016 02:04:38 GMT
+      - Mon, 12 Mar 2018 09:25:47 GMT
       Accept-Ranges:
       - bytes
       Etag:
-      - '"0x8D3D39EA8F71715"'
+      - '"0x8D587FB3D6DAA8F"'
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 369aaef4-001e-001e-5151-b6fc92000000
+      - ff27c990-001e-00c8-61e4-b9b748000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Microsoftazurecompute-Resourcegroupname:
       - miq-azure-test1
       X-Ms-Meta-Microsoftazurecompute-Vmname:
-      - spec0deply1vm0
+      - miq-test-rhel1
       X-Ms-Meta-Microsoftazurecompute-Diskid:
-      - b059fe2a-4ccb-4a50-a235-ea3b7b089730
+      - 0ea91415-9058-46c6-9792-3afcb4da976f
       X-Ms-Meta-Microsoftazurecompute-Diskname:
-      - osdisk
+      - miq-test-rhel1
       X-Ms-Meta-Microsoftazurecompute-Disktype:
       - OSDisk
       X-Ms-Lease-Status:
@@ -3900,29 +3490,29 @@ http_interactions:
       X-Ms-Blob-Type:
       - PageBlob
       X-Ms-Blob-Sequence-Number:
-      - '43'
+      - '372'
       X-Ms-Copy-Id:
-      - 27fb6a34-f422-4f0a-afcb-528942d6012f
+      - b967ea05-82a2-405a-8df9-4615d59df4eb
       X-Ms-Copy-Source:
-      - https://ardfepirv2bl5prdstr06.blob.core.windows.net/a699494373c04fc0bc8f2bb1389d6106/Windows-Server-2012-R2-20160229-en.us-127GB.vhd?sv=2014-02-14&sr=b&si=PirCacheAccountPublisherContainerPolicy&sig=ipib%2Bgp2Sh4hS%2BBx5OUKgXSymDC0Tu0Ge60PGFuy5uk%3D
+      - https://ardfepirv2bl5prdstr06.blob.core.windows.net/a879bbefc56a43abb0ce65052aac09f3/rhel-72-20160302?sv=2014-02-14&sr=b&si=PirCacheAccountPublisherContainerPolicy&sig=2TQ3SKHqVnqe4jVKB4qMCBOphv2nYelKworI7pfckrs%3D
       X-Ms-Copy-Status:
       - success
       X-Ms-Copy-Progress:
-      - 136367309312/136367309312
+      - 32212255232/32212255232
       X-Ms-Copy-Completion-Time:
-      - Mon, 04 Apr 2016 23:24:57 GMT
+      - Fri, 18 Mar 2016 17:23:28 GMT
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:18:51 GMT
+      - Mon, 12 Mar 2018 09:25:50 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:52 GMT
+  recorded_at: Mon, 12 Mar 2018 09:25:55 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1?api-version=2018-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3936,7 +3526,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MzgsIm5iZiI6MTUyMDQ1MzQzOCwiZXhwIjoxNTIwNDU3MzM4LCJhaW8iOiJZMk5nWUxEbUtXMDk5clB4cU9QdGorL1crV3NlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZHNPVmFSUXV2RTJjVVBpcEtWWUFBQSIsInZlciI6IjEuMCJ9.drT5CKw95WRF7LzC0WuhK-fTLpw3j61XMw_DZdrLOWP8sjjsrbn9kF7xjDSTUM0ooF5_1Y-j3dNjvI9crm_F3PMAyhYXmCsKjTJkc3DIK6URy3hqbKiRBNlrutwvILE777NY-uXK9PH-gcaVuV-mNrjrLuxxClMJ3OPpTU8Ux0fj3Nuyf3KrXC27Oks_M_RDqDaXHOTckrdz2m_LNLpi5x0nKCoxwR9r5C1m5IKZ25FSbvyRNwjwz5dReqnv5LxllQMHVWkpvO7i5438wAnnyaS2x211IBiE6_dnV2god8Sp3ZRinXc4aCimUnJl6tLa5EtT_VSmR2QcBSaq0wS_ZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDYzOTgsIm5iZiI6MTUyMDg0NjM5OCwiZXhwIjoxNTIwODUwMjk4LCJhaW8iOiJZMk5nWUREaWt2OGkzWG5nNlVUbjUxbXNxeGZsQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieHBWZjRReC1fMFNKYXRaZUZRTWxBQSIsInZlciI6IjEuMCJ9.XwasNxrTVaqKz-D9MgYSC3bmyr00gxvA0-2ZHY6Ao4d6M-8zyF3EkpgtjvJQmJyigbtLo3aYxJYaliL0Doibjzt0yACsSHn0-fXyHT7SHkg2HOUhlT2YKj6Zd0Livs6YrpkYTLfpXffETPG6mqi0Q-P06FwGkAHh7-BzxH_Gh5I6JxbYFXpqpp184d23kVbcpZd9cBSCOPtIfLo5t-HJLY71rJ_vjTYLRyI2g_8a7RIYwHlViI1_O4-qGCr7eidV9SAQOk6Qg18mVS9Xh9eqtJ7o-7KncA9DnnM_hKy_BFta_jaQK4D1UkYDDGtthSqoIQzA-TGCPYEs4uALG9JgHw
   response:
     status:
       code: 200
@@ -3953,121 +3543,208 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"be3510b0-35c7-48ea-874b-49ac343ba8c9"
+      - W/"5ad0e691-263e-42ca-8a93-833bd4dbf13f"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 96ab95bb-2b38-4612-89e4-94a45374b5e9
+      - c195850e-f08e-4847-a2a1-1324e79f64de
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14967'
+      - '14987'
       X-Ms-Correlation-Request-Id:
-      - a944fea8-b1c1-49dd-9c79-64e73659d8de
+      - 2257649a-7d02-44e6-b4de-b895b0280cd3
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201852Z:a944fea8-b1c1-49dd-9c79-64e73659d8de
+      - WESTEUROPE:20180312T092551Z:2257649a-7d02-44e6-b4de-b895b0280cd3
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:18:51 GMT
+      - Mon, 12 Mar 2018 09:25:50 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"spec0deply1vnet\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet\",\r\n
-        \ \"etag\": \"W/\\\"be3510b0-35c7-48ea-874b-49ac343ba8c9\\\"\",\r\n  \"type\":
+      string: "{\r\n  \"name\": \"miq-test-rhel1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1\",\r\n
+        \ \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/networkSecurityGroups\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"f4a4a6a5-e2e8-47bd-b46f-00592f8fce53\",\r\n    \"securityRules\":
+        [\r\n      {\r\n        \"name\": \"default-allow-ssh\",\r\n        \"id\":
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/securityRules/default-allow-ssh\",\r\n
+        \       \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"protocol\": \"Tcp\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"22\",\r\n          \"sourceAddressPrefix\":
+        \"*\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n          \"access\":
+        \"Allow\",\r\n          \"priority\": 1000,\r\n          \"direction\": \"Inbound\",\r\n
+        \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"rhel1-inbound1\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/securityRules/rhel1-inbound1\",\r\n
+        \       \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"protocol\": \"Tcp\",\r\n          \"sourcePortRange\": \"80\",\r\n
+        \         \"destinationPortRange\": \"80\",\r\n          \"sourceAddressPrefix\":
+        \"*\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n          \"access\":
+        \"Allow\",\r\n          \"priority\": 100,\r\n          \"direction\": \"Inbound\",\r\n
+        \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"rhel1-inbound2\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/securityRules/rhel1-inbound2\",\r\n
+        \       \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"protocol\": \"Tcp\",\r\n          \"sourcePortRange\": \"443\",\r\n
+        \         \"destinationPortRange\": \"443\",\r\n          \"sourceAddressPrefix\":
+        \"*\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n          \"access\":
+        \"Allow\",\r\n          \"priority\": 200,\r\n          \"direction\": \"Inbound\",\r\n
+        \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      }\r\n    ],\r\n    \"defaultSecurityRules\": [\r\n
+        \     {\r\n        \"name\": \"AllowVnetInBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/defaultSecurityRules/AllowVnetInBound\",\r\n
+        \       \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow inbound traffic from all VMs in VNET\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"VirtualNetwork\",\r\n          \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n          \"direction\":
+        \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowAzureLoadBalancerInBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/defaultSecurityRules/AllowAzureLoadBalancerInBound\",\r\n
+        \       \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow inbound traffic from azure load balancer\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"AzureLoadBalancer\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65001,\r\n          \"direction\":
+        \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllInBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/defaultSecurityRules/DenyAllInBound\",\r\n
+        \       \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Deny all inbound traffic\",\r\n          \"protocol\":
+        \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\":
+        \"*\",\r\n          \"sourceAddressPrefix\": \"*\",\r\n          \"destinationAddressPrefix\":
+        \"*\",\r\n          \"access\": \"Deny\",\r\n          \"priority\": 65500,\r\n
+        \         \"direction\": \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n
+        \         \"destinationPortRanges\": [],\r\n          \"sourceAddressPrefixes\":
+        [],\r\n          \"destinationAddressPrefixes\": []\r\n        }\r\n      },\r\n
+        \     {\r\n        \"name\": \"AllowVnetOutBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/defaultSecurityRules/AllowVnetOutBound\",\r\n
+        \       \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow outbound traffic from all VMs to all VMs
+        in VNET\",\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\":
+        \"*\",\r\n          \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"VirtualNetwork\",\r\n          \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n          \"direction\":
+        \"Outbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowInternetOutBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/defaultSecurityRules/AllowInternetOutBound\",\r\n
+        \       \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow outbound traffic from all VMs to Internet\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"*\",\r\n          \"destinationAddressPrefix\": \"Internet\",\r\n          \"access\":
+        \"Allow\",\r\n          \"priority\": 65001,\r\n          \"direction\": \"Outbound\",\r\n
+        \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllOutBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/defaultSecurityRules/DenyAllOutBound\",\r\n
+        \       \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Deny all outbound traffic\",\r\n          \"protocol\":
+        \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\":
+        \"*\",\r\n          \"sourceAddressPrefix\": \"*\",\r\n          \"destinationAddressPrefix\":
+        \"*\",\r\n          \"access\": \"Deny\",\r\n          \"priority\": 65500,\r\n
+        \         \"direction\": \"Outbound\",\r\n          \"sourcePortRanges\":
+        [],\r\n          \"destinationPortRanges\": [],\r\n          \"sourceAddressPrefixes\":
+        [],\r\n          \"destinationAddressPrefixes\": []\r\n        }\r\n      }\r\n
+        \   ],\r\n    \"networkInterfaces\": [\r\n      {\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390\"\r\n
+        \     }\r\n    ]\r\n  }\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:25:56 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDYzOTgsIm5iZiI6MTUyMDg0NjM5OCwiZXhwIjoxNTIwODUwMjk4LCJhaW8iOiJZMk5nWUREaWt2OGkzWG5nNlVUbjUxbXNxeGZsQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieHBWZjRReC1fMFNKYXRaZUZRTWxBQSIsInZlciI6IjEuMCJ9.XwasNxrTVaqKz-D9MgYSC3bmyr00gxvA0-2ZHY6Ao4d6M-8zyF3EkpgtjvJQmJyigbtLo3aYxJYaliL0Doibjzt0yACsSHn0-fXyHT7SHkg2HOUhlT2YKj6Zd0Livs6YrpkYTLfpXffETPG6mqi0Q-P06FwGkAHh7-BzxH_Gh5I6JxbYFXpqpp184d23kVbcpZd9cBSCOPtIfLo5t-HJLY71rJ_vjTYLRyI2g_8a7RIYwHlViI1_O4-qGCr7eidV9SAQOk6Qg18mVS9Xh9eqtJ7o-7KncA9DnnM_hKy_BFta_jaQK4D1UkYDDGtthSqoIQzA-TGCPYEs4uALG9JgHw
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"a8b09238-30fc-4b36-a58d-e3cc69e267c5"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - e726af60-123d-4e80-8864-955561995a98
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Correlation-Request-Id:
+      - c9121d8d-5395-489a-881c-fcd2d99aca9f
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T092554Z:c9121d8d-5395-489a-881c-fcd2d99aca9f
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:25:54 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"miq-azure-test1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1\",\r\n
+        \ \"etag\": \"W/\\\"a8b09238-30fc-4b36-a58d-e3cc69e267c5\\\"\",\r\n  \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
-        \"0bb1f005-1af2-4d4b-966a-89aaf6daefca\",\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\":
-        [\r\n        \"10.0.0.0/16\"\r\n      ]\r\n    },\r\n    \"subnets\": [\r\n
-        \     {\r\n        \"name\": \"Subnet-1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1\",\r\n
-        \       \"etag\": \"W/\\\"be3510b0-35c7-48ea-874b-49ac343ba8c9\\\"\",\r\n
+        \"d74c1e5f-50e4-4c8a-a7fe-78eaddc6b915\",\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\":
+        [\r\n        \"10.16.0.0/16\"\r\n      ]\r\n    },\r\n    \"subnets\": [\r\n
+        \     {\r\n        \"name\": \"default\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\",\r\n
+        \       \"etag\": \"W/\\\"a8b09238-30fc-4b36-a58d-e3cc69e267c5\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"addressPrefix\": \"10.0.0.0/24\",\r\n          \"ipConfigurations\":
-        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1\"\r\n
+        \         \"addressPrefix\": \"10.16.0.0/24\",\r\n          \"ipConfigurations\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241/ipConfigurations/ipconfig1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1/ipConfigurations/miqmismatch1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/dbergerprov1/ipConfigurations/dbergerprov1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/ladas_test_1/ipConfigurations/ladas_test_1\"\r\n
         \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"virtualNetworkPeerings\":
         [],\r\n    \"enableDdosProtection\": false,\r\n    \"enableVmProtection\":
         false\r\n  }\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:52 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MzgsIm5iZiI6MTUyMDQ1MzQzOCwiZXhwIjoxNTIwNDU3MzM4LCJhaW8iOiJZMk5nWUxEbUtXMDk5clB4cU9QdGorL1crV3NlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZHNPVmFSUXV2RTJjVVBpcEtWWUFBQSIsInZlciI6IjEuMCJ9.drT5CKw95WRF7LzC0WuhK-fTLpw3j61XMw_DZdrLOWP8sjjsrbn9kF7xjDSTUM0ooF5_1Y-j3dNjvI9crm_F3PMAyhYXmCsKjTJkc3DIK6URy3hqbKiRBNlrutwvILE777NY-uXK9PH-gcaVuV-mNrjrLuxxClMJ3OPpTU8Ux0fj3Nuyf3KrXC27Oks_M_RDqDaXHOTckrdz2m_LNLpi5x0nKCoxwR9r5C1m5IKZ25FSbvyRNwjwz5dReqnv5LxllQMHVWkpvO7i5438wAnnyaS2x211IBiE6_dnV2god8Sp3ZRinXc4aCimUnJl6tLa5EtT_VSmR2QcBSaq0wS_ZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"b817491c-aab8-4aab-b41d-b07bfffa5639"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - cd144585-f05d-4ec4-ad90-c76fa39f6f12
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14975'
-      X-Ms-Correlation-Request-Id:
-      - ed093efe-7849-4f2f-ab25-e39dddf64514
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201852Z:ed093efe-7849-4f2f-ab25-e39dddf64514
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:18:52 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"spec0deply1nic0\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0\",\r\n
-        \ \"etag\": \"W/\\\"b817491c-aab8-4aab-b41d-b07bfffa5639\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"80ad9866-071d-4e3f-91d0-d47954eccee0\",\r\n    \"ipConfigurations\":
-        [\r\n      {\r\n        \"name\": \"ipconfig1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1\",\r\n
-        \       \"etag\": \"W/\\\"b817491c-aab8-4aab-b41d-b07bfffa5639\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAddress\": \"10.0.0.4\",\r\n          \"privateIPAllocationMethod\":
-        \"Dynamic\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1\"\r\n
-        \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
-        \"IPv4\",\r\n          \"loadBalancerBackendAddressPools\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\"\r\n
-        \           }\r\n          ],\r\n          \"loadBalancerInboundNatRules\":
-        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\":
-        {\r\n      \"dnsServers\": [],\r\n      \"appliedDnsServers\": []\r\n    },\r\n
-        \   \"enableAcceleratedNetworking\": false,\r\n    \"enableIPForwarding\":
-        false,\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0\"\r\n
-        \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
-        \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:52 GMT
+  recorded_at: Mon, 12 Mar 2018 09:25:59 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_500/resource_group_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_500/resource_group_refresh.yml
@@ -1,6 +1,62 @@
 ---
 http_interactions:
 - request:
+    method: post
+    uri: https://login.microsoftonline.com/AZURE_TENANT_ID/oauth2/token
+    body:
+      encoding: UTF-8
+      string: grant_type=client_credentials&client_id=AZURE_CLIENT_ID&client_secret=AZURE_CLIENT_SECRET&resource=https%3A%2F%2Fmanagement.azure.com%2F
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Server:
+      - Microsoft-IIS/10.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Request-Id:
+      - c1515b84-1035-4902-b6ed-577042d73200
+      P3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Set-Cookie:
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzGA_HEYkHYikn3ngdBcuHqc3MOJL7VsKYQgl2LGugAUY1tTLj6PvPtvIbBwJn3kaa6pRSi3N2NeRzr81vENMwWUCRuaBpiCGSd00FbiPy03udDbINRaaebruO9JCLUIeKP1CyBjHhLGwuFez-Fd4kuHiH71xOjUXbIFJyIO934sEgAA;
+        domain=.login.microsoftonline.com; path=/; secure; HttpOnly
+      - stsservicecookie=ests; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=007; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Tue, 13 Mar 2018 08:59:03 GMT
+      Content-Length:
+      - '1505'
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1520935144","not_before":"1520931244","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA5MzEyNDQsIm5iZiI6MTUyMDkzMTI0NCwiZXhwIjoxNTIwOTM1MTQ0LCJhaW8iOiJZMk5nWUhpLzdmYlJuSXNwOGM2TGkrOTl1TnFSQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiaEZ0UndUVVFBa20yN1Zkd1F0Y3lBQSIsInZlciI6IjEuMCJ9.HX_9XFYaoax9exiP3pzCmVChUhN_yZ4klHMUpBEIrC0vtTxVR2ei4dFj2eNAhD31xQ2HuxTg50TrlNQ3zbAKOUN-oF9d9Ht5XDRNpfWG2uGTUVn2mx9cRZmzweM-Lz4JCcvxQmslGgjCluakTytG1aLtvd8Hhu3SEKBZTzGutCrdLxr-8woYwxUJhLArpVHyhrpYAyA0gAWvAhlBWBGthHPVujJvhIYZU2Lf-a0KGmW3TUp_iR49sTWa0gax8zflL0DsJp1iRX4LVNKWZsaNMf-vT5yZX9_0fDkZxX-Bk2mrHbbTfMCH7wQCWnTbH_ewsyuUqPVNSaigqbiBjBZp1A"}'
+    http_version: 
+  recorded_at: Tue, 13 Mar 2018 08:59:04 GMT
+- request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
     body:
@@ -16,7 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA5MzEyNDQsIm5iZiI6MTUyMDkzMTI0NCwiZXhwIjoxNTIwOTM1MTQ0LCJhaW8iOiJZMk5nWUhpLzdmYlJuSXNwOGM2TGkrOTl1TnFSQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiaEZ0UndUVVFBa20yN1Zkd1F0Y3lBQSIsInZlciI6IjEuMCJ9.HX_9XFYaoax9exiP3pzCmVChUhN_yZ4klHMUpBEIrC0vtTxVR2ei4dFj2eNAhD31xQ2HuxTg50TrlNQ3zbAKOUN-oF9d9Ht5XDRNpfWG2uGTUVn2mx9cRZmzweM-Lz4JCcvxQmslGgjCluakTytG1aLtvd8Hhu3SEKBZTzGutCrdLxr-8woYwxUJhLArpVHyhrpYAyA0gAWvAhlBWBGthHPVujJvhIYZU2Lf-a0KGmW3TUp_iR49sTWa0gax8zflL0DsJp1iRX4LVNKWZsaNMf-vT5yZX9_0fDkZxX-Bk2mrHbbTfMCH7wQCWnTbH_ewsyuUqPVNSaigqbiBjBZp1A
   response:
     status:
       code: 200
@@ -35,26 +91,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14997'
+      - '14999'
       X-Ms-Request-Id:
-      - cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - f941294e-6c54-4e86-9b47-b509ff262b3a
       X-Ms-Correlation-Request-Id:
-      - cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - f941294e-6c54-4e86-9b47-b509ff262b3a
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102417Z:cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - WESTEUROPE:20180313T085904Z:f941294e-6c54-4e86-9b47-b509ff262b3a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:17 GMT
+      - Tue, 13 Mar 2018 08:59:04 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID","subscriptionId":"AZURE_SUBSCRIPTION_ID","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:22 GMT
+  recorded_at: Tue, 13 Mar 2018 08:59:04 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers?api-version=2015-01-01
@@ -71,7 +127,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA5MzEyNDQsIm5iZiI6MTUyMDkzMTI0NCwiZXhwIjoxNTIwOTM1MTQ0LCJhaW8iOiJZMk5nWUhpLzdmYlJuSXNwOGM2TGkrOTl1TnFSQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiaEZ0UndUVVFBa20yN1Zkd1F0Y3lBQSIsInZlciI6IjEuMCJ9.HX_9XFYaoax9exiP3pzCmVChUhN_yZ4klHMUpBEIrC0vtTxVR2ei4dFj2eNAhD31xQ2HuxTg50TrlNQ3zbAKOUN-oF9d9Ht5XDRNpfWG2uGTUVn2mx9cRZmzweM-Lz4JCcvxQmslGgjCluakTytG1aLtvd8Hhu3SEKBZTzGutCrdLxr-8woYwxUJhLArpVHyhrpYAyA0gAWvAhlBWBGthHPVujJvhIYZU2Lf-a0KGmW3TUp_iR49sTWa0gax8zflL0DsJp1iRX4LVNKWZsaNMf-vT5yZX9_0fDkZxX-Bk2mrHbbTfMCH7wQCWnTbH_ewsyuUqPVNSaigqbiBjBZp1A
   response:
     status:
       code: 200
@@ -88,21 +144,21 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - '14921'
       X-Ms-Request-Id:
-      - fe3532ca-59a2-474e-9094-8a3697b82bef
+      - ce433f8d-0023-4819-8b66-12f9fee8e25f
       X-Ms-Correlation-Request-Id:
-      - fe3532ca-59a2-474e-9094-8a3697b82bef
+      - ce433f8d-0023-4819-8b66-12f9fee8e25f
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102419Z:fe3532ca-59a2-474e-9094-8a3697b82bef
+      - WESTEUROPE:20180313T085906Z:ce433f8d-0023-4819-8b66-12f9fee8e25f
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:18 GMT
+      - Tue, 13 Mar 2018 08:59:06 GMT
       Content-Length:
-      - '320853'
+      - '322992'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"},{"applicationId":"d87dcbc6-a371-462e-88e3-28ad15ec4e64","roleDefinitionId":"861776c5-e0df-4f95-be4f-ac1eec193323"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["East
@@ -442,7 +498,10 @@ http_interactions:
         Central US","West Europe","North Europe","East US","UK West","UK South","West
         Central US","West US 2","South India","Central India","West India","Canada
         East","Canada Central","Korea South","Korea Central"],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"managedClusters","locations":["East
-        US","West Europe","Central US","Canada Central","Canada East"],"apiVersions":["2017-08-31"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
+        US","West Europe","Central US","Canada Central","Canada East"],"apiVersions":["2017-08-31"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operationresults","locations":["East
+        US","West Europe","Central US","UK West","UK South","West Central US","West
+        US 2","South India","Central India","West India","Canada East","Canada Central","Korea
+        South","Korea Central"],"apiVersions":["2017-08-31","2016-03-30"]},{"resourceType":"locations/operations","locations":["Japan
         East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
@@ -510,7 +569,7 @@ http_interactions:
         US","South Central US","North Europe","West Europe","Southeast Asia","West
         US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"listMigrationdate","locations":["East
         US","South Central US","North Europe","West Europe","Southeast Asia","West
-        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2018-03-01","2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
@@ -612,47 +671,47 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"networkWatchers/lenses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"networkWatchers/lenses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -662,47 +721,52 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2018-02-01","2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"ddosProtectionPlans","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","West
         US 2","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
@@ -1438,57 +1502,57 @@ http_interactions:
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/asyncoperations","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/asyncoperations","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/listAccountSas","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/listAccountSas","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/listServiceSas","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/listServiceSas","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/blobServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/blobServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/tableServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/tableServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/queueServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/queueServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/fileServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/fileServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01","2016-01-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01","2016-01-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
         US","West US","West Europe","North Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":["East
         US","West US","West Europe","North Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.visualstudio","namespace":"microsoft.visualstudio","authorization":{"applicationId":"499b84ac-1321-427f-aa17-267ca6975798","roleDefinitionId":"6a18f445-86f0-4e2e-b8a9-6b9b5677e3d8"},"resourceTypes":[{"resourceType":"account","locations":["North
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.visualstudio","namespace":"microsoft.visualstudio","authorization":{"applicationId":"499b84ac-1321-427f-aa17-267ca6975798","roleDefinitionId":"6a18f445-86f0-4e2e-b8a9-6b9b5677e3d8"},"resourceTypes":[{"resourceType":"account","locations":["North
         Central US","South Central US","East US","West US","Central US","North Europe","West
         Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
         East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/project","locations":["North
@@ -2173,7 +2237,8 @@ http_interactions:
         US","West US 2","East US","East US 2","North Europe","West Europe","Southeast
         Asia","East Asia","North Central US","South Central US","Japan West","Australia
         East","Brazil South","Central India","West Central US","Canada Central","UK
-        South"],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ServiceBus","namespace":"Microsoft.ServiceBus","authorization":{"applicationId":"80a10ef9-8168-493d-abf9-3297c4ef6e3c","roleDefinitionId":"2b7763f7-bbe2-4e19-befe-28c79f1cf7f7"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        South"],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.SecurityGraph","namespace":"Microsoft.SecurityGraph","resourceTypes":[{"resourceType":"operations","locations":["West
+        US"],"apiVersions":["2017-04-01-preview"]},{"resourceType":"diagnosticSettings","locations":[],"apiVersions":["2017-04-01-preview"]},{"resourceType":"diagnosticSettingsCategories","locations":[],"apiVersions":["2017-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ServiceBus","namespace":"Microsoft.ServiceBus","authorization":{"applicationId":"80a10ef9-8168-493d-abf9-3297c4ef6e3c","roleDefinitionId":"2b7763f7-bbe2-4e19-befe-28c79f1cf7f7"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US 2","West
         US","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
@@ -2322,10 +2387,10 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:23 GMT
+  recorded_at: Tue, 13 Mar 2018 08:59:07 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups/miq-azure-test4?api-version=2017-08-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2339,7 +2404,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA5MzEyNDQsIm5iZiI6MTUyMDkzMTI0NCwiZXhwIjoxNTIwOTM1MTQ0LCJhaW8iOiJZMk5nWUhpLzdmYlJuSXNwOGM2TGkrOTl1TnFSQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiaEZ0UndUVVFBa20yN1Zkd1F0Y3lBQSIsInZlciI6IjEuMCJ9.HX_9XFYaoax9exiP3pzCmVChUhN_yZ4klHMUpBEIrC0vtTxVR2ei4dFj2eNAhD31xQ2HuxTg50TrlNQ3zbAKOUN-oF9d9Ht5XDRNpfWG2uGTUVn2mx9cRZmzweM-Lz4JCcvxQmslGgjCluakTytG1aLtvd8Hhu3SEKBZTzGutCrdLxr-8woYwxUJhLArpVHyhrpYAyA0gAWvAhlBWBGthHPVujJvhIYZU2Lf-a0KGmW3TUp_iR49sTWa0gax8zflL0DsJp1iRX4LVNKWZsaNMf-vT5yZX9_0fDkZxX-Bk2mrHbbTfMCH7wQCWnTbH_ewsyuUqPVNSaigqbiBjBZp1A
   response:
     status:
       code: 200
@@ -2349,301 +2414,31 @@ http_interactions:
       - no-cache
       Pragma:
       - no-cache
-      Transfer-Encoding:
-      - chunked
       Content-Type:
       - application/json; charset=utf-8
       Expires:
       - "-1"
-      Etag:
-      - W/"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67"
       Vary:
       - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14941'
       X-Ms-Request-Id:
-      - '080de667-081e-4d58-9e94-9e7243d4200e'
+      - 4f5f3234-411c-4e38-ba8c-f20524e94060
+      X-Ms-Correlation-Request-Id:
+      - 4f5f3234-411c-4e38-ba8c-f20524e94060
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180313T085909Z:4f5f3234-411c-4e38-ba8c-f20524e94060
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Correlation-Request-Id:
-      - '093d49ac-c85f-440e-956b-955b6698dd19'
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102419Z:093d49ac-c85f-440e-956b-955b6698dd19
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:19 GMT
+      - Tue, 13 Mar 2018 08:59:09 GMT
+      Content-Length:
+      - '183'
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1\",\r\n
-        \ \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"7ab88756-810f-4083-95db-8b05d50e38f2\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ],\r\n          \"inboundNatRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"backendIPConfigurations\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\"\r\n
-        \           }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-rule\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\":
-        80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\"\r\n
-        \         },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n
-        \       \"name\": \"rspec-lb-probe\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-NAT\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 3441,\r\n          \"backendPort\":
-        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
+      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4","name":"miq-azure-test4","location":"eastus","properties":{"provisioningState":"Succeeded"}}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:24 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"7a8e5fe7-f777-4435-992b-a54f28c2f28c"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - bd22ca22-a01f-4ecf-9230-a4558fb66931
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Correlation-Request-Id:
-      - 19c674a8-c8da-4b5e-8265-5ebc21926459
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102420Z:19c674a8-c8da-4b5e-8265-5ebc21926459
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Mon, 12 Mar 2018 10:24:19 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb2\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2\",\r\n
-        \ \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"e2e30a77-f81b-43fc-9693-08303e43deed\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/backendAddressPools/rspec-lb2-pool\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\r\n
-        \       }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\": [],\r\n    \"probes\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-probe\",\r\n        \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/probes/rspec-lb2-probe\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\": [],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:25 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"a38434c8-7b23-4092-b7c6-402238eac0dc"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 0fd15240-6a1c-4b39-a4f6-aa53fd8591c2
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Correlation-Request-Id:
-      - 5cc03163-922e-41a1-9601-dba2d7cf2a81
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102421Z:5cc03163-922e-41a1-9601-dba2d7cf2a81
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Mon, 12 Mar 2018 10:24:20 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb1-LoadBalancerFrontEnd\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\",\r\n
-        \ \"etag\": \"W/\\\"a38434c8-7b23-4092-b7c6-402238eac0dc\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"f28e0f25-b372-4edf-97d9-13a9e3b4ba2d\",\r\n    \"ipAddress\":
-        \"40.71.82.83\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\":
-        \"Static\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipTags\": [],\r\n
-        \   \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
-        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:25 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"cddd97d1-6111-4477-8a00-3dc885237a1d"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 1403e5b6-8fa0-4cd3-89b1-76b6c4fd805b
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
-      X-Ms-Correlation-Request-Id:
-      - e4a5f369-a742-466f-bd8f-42e17eaaf9c9
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102421Z:e4a5f369-a742-466f-bd8f-42e17eaaf9c9
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Mon, 12 Mar 2018 10:24:21 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb2-publicip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\",\r\n
-        \ \"etag\": \"W/\\\"cddd97d1-6111-4477-8a00-3dc885237a1d\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"83e7257d-ab94-4229-8eb5-4798f37ef28d\",\r\n    \"publicIPAddressVersion\":
-        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
-        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
-        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:26 GMT
+  recorded_at: Tue, 13 Mar 2018 08:59:09 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_500/security_group_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_500/security_group_refresh.yml
@@ -37,25 +37,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 7282b813-1724-416b-91d7-326575660000
+      - 0e50ae1a-8049-4c2a-a211-e867386c3800
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzqhQKRTr6TI7YMtR71rqu6bRkiBx5D3viwmPg740poGnclzfUh8MxOUAVZSnzKvr40a8x_9fDngQ2bmvcZfFy6NYmzrH1RLpHWU0Ss1-jwAMORs5rAUnxDbreeugg_QQzbeSiAFB_TLAWi9x9kLXN1gIomQu0qGm_MY5Jx77OIScgAA;
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzEOBFD4p4lleKHITbn3CHjuIx6sATiWjrCsJtCeZy_GN9hbimYm9t5nfDEFvPtH55ICmklUTKioYjuAcdDcnKzPn2XZ3BKcPblAKGfy5890AzgS0WAYiW09cI5oAssbGp9gJghoH-xbG4LQFNjKVsP6w0J8LyKg5Wc_AJLesgtiMgAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
       - x-ms-gateway-slice=007; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Wed, 07 Mar 2018 20:16:25 GMT
+      - Tue, 13 Mar 2018 09:00:06 GMT
       Content-Length:
       - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1520457385","not_before":"1520453485","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0ODUsIm5iZiI6MTUyMDQ1MzQ4NSwiZXhwIjoxNTIwNDU3Mzg1LCJhaW8iOiJZMk5nWU5qQnVUVng5OU1Kai9QZUY0akhQV2xXQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRTdpQ2NpUVhhMEdSMXpKbGRXWUFBQSIsInZlciI6IjEuMCJ9.Sw8vyzVAkb3ZDTyEmDxn8_UXnY9Kls8_RIAuJ2sQFfwB1KWik8WwG-Cf-ZhXtctp8QiEg78bosE4woFyHSXNH_20vGyOlFWKLDiPYQzaoC6bm_1ZF4nbBAwoiBIqLU_qBTrqEGrwif3DCxQK5L93XqK1_5znRfVkdVbehypI_wpSj16G1FAu4L-LWX8sJ_lsAgOdx5PAqIDO17DlMA1Wehi1o6X4_WyXfXAQzNHfTGk2USWjMlQkDYtrCgnAb2ZM4JkjrWfXA4TznHgKdb5Zk6nukZgFPZyeFOgt8NNbaI5RoBIBa9L6Q_1rbyGR_jAvAY6GUhGGXZ1tBZos_XWMGA"}'
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1520935206","not_before":"1520931306","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA5MzEzMDYsIm5iZiI6MTUyMDkzMTMwNiwiZXhwIjoxNTIwOTM1MjA2LCJhaW8iOiJZMk5nWUpnUWZrUk50TmxvODhvK0cwYUJLVXF6QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiR3E1UURrbUFLa3lpRWVobk9HdzRBQSIsInZlciI6IjEuMCJ9.YGGsVkQULqdEK0f4YaXOxnwWAGe6kb-ODdKCorOt5aVeNejRQxpVVwvjroEU8mRNaEO-myIeVMj-ZWC6TFGSa5EtHinskLf6KZ8qqMBPGAY7dd1EqxbWh4-C6tzJVpSzFx0UGMC6KcheXVSqcgEMaUcTKGXZ-sZd4v6TYz4T5LWHpgxJ0IzQEtddHROT9huvKFadzxoEBDPVX69rJMZm4gbrZ-4zJZhYaS013tVhrR8bUJeGxINjtQaZEWRTiB_Mr9jKtc18zYK3wOib2Vv16QUhycc7HUWVmwwPjIGmA_ihKR6ZXsd_ofmTvdLH5GcY3YI9F9rLGFR_0ai_WTjFVA"}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:25 GMT
+  recorded_at: Tue, 13 Mar 2018 09:00:06 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -72,7 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0ODUsIm5iZiI6MTUyMDQ1MzQ4NSwiZXhwIjoxNTIwNDU3Mzg1LCJhaW8iOiJZMk5nWU5qQnVUVng5OU1Kai9QZUY0akhQV2xXQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRTdpQ2NpUVhhMEdSMXpKbGRXWUFBQSIsInZlciI6IjEuMCJ9.Sw8vyzVAkb3ZDTyEmDxn8_UXnY9Kls8_RIAuJ2sQFfwB1KWik8WwG-Cf-ZhXtctp8QiEg78bosE4woFyHSXNH_20vGyOlFWKLDiPYQzaoC6bm_1ZF4nbBAwoiBIqLU_qBTrqEGrwif3DCxQK5L93XqK1_5znRfVkdVbehypI_wpSj16G1FAu4L-LWX8sJ_lsAgOdx5PAqIDO17DlMA1Wehi1o6X4_WyXfXAQzNHfTGk2USWjMlQkDYtrCgnAb2ZM4JkjrWfXA4TznHgKdb5Zk6nukZgFPZyeFOgt8NNbaI5RoBIBa9L6Q_1rbyGR_jAvAY6GUhGGXZ1tBZos_XWMGA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA5MzEzMDYsIm5iZiI6MTUyMDkzMTMwNiwiZXhwIjoxNTIwOTM1MjA2LCJhaW8iOiJZMk5nWUpnUWZrUk50TmxvODhvK0cwYUJLVXF6QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiR3E1UURrbUFLa3lpRWVobk9HdzRBQSIsInZlciI6IjEuMCJ9.YGGsVkQULqdEK0f4YaXOxnwWAGe6kb-ODdKCorOt5aVeNejRQxpVVwvjroEU8mRNaEO-myIeVMj-ZWC6TFGSa5EtHinskLf6KZ8qqMBPGAY7dd1EqxbWh4-C6tzJVpSzFx0UGMC6KcheXVSqcgEMaUcTKGXZ-sZd4v6TYz4T5LWHpgxJ0IzQEtddHROT9huvKFadzxoEBDPVX69rJMZm4gbrZ-4zJZhYaS013tVhrR8bUJeGxINjtQaZEWRTiB_Mr9jKtc18zYK3wOib2Vv16QUhycc7HUWVmwwPjIGmA_ihKR6ZXsd_ofmTvdLH5GcY3YI9F9rLGFR_0ai_WTjFVA
   response:
     status:
       code: 200
@@ -91,26 +91,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14998'
+      - '14999'
       X-Ms-Request-Id:
-      - 9fef701a-94cc-473a-8849-321372ce1cb0
+      - 6e2b87a8-2214-4594-9435-b310c49b4747
       X-Ms-Correlation-Request-Id:
-      - 9fef701a-94cc-473a-8849-321372ce1cb0
+      - 6e2b87a8-2214-4594-9435-b310c49b4747
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201625Z:9fef701a-94cc-473a-8849-321372ce1cb0
+      - WESTEUROPE:20180313T090006Z:6e2b87a8-2214-4594-9435-b310c49b4747
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:16:25 GMT
+      - Tue, 13 Mar 2018 09:00:06 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID","subscriptionId":"AZURE_SUBSCRIPTION_ID","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:26 GMT
+  recorded_at: Tue, 13 Mar 2018 09:00:06 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers?api-version=2015-01-01
@@ -127,7 +127,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0ODUsIm5iZiI6MTUyMDQ1MzQ4NSwiZXhwIjoxNTIwNDU3Mzg1LCJhaW8iOiJZMk5nWU5qQnVUVng5OU1Kai9QZUY0akhQV2xXQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRTdpQ2NpUVhhMEdSMXpKbGRXWUFBQSIsInZlciI6IjEuMCJ9.Sw8vyzVAkb3ZDTyEmDxn8_UXnY9Kls8_RIAuJ2sQFfwB1KWik8WwG-Cf-ZhXtctp8QiEg78bosE4woFyHSXNH_20vGyOlFWKLDiPYQzaoC6bm_1ZF4nbBAwoiBIqLU_qBTrqEGrwif3DCxQK5L93XqK1_5znRfVkdVbehypI_wpSj16G1FAu4L-LWX8sJ_lsAgOdx5PAqIDO17DlMA1Wehi1o6X4_WyXfXAQzNHfTGk2USWjMlQkDYtrCgnAb2ZM4JkjrWfXA4TznHgKdb5Zk6nukZgFPZyeFOgt8NNbaI5RoBIBa9L6Q_1rbyGR_jAvAY6GUhGGXZ1tBZos_XWMGA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA5MzEzMDYsIm5iZiI6MTUyMDkzMTMwNiwiZXhwIjoxNTIwOTM1MjA2LCJhaW8iOiJZMk5nWUpnUWZrUk50TmxvODhvK0cwYUJLVXF6QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiR3E1UURrbUFLa3lpRWVobk9HdzRBQSIsInZlciI6IjEuMCJ9.YGGsVkQULqdEK0f4YaXOxnwWAGe6kb-ODdKCorOt5aVeNejRQxpVVwvjroEU8mRNaEO-myIeVMj-ZWC6TFGSa5EtHinskLf6KZ8qqMBPGAY7dd1EqxbWh4-C6tzJVpSzFx0UGMC6KcheXVSqcgEMaUcTKGXZ-sZd4v6TYz4T5LWHpgxJ0IzQEtddHROT9huvKFadzxoEBDPVX69rJMZm4gbrZ-4zJZhYaS013tVhrR8bUJeGxINjtQaZEWRTiB_Mr9jKtc18zYK3wOib2Vv16QUhycc7HUWVmwwPjIGmA_ihKR6ZXsd_ofmTvdLH5GcY3YI9F9rLGFR_0ai_WTjFVA
   response:
     status:
       code: 200
@@ -144,39 +144,37 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
+      - '14933'
       X-Ms-Request-Id:
-      - 29cca612-efc2-4512-8fbe-c5eecd0733b0
+      - 71e0ba2b-1b62-48a3-a1df-614179132ceb
       X-Ms-Correlation-Request-Id:
-      - 29cca612-efc2-4512-8fbe-c5eecd0733b0
+      - 71e0ba2b-1b62-48a3-a1df-614179132ceb
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201627Z:29cca612-efc2-4512-8fbe-c5eecd0733b0
+      - WESTEUROPE:20180313T090010Z:71e0ba2b-1b62-48a3-a1df-614179132ceb
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:16:26 GMT
+      - Tue, 13 Mar 2018 09:00:09 GMT
       Content-Length:
-      - '310505'
+      - '322992'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"},{"applicationId":"d87dcbc6-a371-462e-88e3-28ad15ec4e64","roleDefinitionId":"861776c5-e0df-4f95-be4f-ac1eec193323"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
+      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"},{"applicationId":"d87dcbc6-a371-462e-88e3-28ad15ec4e64","roleDefinitionId":"861776c5-e0df-4f95-be4f-ac1eec193323"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["East
+        Asia","Southeast Asia","Australia East","Australia Southeast","Japan East","Japan
+        West","Central India","South India","West India","West Europe","North Europe","Canada
+        Central","Canada East","Brazil South","West US","Central US","East US","South
+        Central US","East US 2","West Central US","North Central US","West US 2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
         US","Central US","East US","South Central US","West Europe","North Europe","East
         Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
         Central US","North Central US","Japan East","Japan West","Brazil South","Central
         India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"operations","locations":["West
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["East
+        Asia","Southeast Asia","Australia East","Australia Southeast","Japan East","Japan
+        West","Central India","South India","West India","West Europe","North Europe","Canada
+        Central","Canada East","Brazil South","West US","Central US","East US","South
+        Central US","East US 2","West Central US","North Central US","West US 2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"operations","locations":["West
         US","Central US","East US","South Central US","West Europe","North Europe","East
         Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
         Central US","North Central US","Japan East","Japan West","Brazil South","Central
@@ -232,177 +230,177 @@ http_interactions:
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/internalLoadBalancers","locations":[],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"domainNames/slots/roles/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"domainNames/slots/roles/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"domainNames/capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"domainNames/serviceCertificates","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
         US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
         Central","Canada East","UK South","UK West","West US","Central US","South
         Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
-        East","Australia Southeast","West US 2","West Central US","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        East","Australia Southeast","West US 2","West Central US","France Central","South
+        India","Central India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
         US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
         Central","Canada East","UK South","UK West","West US","Central US","South
         Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
-        East","Australia Southeast","West US 2","West Central US","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metrics","locations":["North
+        East","Australia Southeast","West US 2","West Central US","France Central","South
+        India","Central India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metrics","locations":["North
         Central US","South Central US","East US","East US 2","Canada Central","Canada
         East","West US","West US 2","West Central US","Central US","East Asia","Southeast
         Asia","North Europe","West Europe","UK South","UK West","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"resourceTypes","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"moveSubscriptionResources","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"validateSubscriptionMoveAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operationStatuses","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operatingSystems","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"operatingSystemFamilies","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicNetwork","namespace":"Microsoft.ClassicNetwork","resourceTypes":[{"resourceType":"virtualNetworks","locations":["East
+        India","West India","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"resourceTypes","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"moveSubscriptionResources","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"validateSubscriptionMoveAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operationStatuses","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operatingSystems","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"operatingSystemFamilies","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicNetwork","namespace":"Microsoft.ClassicNetwork","resourceTypes":[{"resourceType":"virtualNetworks","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"virtualNetworks/remoteVirtualNetworkPeeringProxies","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01"]},{"resourceType":"virtualNetworks/remoteVirtualNetworkPeeringProxies","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"reservedIps","locations":["East
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01"]},{"resourceType":"reservedIps","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"gatewaySupportedDevices","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"networkSecurityGroups","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"gatewaySupportedDevices","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"networkSecurityGroups","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicStorage","namespace":"Microsoft.ClassicStorage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"expressRouteCrossConnections","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"expressRouteCrossConnections/peerings","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicStorage","namespace":"Microsoft.ClassicStorage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkStorageAccountAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"storageAccounts/services","locations":["West
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkStorageAccountAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"storageAccounts/services","locations":["West
         US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
         Asia","Australia East","Australia Southeast","South India","Central India","West
         India","West US 2","West Central US","East US","East US 2","North Central
         US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
-        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/diagnosticSettings","locations":["West
+        South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/diagnosticSettings","locations":["West
         US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
         Asia","Australia East","Australia Southeast","South India","Central India","West
         India","West US 2","West Central US","East US","East US 2","North Central
         US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
-        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"disks","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"images","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"vmImages","locations":[],"apiVersions":["2016-11-01"]},{"resourceType":"publicImages","locations":[],"apiVersions":["2016-11-01","2016-04-01"]},{"resourceType":"osImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"osPlatformImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute","namespace":"Microsoft.Compute","authorizations":[{"applicationId":"60e6cd67-9c8c-4951-9b3c-23c25a2169af","roleDefinitionId":"e4770acb-272e-4dc8-87f3-12f44a612224"},{"applicationId":"a303894e-f1d8-4a37-bf10-67aa654a0596","roleDefinitionId":"903ac751-8ad5-4e5a-bfc2-5e49f450a241"},{"applicationId":"a8b6bf88-1d1a-4626-b040-9a729ea93c65","roleDefinitionId":"45c8267c-80ba-4b96-9a43-115b8f49fccd"}],"resourceTypes":[{"resourceType":"availabilitySets","locations":["East
+        South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"disks","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"images","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"vmImages","locations":[],"apiVersions":["2016-11-01"]},{"resourceType":"storageAccounts/vmImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"publicImages","locations":[],"apiVersions":["2016-11-01","2016-04-01"]},{"resourceType":"osImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"osPlatformImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute","namespace":"Microsoft.Compute","authorizations":[{"applicationId":"60e6cd67-9c8c-4951-9b3c-23c25a2169af","roleDefinitionId":"e4770acb-272e-4dc8-87f3-12f44a612224"},{"applicationId":"a303894e-f1d8-4a37-bf10-67aa654a0596","roleDefinitionId":"903ac751-8ad5-4e5a-bfc2-5e49f450a241"},{"applicationId":"a8b6bf88-1d1a-4626-b040-9a729ea93c65","roleDefinitionId":"45c8267c-80ba-4b96-9a43-115b8f49fccd"}],"resourceTypes":[{"resourceType":"availabilitySets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations/usages","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations/usages","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"sharedVMImages","locations":["West
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"sharedVMImages","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"sharedVMImages/versions","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"locations/capsoperations","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"disks","locations":["Southeast
@@ -410,27 +408,27 @@ http_interactions:
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"snapshots","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"snapshots","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"locations/diskoperations","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"locations/diskoperations","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"images","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"images","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"]},{"resourceType":"locations/logAnalytics","locations":["East
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"]},{"resourceType":"locations/logAnalytics","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
         US","East US","South Central US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
@@ -500,7 +498,10 @@ http_interactions:
         Central US","West Europe","North Europe","East US","UK West","UK South","West
         Central US","West US 2","South India","Central India","West India","Canada
         East","Canada Central","Korea South","Korea Central"],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"managedClusters","locations":["East
-        US","West Europe","Central US","Canada Central","Canada East"],"apiVersions":["2017-08-31"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
+        US","West Europe","Central US","Canada Central","Canada East"],"apiVersions":["2017-08-31"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operationresults","locations":["East
+        US","West Europe","Central US","UK West","UK South","West Central US","West
+        US 2","South India","Central India","West India","Canada East","Canada Central","Korea
+        South","Korea Central"],"apiVersions":["2017-08-31","2016-03-30"]},{"resourceType":"locations/operations","locations":["Japan
         East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
@@ -547,7 +548,12 @@ http_interactions:
         US","East Asia","East US","East US 2","Japan East","Japan West","North Central
         US","North Europe","South Central US","South India","Southeast Asia","West
         Central US","West Europe","West India","West US","West US 2","UK West","UK
-        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"},{"applicationId":"f5c26e74-f226-4ae8-85f0-b4af0080ac9e","roleDefinitionId":"529d7ae6-e892-4d43-809d-8547aeb90643"}],"resourceTypes":[{"resourceType":"components","locations":["East
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/consumergroups","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/disasterrecoveryconfigs","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"},{"applicationId":"f5c26e74-f226-4ae8-85f0-b4af0080ac9e","roleDefinitionId":"529d7ae6-e892-4d43-809d-8547aeb90643"}],"resourceTypes":[{"resourceType":"components","locations":["East
         US","South Central US","North Europe","West Europe","Southeast Asia","West
         US 2"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
         US","South Central US","North Europe","West Europe","Southeast Asia","West
@@ -563,7 +569,7 @@ http_interactions:
         US","South Central US","North Europe","West Europe","Southeast Asia","West
         US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"listMigrationdate","locations":["East
         US","South Central US","North Europe","West Europe","Southeast Asia","West
-        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2018-03-01","2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
@@ -614,32 +620,32 @@ http_interactions:
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/accessPolicies","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"vaults/accessPolicies","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-10-01","2015-06-01","2014-12-19-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"deletedVaults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01","2014-12-19-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"deletedVaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-10-01"]},{"resourceType":"locations/deletedVaults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations/deletedVaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
         Central US","West Europe","Southeast Asia","Japan East","West Central US"],"apiVersions":["2016-04-01"]},{"resourceType":"webServices","locations":["South
         Central US","West Europe","Southeast Asia","Japan East","East US 2","West
         Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"operations","locations":["South
@@ -665,97 +671,102 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"networkWatchers/lenses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"networkWatchers/lenses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2018-02-01","2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"ddosProtectionPlans","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","West
         US 2","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
@@ -846,7 +857,7 @@ http_interactions:
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
         West","Korea Central","Korea South"],"apiVersions":["2017-07-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ResourceHealth","namespace":"Microsoft.ResourceHealth","authorizations":[{"applicationId":"8bdebf23-c0fe-4187-a378-717ad86f6a53","roleDefinitionId":"cc026344-c8b1-4561-83ba-59eba84b27cc"}],"resourceTypes":[{"resourceType":"availabilityStatuses","locations":[],"apiVersions":["2017-07-01","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"notifications","locations":["Australia
-        Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Security","namespace":"Microsoft.Security","authorization":{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
+        Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Security","namespace":"Microsoft.Security","authorizations":[{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},{"applicationId":"fc780465-2017-40d4-a0c5-307022471b92"}],"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatuses","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/virtualMachines","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/endpoints","locations":["Central
@@ -898,620 +909,650 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Central India","South
         India"],"apiVersions":["2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Sql","namespace":"Microsoft.Sql","authorizations":[{"applicationId":"e4ab13ed-33cb-41b4-9140-6e264582cf85","roleDefinitionId":"ec3ddc95-44dc-47a2-9926-5e9f5ffd44ec"},{"applicationId":"0130cc9f-7ac5-4026-bd5f-80a08a54e6d9","roleDefinitionId":"45e8abf8-0ec4-44f3-9c37-cff4f7779302"},{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},{"applicationId":"76c7f279-7959-468f-8943-3954880e0d8c","roleDefinitionId":"7f7513a8-73f9-4c5f-97a2-c41f0ea783ef"}],"resourceTypes":[{"resourceType":"operations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/capabilities","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/databaseAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/databaseOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverKeyOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/keys","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/encryptionProtector","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/usages","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01","2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/communicationLinks","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administrators","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administratorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/restorableDroppedDatabases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recoverableDatabases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/geoBackupPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/importExportOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/operationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/backupLongTermRetentionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/automaticTuning","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/automaticTuning","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/databases/transparentDataEncryption","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recommendedElasticPools","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/auditingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/connectionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/connectionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies/rules","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/securityAlertPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/securityAlertPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/auditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/extendedAuditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/elasticpools","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-09-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/jobAgentOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/jobAgentAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/disasterRecoveryConfiguration","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/dnsAliases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/failoverGroups","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/virtualNetworkRules","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/virtualNetworkRulesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/virtualNetworkRulesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/databaseRestoreAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metricDefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/aggregatedDatabaseMetrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metricdefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries/queryText","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPools/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/extensions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPoolEstimates","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditRecords","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentScans","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/vulnerabilityAssessments","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessment","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/syncGroups","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups/syncMembers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/syncAgents","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"managedInstances/administrators","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/databases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metricDefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/administratorAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/administratorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncMemberOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncAgentOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncDatabaseIds","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorizations":[{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},{"applicationId":"e406a681-f3d4-42a8-90b6-c2b029497af1"}],"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/capabilities","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/databaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"locations/databaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverKeyOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/keys","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/encryptionProtector","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01","2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/communicationLinks","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/restorableDroppedDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recoverableDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/geoBackupPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/importExportOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/operationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/backupLongTermRetentionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/databases/transparentDataEncryption","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recommendedElasticPools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies/rules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/extendedAuditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/elasticPoolAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/elasticPoolOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/elasticpools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-09-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/jobAgentOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/jobAgentAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/disasterRecoveryConfiguration","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/dnsAliases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/failoverGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/virtualNetworkRules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/virtualNetworkRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/virtualNetworkRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/databaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/aggregatedDatabaseMetrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metricdefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries/queryText","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPools/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/extensions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPoolEstimates","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditRecords","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentScans","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/vulnerabilityAssessments","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessment","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/syncGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups/syncMembers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/syncAgents","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"managedInstances/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/administratorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncMemberOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncAgentOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncDatabaseIds","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/longTermRetentionPolicyOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionPolicyAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionBackupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionBackupAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorizations":[{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},{"applicationId":"e406a681-f3d4-42a8-90b6-c2b029497af1"}],"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/asyncoperations","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/asyncoperations","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/listAccountSas","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/listAccountSas","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/listServiceSas","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/listServiceSas","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/blobServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/blobServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/tableServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/tableServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/queueServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/queueServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/fileServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/fileServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01","2016-01-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01","2016-01-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
         US","West US","West Europe","North Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":["East
         US","West US","West Europe","North Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.visualstudio","namespace":"microsoft.visualstudio","authorization":{"applicationId":"499b84ac-1321-427f-aa17-267ca6975798","roleDefinitionId":"6a18f445-86f0-4e2e-b8a9-6b9b5677e3d8"},"resourceTypes":[{"resourceType":"account","locations":["North
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.visualstudio","namespace":"microsoft.visualstudio","authorization":{"applicationId":"499b84ac-1321-427f-aa17-267ca6975798","roleDefinitionId":"6a18f445-86f0-4e2e-b8a9-6b9b5677e3d8"},"resourceTypes":[{"resourceType":"account","locations":["North
         Central US","South Central US","East US","West US","Central US","North Europe","West
         Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
         East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/project","locations":["North
@@ -1795,12 +1836,12 @@ http_interactions:
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","Canada Central","Canada East","UK South","UK West","West US 2","West
-        Central US","South India","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","South India","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","South India","Canada Central","Canada East","UK South","UK West","West
-        US 2","West Central US","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Capacity","namespace":"Microsoft.Capacity","authorization":{"applicationId":"4d0ad6c7-f6c3-46d8-ab0d-1406d5e6c86b","roleDefinitionId":"FD9C0A9A-4DB9-4F41-8A61-98385DEB6E2D"},"resourceTypes":[{"resourceType":"resources","locations":["South
+        US 2","West Central US","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Capacity","namespace":"Microsoft.Capacity","authorization":{"applicationId":"4d0ad6c7-f6c3-46d8-ab0d-1406d5e6c86b","roleDefinitionId":"FD9C0A9A-4DB9-4F41-8A61-98385DEB6E2D"},"resourceTypes":[{"resourceType":"resources","locations":["South
         Central US"],"apiVersions":["2017-11-01"]},{"resourceType":"reservationOrders","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/reservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/reservations/revisions","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"catalogs","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"appliedReservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"checkOffers","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"checkScopes","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"calculatePrice","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/calculateRefund","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/return","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/split","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/merge","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"validateReservationOrder","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/availableScopes","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Cdn","namespace":"Microsoft.Cdn","resourceTypes":[{"resourceType":"profiles","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
@@ -1876,9 +1917,9 @@ http_interactions:
         2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/updateAccountsCreationSettings","locations":["West
         US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/accountsCreationSettings","locations":["West
         US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2016-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Commerce","namespace":"Microsoft.Commerce","resourceTypes":[{"resourceType":"UsageAggregates","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]},{"resourceType":"RateCard","locations":[],"apiVersions":["2016-08-31-preview","2015-06-01-preview","2015-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Consumption","namespace":"Microsoft.Consumption","resourceTypes":[{"resourceType":"ReservationSummaries","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationTransactions","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Balances","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Marketplaces","locations":[],"apiVersions":["2018-01-31"]},{"resourceType":"Pricesheets","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationDetails","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Budgets","locations":[],"apiVersions":["2018-01-31","2017-12-30-preview"]},{"resourceType":"Terms","locations":[],"apiVersions":["2018-01-31","2017-12-30-preview"]},{"resourceType":"UsageDetails","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview","2017-04-24-preview"]},{"resourceType":"Operations","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview","2017-04-24-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerInstance","namespace":"Microsoft.ContainerInstance","resourceTypes":[{"resourceType":"containerGroups","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/usages","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/operations","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/operations","locations":["West
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
         US"],"apiVersions":["2016-04-08"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.CustomerInsights","namespace":"Microsoft.CustomerInsights","authorization":{"applicationId":"38c77d00-5fcb-4cce-9d93-af4738258e3c","roleDefinitionId":"E006F9C7-F333-477C-8AD6-1F3A9FE87F55"},"resourceTypes":[{"resourceType":"hubs","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/profiles","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/interactions","locations":["East
@@ -1895,7 +1936,9 @@ http_interactions:
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"operations","locations":["East
         US 2"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Databricks","namespace":"Microsoft.Databricks","authorizations":[{"applicationId":"d9327919-6775-4843-9037-3fb0fb0473cb","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},{"applicationId":"2ff814a6-3304-4ab8-85cb-cd0e6f879c1d","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"}],"resourceTypes":[{"resourceType":"workspaces","locations":["West
         US","East US 2","West Europe","East US","North Europe","Southeast Asia","East
-        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]},{"resourceType":"locations","locations":["West
+        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2017-09-01-preview"]},{"resourceType":"workspaces/virtualNetworkPeerings","locations":["West
+        US","East US 2","West Europe","North Europe","East US","Southeast Asia","East
+        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01"]},{"resourceType":"locations","locations":["West
         US","East US 2","West Europe","North Europe","East US","Southeast Asia"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
         US","East US 2","West Europe","East US","North Europe","Southeast Asia","East
         Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataCatalog","namespace":"Microsoft.DataCatalog","resourceTypes":[{"resourceType":"catalogs","locations":["East
@@ -1919,23 +1962,26 @@ http_interactions:
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers/listSasTokens","locations":["East
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataLakeStore","namespace":"Microsoft.DataLakeStore","authorization":{"applicationId":"e9f49c6b-5ce5-44c8-925d-015017e9f7ad","roleDefinitionId":"17eb9cca-f08a-4499-b2d3-852d175f614f"},"resourceTypes":[{"resourceType":"accounts","locations":["East
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/firewallRules","locations":["East
-        US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataMigration","namespace":"Microsoft.DataMigration","authorization":{"applicationId":"a4bad4aa-bf02-4631-9f78-a64ffdba8150","roleDefinitionId":"b831a21d-db98-4760-89cb-bef871952df1","managedByRoleDefinitionId":"6256fb55-9e59-4018-a9e1-76b11c0a4c89"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services/projects","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationStatuses","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
+        US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataMigration","namespace":"Microsoft.DataMigration","authorization":{"applicationId":"a4bad4aa-bf02-4631-9f78-a64ffdba8150","roleDefinitionId":"b831a21d-db98-4760-89cb-bef871952df1","managedByRoleDefinitionId":"6256fb55-9e59-4018-a9e1-76b11c0a4c89"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services/projects","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationStatuses","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
-        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/recoverableServers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
@@ -1959,7 +2005,10 @@ http_interactions:
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
-        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/recoverableServers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
@@ -2015,12 +2064,7 @@ http_interactions:
         US 2","East US","West US","Central US","East US 2","West Central US","West
         Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
         US 2","East US","West US","Central US","East US 2","West Central US","West
-        Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","West
-        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
-        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
-        India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/consumergroups","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/disasterrecoveryconfigs","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
         US 2","South Central US","Central US","Australia Southeast","Central India","West
         Central US","West US 2","Canada East","Canada Central","Brazil South","UK
         South","UK West","East Asia","Australia East","Japan East","Japan West","North
@@ -2131,7 +2175,7 @@ http_interactions:
         West","Japan East","East Asia","Southeast Asia","West Europe","North Europe","East
         US","West US","Australia East","Australia Southeast","Central US","Brazil
         South","Central India","West India","South India","South Central US","Canada
-        Central","Canada East","West Central US","West US 2"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
+        Central","Canada East","West Central US","West US 2"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-05","2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
         Central US","East US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"operations","locations":["West
         Central US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
         Central US","East US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.PolicyInsights","namespace":"Microsoft.PolicyInsights","authorization":{"applicationId":"1d78a85d-813d-46f0-b496-dd72f50a3ec0","roleDefinitionId":"63d2b225-4c34-4641-8768-21a1f7c68ce8"},"resourceTypes":[{"resourceType":"policyEvents","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"policyStates","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
@@ -2163,12 +2207,12 @@ http_interactions:
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
         Central US","South Central US","North Europe","West Europe","East Asia","Southeast
         Asia","West US","East US","Japan West","Japan East","Brazil South","Central
         US","East US 2","Australia East","Australia Southeast","South India","Central
@@ -2193,7 +2237,8 @@ http_interactions:
         US","West US 2","East US","East US 2","North Europe","West Europe","Southeast
         Asia","East Asia","North Central US","South Central US","Japan West","Australia
         East","Brazil South","Central India","West Central US","Canada Central","UK
-        South"],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ServiceBus","namespace":"Microsoft.ServiceBus","authorization":{"applicationId":"80a10ef9-8168-493d-abf9-3297c4ef6e3c","roleDefinitionId":"2b7763f7-bbe2-4e19-befe-28c79f1cf7f7"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        South"],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.SecurityGraph","namespace":"Microsoft.SecurityGraph","resourceTypes":[{"resourceType":"operations","locations":["West
+        US"],"apiVersions":["2017-04-01-preview"]},{"resourceType":"diagnosticSettings","locations":[],"apiVersions":["2017-04-01-preview"]},{"resourceType":"diagnosticSettingsCategories","locations":[],"apiVersions":["2017-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ServiceBus","namespace":"Microsoft.ServiceBus","authorization":{"applicationId":"80a10ef9-8168-493d-abf9-3297c4ef6e3c","roleDefinitionId":"2b7763f7-bbe2-4e19-befe-28c79f1cf7f7"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US 2","West
         US","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
@@ -2208,52 +2253,62 @@ http_interactions:
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/clusterVersions","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"clusters/applications","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operations","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/clusterVersions","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/environments","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operations","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
         Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applianceDefinitions","locations":["West
         Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applications","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
-        Central US"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
+        Central US"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
-        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
-        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups","locations":["West
-        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
-        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups/cloudEndpoints","locations":["West
-        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
-        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups/serverEndpoints","locations":["West
-        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
-        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/registeredServers","locations":["West
-        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
-        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/workflows","locations":["West
-        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
-        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
+        US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
+        US","Canada Central","Canada East","Central US","East US 2","UK South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups","locations":["West
+        US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
+        US","Canada Central","Canada East","Central US","East US 2","UK South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups/cloudEndpoints","locations":["West
+        US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
+        US","Canada Central","Canada East","Central US","East US 2","UK South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups/serverEndpoints","locations":["West
+        US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
+        US","Canada Central","Canada East","Central US","East US 2","UK South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/registeredServers","locations":["West
+        US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
+        US","Canada Central","Canada East","Central US","East US 2","UK South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/workflows","locations":["West
+        US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
+        US","Canada Central","Canada East","Central US","East US 2","UK South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","West Central US","Japan East","Japan West","Australia East","Australia
         Southeast"],"apiVersions":["2017-06-01","2017-05-15","2017-01-01","2016-10-01","2016-06-01","2015-03-15","2014-09-01"]},{"resourceType":"operations","locations":["West
@@ -2332,10 +2387,10 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:27 GMT
+  recorded_at: Tue, 13 Mar 2018 09:00:11 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg?api-version=2018-03-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2349,7 +2404,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0ODUsIm5iZiI6MTUyMDQ1MzQ4NSwiZXhwIjoxNTIwNDU3Mzg1LCJhaW8iOiJZMk5nWU5qQnVUVng5OU1Kai9QZUY0akhQV2xXQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRTdpQ2NpUVhhMEdSMXpKbGRXWUFBQSIsInZlciI6IjEuMCJ9.Sw8vyzVAkb3ZDTyEmDxn8_UXnY9Kls8_RIAuJ2sQFfwB1KWik8WwG-Cf-ZhXtctp8QiEg78bosE4woFyHSXNH_20vGyOlFWKLDiPYQzaoC6bm_1ZF4nbBAwoiBIqLU_qBTrqEGrwif3DCxQK5L93XqK1_5znRfVkdVbehypI_wpSj16G1FAu4L-LWX8sJ_lsAgOdx5PAqIDO17DlMA1Wehi1o6X4_WyXfXAQzNHfTGk2USWjMlQkDYtrCgnAb2ZM4JkjrWfXA4TznHgKdb5Zk6nukZgFPZyeFOgt8NNbaI5RoBIBa9L6Q_1rbyGR_jAvAY6GUhGGXZ1tBZos_XWMGA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA5MzEzMDYsIm5iZiI6MTUyMDkzMTMwNiwiZXhwIjoxNTIwOTM1MjA2LCJhaW8iOiJZMk5nWUpnUWZrUk50TmxvODhvK0cwYUJLVXF6QVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiR3E1UURrbUFLa3lpRWVobk9HdzRBQSIsInZlciI6IjEuMCJ9.YGGsVkQULqdEK0f4YaXOxnwWAGe6kb-ODdKCorOt5aVeNejRQxpVVwvjroEU8mRNaEO-myIeVMj-ZWC6TFGSa5EtHinskLf6KZ8qqMBPGAY7dd1EqxbWh4-C6tzJVpSzFx0UGMC6KcheXVSqcgEMaUcTKGXZ-sZd4v6TYz4T5LWHpgxJ0IzQEtddHROT9huvKFadzxoEBDPVX69rJMZm4gbrZ-4zJZhYaS013tVhrR8bUJeGxINjtQaZEWRTiB_Mr9jKtc18zYK3wOib2Vv16QUhycc7HUWVmwwPjIGmA_ihKR6ZXsd_ofmTvdLH5GcY3YI9F9rLGFR_0ai_WTjFVA
   response:
     status:
       code: 200
@@ -2366,370 +2421,109 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67"
+      - W/"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 717fb338-a866-44fa-ac06-99bb8e2c777e
+      - baa5dd2a-2794-449b-be6e-3de06c5c9f84
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14991'
+      - '14919'
       X-Ms-Correlation-Request-Id:
-      - ca20d417-d127-475c-9ba9-72f152e4bd7e
+      - 0c53e83c-8df6-4a00-a14b-8d6a73becc05
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201628Z:ca20d417-d127-475c-9ba9-72f152e4bd7e
+      - WESTEUROPE:20180313T090016Z:0c53e83c-8df6-4a00-a14b-8d6a73becc05
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:16:27 GMT
+      - Tue, 13 Mar 2018 09:00:15 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1\",\r\n
-        \ \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"7ab88756-810f-4083-95db-8b05d50e38f2\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
+      string: "{\r\n  \"name\": \"miqazure-linux-managed-nsg\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg\",\r\n
+        \ \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/networkSecurityGroups\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
+        \"b4611f96-94a8-4486-94c5-16bb6c7a5c84\",\r\n    \"securityRules\": [\r\n
+        \     {\r\n        \"name\": \"default-allow-ssh\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/securityRules/default-allow-ssh\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ],\r\n          \"inboundNatRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
+        \         \"protocol\": \"TCP\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"22\",\r\n          \"sourceAddressPrefix\":
+        \"*\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n          \"access\":
+        \"Allow\",\r\n          \"priority\": 1000,\r\n          \"direction\": \"Inbound\",\r\n
+        \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      }\r\n    ],\r\n    \"defaultSecurityRules\": [\r\n
+        \     {\r\n        \"name\": \"AllowVnetInBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/AllowVnetInBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"backendIPConfigurations\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\"\r\n
-        \           }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-rule\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
+        \         \"description\": \"Allow inbound traffic from all VMs in VNET\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"VirtualNetwork\",\r\n          \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n          \"direction\":
+        \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowAzureLoadBalancerInBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/AllowAzureLoadBalancerInBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\":
-        80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\"\r\n
-        \         },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n
-        \       \"name\": \"rspec-lb-probe\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
+        \         \"description\": \"Allow inbound traffic from azure load balancer\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"AzureLoadBalancer\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65001,\r\n          \"direction\":
+        \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllInBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/DenyAllInBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-NAT\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
+        \         \"description\": \"Deny all inbound traffic\",\r\n          \"protocol\":
+        \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\":
+        \"*\",\r\n          \"sourceAddressPrefix\": \"*\",\r\n          \"destinationAddressPrefix\":
+        \"*\",\r\n          \"access\": \"Deny\",\r\n          \"priority\": 65500,\r\n
+        \         \"direction\": \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n
+        \         \"destinationPortRanges\": [],\r\n          \"sourceAddressPrefixes\":
+        [],\r\n          \"destinationAddressPrefixes\": []\r\n        }\r\n      },\r\n
+        \     {\r\n        \"name\": \"AllowVnetOutBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/AllowVnetOutBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 3441,\r\n          \"backendPort\":
-        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
+        \         \"description\": \"Allow outbound traffic from all VMs to all VMs
+        in VNET\",\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\":
+        \"*\",\r\n          \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"VirtualNetwork\",\r\n          \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n          \"direction\":
+        \"Outbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowInternetOutBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/AllowInternetOutBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow outbound traffic from all VMs to Internet\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"*\",\r\n          \"destinationAddressPrefix\": \"Internet\",\r\n          \"access\":
+        \"Allow\",\r\n          \"priority\": 65001,\r\n          \"direction\": \"Outbound\",\r\n
+        \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllOutBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/DenyAllOutBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Deny all outbound traffic\",\r\n          \"protocol\":
+        \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\":
+        \"*\",\r\n          \"sourceAddressPrefix\": \"*\",\r\n          \"destinationAddressPrefix\":
+        \"*\",\r\n          \"access\": \"Deny\",\r\n          \"priority\": 65500,\r\n
+        \         \"direction\": \"Outbound\",\r\n          \"sourcePortRanges\":
+        [],\r\n          \"destinationPortRanges\": [],\r\n          \"sourceAddressPrefixes\":
+        [],\r\n          \"destinationAddressPrefixes\": []\r\n        }\r\n      }\r\n
+        \   ],\r\n    \"networkInterfaces\": [\r\n      {\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944\"\r\n
+        \     }\r\n    ]\r\n  }\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:28 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0ODUsIm5iZiI6MTUyMDQ1MzQ4NSwiZXhwIjoxNTIwNDU3Mzg1LCJhaW8iOiJZMk5nWU5qQnVUVng5OU1Kai9QZUY0akhQV2xXQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRTdpQ2NpUVhhMEdSMXpKbGRXWUFBQSIsInZlciI6IjEuMCJ9.Sw8vyzVAkb3ZDTyEmDxn8_UXnY9Kls8_RIAuJ2sQFfwB1KWik8WwG-Cf-ZhXtctp8QiEg78bosE4woFyHSXNH_20vGyOlFWKLDiPYQzaoC6bm_1ZF4nbBAwoiBIqLU_qBTrqEGrwif3DCxQK5L93XqK1_5znRfVkdVbehypI_wpSj16G1FAu4L-LWX8sJ_lsAgOdx5PAqIDO17DlMA1Wehi1o6X4_WyXfXAQzNHfTGk2USWjMlQkDYtrCgnAb2ZM4JkjrWfXA4TznHgKdb5Zk6nukZgFPZyeFOgt8NNbaI5RoBIBa9L6Q_1rbyGR_jAvAY6GUhGGXZ1tBZos_XWMGA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 7e79cb6b-c7e3-4259-95ec-cfb0ec18d9a4
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14977'
-      X-Ms-Correlation-Request-Id:
-      - c4eccdc2-7c76-4f7f-af6c-eb5bffa56c81
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201628Z:c4eccdc2-7c76-4f7f-af6c-eb5bffa56c81
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:16:28 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1\",\r\n
-        \ \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"7ab88756-810f-4083-95db-8b05d50e38f2\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ],\r\n          \"inboundNatRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"backendIPConfigurations\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\"\r\n
-        \           }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-rule\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\":
-        80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\"\r\n
-        \         },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n
-        \       \"name\": \"rspec-lb-probe\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-NAT\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 3441,\r\n          \"backendPort\":
-        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:28 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0ODUsIm5iZiI6MTUyMDQ1MzQ4NSwiZXhwIjoxNTIwNDU3Mzg1LCJhaW8iOiJZMk5nWU5qQnVUVng5OU1Kai9QZUY0akhQV2xXQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRTdpQ2NpUVhhMEdSMXpKbGRXWUFBQSIsInZlciI6IjEuMCJ9.Sw8vyzVAkb3ZDTyEmDxn8_UXnY9Kls8_RIAuJ2sQFfwB1KWik8WwG-Cf-ZhXtctp8QiEg78bosE4woFyHSXNH_20vGyOlFWKLDiPYQzaoC6bm_1ZF4nbBAwoiBIqLU_qBTrqEGrwif3DCxQK5L93XqK1_5znRfVkdVbehypI_wpSj16G1FAu4L-LWX8sJ_lsAgOdx5PAqIDO17DlMA1Wehi1o6X4_WyXfXAQzNHfTGk2USWjMlQkDYtrCgnAb2ZM4JkjrWfXA4TznHgKdb5Zk6nukZgFPZyeFOgt8NNbaI5RoBIBa9L6Q_1rbyGR_jAvAY6GUhGGXZ1tBZos_XWMGA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 1548de99-1985-493f-803f-3f70c866a45b
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14981'
-      X-Ms-Correlation-Request-Id:
-      - 57f7bc24-3192-4942-9f1a-b716d6581728
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201629Z:57f7bc24-3192-4942-9f1a-b716d6581728
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:16:28 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1\",\r\n
-        \ \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"7ab88756-810f-4083-95db-8b05d50e38f2\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ],\r\n          \"inboundNatRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"backendIPConfigurations\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\"\r\n
-        \           }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-rule\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\":
-        80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\"\r\n
-        \         },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n
-        \       \"name\": \"rspec-lb-probe\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-NAT\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 3441,\r\n          \"backendPort\":
-        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:29 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0ODUsIm5iZiI6MTUyMDQ1MzQ4NSwiZXhwIjoxNTIwNDU3Mzg1LCJhaW8iOiJZMk5nWU5qQnVUVng5OU1Kai9QZUY0akhQV2xXQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRTdpQ2NpUVhhMEdSMXpKbGRXWUFBQSIsInZlciI6IjEuMCJ9.Sw8vyzVAkb3ZDTyEmDxn8_UXnY9Kls8_RIAuJ2sQFfwB1KWik8WwG-Cf-ZhXtctp8QiEg78bosE4woFyHSXNH_20vGyOlFWKLDiPYQzaoC6bm_1ZF4nbBAwoiBIqLU_qBTrqEGrwif3DCxQK5L93XqK1_5znRfVkdVbehypI_wpSj16G1FAu4L-LWX8sJ_lsAgOdx5PAqIDO17DlMA1Wehi1o6X4_WyXfXAQzNHfTGk2USWjMlQkDYtrCgnAb2ZM4JkjrWfXA4TznHgKdb5Zk6nukZgFPZyeFOgt8NNbaI5RoBIBa9L6Q_1rbyGR_jAvAY6GUhGGXZ1tBZos_XWMGA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"a38434c8-7b23-4092-b7c6-402238eac0dc"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - ed59d0d4-722d-4977-86ac-42ae3a815a92
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14982'
-      X-Ms-Correlation-Request-Id:
-      - 1522997e-1902-4500-b8de-8a8dac5c69b7
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201629Z:1522997e-1902-4500-b8de-8a8dac5c69b7
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:16:28 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb1-LoadBalancerFrontEnd\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\",\r\n
-        \ \"etag\": \"W/\\\"a38434c8-7b23-4092-b7c6-402238eac0dc\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"f28e0f25-b372-4edf-97d9-13a9e3b4ba2d\",\r\n    \"ipAddress\":
-        \"40.71.82.83\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\":
-        \"Static\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipTags\": [],\r\n
-        \   \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
-        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:29 GMT
+  recorded_at: Tue, 13 Mar 2018 09:00:16 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_500/template_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_500/template_refresh.yml
@@ -1,6 +1,62 @@
 ---
 http_interactions:
 - request:
+    method: post
+    uri: https://login.microsoftonline.com/AZURE_TENANT_ID/oauth2/token
+    body:
+      encoding: UTF-8
+      string: grant_type=client_credentials&client_id=AZURE_CLIENT_ID&client_secret=AZURE_CLIENT_SECRET&resource=https%3A%2F%2Fmanagement.azure.com%2F
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Server:
+      - Microsoft-IIS/10.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Request-Id:
+      - 11ff2321-26ba-4d02-a4df-95da871f1600
+      P3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Set-Cookie:
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzaenYWZ77143WKGTczBVpskypR59PvKG2RnRlQzSz9w8GGM8uWtJ7A2q6KcQnC4-md2eFNvV44D5AarnU7vwe_Duemi_g1apBIs_4wpdxUletM4TKC4qFFrt7fjoY8BJjgg8XaO-Y857xV3c3h86hrjRjT-AQ9nrb0DeN1KUPV8IgAA;
+        domain=.login.microsoftonline.com; path=/; secure; HttpOnly
+      - stsservicecookie=ests; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=007; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 12 Mar 2018 09:40:13 GMT
+      Content-Length:
+      - '1505'
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1520851213","not_before":"1520847313","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDczMTMsIm5iZiI6MTUyMDg0NzMxMywiZXhwIjoxNTIwODUxMjEzLCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSVNQX0Vib21BazJrMzVYYWh4OFdBQSIsInZlciI6IjEuMCJ9.Wu6fVB9E0uRasF_-32jZU8DB0Qxro_-3yuzu9fA5RBm6kNh4wr7dgXmHtzXXz5qgU0xIIO6PJ5R75gsyokGELyqaa9pddZLgambowSG-EHNVrEHlkc-OsoVUjZ8sk3xoPomz3T1C1YhVRn9VsR93oqzZ-DFfkffvePpipNJsJJUVc2ZySS9L6vngQ46sfO9D5i0fcR-o5gez9isdIehot_wG6wl7MN-keGyF8DpqZOHtGjOt39pCqZTj8EjVEAKQvkDQkz5CCqH6dpcRZKdYuFvH2saWx8wzsU3LKx86DDCpwLczSqL-ltc9nfmmQasO3HHvCNsUiRHitwO7FA3iZw"}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:40:18 GMT
+- request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
     body:
@@ -16,7 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDczMTMsIm5iZiI6MTUyMDg0NzMxMywiZXhwIjoxNTIwODUxMjEzLCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSVNQX0Vib21BazJrMzVYYWh4OFdBQSIsInZlciI6IjEuMCJ9.Wu6fVB9E0uRasF_-32jZU8DB0Qxro_-3yuzu9fA5RBm6kNh4wr7dgXmHtzXXz5qgU0xIIO6PJ5R75gsyokGELyqaa9pddZLgambowSG-EHNVrEHlkc-OsoVUjZ8sk3xoPomz3T1C1YhVRn9VsR93oqzZ-DFfkffvePpipNJsJJUVc2ZySS9L6vngQ46sfO9D5i0fcR-o5gez9isdIehot_wG6wl7MN-keGyF8DpqZOHtGjOt39pCqZTj8EjVEAKQvkDQkz5CCqH6dpcRZKdYuFvH2saWx8wzsU3LKx86DDCpwLczSqL-ltc9nfmmQasO3HHvCNsUiRHitwO7FA3iZw
   response:
     status:
       code: 200
@@ -35,26 +91,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14997'
+      - '14999'
       X-Ms-Request-Id:
-      - cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - 73a77cf8-c880-4706-abcc-75bc6dfe9cd6
       X-Ms-Correlation-Request-Id:
-      - cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - 73a77cf8-c880-4706-abcc-75bc6dfe9cd6
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102417Z:cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - WESTEUROPE:20180312T094014Z:73a77cf8-c880-4706-abcc-75bc6dfe9cd6
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:17 GMT
+      - Mon, 12 Mar 2018 09:40:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID","subscriptionId":"AZURE_SUBSCRIPTION_ID","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:22 GMT
+  recorded_at: Mon, 12 Mar 2018 09:40:18 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers?api-version=2015-01-01
@@ -71,7 +127,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDczMTMsIm5iZiI6MTUyMDg0NzMxMywiZXhwIjoxNTIwODUxMjEzLCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSVNQX0Vib21BazJrMzVYYWh4OFdBQSIsInZlciI6IjEuMCJ9.Wu6fVB9E0uRasF_-32jZU8DB0Qxro_-3yuzu9fA5RBm6kNh4wr7dgXmHtzXXz5qgU0xIIO6PJ5R75gsyokGELyqaa9pddZLgambowSG-EHNVrEHlkc-OsoVUjZ8sk3xoPomz3T1C1YhVRn9VsR93oqzZ-DFfkffvePpipNJsJJUVc2ZySS9L6vngQ46sfO9D5i0fcR-o5gez9isdIehot_wG6wl7MN-keGyF8DpqZOHtGjOt39pCqZTj8EjVEAKQvkDQkz5CCqH6dpcRZKdYuFvH2saWx8wzsU3LKx86DDCpwLczSqL-ltc9nfmmQasO3HHvCNsUiRHitwO7FA3iZw
   response:
     status:
       code: 200
@@ -88,19 +144,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - '14995'
       X-Ms-Request-Id:
-      - fe3532ca-59a2-474e-9094-8a3697b82bef
+      - ce9b109d-f6a3-4fa5-bd18-25729a5935a4
       X-Ms-Correlation-Request-Id:
-      - fe3532ca-59a2-474e-9094-8a3697b82bef
+      - ce9b109d-f6a3-4fa5-bd18-25729a5935a4
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102419Z:fe3532ca-59a2-474e-9094-8a3697b82bef
+      - WESTEUROPE:20180312T094016Z:ce9b109d-f6a3-4fa5-bd18-25729a5935a4
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:18 GMT
+      - Mon, 12 Mar 2018 09:40:15 GMT
       Content-Length:
       - '320853'
     body:
@@ -2322,10 +2378,10 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:23 GMT
+  recorded_at: Mon, 12 Mar 2018 09:40:20 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Storage/storageAccounts?api-version=2017-10-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2339,7 +2395,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDczMTMsIm5iZiI6MTUyMDg0NzMxMywiZXhwIjoxNTIwODUxMjEzLCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSVNQX0Vib21BazJrMzVYYWh4OFdBQSIsInZlciI6IjEuMCJ9.Wu6fVB9E0uRasF_-32jZU8DB0Qxro_-3yuzu9fA5RBm6kNh4wr7dgXmHtzXXz5qgU0xIIO6PJ5R75gsyokGELyqaa9pddZLgambowSG-EHNVrEHlkc-OsoVUjZ8sk3xoPomz3T1C1YhVRn9VsR93oqzZ-DFfkffvePpipNJsJJUVc2ZySS9L6vngQ46sfO9D5i0fcR-o5gez9isdIehot_wG6wl7MN-keGyF8DpqZOHtGjOt39pCqZTj8EjVEAKQvkDQkz5CCqH6dpcRZKdYuFvH2saWx8wzsU3LKx86DDCpwLczSqL-ltc9nfmmQasO3HHvCNsUiRHitwO7FA3iZw
   response:
     status:
       code: 200
@@ -2349,96 +2405,36 @@ http_interactions:
       - no-cache
       Pragma:
       - no-cache
-      Transfer-Encoding:
-      - chunked
       Content-Type:
       - application/json; charset=utf-8
       Expires:
       - "-1"
-      Etag:
-      - W/"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - '080de667-081e-4d58-9e94-9e7243d4200e'
+      - 3f5ab862-c831-4cfe-84a0-4c4ec61446d8
+      X-Ms-Correlation-Request-Id:
+      - 3f5ab862-c831-4cfe-84a0-4c4ec61446d8
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T094018Z:3f5ab862-c831-4cfe-84a0-4c4ec61446d8
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Correlation-Request-Id:
-      - '093d49ac-c85f-440e-956b-955b6698dd19'
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102419Z:093d49ac-c85f-440e-956b-955b6698dd19
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:19 GMT
+      - Mon, 12 Mar 2018 09:40:18 GMT
+      Content-Length:
+      - '8649'
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1\",\r\n
-        \ \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"7ab88756-810f-4083-95db-8b05d50e38f2\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ],\r\n          \"inboundNatRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"backendIPConfigurations\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\"\r\n
-        \           }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-rule\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\":
-        80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\"\r\n
-        \         },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n
-        \       \"name\": \"rspec-lb-probe\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-NAT\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 3441,\r\n          \"backendPort\":
-        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
+      string: '{"value":[{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","name":"miqazuretest18686","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T17:22:54.7808677Z","primaryEndpoints":{"blob":"https://miqazuretest18686.blob.core.windows.net/","queue":"https://miqazuretest18686.queue.core.windows.net/","table":"https://miqazuretest18686.table.core.windows.net/","file":"https://miqazuretest18686.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","name":"miqazuretest14047","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T17:30:25.7028008Z","primaryEndpoints":{"blob":"https://miqazuretest14047.blob.core.windows.net/","queue":"https://miqazuretest14047.queue.core.windows.net/","table":"https://miqazuretest14047.table.core.windows.net/","file":"https://miqazuretest14047.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Premium_LRS","tier":"Premium"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb","name":"rspeclb","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-09-02T16:29:11.6823797Z","primaryEndpoints":{"blob":"https://rspeclb.blob.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","name":"spec0deply1stor","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-04-04T23:05:07.8274794Z","primaryEndpoints":{"blob":"https://spec0deply1stor.blob.core.windows.net/","queue":"https://spec0deply1stor.queue.core.windows.net/","table":"https://spec0deply1stor.table.core.windows.net/","file":"https://spec0deply1stor.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Storage/storageAccounts/miqazuretest26611","name":"miqazuretest26611","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2211656Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2211656Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-05-02T18:01:29.2743021Z","primaryEndpoints":{"blob":"https://miqazuretest26611.blob.core.windows.net/","queue":"https://miqazuretest26611.queue.core.windows.net/","table":"https://miqazuretest26611.table.core.windows.net/","file":"https://miqazuretest26611.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","name":"miqazuretest16487","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T17:26:55.3231669Z","primaryEndpoints":{"blob":"https://miqazuretest16487.blob.core.windows.net/","queue":"https://miqazuretest16487.queue.core.windows.net/","table":"https://miqazuretest16487.table.core.windows.net/","file":"https://miqazuretest16487.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Storage/storageAccounts/miqazuretest32946","name":"miqazuretest32946","type":"Microsoft.Storage/storageAccounts","location":"westus","tags":{"delete":"false"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.0404359Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.0404359Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T21:18:37.0793411Z","primaryEndpoints":{"blob":"https://miqazuretest32946.blob.core.windows.net/","queue":"https://miqazuretest32946.queue.core.windows.net/","table":"https://miqazuretest32946.table.core.windows.net/","file":"https://miqazuretest32946.file.core.windows.net/"},"primaryLocation":"westus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Storage/storageAccounts/miqazureshared1","name":"miqazureshared1","type":"Microsoft.Storage/storageAccounts","location":"centralus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.1935084Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.1935084Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T20:42:52.498085Z","primaryEndpoints":{"blob":"https://miqazureshared1.blob.core.windows.net/","queue":"https://miqazureshared1.queue.core.windows.net/","table":"https://miqazureshared1.table.core.windows.net/","file":"https://miqazureshared1.file.core.windows.net/"},"primaryLocation":"centralus","statusOfPrimary":"available","secondaryLocation":"eastus2","statusOfSecondary":"available","secondaryEndpoints":{"blob":"https://miqazureshared1-secondary.blob.core.windows.net/","queue":"https://miqazureshared1-secondary.queue.core.windows.net/","table":"https://miqazureshared1-secondary.table.core.windows.net/"}}}]}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:24 GMT
+  recorded_at: Mon, 12 Mar 2018 09:40:23 GMT
 - request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2?api-version=2018-01-01
+    method: post
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686/listKeys?api-version=2017-10-01
     body:
-      encoding: US-ASCII
+      encoding: ASCII-8BIT
       string: ''
     headers:
       Accept:
@@ -2450,7 +2446,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDczMTMsIm5iZiI6MTUyMDg0NzMxMywiZXhwIjoxNTIwODUxMjEzLCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSVNQX0Vib21BazJrMzVYYWh4OFdBQSIsInZlciI6IjEuMCJ9.Wu6fVB9E0uRasF_-32jZU8DB0Qxro_-3yuzu9fA5RBm6kNh4wr7dgXmHtzXXz5qgU0xIIO6PJ5R75gsyokGELyqaa9pddZLgambowSG-EHNVrEHlkc-OsoVUjZ8sk3xoPomz3T1C1YhVRn9VsR93oqzZ-DFfkffvePpipNJsJJUVc2ZySS9L6vngQ46sfO9D5i0fcR-o5gez9isdIehot_wG6wl7MN-keGyF8DpqZOHtGjOt39pCqZTj8EjVEAKQvkDQkz5CCqH6dpcRZKdYuFvH2saWx8wzsU3LKx86DDCpwLczSqL-ltc9nfmmQasO3HHvCNsUiRHitwO7FA3iZw
+      Content-Length:
+      - '0'
   response:
     status:
       code: 200
@@ -2463,63 +2461,129 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Content-Type:
-      - application/json; charset=utf-8
+      - application/json
       Expires:
       - "-1"
-      Etag:
-      - W/"7a8e5fe7-f777-4435-992b-a54f28c2f28c"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - bd22ca22-a01f-4ecf-9230-a4558fb66931
+      - c33bdfa6-ac5b-4919-99d8-fc6cee8ff15e
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Writes:
+      - '1198'
       X-Ms-Correlation-Request-Id:
-      - 19c674a8-c8da-4b5e-8265-5ebc21926459
+      - 39c18185-1d23-41ef-998b-dc7a60bf321e
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102420Z:19c674a8-c8da-4b5e-8265-5ebc21926459
+      - WESTEUROPE:20180312T094019Z:39c18185-1d23-41ef-998b-dc7a60bf321e
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:19 GMT
+      - Mon, 12 Mar 2018 09:40:19 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb2\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2\",\r\n
-        \ \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"e2e30a77-f81b-43fc-9693-08303e43deed\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/backendAddressPools/rspec-lb2-pool\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\r\n
-        \       }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\": [],\r\n    \"probes\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-probe\",\r\n        \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/probes/rspec-lb2-probe\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\": [],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
+      string: '{"keys":[{"keyName":"key1","value":"32PV5jeBt8nw1XvFbZokY26SXchbD6H2tw/YrteEYVE0kpMLKrZ74VrwaIjDyucdi/RxDaAlf7dJIilLS7muNw==","permissions":"Full"},{"keyName":"key2","value":"Eo5x9CQJL1/wl6Tkj5N7M5eEdw6Hym6AeyTt3xjcDl30sV8Iadro6ywZzOHQwNDlmrDaBF6x2a9ZFL7zswxQ7w==","permissions":"Full"}]}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:25 GMT
+  recorded_at: Mon, 12 Mar 2018 09:40:24 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd?api-version=2018-01-01
+    uri: https://miqazuretest18686.blob.core.windows.net/?comp=list
     body:
       encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:40:24 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Authorization:
+      - SharedKey miqazuretest18686:mTbqVIRtde4/0et/2LkkgohmSwmAJ1eWjwWzX2bXAnk=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/xml
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 5117bb64-001e-0054-73e6-b9ccf5000000
+      X-Ms-Version:
+      - '2016-05-31'
+      Date:
+      - Mon, 12 Mar 2018 09:40:19 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9taXFhenVyZXRlc3QxODY4Ni5ibG9iLmNvcmUud2luZG93cy5uZXQvIj48Q29udGFpbmVycz48Q29udGFpbmVyPjxOYW1lPmJvb3RkaWFnbm9zdGljcy1taXF0ZXN0cmgtMDNlODQ2N2ItYmFhYi00ODY3LTljYzQtMTU3MzM2YjdlMmU0PC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPkZyaSwgMTggTWFyIDIwMTYgMTc6MjM6MjggR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPiIweDhEMzRGNTIwNTFCRENDMCI8L0V0YWc+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQ29udGFpbmVyPjxDb250YWluZXI+PE5hbWU+dmhkczwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5GcmksIDE4IE1hciAyMDE2IDE3OjIzOjI4IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4iMHg4RDM0RjUyMDU0RDgwMDUiPC9FdGFnPjxMZWFzZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJhdGlvbj5pbmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48L1Byb3BlcnRpZXM+PC9Db250YWluZXI+PC9Db250YWluZXJzPjxOZXh0TWFya2VyIC8+PC9FbnVtZXJhdGlvblJlc3VsdHM+
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:40:24 GMT
+- request:
+    method: get
+    uri: https://miqazuretest18686.blob.core.windows.net/vhds?comp=list&restype=container
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:40:24 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Authorization:
+      - SharedKey miqazuretest18686:zeExlPlo7bY7NEZLMpxGdojO5cpX4PKWBblHy6Cp2uk=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/xml
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 3bf0b13c-001e-00e4-75e6-b93575000000
+      X-Ms-Version:
+      - '2016-05-31'
+      Date:
+      - Mon, 12 Mar 2018 09:40:20 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9taXFhenVyZXRlc3QxODY4Ni5ibG9iLmNvcmUud2luZG93cy5uZXQvIiBDb250YWluZXJOYW1lPSJ2aGRzIj48QmxvYnM+PEJsb2I+PE5hbWU+bWlxLXRlc3QtcmhlbDEyMDE2MjE4MTEyMjQzLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5Nb24sIDEyIE1hciAyMDE4IDA5OjQwOjE5IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhENTg3RkQ0NEVBQkZCQzwvRXRhZz48Q29udGVudC1MZW5ndGg+MzIyMTIyNTUyMzI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5kUUwrWEhqRk5QZG9NRXdlSTYzZndRPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4zNzI8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+bG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5sZWFzZWQ8L0xlYXNlU3RhdGU+PExlYXNlRHVyYXRpb24+aW5maW5pdGU8L0xlYXNlRHVyYXRpb24+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PC9CbG9icz48TmV4dE1hcmtlciAvPjwvRW51bWVyYXRpb25SZXN1bHRzPg==
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:40:25 GMT
+- request:
+    method: post
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047/listKeys?api-version=2017-10-01
+    body:
+      encoding: ASCII-8BIT
       string: ''
     headers:
       Accept:
@@ -2531,7 +2595,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDczMTMsIm5iZiI6MTUyMDg0NzMxMywiZXhwIjoxNTIwODUxMjEzLCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSVNQX0Vib21BazJrMzVYYWh4OFdBQSIsInZlciI6IjEuMCJ9.Wu6fVB9E0uRasF_-32jZU8DB0Qxro_-3yuzu9fA5RBm6kNh4wr7dgXmHtzXXz5qgU0xIIO6PJ5R75gsyokGELyqaa9pddZLgambowSG-EHNVrEHlkc-OsoVUjZ8sk3xoPomz3T1C1YhVRn9VsR93oqzZ-DFfkffvePpipNJsJJUVc2ZySS9L6vngQ46sfO9D5i0fcR-o5gez9isdIehot_wG6wl7MN-keGyF8DpqZOHtGjOt39pCqZTj8EjVEAKQvkDQkz5CCqH6dpcRZKdYuFvH2saWx8wzsU3LKx86DDCpwLczSqL-ltc9nfmmQasO3HHvCNsUiRHitwO7FA3iZw
+      Content-Length:
+      - '0'
   response:
     status:
       code: 200
@@ -2544,48 +2610,3200 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Content-Type:
-      - application/json; charset=utf-8
+      - application/json
       Expires:
       - "-1"
-      Etag:
-      - W/"a38434c8-7b23-4092-b7c6-402238eac0dc"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 0fd15240-6a1c-4b39-a4f6-aa53fd8591c2
+      - 4de02b11-a0a7-4c0e-bd7b-bb54d338474a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Writes:
+      - '1199'
       X-Ms-Correlation-Request-Id:
-      - 5cc03163-922e-41a1-9601-dba2d7cf2a81
+      - ad90292b-3d34-4880-8966-e6f00585d8e4
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102421Z:5cc03163-922e-41a1-9601-dba2d7cf2a81
+      - WESTEUROPE:20180312T094021Z:ad90292b-3d34-4880-8966-e6f00585d8e4
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:20 GMT
+      - Mon, 12 Mar 2018 09:40:20 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb1-LoadBalancerFrontEnd\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\",\r\n
-        \ \"etag\": \"W/\\\"a38434c8-7b23-4092-b7c6-402238eac0dc\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"f28e0f25-b372-4edf-97d9-13a9e3b4ba2d\",\r\n    \"ipAddress\":
-        \"40.71.82.83\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\":
-        \"Static\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipTags\": [],\r\n
-        \   \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
-        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
+      string: '{"keys":[{"keyName":"key1","value":"9hGLwV9mjvAc1ARzeGwpsS9oZPLqOBzHCCHjeixyt1wpPYVn32cXmm3Gs9ogFPXZhDH61PAXxud0Dg/qwOnJ1w==","permissions":"Full"},{"keyName":"key2","value":"FfW8btVjJE2LkKHvN8Prr3FDX71BrS4SnMkONq2fLVPPm6x7vqqjeDSWDh17aI4CBLYf3Y1pc6njkbz53HdMYg==","permissions":"Full"}]}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:25 GMT
+  recorded_at: Mon, 12 Mar 2018 09:40:26 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip?api-version=2018-01-01
+    uri: https://miqazuretest14047.blob.core.windows.net/?comp=list
     body:
       encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:40:26 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Authorization:
+      - SharedKey miqazuretest14047:ohkhHD8LXsEbUG/Fbm6hrJeRM0uaCwMOb5FRxIlS5ZM=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/xml
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 74a3d2f0-001e-009c-53e6-b95dc2000000
+      X-Ms-Version:
+      - '2016-05-31'
+      Date:
+      - Mon, 12 Mar 2018 09:40:22 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9taXFhenVyZXRlc3QxNDA0Ny5ibG9iLmNvcmUud2luZG93cy5uZXQvIj48Q29udGFpbmVycz48Q29udGFpbmVyPjxOYW1lPmJvb3RkaWFnbm9zdGljcy1taXFhenVyZWMtNzk2YzViY2MtMzM4YS00NDhkLWI2MWMtMTY1Mjc5YTdmYjNlPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPk1vbiwgMjEgTWFyIDIwMTYgMTY6NTA6MTMgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPiIweDhEMzUxQThERjlBNjcxNCI8L0V0YWc+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQ29udGFpbmVyPjxDb250YWluZXI+PE5hbWU+Ym9vdGRpYWdub3N0aWNzLW1pcXRlc3R3aS02ZTU1NWI4OC0zZmQ0LTRiNzItYTQwNC00YmJhNWQxMWRlOTM8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+RnJpLCAxOCBNYXIgMjAxNiAxNzozMDo1OSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+IjB4OEQzNEY1MzEyNTlFMTY1IjwvRXRhZz48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9Db250YWluZXI+PENvbnRhaW5lcj48TmFtZT5ib290ZGlhZ25vc3RpY3MtbWlxdGVzdHdpLWI5N2ZmNDg4LWUxMTQtNDBlZC04ZDdhLWY0NTAwZDczZWVjMDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UdWUsIDIyIE1hciAyMDE2IDE2OjE3OjA2IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4iMHg4RDM1MjZENjk4RUQxODkiPC9FdGFnPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0NvbnRhaW5lcj48Q29udGFpbmVyPjxOYW1lPmJvb3RkaWFnbm9zdGljcy1taXF0ZXN0d2ktZTE3YTk1YjAtZjRmYi00MTk2LTkzYzUtMGM4YmU3ZDVjNTM2PC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlR1ZSwgMjIgTWFyIDIwMTYgMTY6NDA6MzEgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPiIweDhEMzUyNzBBRURCNTBBQiI8L0V0YWc+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQ29udGFpbmVyPjxDb250YWluZXI+PE5hbWU+Y29waWVzPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPkZyaSwgMTcgSnVuIDIwMTYgMTQ6MDk6MDUgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPiIweDhEMzk2QjhGMTE4M0QzMiI8L0V0YWc+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQ29udGFpbmVyPjxDb250YWluZXI+PE5hbWU+bWFuYWdlaXE8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+V2VkLCAyMCBBcHIgMjAxNiAxNjowNDo1NCBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+IjB4OEQzNjkzNTgyRkJENTg0IjwvRXRhZz48TGVhc2VTdGF0dXM+bG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5sZWFzZWQ8L0xlYXNlU3RhdGU+PExlYXNlRHVyYXRpb24+aW5maW5pdGU8L0xlYXNlRHVyYXRpb24+PC9Qcm9wZXJ0aWVzPjwvQ29udGFpbmVyPjxDb250YWluZXI+PE5hbWU+c3lzdGVtPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlR1ZSwgMjIgTWFyIDIwMTYgMTc6MDg6MDEgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPiIweDhEMzUyNzQ4NjUxNkJGOCI8L0V0YWc+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQ29udGFpbmVyPjxDb250YWluZXI+PE5hbWU+dmhkczwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5GcmksIDE4IE1hciAyMDE2IDE3OjMwOjU5IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4iMHg4RDM0RjUzMTI3NjQ5RUUiPC9FdGFnPjxMZWFzZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJhdGlvbj5pbmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48L1Byb3BlcnRpZXM+PC9Db250YWluZXI+PC9Db250YWluZXJzPjxOZXh0TWFya2VyIC8+PC9FbnVtZXJhdGlvblJlc3VsdHM+
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:40:27 GMT
+- request:
+    method: get
+    uri: https://miqazuretest14047.blob.core.windows.net/copies?comp=list&restype=container
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:40:27 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Authorization:
+      - SharedKey miqazuretest14047:iZ7YU0PZ/Kxr+Ox9qGh9kHYToCjPoGnGV60Strm6V1U=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/xml
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 4ba8e70c-001e-003c-09e6-b992a4000000
+      X-Ms-Version:
+      - '2016-05-31'
+      Date:
+      - Mon, 12 Mar 2018 09:40:22 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9taXFhenVyZXRlc3QxNDA0Ny5ibG9iLmNvcmUud2luZG93cy5uZXQvIiBDb250YWluZXJOYW1lPSJjb3BpZXMiPjxCbG9icz48QmxvYj48TmFtZT50ZXN0LXdpbjJrMTItY29waWVkLXsxMjM0NX08L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+RnJpLCAxNyBKdW4gMjAxNiAxNDoxMzozMCBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDM5NkI5OEYyOUQ3NEM8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjE8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48L0Jsb2JzPjxOZXh0TWFya2VyIC8+PC9FbnVtZXJhdGlvblJlc3VsdHM+
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:40:27 GMT
+- request:
+    method: get
+    uri: https://miqazuretest14047.blob.core.windows.net/manageiq?comp=list&restype=container
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:40:27 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Authorization:
+      - SharedKey miqazuretest14047:phtzV0lmXJ7cadTp00ErLwNahcMqD5xOKVQRz2EdhzQ=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/xml
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - cb66789b-001e-0068-64e6-b9782e000000
+      X-Ms-Version:
+      - '2016-05-31'
+      Date:
+      - Mon, 12 Mar 2018 09:40:23 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9taXFhenVyZXRlc3QxNDA0Ny5ibG9iLmNvcmUud2luZG93cy5uZXQvIiBDb250YWluZXJOYW1lPSJtYW5hZ2VpcSI+PEJsb2JzPjxCbG9iPjxOYW1lPmF6ZG11MDAwNF85YzcwNjBiYi0yN2Y5LTRmOTAtYjc4NS1lMTg5NzE2MjY5ZjgudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlR1ZSwgMjcgU2VwIDIwMTYgMTg6MzU6MjUgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzRTcwNTBCRjU2NDJEPC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj40PC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+YXpkbXUwMDA1X2IyZDkxYTdlLWY0ZTEtNDI4OS1iNGU3LTFjNWZhMmRkZTQyZS52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VGh1LCAwNiBPY3QgMjAxNiAxODozNTo0NSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDNFRTE3OTYwRjUxREI8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjE8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5hemRtdTAwMDZfYmZhMTEzNTctNmE4MC00ZGUxLWIzOTUtNjdlODcwYzE0YTkxLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UaHUsIDA2IE9jdCAyMDE2IDE4OjM1OjQ2IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0VFMTc5NjM3MDdDNzwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MTwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmF6ZG11MDAwNy42ZDQ1Y2VjZC00N2U2LTRjNGMtYjFlMi1hYmQzYzFkNmRlOTcuc3RhdHVzPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlNhdCwgMDggT2N0IDIwMTYgMTQ6MDE6NTcgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzRUY4M0FBODk5NjE3PC9FdGFnPjxDb250ZW50LUxlbmd0aD41MTc8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5PR3Vxb1pIVThNUCtwT3RlWGZuTzNBPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48QmxvYlR5cGU+QmxvY2tCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5hemRtdTAwMDdfNmZmY2VhOWMtZDM2Zi00ZGVhLThjMDMtY2NiNWM2NWY3YjAxLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5TYXQsIDA4IE9jdCAyMDE2IDE0OjAyOjEwIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0VGODNCMjU2QkREMzwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MzwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJhdGlvbj5pbmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5hemRtdTAwMDguOWNjYTAwOGQtYzY2Zi00YzI1LWJmMjEtYjgyZDQ1OWM4YWIyLnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5TYXQsIDE1IE9jdCAyMDE2IDE0OjAyOjEzIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0Y1MDNERDBEQTk0RDwvRXRhZz48Q29udGVudC1MZW5ndGg+NTE3PC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+cTI5OTBmRkU1TGMwZHlUM0QrdVpzQT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+YXpkbXUwMDA4XzM3NzAwMDlmLWMzMjUtNDNmYS1hODMwLTFlMmJkNGNhMmFmOC52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+U2F0LCAxNSBPY3QgMjAxNiAxNDowMjoyMyBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDNGNTAzRTJFRUIyMTE8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjk8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+bG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5sZWFzZWQ8L0xlYXNlU3RhdGU+PExlYXNlRHVyYXRpb24+aW5maW5pdGU8L0xlYXNlRHVyYXRpb24+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+YXpkbXUwMDA5LmRhNDMxZTJjLWIwZjktNGFhYy1iZDMyLWMxYThiNTQzYWU1MC5zdGF0dXM8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+U2F0LCAxNSBPY3QgMjAxNiAxNDowNTo0MiBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDNGNTA0NTlDQTNCODM8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjUxNzwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PjVqNklnZHByRW15Y2p4WkdJTEQ1cWc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjxCbG9iVHlwZT5CbG9ja0Jsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmF6ZG11MDAwOV8yMWRmMzc2MC03MzBlLTRkNjYtYTUwOS04ZmQ3YmQzY2FhMWMudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlNhdCwgMTUgT2N0IDIwMTYgMTQ6MDU6NTUgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzRjUwNDYxNjNCRkY4PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4xMTwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJhdGlvbj5pbmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5hemRtdTAwMTAuYTIxMmY0NTAtMmVmYi00YTQwLWIyMmUtMGMzNzExZWJlYzU2LnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5TYXQsIDE1IE9jdCAyMDE2IDE0OjA3OjE5IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0Y1MDQ5M0JGMEUyMTwvRXRhZz48Q29udGVudC1MZW5ndGg+NTE3PC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+Y3hNbEJPSmNNODBFaGpWTnEvM0VhQT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+YXpkbXUwMDEwXzM0NGQ2M2ZkLTU2ODMtNDg3ZS1iM2VmLWI4NjMzZmIxYzdmMi52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+U2F0LCAxNSBPY3QgMjAxNiAxNDowNzozNSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDNGNTA0OUQyMEEyNTQ8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjk8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+bG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5sZWFzZWQ8L0xlYXNlU3RhdGU+PExlYXNlRHVyYXRpb24+aW5maW5pdGU8L0xlYXNlRHVyYXRpb24+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+YXpkbXUwMDExLmRjNzU0YmVkLTMyZDgtNGY1MC05NTJkLTRkMDk1OGNjY2Q5OS5zdGF0dXM8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+U2F0LCAxNSBPY3QgMjAxNiAxNDoxMDoxOCBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDNGNTA0RkU2RkU2OTQ8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjUxNzwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlBCaXZKVXV0MlVMaXE3bjhPN2ZzSXc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjxCbG9iVHlwZT5CbG9ja0Jsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmF6ZG11MDAxMV81YWJjMDZiOC0zOTczLTRmNDAtYWJkOC0zNGRhMDJlMzFlZjYudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlNhdCwgMTUgT2N0IDIwMTYgMTQ6MTA6MzcgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzRjUwNTA5OEM4RjM1PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4zPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+bGVhc2VkPC9MZWFzZVN0YXRlPjxMZWFzZUR1cmF0aW9uPmluZmluaXRlPC9MZWFzZUR1cmF0aW9uPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmF6ZG11MDAxMi5hZDUyYzIxYi1hZjNiLTQ2ZTItYWRmYy1kODc5ODQ2MTM0YWYuc3RhdHVzPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlNhdCwgMTUgT2N0IDIwMTYgMTQ6MTM6MTcgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzRjUwNTY5NEM2RDlGPC9FdGFnPjxDb250ZW50LUxlbmd0aD41MTc8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5LdDdVQmdSbUh4Y0VxdkpUUk1WZmdnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48QmxvYlR5cGU+QmxvY2tCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5hemRtdTAwMTJfYmZjMTIxMTktYWI1My00ZjgyLWJlOWItZDQ3MTcwYWI4YWIyLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5TYXQsIDE1IE9jdCAyMDE2IDE0OjEzOjM0IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0Y1MDU3MkUwREUyNTwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+NjwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJhdGlvbj5pbmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5iaWxseTFfMjA0MDFiMjctOWRhNC00Mjc2LWEzOTAtZDU5NDk1YWVhOTU0LnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UaHUsIDE1IFNlcCAyMDE2IDIyOjEwOjUxIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0REQjUyNzk4OEU0RDwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MTwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmJpbGx5Ml8yZGZiODYxMy1jMWMxLTQ1NjItOTMwNy1kYjhjOWIxYjI0MjYudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPkZyaSwgMTYgU2VwIDIwMTYgMTI6NDM6NTUgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzREUyRjFGMDMyNTg0PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4xPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+YnJvbmFnaDAzMTZpXzRjZmMyYjY2LWFiYmYtNDVkYS04YTlmLTMwNzQ2YmQ1NWQ2ZC52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+V2VkLCAyNiBKdWwgMjAxNyAyMDo1ODo1MCBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDRENDY5MURERDk5RUU8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjkxPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+YnJvbmFnaDMxNmdfMjEzN2NlYzEtYTM2ZC00YmJkLWE4ZDMtNTlkNjg2MmMyYmI5LnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5Nb24sIDMwIE9jdCAyMDE3IDE5OjUyOjEyIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhENTFGQ0ZCNkFCRjg3MDwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MjMwNDwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmJyb25hZ2gzMTZoX2JmY2Q1YTA5LTEwZjUtNDY2NC04MTMzLWYzZjUzNTU0Yjg2OC52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+V2VkLCAyNCBKYW4gMjAxOCAxOTo1MDowNSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDU2MzYzQUEzNDNFRDM8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjMyNzwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJhdGlvbj5pbmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5icm9uYWdoNDI3Xzk1NDU4NDk0LTQ0NDYtNDUwZC05YTRhLTc5MmQxNGQwOTcxNy52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+TW9uLCAzMCBPY3QgMjAxNyAxOTo1NTozNSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDUxRkQwMkY4ODdBNTk8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjY1PC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+YnJvbmFnaGZpcDcxNGFfNGE2M2RmOTktOWY3My00YjhkLTkyM2YtZGMwNjYxN2Q2NjBkLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5XZWQsIDAzIEF1ZyAyMDE2IDE1OjM0OjAxIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0JCQjM5ODA0MUFCNDwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MTE5PC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+YnJvbmFnaG5vcG9ydF85OTQzYTQ5OS1iMmVjLTQxZTMtOWE4NS1jMTQ0OTRmMThjZWMudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPk1vbiwgMjUgSnVsIDIwMTYgMTY6Mzg6NTEgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzQjRBQTI5MEIwRDE1PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4xMDc8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5icm9uYWdocmV1c2VpcF9jMzNhNjU0OS1jYzRkLTRlM2YtOTQ1ZC0yOGI2Y2EwODgwZjAudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPldlZCwgMDMgQXVnIDIwMTYgMTU6MzM6NDggR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzQkJCMzkwMUJERTJFPC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4xMDI8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5icm9uYWdocnNwZWMzXzAzNGM5MzhiLWVhYTktNDM5OS04ZWQyLWNiNzIxNmZhYmYwYi52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VGh1LCAyOCBBcHIgMjAxNiAxNDoxMjo0OSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDM2RjZGMkUyOTk2MkY8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjEzPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+YnJvbmFnaHRlc3QyM19lMjM2MDlmYi05YzdjLTQxM2MtOWJlNi05YTBlMWM5Y2RiZDcudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPkZyaSwgMTMgTWF5IDIwMTYgMjE6MTE6NDggR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzN0I3MzMyNzI4RTNDPC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4yPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+YnJvbmFnaHdpdGhzXzczYjlhOTVhLWRkZTEtNDNiNS04MTM5LTJiYjA0NjVkMzkxYS52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VGh1LCAyOCBBcHIgMjAxNiAxNDo1NjozNSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDM2Rjc1NEI0Qjg0RTY8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjM8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5ic21ldHJpY3NfMjA3NTNhZjgtNWFiOC00NWFmLTg1NDUtNGVjMDk2OTg1YWE0LnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UaHUsIDE3IE5vdiAyMDE2IDE5OjIxOjUwIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhENDBGMUVGQjM2MTU3MTwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MTM8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5id2VpdGVzdF8wMDAyX2ExNTZiZTljLTJmYmUtNDFlYi05NTY0LWZiY2IyNTUzZWUzMy52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VHVlLCAyOSBOb3YgMjAxNiAxNDo1NzoxNiBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDQxODY4MDJDNTY2NzE8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjk5NjwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmRiZXJnZXItZGVsZXRlX2EyYTVkNDNmLWFhMDUtNGQ2MS04ZGE4LTk1MDg2YTRkMzU3ZS52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+V2VkLCAxMiBBcHIgMjAxNyAxNzo1Mzo0NSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDQ4MUNDRERCNUUzRjk8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjc8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5kYmVyZ2VyLWRlbGV0ZW1lMV9lZWZjMTcyNy0wMTliLTQyODUtYTVmOC0wODY5ZWZlOGEwMzcudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPkZyaSwgMjYgQXVnIDIwMTYgMjI6NDg6MDIgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzQ0UwMzA5NDY5RUM0PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4xPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+ZGJlcmdlcnByb3YxLmY3YmEyZGUxLTJiMzMtNDU4NS05YTdiLTJiYWQyZGFkZjY2NC5zdGF0dXM8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+U2F0LCAwMyBTZXAgMjAxNiAxNDowODoxNyBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDNENDAzQzBFODU2OUI8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjQ2MTY8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5mRnhTek9RUjVEUFNzSnphRmMvV1l3PT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48QmxvYlR5cGU+QmxvY2tCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5kYmVyZ2VycHJvdjFfN2I3MjdiYWQtY2I4My00YWEyLWE3NjgtMDc0Yzg3N2Q2YjNiLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5TYXQsIDAzIFNlcCAyMDE2IDE0OjA4OjMxIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0Q0MDNDOTMwNzYyMzwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+OTg8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+bG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5sZWFzZWQ8L0xlYXNlU3RhdGU+PExlYXNlRHVyYXRpb24+aW5maW5pdGU8L0xlYXNlRHVyYXRpb24+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+ZGJlcmdlcnByb3YxXzlhNzhhYTRjLWQ1ZjYtNGQ1OC1iMDgzLTkwNjkxZWRhN2I2NC52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VGh1LCAwMSBTZXAgMjAxNiAxOTo0ODo0NSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDNEMkEwRkJDQUNERDM8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjIzODwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmRiZXJnZXJwcm92Ml9hN2JlNmQzNi1kMGNhLTRmYWQtOGNkMC1mYzJmMDQ4ZTA0NDYudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlRodSwgMDEgU2VwIDIwMTYgMTk6NDg6NTQgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzRDJBMTAxQTU0QTU4PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4xNjU8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5kYmVyZ2VyeF82MDg3M2E2ZS03MDllLTQwOWYtODA0OC05ZGNhYmMwOWQ0NjcudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPk1vbiwgMDMgQXByIDIwMTcgMTg6NTY6MDAgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQ0N0FDMzExQjgzMDZCPC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj41PC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+ZHJlMDAwMV9kZDM4MDMyMC03YWQxLTQ4NTktYWY3YS04YTg1OTA5NGQzZDcudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPk1vbiwgMTIgTWFyIDIwMTggMDk6NDA6MjEgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQ1ODdGRDQ2MEY4QTc2PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4zPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+bGVhc2VkPC9MZWFzZVN0YXRlPjxMZWFzZUR1cmF0aW9uPmluZmluaXRlPC9MZWFzZUR1cmF0aW9uPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmRyZTAwMDJfZDU5MzUzMzgtOTljOC00YjQyLThjNmItMDkzMjMzZDM4ZGNmLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5Nb24sIDEyIE1hciAyMDE4IDA5OjQwOjIwIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhENTg3RkQ0NTlBMTY4QjwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MjwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJhdGlvbj5pbmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5kcmUwMDAzXzYyYzhhZjA1LTY1ZjgtNDI0Yy04OTU0LWRjY2MwYWM4ZTI3Yi52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+TW9uLCAxMiBNYXIgMjAxOCAwOTo0MDoxOCBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDU4N0ZENDQ4RjFCQkI8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjI8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+bG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5sZWFzZWQ8L0xlYXNlU3RhdGU+PExlYXNlRHVyYXRpb24+aW5maW5pdGU8L0xlYXNlRHVyYXRpb24+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+ZHJldzFfNWMzNWY2OTUtYjJhZS00ZDg2LTkzN2YtZmNjNmZjYmI5ZmIwLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UaHUsIDE1IFNlcCAyMDE2IDIyOjI4OjQ4IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0REQjdBOTZCODAwMDwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MTwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmRyZXdBenVyZVRlc3QxMDAwNF8zMWQyYzk1OC0wNjQ2LTQ5NGQtOWZjYi00ZDNkMGQyNTgwMWIudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPk1vbiwgMTIgTWFyIDIwMTggMDk6NDA6MjAgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQ1ODdGRDQ1OTcwODhCPC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4zPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+bGVhc2VkPC9MZWFzZVN0YXRlPjxMZWFzZUR1cmF0aW9uPmluZmluaXRlPC9MZWFzZUR1cmF0aW9uPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmRyZXdhenVyZTAwMDEuYTAxNWQ4YzYtNDlhYy00ZDhmLTg0MzMtZjUzZTViODkxNWQyLnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5TYXQsIDE1IE9jdCAyMDE2IDE0OjE2OjI2IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0Y1MDVEOTZDRkFFRjwvRXRhZz48Q29udGVudC1MZW5ndGg+NTE3PC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+ODZTUmhRdVlOcFo4SnpINEIyLzVpZz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+ZHJld2F6dXJlMDAwMV80YmM3ZDEyMi1jYzMxLTQxNTAtYWJjZS1jMTdlMGJiOWE5Y2YudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlNhdCwgMTUgT2N0IDIwMTYgMTQ6MTY6MzggR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzRjUwNUUwQTY5NEI4PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj43PC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+bGVhc2VkPC9MZWFzZVN0YXRlPjxMZWFzZUR1cmF0aW9uPmluZmluaXRlPC9MZWFzZUR1cmF0aW9uPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmRyZXdhenVyZTAwMDIuMzA4ZGFhYWUtZGFjMS00ODRlLThhYzgtOThkYjA0NGFjYzMyLnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5TYXQsIDE1IE9jdCAyMDE2IDE0OjE5OjI3IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0Y1MDY0NUI2RDg5MDwvRXRhZz48Q29udGVudC1MZW5ndGg+NTE3PC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+NWdKbVFmakZ3VTNBcEhUdEFFbVp4Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+ZHJld2F6dXJlMDAwMl9lZTlmNjhlMC00ZGIyLTQ3NjctOTFjNi0wMjI1NTRkNjVhOGIudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlNhdCwgMTUgT2N0IDIwMTYgMTQ6MTk6NDIgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzRjUwNjRFNDExMjI2PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj42PC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+bGVhc2VkPC9MZWFzZVN0YXRlPjxMZWFzZUR1cmF0aW9uPmluZmluaXRlPC9MZWFzZUR1cmF0aW9uPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmpiX3dpbl9kZW1vX3ZtX2FkODljMDgwLThiMWQtNDdhMi04YTczLWVlNmQ3YTUzYzZjYy52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VHVlLCAwOSBNYXkgMjAxNyAxOTozNjo1NiBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDQ5NzEyQzBGNzExMzU8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjU8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5qdWxpYW5fdGVzdF8wMDFfNzJjNDBhYTgtMGIxNi00MWE5LTlhZTgtYTFhYTc3YjBlOTk2LnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5Nb24sIDEyIE1hciAyMDE4IDA5OjQwOjIxIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhENTg3RkQ0NjFCRTk5NzwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MjwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJhdGlvbj5pbmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5sdWN5XzJfZWVmMDc4YTgtOWJmZS00NjllLTkzNDAtZTAzNDJhNGZlM2JjLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UdWUsIDI5IE5vdiAyMDE2IDE2OjA3OjA3IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhENDE4NzFDNEU1QUM0QjwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MjwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmx1Y3lfM19kMTI0YjQyYy03Y2YxLTQxODQtOTY4My03OTljNTg0YTU5MTkudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlRodSwgMDMgQXVnIDIwMTcgMjA6Mzc6MDcgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQ0REFBRjY4NUFCMjk3PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj40PC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+bHVjeV80XzI2MTg1N2IxLWZiMzUtNGNlMC1iN2I3LWZkMTQ4YzdlNmViZC52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VHVlLCAyOSBOb3YgMjAxNiAxODo0Njo1NSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDQxODg4MTc2OThBNDg8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjE8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5zZWN0ZXN0Ml84NGFkN2IyYi05MTAwLTQwZGItODk5Ny1hMzE5MTJjZjI3YzEudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPldlZCwgMjAgQXByIDIwMTYgMTg6MTg6MjYgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzNjk0ODJBOTI3Rjk1PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4xPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+dGVzdC1iaWxseS1henVyZTMzX2E2NzZjYTM0LWM0M2YtNGY1OC1hOTZjLTMwY2YwNjQ1ZjZlYS52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+TW9uLCAxMiBTZXAgMjAxNiAxNzoyNTozOSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDNEQjMxRDBEREY5RUY8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjM8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT50ZXN0LWJpbGx5LWF6dXJlMzRfM2MxY2MyYjYtMTc0YS00M2JiLTlkMzAtYjM0OTU0NDRkOWY2LnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5Nb24sIDEyIFNlcCAyMDE2IDE3OjIwOjM5IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0RCMzExRTJCOERGRDwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MTwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPnRlc3QtYmlsbHktYXp1cmUzNV9jYWVhZjRhZi1iNDg2LTRlZGMtOTg0Ny1iNjU4YTBlMTk3YzIudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlR1ZSwgMTMgU2VwIDIwMTYgMTU6NDQ6NTcgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzREJFQ0U5RTkxRkNEPC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4xPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+dGVzdC1iaWxseS1henVyZTM2X2Y4OGY1OWE3LWNjNmYtNDQ2NC04OGJhLTYxYWRjYTc5MmVjYy52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VHVlLCAxMyBTZXAgMjAxNiAxNjoxNjoyNyBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDNEQkYxNTA5QTkyOUM8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjE8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT50ZXN0LWJpbGx5LWF6dXJlMzhfZTkzNGUzZjAtZjNkOC00YjViLTgwMTUtNTVlNWJkMzkyY2JjLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UdWUsIDEzIFNlcCAyMDE2IDIxOjIyOjU5IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0RDMUMyMkZEMjlCNTwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MTwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPnRlc3QtYmlsbHktYXp1cmU0MF83OGMwYWUxYy0yYjEyLTRhYTgtYmIzYy1iZjYyNzBjMTFkMWMudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlRodSwgMTUgU2VwIDIwMTYgMjE6MDU6MTcgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzRERBQkZGMjVBRDlGPC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4xPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+dGVzdC1iaWxseS1henVyZTUxX2Q4ZDE1ODgwLTE5MWYtNDIyMS05OWNjLWNiMTAyYmE0ZGNmOC52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+RnJpLCAyMyBTZXAgMjAxNiAxNDoxODo0NiBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDNFM0JDODdGNkU3NDA8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjE8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT50ZXN0LWJpbGx5YTM3X2YyZjBlOTYyLWQzYzctNDAyOS05YjJkLTE0OTgyZTY2NzAxNi52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VGh1LCAxNSBTZXAgMjAxNiAxNDo1OTowNCBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDNERDc4RDYxN0ZFQzM8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjE8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT50ZXN0YmlsbHlhYWFfOTUzZTkxM2QtNjYyNS00NzFmLWI2ZjAtNGU5MzUzNzIzYzM5LnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UaHUsIDE1IFNlcCAyMDE2IDE0OjU5OjM5IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0RENzhFQUFBMTdDRjwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MTwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPnRlc3RiaWxseXp6enpfNDNjZmEzMGUtMmQ3Mi00OWFmLWE3MmQtMWU3NjRkZmJmNzU2LnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UaHUsIDE1IFNlcCAyMDE2IDE1OjA0OjMxIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0RENzk5OEY2MUNCMjwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MjwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjwvQmxvYnM+PE5leHRNYXJrZXIgLz48L0VudW1lcmF0aW9uUmVzdWx0cz4=
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:40:28 GMT
+- request:
+    method: head
+    uri: https://miqazuretest14047.blob.core.windows.net/manageiq/azdmu0004_9c7060bb-27f9-4f90-b785-e189716269f8.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:40:28 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey miqazuretest14047:xIpZ+D4+QC5N6tyjLH6vQJLFi9AcQaSoQmb0y0lyNmw=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - VbYhW9/6NOXzQVK/vQkdvg==
+      Last-Modified:
+      - Tue, 27 Sep 2016 18:35:25 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D3E7050BF5642D"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - f8c94cd0-001e-0043-5ee6-b90c96000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '4'
+      X-Ms-Copy-Id:
+      - eec4aa1a-8583-476b-83f4-a4eacf9f4472
+      X-Ms-Copy-Source:
+      - https://miqazuretest14047.blob.core.windows.net/system/Microsoft.Compute/Images/miq-test-container/test-win2k12-img-osDisk.e17a95b0-f4fb-4196-93c5-0c8be7d5c536.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=5Gh8F9hiPimv8f%2BVGFene145jChHlOuuNzzCF6STBFI%3D&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Thu, 22 Sep 2016 17:13:19 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Mon, 12 Mar 2018 09:40:23 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:40:29 GMT
+- request:
+    method: head
+    uri: https://miqazuretest14047.blob.core.windows.net/manageiq/azdmu0005_b2d91a7e-f4e1-4289-b4e7-1c5fa2dde42e.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:40:29 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey miqazuretest14047:innmRgtjxqfw8yR5f8jQ5e1S2WvrawGGGoFVaHxqN4A=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - VbYhW9/6NOXzQVK/vQkdvg==
+      Last-Modified:
+      - Thu, 06 Oct 2016 18:35:45 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D3EE17960F51DB"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 6288ea38-001e-010f-7ee6-b98ddc000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '1'
+      X-Ms-Copy-Id:
+      - 4680ccde-afdd-40a5-b87d-29187315d6cc
+      X-Ms-Copy-Source:
+      - https://miqazuretest14047.blob.core.windows.net/system/Microsoft.Compute/Images/miq-test-container/test-win2k12-img-osDisk.e17a95b0-f4fb-4196-93c5-0c8be7d5c536.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=5Gh8F9hiPimv8f%2BVGFene145jChHlOuuNzzCF6STBFI%3D&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Thu, 06 Oct 2016 16:28:07 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Mon, 12 Mar 2018 09:40:24 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:40:29 GMT
+- request:
+    method: head
+    uri: https://miqazuretest14047.blob.core.windows.net/manageiq/azdmu0006_bfa11357-6a80-4de1-b395-67e870c14a91.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:40:29 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey miqazuretest14047:OQ7vVpyFoYfSLHyP1nBU/vHhyz5U72JypcDfyCFDrEc=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - VbYhW9/6NOXzQVK/vQkdvg==
+      Last-Modified:
+      - Thu, 06 Oct 2016 18:35:46 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D3EE17963707C7"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 1f163a79-001e-009b-54e6-b9ab47000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '1'
+      X-Ms-Copy-Id:
+      - 3da53fd8-9764-43fa-94dc-06476792a4b8
+      X-Ms-Copy-Source:
+      - https://miqazuretest14047.blob.core.windows.net/system/Microsoft.Compute/Images/miq-test-container/test-win2k12-img-osDisk.e17a95b0-f4fb-4196-93c5-0c8be7d5c536.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=5Gh8F9hiPimv8f%2BVGFene145jChHlOuuNzzCF6STBFI%3D&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Thu, 06 Oct 2016 17:23:59 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Mon, 12 Mar 2018 09:40:25 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:40:30 GMT
+- request:
+    method: head
+    uri: https://miqazuretest14047.blob.core.windows.net/manageiq/billy1_20401b27-9da4-4276-a390-d59495aea954.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:40:30 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey miqazuretest14047:40rvn+VSV0DFjh9WpAosO1NVgOh3sHeIPeBotJPc4Mg=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - VbYhW9/6NOXzQVK/vQkdvg==
+      Last-Modified:
+      - Thu, 15 Sep 2016 22:10:51 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D3DDB527988E4D"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 8da6d9d3-001e-013f-7ce6-b9d7f6000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '1'
+      X-Ms-Copy-Id:
+      - d13c0f18-5dee-4a79-b402-0f0f0462caf5
+      X-Ms-Copy-Source:
+      - https://miqazuretest14047.blob.core.windows.net/system/Microsoft.Compute/Images/miq-test-container/test-win2k12-img-osDisk.e17a95b0-f4fb-4196-93c5-0c8be7d5c536.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=5Gh8F9hiPimv8f%2BVGFene145jChHlOuuNzzCF6STBFI%3D&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Thu, 15 Sep 2016 18:11:19 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Mon, 12 Mar 2018 09:40:26 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:40:31 GMT
+- request:
+    method: head
+    uri: https://miqazuretest14047.blob.core.windows.net/manageiq/billy2_2dfb8613-c1c1-4562-9307-db8c9b1b2426.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:40:31 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey miqazuretest14047:Yz3BVviXAfbgu3cPSBqWOOrobKm8TEg5s7auBSptVlc=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - VbYhW9/6NOXzQVK/vQkdvg==
+      Last-Modified:
+      - Fri, 16 Sep 2016 12:43:55 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D3DE2F1F032584"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - dd86ab3c-001e-00df-2ce6-b9772b000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '1'
+      X-Ms-Copy-Id:
+      - b7212717-2bf4-43ca-a315-dce82593ce1e
+      X-Ms-Copy-Source:
+      - https://miqazuretest14047.blob.core.windows.net/system/Microsoft.Compute/Images/miq-test-container/test-win2k12-img-osDisk.e17a95b0-f4fb-4196-93c5-0c8be7d5c536.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=5Gh8F9hiPimv8f%2BVGFene145jChHlOuuNzzCF6STBFI%3D&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Thu, 15 Sep 2016 21:21:11 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Mon, 12 Mar 2018 09:40:26 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:40:31 GMT
+- request:
+    method: head
+    uri: https://miqazuretest14047.blob.core.windows.net/manageiq/bronagh0316i_4cfc2b66-abbf-45da-8a9f-30746bd55d6d.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:40:31 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey miqazuretest14047:6QbyBDdJc+x1Z8+YoK0QdSY2FcPpOsY6oUwSUECQf/Q=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - VbYhW9/6NOXzQVK/vQkdvg==
+      Last-Modified:
+      - Wed, 26 Jul 2017 20:58:50 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D4D4691DDD99EE"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - bceca1b0-001e-010b-33e6-b9785e000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '91'
+      X-Ms-Copy-Id:
+      - 46deca02-32c3-4283-b6ce-342e5339d592
+      X-Ms-Copy-Source:
+      - https://miqazuretest14047.blob.core.windows.net/system/Microsoft.Compute/Images/miq-test-container/test-win2k12-img-osDisk.e17a95b0-f4fb-4196-93c5-0c8be7d5c536.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=5Gh8F9hiPimv8f%2bVGFene145jChHlOuuNzzCF6STBFI%3d&se=9999-01-01T00%3a00%3a00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Thu, 16 Mar 2017 15:35:22 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Mon, 12 Mar 2018 09:40:27 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:40:32 GMT
+- request:
+    method: head
+    uri: https://miqazuretest14047.blob.core.windows.net/manageiq/bronagh316g_2137cec1-a36d-4bbd-a8d3-59d6862c2bb9.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:40:32 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey miqazuretest14047:lo9vU6egvujlbnunXS+jrnAY6ZG6Osk6kDCb96Oo4AI=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - VbYhW9/6NOXzQVK/vQkdvg==
+      Last-Modified:
+      - Mon, 30 Oct 2017 19:52:12 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D51FCFB6ABF870"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 21647dfc-001e-005b-02e6-b92103000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '2304'
+      X-Ms-Copy-Id:
+      - cac86379-2c54-4abd-80d1-bbb24d54af78
+      X-Ms-Copy-Source:
+      - https://miqazuretest14047.blob.core.windows.net/system/Microsoft.Compute/Images/miq-test-container/test-win2k12-img-osDisk.e17a95b0-f4fb-4196-93c5-0c8be7d5c536.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=5Gh8F9hiPimv8f%2bVGFene145jChHlOuuNzzCF6STBFI%3d&se=9999-01-01T00%3a00%3a00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Thu, 16 Mar 2017 15:00:36 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Mon, 12 Mar 2018 09:40:27 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:40:32 GMT
+- request:
+    method: head
+    uri: https://miqazuretest14047.blob.core.windows.net/manageiq/bronagh427_95458494-4446-450d-9a4a-792d14d09717.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:40:32 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey miqazuretest14047:1zGYg3SyXjijR2GQz3gXN59gl4kInouKD8W599GLxhw=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - VbYhW9/6NOXzQVK/vQkdvg==
+      Last-Modified:
+      - Mon, 30 Oct 2017 19:55:35 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D51FD02F887A59"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - b052c593-001e-000f-22e6-b9cb89000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '65'
+      X-Ms-Copy-Id:
+      - 10dc495f-54c5-4f40-b435-ef94e17dedf2
+      X-Ms-Copy-Source:
+      - https://miqazuretest14047.blob.core.windows.net/system/Microsoft.Compute/Images/miq-test-container/test-win2k12-img-osDisk.e17a95b0-f4fb-4196-93c5-0c8be7d5c536.vhd?sv=2015-12-11&sr=b&sk=system-1&sig=g1Xi8z6%2fPY7F1q4P5o1taM4NsmJHAuCBwwcsLaFy3Zo%3d&se=9999-01-01T00%3a00%3a00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Thu, 27 Apr 2017 17:41:38 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Mon, 12 Mar 2018 09:40:28 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:40:33 GMT
+- request:
+    method: head
+    uri: https://miqazuretest14047.blob.core.windows.net/manageiq/bronaghfip714a_4a63df99-9f73-4b8d-923f-dc06617d660d.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:40:33 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey miqazuretest14047:sH7gOrmDZtvMvyNV5Eq6Yyc7cKCC5qQlnJOFaDsAz5g=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - VbYhW9/6NOXzQVK/vQkdvg==
+      Last-Modified:
+      - Wed, 03 Aug 2016 15:34:01 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D3BBB398041AB4"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 25b5d6d3-001e-00c7-5be6-b95abe000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '119'
+      X-Ms-Copy-Id:
+      - 65f562f8-12bd-4c26-88ee-958f5c0da5ca
+      X-Ms-Copy-Source:
+      - https://miqazuretest14047.blob.core.windows.net/system/Microsoft.Compute/Images/miq-test-container/test-win2k12-img-osDisk.e17a95b0-f4fb-4196-93c5-0c8be7d5c536.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=5Gh8F9hiPimv8f%2BVGFene145jChHlOuuNzzCF6STBFI%3D&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Thu, 14 Jul 2016 19:22:00 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Mon, 12 Mar 2018 09:40:29 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:40:34 GMT
+- request:
+    method: head
+    uri: https://miqazuretest14047.blob.core.windows.net/manageiq/bronaghnoport_9943a499-b2ec-41e3-9a85-c14494f18cec.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:40:34 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey miqazuretest14047:aQUXSdxUODzpp7G6k41fq/zHYQAg6CRGCZJAiKjacZI=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - VbYhW9/6NOXzQVK/vQkdvg==
+      Last-Modified:
+      - Mon, 25 Jul 2016 16:38:51 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D3B4AA290B0D15"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 0c27fc59-001e-011f-6ee6-b9bb3a000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '107'
+      X-Ms-Copy-Id:
+      - dfb1ffe5-9577-4ecb-b8a4-a2fa404c8674
+      X-Ms-Copy-Source:
+      - https://miqazuretest14047.blob.core.windows.net/system/Microsoft.Compute/Images/miq-test-container/test-win2k12-img-osDisk.e17a95b0-f4fb-4196-93c5-0c8be7d5c536.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=5Gh8F9hiPimv8f%2BVGFene145jChHlOuuNzzCF6STBFI%3D&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Thu, 14 Jul 2016 19:36:24 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Mon, 12 Mar 2018 09:40:29 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:40:34 GMT
+- request:
+    method: head
+    uri: https://miqazuretest14047.blob.core.windows.net/manageiq/bronaghreuseip_c33a6549-cc4d-4e3f-945d-28b6ca0880f0.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:40:34 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey miqazuretest14047:fgs6J1K7AexU54KWWsE7xwMJTHJBadB4F4lcxunQ/C8=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - VbYhW9/6NOXzQVK/vQkdvg==
+      Last-Modified:
+      - Wed, 03 Aug 2016 15:33:48 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D3BBB3901BDE2E"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - de8841d9-001e-00d3-24e6-b999da000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '102'
+      X-Ms-Copy-Id:
+      - 179a7b02-d954-479e-858f-689891b5e517
+      X-Ms-Copy-Source:
+      - https://miqazuretest14047.blob.core.windows.net/system/Microsoft.Compute/Images/miq-test-container/test-win2k12-img-osDisk.e17a95b0-f4fb-4196-93c5-0c8be7d5c536.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=5Gh8F9hiPimv8f%2BVGFene145jChHlOuuNzzCF6STBFI%3D&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Thu, 14 Jul 2016 19:27:26 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Mon, 12 Mar 2018 09:40:30 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:40:35 GMT
+- request:
+    method: head
+    uri: https://miqazuretest14047.blob.core.windows.net/manageiq/bronaghrspec3_034c938b-eaa9-4399-8ed2-cb7216fabf0b.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:40:35 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey miqazuretest14047:LdnVnovPNJZtbwAjQG+aKPFkw93VI0DOif2+VAa3mkI=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - VbYhW9/6NOXzQVK/vQkdvg==
+      Last-Modified:
+      - Thu, 28 Apr 2016 14:12:49 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D36F6F2E29962F"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - bb8ab878-001e-0073-19e6-b956bc000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '13'
+      X-Ms-Copy-Id:
+      - 84b41d07-b6d7-4587-8016-53106261d597
+      X-Ms-Copy-Source:
+      - https://miqazuretest14047.blob.core.windows.net/system/Microsoft.Compute/Images/miq-test-container/test-win2k12-img-osDisk.e17a95b0-f4fb-4196-93c5-0c8be7d5c536.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=LI47CT7Q5j8kE6chefTOnX%2BRMrjkSBD0aAcew1S4Zg4%3D&st=2016-04-27T19%3A20%3A13Z&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Wed, 27 Apr 2016 19:35:14 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Mon, 12 Mar 2018 09:40:30 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:40:35 GMT
+- request:
+    method: head
+    uri: https://miqazuretest14047.blob.core.windows.net/manageiq/bronaghtest23_e23609fb-9c7c-413c-9be6-9a0e1c9cdbd7.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:40:35 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey miqazuretest14047:Mn9nEmWismJXt4iGg+CVo4GDPqB9Fc8CaPxQ7/EsW/Y=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - VbYhW9/6NOXzQVK/vQkdvg==
+      Last-Modified:
+      - Fri, 13 May 2016 21:11:48 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D37B7332728E3C"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - eaa26ee6-001e-00ef-7ae6-b92d01000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '2'
+      X-Ms-Copy-Id:
+      - 66851399-f938-44ec-852f-210b5331e3e4
+      X-Ms-Copy-Source:
+      - https://miqazuretest14047.blob.core.windows.net/system/Microsoft.Compute/Images/miq-test-container/test-win2k12-img-osDisk.e17a95b0-f4fb-4196-93c5-0c8be7d5c536.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=D6dgCT1L76l4aIk1Tjgo5Q34oXGG7%2FbEsDy6XagbI9o%3D&st=2016-05-13T20%3A47%3A18Z&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Fri, 13 May 2016 21:02:19 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Mon, 12 Mar 2018 09:40:30 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:40:36 GMT
+- request:
+    method: head
+    uri: https://miqazuretest14047.blob.core.windows.net/manageiq/bronaghwiths_73b9a95a-dde1-43b5-8139-2bb0465d391a.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:40:36 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey miqazuretest14047:JkX0D28ahuMrTUhF1xvmSTjjFFrZ78ge48GPCiNwQgw=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - VbYhW9/6NOXzQVK/vQkdvg==
+      Last-Modified:
+      - Thu, 28 Apr 2016 14:56:35 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D36F754B4B84E6"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 1bfdd576-001e-0106-4be6-b99752000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '3'
+      X-Ms-Copy-Id:
+      - 85aaddf0-542f-480f-a64f-d638bc392b51
+      X-Ms-Copy-Source:
+      - https://miqazuretest14047.blob.core.windows.net/system/Microsoft.Compute/Images/miq-test-container/test-win2k12-img-osDisk.e17a95b0-f4fb-4196-93c5-0c8be7d5c536.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=VcM9HDnYJb6sA2neKdEfzKIpEI2lh%2BZ6rnZEVpFak2I%3D&st=2016-04-28T14%3A02%3A58Z&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Thu, 28 Apr 2016 14:17:59 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Mon, 12 Mar 2018 09:40:31 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:40:36 GMT
+- request:
+    method: head
+    uri: https://miqazuretest14047.blob.core.windows.net/manageiq/bsmetrics_20753af8-5ab8-45af-8545-4ec096985aa4.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:40:36 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey miqazuretest14047:nLOoxHT6tdxVve5LshfDVzh0GC9rhfB4ibddUrzVrpc=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - VbYhW9/6NOXzQVK/vQkdvg==
+      Last-Modified:
+      - Thu, 17 Nov 2016 19:21:50 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D40F1EFB361571"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 785e1e7f-001e-0092-80e6-b9b1c9000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '13'
+      X-Ms-Copy-Id:
+      - 60cc6e9e-ffd2-4660-b1d1-2ed17ef81a16
+      X-Ms-Copy-Source:
+      - https://miqazuretest14047.blob.core.windows.net/system/Microsoft.Compute/Images/miq-test-container/test-win2k12-img-osDisk.e17a95b0-f4fb-4196-93c5-0c8be7d5c536.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=5Gh8F9hiPimv8f%2BVGFene145jChHlOuuNzzCF6STBFI%3D&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Mon, 07 Nov 2016 16:18:47 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Mon, 12 Mar 2018 09:40:31 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:40:37 GMT
+- request:
+    method: head
+    uri: https://miqazuretest14047.blob.core.windows.net/manageiq/bweitest_0002_a156be9c-2fbe-41eb-9564-fbcb2553ee33.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:40:37 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey miqazuretest14047:lnmzXeo/fdc0aHtNMFMDffFpHlK9NN29QqCxmv/IjjQ=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - VbYhW9/6NOXzQVK/vQkdvg==
+      Last-Modified:
+      - Tue, 29 Nov 2016 14:57:16 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D4186802C56671"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 3523afa4-001e-0122-56e6-b90e1c000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '996'
+      X-Ms-Copy-Id:
+      - 132b5a37-c556-4c09-84f2-78b51b878335
+      X-Ms-Copy-Source:
+      - https://miqazuretest14047.blob.core.windows.net/system/Microsoft.Compute/Images/miq-test-container/test-win2k12-img-osDisk.e17a95b0-f4fb-4196-93c5-0c8be7d5c536.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=5Gh8F9hiPimv8f%2BVGFene145jChHlOuuNzzCF6STBFI%3D&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Tue, 28 Jun 2016 18:28:39 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Mon, 12 Mar 2018 09:40:32 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:40:37 GMT
+- request:
+    method: head
+    uri: https://miqazuretest14047.blob.core.windows.net/manageiq/dberger-delete_a2a5d43f-aa05-4d61-8da8-95086a4d357e.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:40:37 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey miqazuretest14047:apOh8+VRNwSWdCgqu/iJVkqXsKtSX2i+lzr1wg5cTBE=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - VbYhW9/6NOXzQVK/vQkdvg==
+      Last-Modified:
+      - Wed, 12 Apr 2017 17:53:45 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D481CCDDB5E3F9"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 19cd94bd-001e-0072-3ae6-b95741000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '7'
+      X-Ms-Copy-Id:
+      - 18656d46-e38a-49f2-9494-1fb692c3229e
+      X-Ms-Copy-Source:
+      - https://miqazuretest14047.blob.core.windows.net/system/Microsoft.Compute/Images/miq-test-container/test-win2k12-img-osDisk.e17a95b0-f4fb-4196-93c5-0c8be7d5c536.vhd?sv=2015-12-11&sr=b&sk=system-1&sig=g1Xi8z6%2fPY7F1q4P5o1taM4NsmJHAuCBwwcsLaFy3Zo%3d&se=9999-01-01T00%3a00%3a00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Sun, 09 Apr 2017 23:44:16 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Mon, 12 Mar 2018 09:40:33 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:40:38 GMT
+- request:
+    method: head
+    uri: https://miqazuretest14047.blob.core.windows.net/manageiq/dberger-deleteme1_eefc1727-019b-4285-a5f8-0869efe8a037.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:40:38 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey miqazuretest14047:nC6XhQzzdZ4FOyskcsgrXUwoEXJJo5/ZaWxxFCjIBNQ=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - VbYhW9/6NOXzQVK/vQkdvg==
+      Last-Modified:
+      - Fri, 26 Aug 2016 22:48:02 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D3CE0309469EC4"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - f6cd87a7-001e-0076-1fe6-b9a2c3000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '1'
+      X-Ms-Copy-Id:
+      - 6b10e24b-5956-4d4e-bc60-f964a1a50eb6
+      X-Ms-Copy-Source:
+      - https://miqazuretest14047.blob.core.windows.net/system/Microsoft.Compute/Images/miq-test-container/test-win2k12-img-osDisk.e17a95b0-f4fb-4196-93c5-0c8be7d5c536.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=5Gh8F9hiPimv8f%2BVGFene145jChHlOuuNzzCF6STBFI%3D&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Fri, 26 Aug 2016 22:15:06 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Mon, 12 Mar 2018 09:40:34 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:40:39 GMT
+- request:
+    method: head
+    uri: https://miqazuretest14047.blob.core.windows.net/manageiq/dbergerprov1_9a78aa4c-d5f6-4d58-b083-90691eda7b64.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:40:39 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey miqazuretest14047:LAtQ1jAW3Ni82r3GS/o42p2eiZjx/y18qEWnscStXXE=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - VbYhW9/6NOXzQVK/vQkdvg==
+      Last-Modified:
+      - Thu, 01 Sep 2016 19:48:45 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D3D2A0FBCACDD3"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 7fd40cab-001e-012e-1fe6-b9e0ed000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '238'
+      X-Ms-Copy-Id:
+      - 7d90a223-3d80-41fa-9a03-20404494af69
+      X-Ms-Copy-Source:
+      - https://miqazuretest14047.blob.core.windows.net/system/Microsoft.Compute/Images/miq-test-container/test-win2k12-img-osDisk.e17a95b0-f4fb-4196-93c5-0c8be7d5c536.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=5Gh8F9hiPimv8f%2BVGFene145jChHlOuuNzzCF6STBFI%3D&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Mon, 08 Aug 2016 16:46:08 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Mon, 12 Mar 2018 09:40:34 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:40:39 GMT
+- request:
+    method: head
+    uri: https://miqazuretest14047.blob.core.windows.net/manageiq/dbergerprov2_a7be6d36-d0ca-4fad-8cd0-fc2f048e0446.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:40:39 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey miqazuretest14047:tALE9y1Ju5xIGz74Jlfx36rBysGs2DcDG7gFH53vCx4=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - VbYhW9/6NOXzQVK/vQkdvg==
+      Last-Modified:
+      - Thu, 01 Sep 2016 19:48:54 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D3D2A101A54A58"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 435ddb13-001e-0006-6fe6-b9d107000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '165'
+      X-Ms-Copy-Id:
+      - 1db48d4b-3188-4e71-9552-cddd47ce2cf9
+      X-Ms-Copy-Source:
+      - https://miqazuretest14047.blob.core.windows.net/system/Microsoft.Compute/Images/miq-test-container/test-win2k12-img-osDisk.e17a95b0-f4fb-4196-93c5-0c8be7d5c536.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=5Gh8F9hiPimv8f%2BVGFene145jChHlOuuNzzCF6STBFI%3D&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Mon, 08 Aug 2016 21:23:53 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Mon, 12 Mar 2018 09:40:35 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:40:40 GMT
+- request:
+    method: head
+    uri: https://miqazuretest14047.blob.core.windows.net/manageiq/dbergerx_60873a6e-709e-409f-8048-9dcabc09d467.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:40:40 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey miqazuretest14047:OiCZ9V0Uzhvhqy9e3cQ+PTsgNwXQifNfQY2pCwzTm4o=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - VbYhW9/6NOXzQVK/vQkdvg==
+      Last-Modified:
+      - Mon, 03 Apr 2017 18:56:00 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D47AC311B8306B"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - c54246d1-001e-00e6-2ae6-b9378f000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '5'
+      X-Ms-Copy-Id:
+      - 970a4f72-6240-47c3-a67b-16778ececfc2
+      X-Ms-Copy-Source:
+      - https://miqazuretest14047.blob.core.windows.net/system/Microsoft.Compute/Images/miq-test-container/test-win2k12-img-osDisk.e17a95b0-f4fb-4196-93c5-0c8be7d5c536.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=5Gh8F9hiPimv8f%2BVGFene145jChHlOuuNzzCF6STBFI%3D&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Fri, 16 Dec 2016 20:12:13 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Mon, 12 Mar 2018 09:40:35 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:40:40 GMT
+- request:
+    method: head
+    uri: https://miqazuretest14047.blob.core.windows.net/manageiq/drew1_5c35f695-b2ae-4d86-937f-fcc6fcbb9fb0.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:40:40 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey miqazuretest14047:H84cqIgglllwIRdI88iL9K5B53rQN/oG7Qq4EjhXd9s=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - VbYhW9/6NOXzQVK/vQkdvg==
+      Last-Modified:
+      - Thu, 15 Sep 2016 22:28:48 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D3DDB7A96B8000"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - afdd1d3a-001e-013a-75e6-b92389000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '1'
+      X-Ms-Copy-Id:
+      - 89ed087a-0134-48e7-abb8-9564b9569237
+      X-Ms-Copy-Source:
+      - https://miqazuretest14047.blob.core.windows.net/system/Microsoft.Compute/Images/miq-test-container/test-win2k12-img-osDisk.e17a95b0-f4fb-4196-93c5-0c8be7d5c536.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=5Gh8F9hiPimv8f%2BVGFene145jChHlOuuNzzCF6STBFI%3D&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Thu, 15 Sep 2016 22:16:59 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Mon, 12 Mar 2018 09:40:36 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:40:41 GMT
+- request:
+    method: head
+    uri: https://miqazuretest14047.blob.core.windows.net/manageiq/jb_win_demo_vm_ad89c080-8b1d-47a2-8a73-ee6d7a53c6cc.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:40:41 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey miqazuretest14047:9Gj4jvNRztOF1T9ZPD72GF8xYcX8HlZ9fYmeXOYO1iw=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - VbYhW9/6NOXzQVK/vQkdvg==
+      Last-Modified:
+      - Tue, 09 May 2017 19:36:56 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D49712C0F71135"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 225723f7-001e-011a-74e6-b94f45000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '5'
+      X-Ms-Copy-Id:
+      - 816caf6b-baaf-42dd-a29c-ca301e55dc7b
+      X-Ms-Copy-Source:
+      - https://miqazuretest14047.blob.core.windows.net/system/Microsoft.Compute/Images/miq-test-container/test-win2k12-img-osDisk.e17a95b0-f4fb-4196-93c5-0c8be7d5c536.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=5Gh8F9hiPimv8f%2bVGFene145jChHlOuuNzzCF6STBFI%3d&se=9999-01-01T00%3a00%3a00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Fri, 17 Mar 2017 06:06:34 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Mon, 12 Mar 2018 09:40:36 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:40:41 GMT
+- request:
+    method: head
+    uri: https://miqazuretest14047.blob.core.windows.net/manageiq/lucy_2_eef078a8-9bfe-469e-9340-e0342a4fe3bc.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:40:41 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey miqazuretest14047:TmeHNcl0Rq45Qpsk+85WtP7lMzn6Wjgqibpln7SdvqQ=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - VbYhW9/6NOXzQVK/vQkdvg==
+      Last-Modified:
+      - Tue, 29 Nov 2016 16:07:07 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D41871C4E5AC4B"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 2071930b-001e-002e-3ae6-b9a6b8000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '2'
+      X-Ms-Copy-Id:
+      - eae39deb-b81b-4271-a8b7-2c80db51f83c
+      X-Ms-Copy-Source:
+      - https://miqazuretest14047.blob.core.windows.net/system/Microsoft.Compute/Images/miq-test-container/test-win2k12-img-osDisk.e17a95b0-f4fb-4196-93c5-0c8be7d5c536.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=5Gh8F9hiPimv8f%2BVGFene145jChHlOuuNzzCF6STBFI%3D&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Mon, 28 Nov 2016 23:14:31 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Mon, 12 Mar 2018 09:40:37 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:40:42 GMT
+- request:
+    method: head
+    uri: https://miqazuretest14047.blob.core.windows.net/manageiq/lucy_3_d124b42c-7cf1-4184-9683-799c584a5919.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:40:42 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey miqazuretest14047:dYTR8rADIcJDTYK7gjonaW2qezVO+xrI0LqXPBC8x9c=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - VbYhW9/6NOXzQVK/vQkdvg==
+      Last-Modified:
+      - Thu, 03 Aug 2017 20:37:07 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D4DAAF685AB297"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 9dfbbfe6-001e-0135-33e6-b9ce7f000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '4'
+      X-Ms-Copy-Id:
+      - 7e6bfae6-d00b-4b57-a8ab-2da86998bf1b
+      X-Ms-Copy-Source:
+      - https://miqazuretest14047.blob.core.windows.net/system/Microsoft.Compute/Images/miq-test-container/test-win2k12-img-osDisk.e17a95b0-f4fb-4196-93c5-0c8be7d5c536.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=5Gh8F9hiPimv8f%2BVGFene145jChHlOuuNzzCF6STBFI%3D&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Tue, 29 Nov 2016 16:21:23 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Mon, 12 Mar 2018 09:40:38 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:40:43 GMT
+- request:
+    method: head
+    uri: https://miqazuretest14047.blob.core.windows.net/manageiq/lucy_4_261857b1-fb35-4ce0-b7b7-fd148c7e6ebd.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:40:43 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey miqazuretest14047:D6WvTsciGvqDshnFUlJFyzVH7dv/nwgh7TVwT4ATMeY=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - VbYhW9/6NOXzQVK/vQkdvg==
+      Last-Modified:
+      - Tue, 29 Nov 2016 18:46:55 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D4188817698A48"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - c2b8b7df-001e-0139-34e6-b9208e000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '1'
+      X-Ms-Copy-Id:
+      - 9837fcf2-407d-4b5d-8204-2705e5027653
+      X-Ms-Copy-Source:
+      - https://miqazuretest14047.blob.core.windows.net/system/Microsoft.Compute/Images/miq-test-container/test-win2k12-img-osDisk.e17a95b0-f4fb-4196-93c5-0c8be7d5c536.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=5Gh8F9hiPimv8f%2BVGFene145jChHlOuuNzzCF6STBFI%3D&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Tue, 29 Nov 2016 18:29:15 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Mon, 12 Mar 2018 09:40:38 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:40:43 GMT
+- request:
+    method: head
+    uri: https://miqazuretest14047.blob.core.windows.net/manageiq/sectest2_84ad7b2b-9100-40db-8997-a31912cf27c1.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:40:43 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey miqazuretest14047:6vVCDznziPAEEkeqAR5m4ZjUVB3k5cW69XNyCr8iJ8A=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - VbYhW9/6NOXzQVK/vQkdvg==
+      Last-Modified:
+      - Wed, 20 Apr 2016 18:18:26 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D369482A927F95"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - d34f5a0e-001e-0075-7ce6-b9a1c4000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '1'
+      X-Ms-Copy-Id:
+      - a46ba27d-357f-4abe-9af1-24fc8c741896
+      X-Ms-Copy-Source:
+      - https://miqazuretest14047.blob.core.windows.net/system/Microsoft.Compute/Images/miq-test-container/test-win2k12-img-osDisk.e17a95b0-f4fb-4196-93c5-0c8be7d5c536.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=lYt%2BpYh8i9T8VnXGjGHlh4WiiQs%2B5wB%2BO6WhLOfAEjo%3D&st=2016-04-20T15%3A49%3A53Z&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Wed, 20 Apr 2016 16:04:56 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Mon, 12 Mar 2018 09:40:39 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:40:44 GMT
+- request:
+    method: head
+    uri: https://miqazuretest14047.blob.core.windows.net/manageiq/test-billy-azure33_a676ca34-c43f-4f58-a96c-30cf0645f6ea.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:40:44 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey miqazuretest14047:cuSGcSAzp0YHgJyp3LGW3x3v4GV71d1/y0VQOJX3DP4=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - VbYhW9/6NOXzQVK/vQkdvg==
+      Last-Modified:
+      - Mon, 12 Sep 2016 17:25:39 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D3DB31D0DDF9EF"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 2e771381-001e-0065-7ee6-b99722000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '3'
+      X-Ms-Copy-Id:
+      - ed24a039-e996-47a2-946a-7e64ac711bc8
+      X-Ms-Copy-Source:
+      - https://miqazuretest14047.blob.core.windows.net/system/Microsoft.Compute/Images/miq-test-container/test-win2k12-img-osDisk.e17a95b0-f4fb-4196-93c5-0c8be7d5c536.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=5Gh8F9hiPimv8f%2BVGFene145jChHlOuuNzzCF6STBFI%3D&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Thu, 08 Sep 2016 22:39:40 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Mon, 12 Mar 2018 09:40:39 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:40:44 GMT
+- request:
+    method: head
+    uri: https://miqazuretest14047.blob.core.windows.net/manageiq/test-billy-azure34_3c1cc2b6-174a-43bb-9d30-b3495444d9f6.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:40:44 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey miqazuretest14047:9zEIgrcVJk2QmxWA+LLdXmHbd/dSrZxUOuxJzQHugzo=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - VbYhW9/6NOXzQVK/vQkdvg==
+      Last-Modified:
+      - Mon, 12 Sep 2016 17:20:39 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D3DB311E2B8DFD"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 1ae184d8-001e-00f5-57e6-b9026e000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '1'
+      X-Ms-Copy-Id:
+      - 843fe2c2-3816-4abb-b234-0f668fe23f63
+      X-Ms-Copy-Source:
+      - https://miqazuretest14047.blob.core.windows.net/system/Microsoft.Compute/Images/miq-test-container/test-win2k12-img-osDisk.e17a95b0-f4fb-4196-93c5-0c8be7d5c536.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=5Gh8F9hiPimv8f%2BVGFene145jChHlOuuNzzCF6STBFI%3D&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Fri, 09 Sep 2016 17:03:06 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Mon, 12 Mar 2018 09:40:40 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:40:45 GMT
+- request:
+    method: head
+    uri: https://miqazuretest14047.blob.core.windows.net/manageiq/test-billy-azure35_caeaf4af-b486-4edc-9847-b658a0e197c2.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:40:45 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey miqazuretest14047:GaFzEQK0WVTc5pGP4uDI2BP4tgtOyYoL4gmZEaP+6lw=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - VbYhW9/6NOXzQVK/vQkdvg==
+      Last-Modified:
+      - Tue, 13 Sep 2016 15:44:57 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D3DBECE9E91FCD"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - aef8fa2a-001e-00bd-1ce6-b930f3000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '1'
+      X-Ms-Copy-Id:
+      - d53de01e-8564-489c-a6ad-fce9fa60374a
+      X-Ms-Copy-Source:
+      - https://miqazuretest14047.blob.core.windows.net/system/Microsoft.Compute/Images/miq-test-container/test-win2k12-img-osDisk.e17a95b0-f4fb-4196-93c5-0c8be7d5c536.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=5Gh8F9hiPimv8f%2BVGFene145jChHlOuuNzzCF6STBFI%3D&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Tue, 13 Sep 2016 15:27:27 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Mon, 12 Mar 2018 09:40:40 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:40:46 GMT
+- request:
+    method: head
+    uri: https://miqazuretest14047.blob.core.windows.net/manageiq/test-billy-azure36_f88f59a7-cc6f-4464-88ba-61adca792ecc.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:40:46 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey miqazuretest14047:qmYabejqtaXbf6mSfiKOItyxhnM4rIMOWrWaf7SseLU=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - VbYhW9/6NOXzQVK/vQkdvg==
+      Last-Modified:
+      - Tue, 13 Sep 2016 16:16:27 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D3DBF1509A929C"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 9395cdfa-001e-0085-5fe6-b971aa000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '1'
+      X-Ms-Copy-Id:
+      - d8c280ca-2b6b-407c-9bde-393ada3156d1
+      X-Ms-Copy-Source:
+      - https://miqazuretest14047.blob.core.windows.net/system/Microsoft.Compute/Images/miq-test-container/test-win2k12-img-osDisk.e17a95b0-f4fb-4196-93c5-0c8be7d5c536.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=5Gh8F9hiPimv8f%2BVGFene145jChHlOuuNzzCF6STBFI%3D&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Tue, 13 Sep 2016 15:55:45 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Mon, 12 Mar 2018 09:40:42 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:40:46 GMT
+- request:
+    method: head
+    uri: https://miqazuretest14047.blob.core.windows.net/manageiq/test-billy-azure38_e934e3f0-f3d8-4b5b-8015-55e5bd392cbc.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:40:46 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey miqazuretest14047:RAkx/hp7xEXle7j/x5eOz4hegc8mQUTnIXZISj/IoQM=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - VbYhW9/6NOXzQVK/vQkdvg==
+      Last-Modified:
+      - Tue, 13 Sep 2016 21:22:59 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D3DC1C22FD29B5"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 1ae500d7-001e-0115-25e6-b9a2b3000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '1'
+      X-Ms-Copy-Id:
+      - 8e5d1222-fdfb-4ae8-ae35-9d1e84718da9
+      X-Ms-Copy-Source:
+      - https://miqazuretest14047.blob.core.windows.net/system/Microsoft.Compute/Images/miq-test-container/test-win2k12-img-osDisk.e17a95b0-f4fb-4196-93c5-0c8be7d5c536.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=5Gh8F9hiPimv8f%2BVGFene145jChHlOuuNzzCF6STBFI%3D&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Tue, 13 Sep 2016 20:12:03 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Mon, 12 Mar 2018 09:40:42 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:40:47 GMT
+- request:
+    method: head
+    uri: https://miqazuretest14047.blob.core.windows.net/manageiq/test-billy-azure40_78c0ae1c-2b12-4aa8-bb3c-bf6270c11d1c.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:40:47 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey miqazuretest14047:305SAkNOWshlc3K/3r6l5/L2+Zs2m7NmB/BFExn1ytM=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - VbYhW9/6NOXzQVK/vQkdvg==
+      Last-Modified:
+      - Thu, 15 Sep 2016 21:05:17 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D3DDABFF25AD9F"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 7f10e0fa-001e-00dd-4de6-b975d1000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '1'
+      X-Ms-Copy-Id:
+      - 52ef61fe-23ac-4c16-8433-3914079392b1
+      X-Ms-Copy-Source:
+      - https://miqazuretest14047.blob.core.windows.net/system/Microsoft.Compute/Images/miq-test-container/test-win2k12-img-osDisk.e17a95b0-f4fb-4196-93c5-0c8be7d5c536.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=5Gh8F9hiPimv8f%2BVGFene145jChHlOuuNzzCF6STBFI%3D&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Thu, 15 Sep 2016 18:02:47 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Mon, 12 Mar 2018 09:40:43 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:40:48 GMT
+- request:
+    method: head
+    uri: https://miqazuretest14047.blob.core.windows.net/manageiq/test-billy-azure51_d8d15880-191f-4221-99cc-cb102ba4dcf8.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:40:48 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey miqazuretest14047:MvbISucFibaNzcSA+PtGKh4ugeXBJZn+sFNBr5DPQU8=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - VbYhW9/6NOXzQVK/vQkdvg==
+      Last-Modified:
+      - Fri, 23 Sep 2016 14:18:46 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D3E3BC87F6E740"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - aedd557a-001e-0041-01e6-b90e6c000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '1'
+      X-Ms-Copy-Id:
+      - 206fd419-fad5-4de4-ac65-5662e465629e
+      X-Ms-Copy-Source:
+      - https://miqazuretest14047.blob.core.windows.net/system/Microsoft.Compute/Images/miq-test-container/test-win2k12-img-osDisk.e17a95b0-f4fb-4196-93c5-0c8be7d5c536.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=5Gh8F9hiPimv8f%2BVGFene145jChHlOuuNzzCF6STBFI%3D&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Fri, 23 Sep 2016 13:33:24 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Mon, 12 Mar 2018 09:40:43 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:40:48 GMT
+- request:
+    method: head
+    uri: https://miqazuretest14047.blob.core.windows.net/manageiq/test-billya37_f2f0e962-d3c7-4029-9b2d-14982e667016.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:40:48 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey miqazuretest14047:17w+QfSd9LGFatzkopCGJjJtAtQVKAfkYUVahkaTvts=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - VbYhW9/6NOXzQVK/vQkdvg==
+      Last-Modified:
+      - Thu, 15 Sep 2016 14:59:04 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D3DD78D617FEC3"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 9edc2a0a-001e-006d-80e6-b98c51000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '1'
+      X-Ms-Copy-Id:
+      - 756ccfe8-f7c9-4c1f-bf69-ecf26a80ccf8
+      X-Ms-Copy-Source:
+      - https://miqazuretest14047.blob.core.windows.net/system/Microsoft.Compute/Images/miq-test-container/test-win2k12-img-osDisk.e17a95b0-f4fb-4196-93c5-0c8be7d5c536.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=5Gh8F9hiPimv8f%2BVGFene145jChHlOuuNzzCF6STBFI%3D&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Tue, 13 Sep 2016 20:51:15 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Mon, 12 Mar 2018 09:40:43 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:40:49 GMT
+- request:
+    method: head
+    uri: https://miqazuretest14047.blob.core.windows.net/manageiq/testbillyaaa_953e913d-6625-471f-b6f0-4e9353723c39.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:40:49 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey miqazuretest14047:CQTs0K3qn9kAr9cbCloV6/pzK0KxMdBp/T8vlryQZgw=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - VbYhW9/6NOXzQVK/vQkdvg==
+      Last-Modified:
+      - Thu, 15 Sep 2016 14:59:39 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D3DD78EAAA17CF"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - aab19d02-001e-0021-23e6-b94b4e000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '1'
+      X-Ms-Copy-Id:
+      - f2788f74-743f-41d7-a542-ff55bc29bd83
+      X-Ms-Copy-Source:
+      - https://miqazuretest14047.blob.core.windows.net/system/Microsoft.Compute/Images/miq-test-container/test-win2k12-img-osDisk.e17a95b0-f4fb-4196-93c5-0c8be7d5c536.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=5Gh8F9hiPimv8f%2BVGFene145jChHlOuuNzzCF6STBFI%3D&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Tue, 13 Sep 2016 20:35:31 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Mon, 12 Mar 2018 09:40:43 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:40:49 GMT
+- request:
+    method: head
+    uri: https://miqazuretest14047.blob.core.windows.net/manageiq/testbillyzzzz_43cfa30e-2d72-49af-a72d-1e764dfbf756.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:40:49 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey miqazuretest14047:m5kD/HJwNYtinYoRokCSZjz9k7i1EbOy3S4NP6UVnw4=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - VbYhW9/6NOXzQVK/vQkdvg==
+      Last-Modified:
+      - Thu, 15 Sep 2016 15:04:31 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D3DD7998F61CB2"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 317518ca-001e-0061-3fe6-b962a0000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '2'
+      X-Ms-Copy-Id:
+      - b608d345-b3a7-4b4f-97c4-0fe649fda958
+      X-Ms-Copy-Source:
+      - https://miqazuretest14047.blob.core.windows.net/system/Microsoft.Compute/Images/miq-test-container/test-win2k12-img-osDisk.e17a95b0-f4fb-4196-93c5-0c8be7d5c536.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=5Gh8F9hiPimv8f%2BVGFene145jChHlOuuNzzCF6STBFI%3D&se=9999-01-01T00%3A00%3A00Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Tue, 13 Sep 2016 19:41:12 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Mon, 12 Mar 2018 09:40:45 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:40:50 GMT
+- request:
+    method: get
+    uri: https://miqazuretest14047.blob.core.windows.net/system?comp=list&restype=container
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:40:50 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Authorization:
+      - SharedKey miqazuretest14047:T2Q49TD9y1f6TQDOHVgpIprLRTHfnDXjsrnSj8Z37Y4=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/xml
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - dc51a077-001e-008c-41e6-b96b24000000
+      X-Ms-Version:
+      - '2016-05-31'
+      Date:
+      - Mon, 12 Mar 2018 09:40:45 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9taXFhenVyZXRlc3QxNDA0Ny5ibG9iLmNvcmUud2luZG93cy5uZXQvIiBDb250YWluZXJOYW1lPSJzeXN0ZW0iPjxCbG9icz48QmxvYj48TmFtZT5NaWNyb3NvZnQuQ29tcHV0ZS9JbWFnZXMvbWlxLXRlc3QtY29udGFpbmVyL3Rlc3Qtd2luMmsxMi1pbWctb3NEaXNrLmUxN2E5NWIwLWY0ZmItNDE5Ni05M2M1LTBjOGJlN2Q1YzUzNi52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VHVlLCAyMiBNYXIgMjAxNiAxNzowODowMiBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDM1Mjc0ODc1QjRGOTE8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjE8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5NaWNyb3NvZnQuQ29tcHV0ZS9JbWFnZXMvbWlxLXRlc3QtY29udGFpbmVyL3Rlc3Qtd2luMmsxMi1pbWctdm1UZW1wbGF0ZS5lMTdhOTViMC1mNGZiLTQxOTYtOTNjNS0wYzhiZTdkNWM1MzYuanNvbjwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UdWUsIDIyIE1hciAyMDE2IDE3OjA4OjAzIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMzUyNzQ4Nzk3QTNCMDwvRXRhZz48Q29udGVudC1MZW5ndGg+MjAyNDwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9qc29uPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5zdURBYnR6RnBBVEpGYk55RDRLVWhBPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48QmxvYlR5cGU+QmxvY2tCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48L0Jsb2JzPjxOZXh0TWFya2VyIC8+PC9FbnVtZXJhdGlvblJlc3VsdHM+
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:40:51 GMT
+- request:
+    method: head
+    uri: https://miqazuretest14047.blob.core.windows.net/system/Microsoft.Compute/Images/miq-test-container/test-win2k12-img-osDisk.e17a95b0-f4fb-4196-93c5-0c8be7d5c536.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:40:51 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey miqazuretest14047:n5C+wTrmMAKEHGnWImor1OcnYV6zuMaZ9hZIdyCORF0=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - VbYhW9/6NOXzQVK/vQkdvg==
+      Last-Modified:
+      - Tue, 22 Mar 2016 17:08:02 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D35274875B4F91"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - de43fd9a-001e-00a4-38e6-b91c9b000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Meta-Microsoftazurecompute-Capturedvmkey:
+      - "/Subscriptions/AZURE_SUBSCRIPTION_ID/ResourceGroups/MIQ-AZURE-TEST1/VMs/MIQ-TEST-WINIMG"
+      X-Ms-Meta-Microsoftazurecompute-Imagetype:
+      - OSDisk
+      X-Ms-Meta-Microsoftazurecompute-Osstate:
+      - Generalized
+      X-Ms-Meta-Microsoftazurecompute-Ostype:
+      - Windows
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '1'
+      X-Ms-Copy-Id:
+      - 5e86815c-7940-4fbc-a743-1afe6f82cccc
+      X-Ms-Copy-Source:
+      - https://miqazuretest14047.blob.core.windows.net/vhds/miq-test-winimg201622210407.vhd?sv=2014-02-14&sr=b&sk=system-1&sig=2HwUe6%2FumcrsmlXMJXoIKLHUa7vHYZesuIsLK3M3gkM%3D&st=2016-03-22T16%3A53%3A01Z&se=2016-03-22T18%3A08%3A01Z&sp=rw
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Tue, 22 Mar 2016 17:08:02 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Mon, 12 Mar 2018 09:40:46 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:40:51 GMT
+- request:
+    method: get
+    uri: https://miqazuretest14047.blob.core.windows.net/vhds?comp=list&restype=container
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:40:51 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Authorization:
+      - SharedKey miqazuretest14047:7vsMsl0p/g0pAeRmgYWYzErC6Z14Yipf++RSx+K0BuQ=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/xml
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 1e422cad-001e-001c-64e6-b9fe68000000
+      X-Ms-Version:
+      - '2016-05-31'
+      Date:
+      - Mon, 12 Mar 2018 09:40:46 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9taXFhenVyZXRlc3QxNDA0Ny5ibG9iLmNvcmUud2luZG93cy5uZXQvIiBDb250YWluZXJOYW1lPSJ2aGRzIj48QmxvYnM+PEJsb2I+PE5hbWU+bWlxLXRlc3Qtd2luMTIyMDE2MjE4MTEzMDE0LnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UaHUsIDE5IE9jdCAyMDE3IDAyOjAxOjM2IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhENTE2OTU1NDUyOTlERTwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MjkzPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+bGVhc2VkPC9MZWFzZVN0YXRlPjxMZWFzZUR1cmF0aW9uPmluZmluaXRlPC9MZWFzZUR1cmF0aW9uPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPm1pcS10ZXN0LXdpbmltZy5iOTdmZjQ4OC1lMTE0LTQwZWQtOGQ3YS1mNDUwMGQ3M2VlYzAuc3RhdHVzPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlR1ZSwgMjIgTWFyIDIwMTYgMTY6MzA6MjkgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzNTI2RjQ4MUUyQzQ3PC9FdGFnPjxDb250ZW50LUxlbmd0aD44ODQ8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT4xSytsTEp6c3U0SjVBbW5qcUJ1dVhBPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48QmxvYlR5cGU+QmxvY2tCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5taXEtdGVzdC13aW5pbWcuZTE3YTk1YjAtZjRmYi00MTk2LTkzYzUtMGM4YmU3ZDVjNTM2LnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UdWUsIDIyIE1hciAyMDE2IDE2OjU4OjQwIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMzUyNzMzN0VGQTA4MTwvRXRhZz48Q29udGVudC1MZW5ndGg+ODg0PC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+RFNCbitSZkhBZ0JGRFgrUzh6OVd1QT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+bWlxLXRlc3Qtd2luaW1nMjAxNjIyMjEwMTY0My52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VHVlLCAyMiBNYXIgMjAxNiAxNjozNzo0MiBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDM1MjcwNEEzQjFFQTY8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjE8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5taXEtdGVzdC13aW5pbWcyMDE2MjIyMTA0MDcudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlR1ZSwgMjIgTWFyIDIwMTYgMTY6NTk6MDAgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzNTI3MzQzQkEzMTUyPC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4xPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+bGVhc2VkPC9MZWFzZVN0YXRlPjxMZWFzZUR1cmF0aW9uPmluZmluaXRlPC9MZWFzZUR1cmF0aW9uPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPm1pcWF6dXJlLWNlbnRvczEuNzk2YzViY2MtMzM4YS00NDhkLWI2MWMtMTY1Mjc5YTdmYjNlLnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5GcmksIDIyIEFwciAyMDE2IDE5OjA1OjQ2IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMzZBRTExQzQ3ODkxMDwvRXRhZz48Q29udGVudC1MZW5ndGg+NjgzPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+eExRZy9FbWJRNnVRR0VGaStiWG0zZz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+bWlxYXp1cmUtY2VudG9zMTIwMTYyMjExMDQ5NDYudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPkZyaSwgMjIgQXByIDIwMTYgMTk6MDU6NTggR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzNkFFMTIzOTU0QjM1PC9FdGFnPjxDb250ZW50LUxlbmd0aD4zMjIxMjI1NTIzMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PmJMSzdyZ1Q3SWdNTlgyWXhMOUJDeWc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjE8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+bG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5sZWFzZWQ8L0xlYXNlU3RhdGU+PExlYXNlRHVyYXRpb24+aW5maW5pdGU8L0xlYXNlRHVyYXRpb24+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PC9CbG9icz48TmV4dE1hcmtlciAvPjwvRW51bWVyYXRpb25SZXN1bHRzPg==
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:40:52 GMT
+- request:
+    method: head
+    uri: https://miqazuretest14047.blob.core.windows.net/vhds/miq-test-winimg2016222101643.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:40:52 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey miqazuretest14047:KGJRwSK04kELHck5GLidXvXao567D0WKGggG/4qMk0I=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - VbYhW9/6NOXzQVK/vQkdvg==
+      Last-Modified:
+      - Tue, 22 Mar 2016 16:37:42 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D352704A3B1EA6"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - cd9263fd-001e-0110-4fe6-b956cc000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '1'
+      X-Ms-Copy-Id:
+      - 3c0639b5-b6b2-4eac-a356-26e780749f96
+      X-Ms-Copy-Source:
+      - https://ardfepirv2bl5prdstr06.blob.core.windows.net/a699494373c04fc0bc8f2bb1389d6106/Windows-Server-2012-R2-20160229-en.us-127GB.vhd?sv=2014-02-14&sr=b&si=PirCacheAccountPublisherContainerPolicy&sig=ipib%2Bgp2Sh4hS%2BBx5OUKgXSymDC0Tu0Ge60PGFuy5uk%3D
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Tue, 22 Mar 2016 16:17:06 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Mon, 12 Mar 2018 09:40:48 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:40:53 GMT
+- request:
+    method: post
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb/listKeys?api-version=2017-10-01
+    body:
+      encoding: ASCII-8BIT
       string: ''
     headers:
       Accept:
@@ -2597,7 +5815,9 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDczMTMsIm5iZiI6MTUyMDg0NzMxMywiZXhwIjoxNTIwODUxMjEzLCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSVNQX0Vib21BazJrMzVYYWh4OFdBQSIsInZlciI6IjEuMCJ9.Wu6fVB9E0uRasF_-32jZU8DB0Qxro_-3yuzu9fA5RBm6kNh4wr7dgXmHtzXXz5qgU0xIIO6PJ5R75gsyokGELyqaa9pddZLgambowSG-EHNVrEHlkc-OsoVUjZ8sk3xoPomz3T1C1YhVRn9VsR93oqzZ-DFfkffvePpipNJsJJUVc2ZySS9L6vngQ46sfO9D5i0fcR-o5gez9isdIehot_wG6wl7MN-keGyF8DpqZOHtGjOt39pCqZTj8EjVEAKQvkDQkz5CCqH6dpcRZKdYuFvH2saWx8wzsU3LKx86DDCpwLczSqL-ltc9nfmmQasO3HHvCNsUiRHitwO7FA3iZw
+      Content-Length:
+      - '0'
   response:
     status:
       code: 200
@@ -2610,40 +5830,844 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Content-Type:
-      - application/json; charset=utf-8
+      - application/json
       Expires:
       - "-1"
-      Etag:
-      - W/"cddd97d1-6111-4477-8a00-3dc885237a1d"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 1403e5b6-8fa0-4cd3-89b1-76b6c4fd805b
+      - 03244365-a2c3-47bf-94bc-3ffe4478fa58
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Writes:
+      - '1199'
       X-Ms-Correlation-Request-Id:
-      - e4a5f369-a742-466f-bd8f-42e17eaaf9c9
+      - 8ba3a4b3-1426-4941-8508-511047b04cdc
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102421Z:e4a5f369-a742-466f-bd8f-42e17eaaf9c9
+      - WESTEUROPE:20180312T094048Z:8ba3a4b3-1426-4941-8508-511047b04cdc
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:21 GMT
+      - Mon, 12 Mar 2018 09:40:48 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb2-publicip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\",\r\n
-        \ \"etag\": \"W/\\\"cddd97d1-6111-4477-8a00-3dc885237a1d\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"83e7257d-ab94-4229-8eb5-4798f37ef28d\",\r\n    \"publicIPAddressVersion\":
-        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
-        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
-        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
+      string: '{"keys":[{"keyName":"key1","value":"xMvZwiumnKCZnYVJjdtGLqaO1c2v6ERPx4XPDZO7TM1l7/jM1TxAAgtfCMkRn72aRPhqLqwWAn8n5a1iSGRHtA==","permissions":"Full"},{"keyName":"key2","value":"3nDvKhjGAIAvgnH2reuv7tzyeb/0dddgVeUT13VODYD5xO/jeAvQ7tkF3JqP2BAuFrmQqMB4GLkB4/cW4veYeA==","permissions":"Full"}]}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:26 GMT
+  recorded_at: Mon, 12 Mar 2018 09:40:53 GMT
+- request:
+    method: get
+    uri: https://rspeclb.blob.core.windows.net/?comp=list
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:40:53 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Authorization:
+      - SharedKey rspeclb:RQTSQ7ozhTFqhhKdTSLQ5qfiDHhR/QMeUDak/VSYKHA=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/xml
+      Vary:
+      - Origin
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - f03f6f6e-501c-0001-61e6-b9643a000000
+      X-Ms-Version:
+      - '2016-05-31'
+      Date:
+      - Mon, 12 Mar 2018 09:40:48 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPEVudW1lcmF0aW9uUmVzdWx0cyBTZXJ2aWNlRW5kcG9pbnQ9Imh0dHBzOi8vcnNwZWNsYi5ibG9iLmNvcmUud2luZG93cy5uZXQvIj48Q29udGFpbmVycz48Q29udGFpbmVyPjxOYW1lPnZoZHM8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+RnJpLCAwMiBTZXAgMjAxNiAxNjoyOTo0MSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+JnF1b3Q7MHg4RDNEMzRFNTcwREZDMEEmcXVvdDs8L0V0YWc+PExlYXNlU3RhdHVzPmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+bGVhc2VkPC9MZWFzZVN0YXRlPjxMZWFzZUR1cmF0aW9uPmluZmluaXRlPC9MZWFzZUR1cmF0aW9uPjwvUHJvcGVydGllcz48L0NvbnRhaW5lcj48L0NvbnRhaW5lcnM+PE5leHRNYXJrZXIvPjwvRW51bWVyYXRpb25SZXN1bHRzPg==
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:40:53 GMT
+- request:
+    method: get
+    uri: https://rspeclb.blob.core.windows.net/vhds?comp=list&restype=container
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:40:53 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Authorization:
+      - SharedKey rspeclb:PwW0LWRYhw8KVnqf6X2drfd0HVFMurAxuPoxMwno+Vk=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/xml
+      Vary:
+      - Origin
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - e6acc53c-f01c-0061-5ee6-b92118000000
+      X-Ms-Version:
+      - '2016-05-31'
+      Date:
+      - Mon, 12 Mar 2018 09:40:49 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPEVudW1lcmF0aW9uUmVzdWx0cyBTZXJ2aWNlRW5kcG9pbnQ9Imh0dHBzOi8vcnNwZWNsYi5ibG9iLmNvcmUud2luZG93cy5uZXQvIiBDb250YWluZXJOYW1lPSJ2aGRzIj48QmxvYnM+PEJsb2I+PE5hbWU+cnNwZWMtbGItYTIwMTY4MjEyMjgzOS52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+U2F0LCAwMyBTZXAgMjAxNiAxNDowMzoxNSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDNENDAzMENBMEFCRUY8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjMyMjEyMjU1MjMyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nLz48Q29udGVudC1MYW5ndWFnZS8+PENvbnRlbnQtTUQ1PjhCVzVocXJuT0xvUUlObFowNW9keEE9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wvPjxDb250ZW50LURpc3Bvc2l0aW9uLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4xPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+bGVhc2VkPC9MZWFzZVN0YXRlPjxMZWFzZUR1cmF0aW9uPmluZmluaXRlPC9MZWFzZUR1cmF0aW9uPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPnJzcGVjLWxiLWIyMDE2ODIxMjM2NTAudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlNhdCwgMDMgU2VwIDIwMTYgMTQ6MDU6NDAgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzRDQwMzYyRkUzODk4PC9FdGFnPjxDb250ZW50LUxlbmd0aD4zMjIxMjI1NTIzMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZy8+PENvbnRlbnQtTGFuZ3VhZ2UvPjxDb250ZW50LU1ENT44Qlc1aHFybk9Mb1FJTmxaMDVvZHhBPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sLz48Q29udGVudC1EaXNwb3NpdGlvbi8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MTwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJhdGlvbj5pbmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48L0Jsb2JzPjxOZXh0TWFya2VyLz48L0VudW1lcmF0aW9uUmVzdWx0cz4=
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:40:54 GMT
+- request:
+    method: post
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor/listKeys?api-version=2017-10-01
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDczMTMsIm5iZiI6MTUyMDg0NzMxMywiZXhwIjoxNTIwODUxMjEzLCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSVNQX0Vib21BazJrMzVYYWh4OFdBQSIsInZlciI6IjEuMCJ9.Wu6fVB9E0uRasF_-32jZU8DB0Qxro_-3yuzu9fA5RBm6kNh4wr7dgXmHtzXXz5qgU0xIIO6PJ5R75gsyokGELyqaa9pddZLgambowSG-EHNVrEHlkc-OsoVUjZ8sk3xoPomz3T1C1YhVRn9VsR93oqzZ-DFfkffvePpipNJsJJUVc2ZySS9L6vngQ46sfO9D5i0fcR-o5gez9isdIehot_wG6wl7MN-keGyF8DpqZOHtGjOt39pCqZTj8EjVEAKQvkDQkz5CCqH6dpcRZKdYuFvH2saWx8wzsU3LKx86DDCpwLczSqL-ltc9nfmmQasO3HHvCNsUiRHitwO7FA3iZw
+      Content-Length:
+      - '0'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 9dac45f4-9f85-42b3-84ce-53418370add4
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Writes:
+      - '1199'
+      X-Ms-Correlation-Request-Id:
+      - 1e543e13-8c8e-4ff6-894a-244221277546
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T094050Z:1e543e13-8c8e-4ff6-894a-244221277546
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:40:50 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"keys":[{"keyName":"key1","value":"68JHlwL/JgyPmvNCqop65JbepxzK0RGKJ4uD6EKszcgv1nRUJKkxO6u4OoyW/6YPT+FMJxvzEBrCGD/bduFGJQ==","permissions":"Full"},{"keyName":"key2","value":"NCT/sPC/+mrVRzXq/V5IwjN2SPaWRF4kY2coPHzJ8f+IkWMUIyfUgYTAN//h4KnxeWuX9OkY1CPyssDhDs91fw==","permissions":"Full"}]}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:40:54 GMT
+- request:
+    method: get
+    uri: https://spec0deply1stor.blob.core.windows.net/?comp=list
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:40:54 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Authorization:
+      - SharedKey spec0deply1stor:b3TI+OetgS14nXSqv9P9rW4UPPrk3EGiFL385Qwz1/A=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/xml
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 7173ce8a-001e-0124-36e6-b9f964000000
+      X-Ms-Version:
+      - '2016-05-31'
+      Date:
+      - Mon, 12 Mar 2018 09:40:50 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9zcGVjMGRlcGx5MXN0b3IuYmxvYi5jb3JlLndpbmRvd3MubmV0LyI+PENvbnRhaW5lcnM+PENvbnRhaW5lcj48TmFtZT5ib290ZGlhZ25vc3RpY3Mtc3BlYzBkZXBsLTRkMTUwMmQ1LTM1MWEtNDJmNC04NTY5LTIyMjg0ZjkwNmQ2ODwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5Nb24sIDA0IEFwciAyMDE2IDIzOjI0OjU2IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4iMHg4RDM1Q0UwNTU2MzlCQjMiPC9FdGFnPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0NvbnRhaW5lcj48Q29udGFpbmVyPjxOYW1lPmJvb3RkaWFnbm9zdGljcy1zcGVjMGRlcGwtZDcwMjIwMDgtZjZiMS00ZjRjLThiZTgtZTJkNjc3ZWYzMjYxPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPk1vbiwgMDQgQXByIDIwMTYgMjM6MjQ6NTYgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPiIweDhEMzVDRTA1NTg1QjcwQyI8L0V0YWc+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQ29udGFpbmVyPjxDb250YWluZXI+PE5hbWU+dmhkczwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5Nb24sIDA0IEFwciAyMDE2IDIzOjI0OjU3IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4iMHg4RDM1Q0UwNTVDRkEzN0IiPC9FdGFnPjxMZWFzZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJhdGlvbj5pbmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48L1Byb3BlcnRpZXM+PC9Db250YWluZXI+PC9Db250YWluZXJzPjxOZXh0TWFya2VyIC8+PC9FbnVtZXJhdGlvblJlc3VsdHM+
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:40:55 GMT
+- request:
+    method: get
+    uri: https://spec0deply1stor.blob.core.windows.net/vhds?comp=list&restype=container
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:40:55 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Authorization:
+      - SharedKey spec0deply1stor:0XTQnNawn+dZH+hrNJv/r+5+EnYRc1mkPk7Z495EHWw=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/xml
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - efa9b01f-001e-004c-71e6-b9e160000000
+      X-Ms-Version:
+      - '2016-05-31'
+      Date:
+      - Mon, 12 Mar 2018 09:40:52 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9zcGVjMGRlcGx5MXN0b3IuYmxvYi5jb3JlLndpbmRvd3MubmV0LyIgQ29udGFpbmVyTmFtZT0idmhkcyI+PEJsb2JzPjxCbG9iPjxOYW1lPm9zZGlzazAudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlNhdCwgMDMgU2VwIDIwMTYgMDI6MDQ6MzggR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzRDM5RUE4RjcxNzE1PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj40MzwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJhdGlvbj5pbmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5vc2Rpc2sxLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5TYXQsIDAzIFNlcCAyMDE2IDAyOjA2OjM3IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0QzOUVGMDJFMTZCNzwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+NTM8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+bG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5sZWFzZWQ8L0xlYXNlU3RhdGU+PExlYXNlRHVyYXRpb24+aW5maW5pdGU8L0xlYXNlRHVyYXRpb24+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+c3BlYzBkZXBseTF2bTAuZDcwMjIwMDgtZjZiMS00ZjRjLThiZTgtZTJkNjc3ZWYzMjYxLnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5TYXQsIDAzIFNlcCAyMDE2IDAyOjA0OjIxIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0QzOUU5RUU4ODdGQzwvRXRhZz48Q29udGVudC1MZW5ndGg+MjQyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+TjBqdys3eUJtbnA2c3hMTEkzbmNFQT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+c3BlYzBkZXBseTF2bTEuNGQxNTAyZDUtMzUxYS00MmY0LTg1NjktMjIyODRmOTA2ZDY4LnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5TYXQsIDAzIFNlcCAyMDE2IDAyOjA2OjMwIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0QzOUVFQkNEMEUyMjwvRXRhZz48Q29udGVudC1MZW5ndGg+MjQyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+ZTNZVWlxWHBZcU81bGcvZnhabzRUQT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PC9CbG9icz48TmV4dE1hcmtlciAvPjwvRW51bWVyYXRpb25SZXN1bHRzPg==
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:40:57 GMT
+- request:
+    method: post
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Storage/storageAccounts/miqazuretest26611/listKeys?api-version=2017-10-01
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDczMTMsIm5iZiI6MTUyMDg0NzMxMywiZXhwIjoxNTIwODUxMjEzLCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSVNQX0Vib21BazJrMzVYYWh4OFdBQSIsInZlciI6IjEuMCJ9.Wu6fVB9E0uRasF_-32jZU8DB0Qxro_-3yuzu9fA5RBm6kNh4wr7dgXmHtzXXz5qgU0xIIO6PJ5R75gsyokGELyqaa9pddZLgambowSG-EHNVrEHlkc-OsoVUjZ8sk3xoPomz3T1C1YhVRn9VsR93oqzZ-DFfkffvePpipNJsJJUVc2ZySS9L6vngQ46sfO9D5i0fcR-o5gez9isdIehot_wG6wl7MN-keGyF8DpqZOHtGjOt39pCqZTj8EjVEAKQvkDQkz5CCqH6dpcRZKdYuFvH2saWx8wzsU3LKx86DDCpwLczSqL-ltc9nfmmQasO3HHvCNsUiRHitwO7FA3iZw
+      Content-Length:
+      - '0'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 1475ebb9-61ef-4415-8ea7-66217bb56e58
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Writes:
+      - '1199'
+      X-Ms-Correlation-Request-Id:
+      - 93e46156-34f4-4397-9e16-f214bc1a7cf5
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T094055Z:93e46156-34f4-4397-9e16-f214bc1a7cf5
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:40:54 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"keys":[{"keyName":"key1","value":"Hh1rIrLFYOsfGuufnXsDBIZhDPUM0RWfl1XnZojGXRDo2TRjpQFisw3U7OfrizJ0J7fcN1535PrBniNUt/sVcw==","permissions":"Full"},{"keyName":"key2","value":"EZOKcIq7u+qCjHAIWfhDG0VGJe6sez+D+lYt5cbevX1njlWq+Z2lkffcTOsR/Pe4cDZg4OBCO1SymcWm3A35RA==","permissions":"Full"}]}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:40:59 GMT
+- request:
+    method: get
+    uri: https://miqazuretest26611.blob.core.windows.net/?comp=list
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:40:59 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Authorization:
+      - SharedKey miqazuretest26611:N/6mizq2ms2oqh3tSwULe8aVsX+BeWr+u3i9IWJ42MY=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/xml
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 700ab4a9-401e-00fa-7fe6-b901a8000000
+      X-Ms-Version:
+      - '2016-05-31'
+      Date:
+      - Mon, 12 Mar 2018 09:40:55 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9taXFhenVyZXRlc3QyNjYxMS5ibG9iLmNvcmUud2luZG93cy5uZXQvIj48Q29udGFpbmVycz48Q29udGFpbmVyPjxOYW1lPmJvb3RkaWFnbm9zdGljcy1qZm1ldHJpY3MtOTA0Y2M5ODEtZmE0ZC00ZGFmLWI4YjEtZGZjMGYwMTkzOGI1PC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPk1vbiwgMDIgTWF5IDIwMTYgMTg6MDI6MDEgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPiIweDhEMzcyQjNEQzk5NTRCRCI8L0V0YWc+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQ29udGFpbmVyPjxDb250YWluZXI+PE5hbWU+bWFuYWdlaXE8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VHVlLCAxNyBNYXkgMjAxNiAxODo0Mzo0NiBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+IjB4OEQzN0U4MzJFMjMwNEVEIjwvRXRhZz48TGVhc2VTdGF0dXM+bG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5sZWFzZWQ8L0xlYXNlU3RhdGU+PExlYXNlRHVyYXRpb24+aW5maW5pdGU8L0xlYXNlRHVyYXRpb24+PC9Qcm9wZXJ0aWVzPjwvQ29udGFpbmVyPjxDb250YWluZXI+PE5hbWU+dmhkczwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5Nb24sIDAyIE1heSAyMDE2IDE4OjAyOjAxIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4iMHg4RDM3MkIzRENCNjBCNTEiPC9FdGFnPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0NvbnRhaW5lcj48L0NvbnRhaW5lcnM+PE5leHRNYXJrZXIgLz48L0VudW1lcmF0aW9uUmVzdWx0cz4=
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:41:00 GMT
+- request:
+    method: get
+    uri: https://miqazuretest26611.blob.core.windows.net/manageiq?comp=list&restype=container
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:41:00 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Authorization:
+      - SharedKey miqazuretest26611:WBKi2EBA+7LM9ikqBton3W1cNPjXpByp5Bdq73s8Wjc=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/xml
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 6b2281fb-001e-013e-5be6-b9383b000000
+      X-Ms-Version:
+      - '2016-05-31'
+      Date:
+      - Mon, 12 Mar 2018 09:40:56 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9taXFhenVyZXRlc3QyNjYxMS5ibG9iLmNvcmUud2luZG93cy5uZXQvIiBDb250YWluZXJOYW1lPSJtYW5hZ2VpcSI+PEJsb2JzPjxCbG9iPjxOYW1lPm1pcW1pc21hdGNoMV81NzMwMmVlZS00NDJlLTRkYzUtOWIxMC04OTBlYjI5Njc0Y2QudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlR1ZSwgMTcgTWF5IDIwMTYgMTk6MTU6NDQgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzN0U4N0E1NTY0N0E1PC9FdGFnPjxDb250ZW50LUxlbmd0aD4zMTQ1NzI4MDUxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PmhLZE9qa2F1cDdzQi9uemtXZXVoV0E9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjM8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5taXFtaXNtYXRjaDFfODAyMTc0M2EtNTk1Ny00ZGMxLWE2NDUtY2EyMTBkNWQ3ZmM1LnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UdWUsIDA2IE1hciAyMDE4IDIyOjI3OjUzIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhENTgzQjE4MEMwMkEzODwvRXRhZz48Q29udGVudC1MZW5ndGg+MzE0NTcyODA1MTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5oS2RPamthdXA3c0IvbnprV2V1aFdBPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4xNTU8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+bG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5sZWFzZWQ8L0xlYXNlU3RhdGU+PExlYXNlRHVyYXRpb24+aW5maW5pdGU8L0xlYXNlRHVyYXRpb24+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+bWlxbWlzbWF0Y2gxXzgxOGExZjI3LTAxYTYtNDdkYS1hNjU1LWQ5YjcyOTQ4MzRiNS52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VHVlLCAxNyBNYXkgMjAxNiAxOTo1Nzo1NSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDM3RThEODk3RUZDOEE8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjMxNDU3MjgwNTEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+aEtkT2prYXVwN3NCL256a1dldWhXQT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MTwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjwvQmxvYnM+PE5leHRNYXJrZXIgLz48L0VudW1lcmF0aW9uUmVzdWx0cz4=
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:41:01 GMT
+- request:
+    method: head
+    uri: https://miqazuretest26611.blob.core.windows.net/manageiq/miqmismatch1_57302eee-442e-4dc5-9b10-890eb29674cd.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:41:01 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey miqazuretest26611:Fh3pNOWwNduFE2adUS5j/d40EBfwufayiVw1xwfVMx0=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '31457280512'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - hKdOjkaup7sB/nzkWeuhWA==
+      Last-Modified:
+      - Tue, 17 May 2016 19:15:44 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D37E87A55647A5"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 0f6c477c-d01e-0055-48e6-b92338000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '3'
+      X-Ms-Copy-Id:
+      - 6b0ee745-43fd-429e-905a-6a17b52b9434
+      X-Ms-Copy-Source:
+      - https://ardfepirv2bl5prdstr04.blob.core.windows.net/r-b39f27a8b8c64d52b05eac6a62ebad85-r2/Ubuntu-16_04-LTS-amd64-server-20160420.3-en-us-30GB?sv=2014-02-14&sr=b&si=PirCacheAccountPublisherContainerPolicy&sig=5jG5r878nDOc8EkQnpfaUq9uSR7TyXDM%2BSPP5ntEAFw%3D
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 31457280512/31457280512
+      X-Ms-Copy-Completion-Time:
+      - Tue, 17 May 2016 18:43:47 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Mon, 12 Mar 2018 09:40:56 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:41:01 GMT
+- request:
+    method: head
+    uri: https://miqazuretest26611.blob.core.windows.net/manageiq/miqmismatch1_818a1f27-01a6-47da-a655-d9b7294834b5.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:41:01 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey miqazuretest26611:o1hdxgaQMtQMB9bFjWyiyBVkD40Uq4DyMA/O1hF0m0o=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '31457280512'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - hKdOjkaup7sB/nzkWeuhWA==
+      Last-Modified:
+      - Tue, 17 May 2016 19:57:55 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D37E8D897EFC8A"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 51106b98-901e-0034-07e6-b967e7000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '1'
+      X-Ms-Copy-Id:
+      - 98fe8115-0771-49ae-955b-5a794d0908d0
+      X-Ms-Copy-Source:
+      - https://ardfepirv2bl5prdstr04.blob.core.windows.net/r-b39f27a8b8c64d52b05eac6a62ebad85-r2/Ubuntu-16_04-LTS-amd64-server-20160420.3-en-us-30GB?sv=2014-02-14&sr=b&si=PirCacheAccountPublisherContainerPolicy&sig=5jG5r878nDOc8EkQnpfaUq9uSR7TyXDM%2BSPP5ntEAFw%3D
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 31457280512/31457280512
+      X-Ms-Copy-Completion-Time:
+      - Tue, 17 May 2016 19:19:19 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Mon, 12 Mar 2018 09:40:56 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:41:02 GMT
+- request:
+    method: get
+    uri: https://miqazuretest26611.blob.core.windows.net/vhds?comp=list&restype=container
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:41:02 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Authorization:
+      - SharedKey miqazuretest26611:dpddc4llNW9oRWCKrmwLGLuMYwi0SZMIZxcjRPQ28nc=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/xml
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 7f3d0cf1-f01e-012b-72e6-b9faa2000000
+      X-Ms-Version:
+      - '2016-05-31'
+      Date:
+      - Mon, 12 Mar 2018 09:40:57 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9taXFhenVyZXRlc3QyNjYxMS5ibG9iLmNvcmUud2luZG93cy5uZXQvIiBDb250YWluZXJOYW1lPSJ2aGRzIj48QmxvYnM+PEJsb2I+PE5hbWU+amYtbWV0cmljcy0xMjAxNjQyMTQxMjAudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPk1vbiwgMDIgTWF5IDIwMTYgMjA6MDE6NTUgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzNzJDNDlDQ0UzMUNGPC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj40PC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PC9CbG9icz48TmV4dE1hcmtlciAvPjwvRW51bWVyYXRpb25SZXN1bHRzPg==
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:41:02 GMT
+- request:
+    method: head
+    uri: https://miqazuretest26611.blob.core.windows.net/vhds/jf-metrics-120164214120.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:41:02 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey miqazuretest26611:gQ58CT6BJXSyiv5vg2QFZefXcR9GqUpeyyqjwx18hkE=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - VbYhW9/6NOXzQVK/vQkdvg==
+      Last-Modified:
+      - Mon, 02 May 2016 20:01:55 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D372C49CCE31CF"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - f9c71076-d01e-0092-5ee6-b95ff9000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Lease-Status:
+      - unlocked
+      X-Ms-Lease-State:
+      - available
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '4'
+      X-Ms-Copy-Id:
+      - f84da2eb-c18a-4247-a7d6-4101240bf7f2
+      X-Ms-Copy-Source:
+      - https://ardfepirv2bl5prdstr04.blob.core.windows.net/a699494373c04fc0bc8f2bb1389d6106/Windows-Server-2012-R2-20160229-en.us-127GB.vhd?sv=2014-02-14&sr=b&si=PirCacheAccountPublisherContainerPolicy&sig=4nmIc5Zc2qmDJgN%2B04ix8pVl5oTfuDZwDqPR8xeAy9o%3D
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Mon, 02 May 2016 18:02:01 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Mon, 12 Mar 2018 09:40:58 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:41:03 GMT
+- request:
+    method: post
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487/listKeys?api-version=2017-10-01
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDczMTMsIm5iZiI6MTUyMDg0NzMxMywiZXhwIjoxNTIwODUxMjEzLCJhaW8iOiJZMk5nWUxoM09aN3phTjIvaHB0eVRadmo1bC9iQ2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiSVNQX0Vib21BazJrMzVYYWh4OFdBQSIsInZlciI6IjEuMCJ9.Wu6fVB9E0uRasF_-32jZU8DB0Qxro_-3yuzu9fA5RBm6kNh4wr7dgXmHtzXXz5qgU0xIIO6PJ5R75gsyokGELyqaa9pddZLgambowSG-EHNVrEHlkc-OsoVUjZ8sk3xoPomz3T1C1YhVRn9VsR93oqzZ-DFfkffvePpipNJsJJUVc2ZySS9L6vngQ46sfO9D5i0fcR-o5gez9isdIehot_wG6wl7MN-keGyF8DpqZOHtGjOt39pCqZTj8EjVEAKQvkDQkz5CCqH6dpcRZKdYuFvH2saWx8wzsU3LKx86DDCpwLczSqL-ltc9nfmmQasO3HHvCNsUiRHitwO7FA3iZw
+      Content-Length:
+      - '0'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - f3aaf1f4-a44f-4474-9ae7-369647d72658
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Writes:
+      - '1198'
+      X-Ms-Correlation-Request-Id:
+      - 944a34be-72d9-412e-bf9d-6075eeb35494
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T094059Z:944a34be-72d9-412e-bf9d-6075eeb35494
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:40:58 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"keys":[{"keyName":"key1","value":"ELTQwCiFqVImh96hlGId6JwT3r2zczvyeG7cA2HURT1oTYsFnPeRQjgVTV/j4GSG+XCYe5YOthB26dPcd/8JXQ==","permissions":"Full"},{"keyName":"key2","value":"uNJn8gcE3/hHHewm5z+vzty/mieLySe+jKn3t0ZKcivOk95ggorfeXAxvsiehK2HiqQWMAvdhQKU+3Ero0YHyA==","permissions":"Full"}]}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:41:03 GMT
+- request:
+    method: get
+    uri: https://miqazuretest16487.blob.core.windows.net/?comp=list
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:41:03 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Authorization:
+      - SharedKey miqazuretest16487:mH4f4MwZMf7D9poeZhz75aOX/W2gUvyUkvGTcTeayXM=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/xml
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 173b4950-001e-0034-02e6-b989d7000000
+      X-Ms-Version:
+      - '2016-05-31'
+      Date:
+      - Mon, 12 Mar 2018 09:40:58 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9taXFhenVyZXRlc3QxNjQ4Ny5ibG9iLmNvcmUud2luZG93cy5uZXQvIj48Q29udGFpbmVycz48Q29udGFpbmVyPjxOYW1lPmJvb3RkaWFnbm9zdGljcy1taXF0ZXN0dWItYzRkNTc3YWUtNGJlOC00MWMxLTg0ZjgtNjQyMzIwOTEwYTVlPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPkZyaSwgMTggTWFyIDIwMTYgMTc6Mjc6MzAgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPiIweDhEMzRGNTI5NUM2RTcwQyI8L0V0YWc+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQ29udGFpbmVyPjxDb250YWluZXI+PE5hbWU+Ym9vdGRpYWdub3N0aWNzLXJzcGVjbGJhLTIzYjBiZWFiLTE2ZDItNDEzNS1hMDFmLTJmZTcxMzIxN2ZkMDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5GcmksIDAyIFNlcCAyMDE2IDE2OjI5OjQwIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4iMHg4RDNEMzRFNTZFNEJCMkIiPC9FdGFnPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0NvbnRhaW5lcj48Q29udGFpbmVyPjxOYW1lPnZoZHM8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+RnJpLCAxOCBNYXIgMjAxNiAxNzoyNzozMCBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+IjB4OEQzNEY1Mjk1REZDQzIyIjwvRXRhZz48TGVhc2VTdGF0dXM+bG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5sZWFzZWQ8L0xlYXNlU3RhdGU+PExlYXNlRHVyYXRpb24+aW5maW5pdGU8L0xlYXNlRHVyYXRpb24+PC9Qcm9wZXJ0aWVzPjwvQ29udGFpbmVyPjwvQ29udGFpbmVycz48TmV4dE1hcmtlciAvPjwvRW51bWVyYXRpb25SZXN1bHRzPg==
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:41:04 GMT
+- request:
+    method: get
+    uri: https://miqazuretest16487.blob.core.windows.net/vhds?comp=list&restype=container
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 09:41:04 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Authorization:
+      - SharedKey miqazuretest16487:vLXMwW+3wFyoWOiiKBOD3N7Q6YmKXDQI2NBgytpt5uA=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/xml
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 7f20c6ef-001e-0038-73e6-b96726000000
+      X-Ms-Version:
+      - '2016-05-31'
+      Date:
+      - Mon, 12 Mar 2018 09:40:59 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9taXFhenVyZXRlc3QxNjQ4Ny5ibG9iLmNvcmUud2luZG93cy5uZXQvIiBDb250YWluZXJOYW1lPSJ2aGRzIj48QmxvYnM+PEJsb2I+PE5hbWU+bWlxLXRlc3QtdWJ1bnR1MS5jNGQ1NzdhZS00YmU4LTQxYzEtODRmOC02NDIzMjA5MTBhNWUuc3RhdHVzPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPldlZCwgMjIgSnVuIDIwMTYgMjE6NTc6MDUgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzOUFFODI2NjgyQTA1PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xNzY2PC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+WlVyb1NISk1HTFRDZkRwOSt0dkNyUT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+bWlxLXRlc3QtdWJ1bnR1MTIwMTYyMTgxMTI2NDcudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPldlZCwgMjIgSnVuIDIwMTYgMjE6NTc6MzMgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzOUFFODM3MEJGOTBDPC9FdGFnPjxDb250ZW50LUxlbmd0aD4zMTQ1NzI4MDUxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PmhLZE9qa2F1cDdzQi9uemtXZXVoV0E9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjI2NDwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJhdGlvbj5pbmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48L0Jsb2JzPjxOZXh0TWFya2VyIC8+PC9FbnVtZXJhdGlvblJlc3VsdHM+
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:41:04 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_500/vm_with_managed_disk_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted/targeted_api_collection_threshold_500/vm_with_managed_disk_refresh.yml
@@ -1,6 +1,62 @@
 ---
 http_interactions:
 - request:
+    method: post
+    uri: https://login.microsoftonline.com/AZURE_TENANT_ID/oauth2/token
+    body:
+      encoding: UTF-8
+      string: grant_type=client_credentials&client_id=AZURE_CLIENT_ID&client_secret=AZURE_CLIENT_SECRET&resource=https%3A%2F%2Fmanagement.azure.com%2F
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Server:
+      - Microsoft-IIS/10.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Request-Id:
+      - 66cc6864-b005-4802-a01b-cf20d17b1c00
+      P3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Set-Cookie:
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzXIRqmt7GAPPRxPM6y1K_e48MioZsIuY3Q4c7haNj8Vphxc3Cb6iqew7UplMggyM4RFNvgSkcyLA7OYl61xC--L0GXmgaTu_7lUJcjJm2_YSQ-RL8FJN8J39nISCrsufKUJbIe50I31sNoxr7bKNZcia3Ezq-tT9rr5rNDyvFHlwgAA;
+        domain=.login.microsoftonline.com; path=/; secure; HttpOnly
+      - stsservicecookie=ests; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=004; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 12 Mar 2018 09:33:06 GMT
+      Content-Length:
+      - '1505'
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1520850787","not_before":"1520846887","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDY4ODcsIm5iZiI6MTUyMDg0Njg4NywiZXhwIjoxNTIwODUwNzg3LCJhaW8iOiJZMk5nWUZqSTNsdDNLY0ZkZlpMbXF5OVZ0ZXNYQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWkdqTVpnV3dBa2lnRzg4ZzBYc2NBQSIsInZlciI6IjEuMCJ9.LrTuVc0V5NgwLKxPeVGGfEalgK2xEDJKIeWg9opVlj681I1kl-vl42Lfm3NURP8Q2jKOj8nqtogmi3SHn0wNlAEwv83DOacgSipi14Llvr4X6it8alMqx0aJDQgdYKHgyycj4KHqy9Kou2Guh6G0B0FFAJGM0Enh3D_1iKvpdORMGLBJgSG4w4A6ghO7D9J5ssbQM7XdIhvzueWtYd4wib1_hXkkA3xXUEAOPxwTl12Z6v1B431lA6jL5DG9kImdDqqjjASRqiz3amzVRzyGMHBEUTcftOONh_OWNdpDPxF-FFHAnOSVJcvYOLj8eRVJktld6CXN6OnI-5NCpFA6Wg"}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:33:11 GMT
+- request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
     body:
@@ -16,7 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDY4ODcsIm5iZiI6MTUyMDg0Njg4NywiZXhwIjoxNTIwODUwNzg3LCJhaW8iOiJZMk5nWUZqSTNsdDNLY0ZkZlpMbXF5OVZ0ZXNYQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWkdqTVpnV3dBa2lnRzg4ZzBYc2NBQSIsInZlciI6IjEuMCJ9.LrTuVc0V5NgwLKxPeVGGfEalgK2xEDJKIeWg9opVlj681I1kl-vl42Lfm3NURP8Q2jKOj8nqtogmi3SHn0wNlAEwv83DOacgSipi14Llvr4X6it8alMqx0aJDQgdYKHgyycj4KHqy9Kou2Guh6G0B0FFAJGM0Enh3D_1iKvpdORMGLBJgSG4w4A6ghO7D9J5ssbQM7XdIhvzueWtYd4wib1_hXkkA3xXUEAOPxwTl12Z6v1B431lA6jL5DG9kImdDqqjjASRqiz3amzVRzyGMHBEUTcftOONh_OWNdpDPxF-FFHAnOSVJcvYOLj8eRVJktld6CXN6OnI-5NCpFA6Wg
   response:
     status:
       code: 200
@@ -35,26 +91,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14997'
+      - '14998'
       X-Ms-Request-Id:
-      - cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - 2c5fda2d-ca72-422c-bc2d-1bf6a8e6fa1a
       X-Ms-Correlation-Request-Id:
-      - cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - 2c5fda2d-ca72-422c-bc2d-1bf6a8e6fa1a
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102417Z:cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - WESTEUROPE:20180312T093309Z:2c5fda2d-ca72-422c-bc2d-1bf6a8e6fa1a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:17 GMT
+      - Mon, 12 Mar 2018 09:33:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID","subscriptionId":"AZURE_SUBSCRIPTION_ID","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:22 GMT
+  recorded_at: Mon, 12 Mar 2018 09:33:14 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers?api-version=2015-01-01
@@ -71,7 +127,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDY4ODcsIm5iZiI6MTUyMDg0Njg4NywiZXhwIjoxNTIwODUwNzg3LCJhaW8iOiJZMk5nWUZqSTNsdDNLY0ZkZlpMbXF5OVZ0ZXNYQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWkdqTVpnV3dBa2lnRzg4ZzBYc2NBQSIsInZlciI6IjEuMCJ9.LrTuVc0V5NgwLKxPeVGGfEalgK2xEDJKIeWg9opVlj681I1kl-vl42Lfm3NURP8Q2jKOj8nqtogmi3SHn0wNlAEwv83DOacgSipi14Llvr4X6it8alMqx0aJDQgdYKHgyycj4KHqy9Kou2Guh6G0B0FFAJGM0Enh3D_1iKvpdORMGLBJgSG4w4A6ghO7D9J5ssbQM7XdIhvzueWtYd4wib1_hXkkA3xXUEAOPxwTl12Z6v1B431lA6jL5DG9kImdDqqjjASRqiz3amzVRzyGMHBEUTcftOONh_OWNdpDPxF-FFHAnOSVJcvYOLj8eRVJktld6CXN6OnI-5NCpFA6Wg
   response:
     status:
       code: 200
@@ -88,19 +144,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - '14996'
       X-Ms-Request-Id:
-      - fe3532ca-59a2-474e-9094-8a3697b82bef
+      - 79606c84-54ee-416d-b413-4bd5627b3175
       X-Ms-Correlation-Request-Id:
-      - fe3532ca-59a2-474e-9094-8a3697b82bef
+      - 79606c84-54ee-416d-b413-4bd5627b3175
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102419Z:fe3532ca-59a2-474e-9094-8a3697b82bef
+      - WESTEUROPE:20180312T093310Z:79606c84-54ee-416d-b413-4bd5627b3175
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:18 GMT
+      - Mon, 12 Mar 2018 09:33:09 GMT
       Content-Length:
       - '320853'
     body:
@@ -2322,10 +2378,10 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:23 GMT
+  recorded_at: Mon, 12 Mar 2018 09:33:14 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed?api-version=2017-12-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2339,7 +2395,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDY4ODcsIm5iZiI6MTUyMDg0Njg4NywiZXhwIjoxNTIwODUwNzg3LCJhaW8iOiJZMk5nWUZqSTNsdDNLY0ZkZlpMbXF5OVZ0ZXNYQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWkdqTVpnV3dBa2lnRzg4ZzBYc2NBQSIsInZlciI6IjEuMCJ9.LrTuVc0V5NgwLKxPeVGGfEalgK2xEDJKIeWg9opVlj681I1kl-vl42Lfm3NURP8Q2jKOj8nqtogmi3SHn0wNlAEwv83DOacgSipi14Llvr4X6it8alMqx0aJDQgdYKHgyycj4KHqy9Kou2Guh6G0B0FFAJGM0Enh3D_1iKvpdORMGLBJgSG4w4A6ghO7D9J5ssbQM7XdIhvzueWtYd4wib1_hXkkA3xXUEAOPxwTl12Z6v1B431lA6jL5DG9kImdDqqjjASRqiz3amzVRzyGMHBEUTcftOONh_OWNdpDPxF-FFHAnOSVJcvYOLj8eRVJktld6CXN6OnI-5NCpFA6Wg
   response:
     status:
       code: 200
@@ -2355,88 +2411,56 @@ http_interactions:
       - application/json; charset=utf-8
       Expires:
       - "-1"
-      Etag:
-      - W/"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67"
       Vary:
       - Accept-Encoding
-      X-Ms-Request-Id:
-      - '080de667-081e-4d58-9e94-9e7243d4200e'
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/LowCostGet3Min;4745,Microsoft.Compute/LowCostGet30Min;37868
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      X-Ms-Request-Id:
+      - 41849d5e-81ac-4f6e-9681-c7f1a1c50c35
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
+      - '14993'
       X-Ms-Correlation-Request-Id:
-      - '093d49ac-c85f-440e-956b-955b6698dd19'
+      - d6f6cfd7-c436-4769-9bac-191e0337cfef
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102419Z:093d49ac-c85f-440e-956b-955b6698dd19
+      - WESTEUROPE:20180312T093311Z:d6f6cfd7-c436-4769-9bac-191e0337cfef
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:19 GMT
+      - Mon, 12 Mar 2018 09:33:11 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1\",\r\n
-        \ \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"7ab88756-810f-4083-95db-8b05d50e38f2\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ],\r\n          \"inboundNatRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"backendIPConfigurations\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\"\r\n
-        \           }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-rule\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\":
-        80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\"\r\n
-        \         },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n
-        \       \"name\": \"rspec-lb-probe\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-NAT\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 3441,\r\n          \"backendPort\":
-        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
+      string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"61b7c052-1d09-4898-b995-cce5676aaab0\",\r\n
+        \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Basic_A0\"\r\n    },\r\n
+        \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
+        \"RedHat\",\r\n        \"offer\": \"RHEL\",\r\n        \"sku\": \"7.3\",\r\n
+        \       \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
+        \"Linux\",\r\n        \"name\": \"miqazure-linux-managed_OsDisk_1_7b2bdf790a7d4379ace2846d307730cd\",\r\n
+        \       \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n
+        \       \"managedDisk\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/disks/miqazure-linux-managed_OsDisk_1_7b2bdf790a7d4379ace2846d307730cd\"\r\n
+        \       }\r\n      },\r\n      \"dataDisks\": [\r\n        {\r\n          \"lun\":
+        0,\r\n          \"name\": \"miqazure-linux-managed-data-disk\",\r\n          \"createOption\":
+        \"Attach\",\r\n          \"caching\": \"None\",\r\n          \"managedDisk\":
+        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/disks/miqazure-linux-managed-data-disk\"\r\n
+        \         }\r\n        }\r\n      ]\r\n    },\r\n    \"osProfile\": {\r\n
+        \     \"computerName\": \"miqazure-linux-managed\",\r\n      \"adminUsername\":
+        \"dberger\",\r\n      \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\":
+        false\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\":
+        {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944\"}]},\r\n
+        \   \"provisioningState\": \"Succeeded\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n
+        \ \"location\": \"eastus\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed\",\r\n
+        \ \"name\": \"miqazure-linux-managed\"\r\n}"
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:24 GMT
+  recorded_at: Mon, 12 Mar 2018 09:33:16 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944?api-version=2018-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2450,7 +2474,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDY4ODcsIm5iZiI6MTUyMDg0Njg4NywiZXhwIjoxNTIwODUwNzg3LCJhaW8iOiJZMk5nWUZqSTNsdDNLY0ZkZlpMbXF5OVZ0ZXNYQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWkdqTVpnV3dBa2lnRzg4ZzBYc2NBQSIsInZlciI6IjEuMCJ9.LrTuVc0V5NgwLKxPeVGGfEalgK2xEDJKIeWg9opVlj681I1kl-vl42Lfm3NURP8Q2jKOj8nqtogmi3SHn0wNlAEwv83DOacgSipi14Llvr4X6it8alMqx0aJDQgdYKHgyycj4KHqy9Kou2Guh6G0B0FFAJGM0Enh3D_1iKvpdORMGLBJgSG4w4A6ghO7D9J5ssbQM7XdIhvzueWtYd4wib1_hXkkA3xXUEAOPxwTl12Z6v1B431lA6jL5DG9kImdDqqjjASRqiz3amzVRzyGMHBEUTcftOONh_OWNdpDPxF-FFHAnOSVJcvYOLj8eRVJktld6CXN6OnI-5NCpFA6Wg
   response:
     status:
       code: 200
@@ -2467,123 +2491,52 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"7a8e5fe7-f777-4435-992b-a54f28c2f28c"
+      - W/"b6339880-8ead-4c9e-b5c0-f38c4f8612d5"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - bd22ca22-a01f-4ecf-9230-a4558fb66931
+      - ee8d58f9-b3b1-43c3-b89c-a877d8cd5cca
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
+      - '14995'
       X-Ms-Correlation-Request-Id:
-      - 19c674a8-c8da-4b5e-8265-5ebc21926459
+      - 84f444db-c240-44c1-a47f-adcad92d4a18
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102420Z:19c674a8-c8da-4b5e-8265-5ebc21926459
+      - WESTEUROPE:20180312T093312Z:84f444db-c240-44c1-a47f-adcad92d4a18
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:19 GMT
+      - Mon, 12 Mar 2018 09:33:12 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb2\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2\",\r\n
-        \ \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"e2e30a77-f81b-43fc-9693-08303e43deed\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/backendAddressPools/rspec-lb2-pool\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\r\n
-        \       }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\": [],\r\n    \"probes\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-probe\",\r\n        \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/probes/rspec-lb2-probe\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\": [],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:25 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"a38434c8-7b23-4092-b7c6-402238eac0dc"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 0fd15240-6a1c-4b39-a4f6-aa53fd8591c2
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Correlation-Request-Id:
-      - 5cc03163-922e-41a1-9601-dba2d7cf2a81
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102421Z:5cc03163-922e-41a1-9601-dba2d7cf2a81
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Mon, 12 Mar 2018 10:24:20 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb1-LoadBalancerFrontEnd\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\",\r\n
-        \ \"etag\": \"W/\\\"a38434c8-7b23-4092-b7c6-402238eac0dc\\\"\",\r\n  \"location\":
+      string: "{\r\n  \"name\": \"miqazure-linux-manag944\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944\",\r\n
+        \ \"etag\": \"W/\\\"b6339880-8ead-4c9e-b5c0-f38c4f8612d5\\\"\",\r\n  \"location\":
         \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"f28e0f25-b372-4edf-97d9-13a9e3b4ba2d\",\r\n    \"ipAddress\":
-        \"40.71.82.83\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\":
-        \"Static\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipTags\": [],\r\n
-        \   \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
-        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
+        \   \"resourceGuid\": \"c5e8b90e-5a78-49b0-b224-b70ed3fb45e5\",\r\n    \"ipConfigurations\":
+        [\r\n      {\r\n        \"name\": \"ipconfig1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944/ipConfigurations/ipconfig1\",\r\n
+        \       \"etag\": \"W/\\\"b6339880-8ead-4c9e-b5c0-f38c4f8612d5\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"privateIPAddress\": \"172.25.0.4\",\r\n          \"privateIPAllocationMethod\":
+        \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqazure-linux-managed-ip\"\r\n
+        \         },\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2/subnets/default\"\r\n
+        \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
+        \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\":
+        [],\r\n      \"appliedDnsServers\": []\r\n    },\r\n    \"enableAcceleratedNetworking\":
+        false,\r\n    \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\":
+        {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg\"\r\n
+        \   },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed\"\r\n
+        \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
+        \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:25 GMT
+  recorded_at: Mon, 12 Mar 2018 09:33:17 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed/instanceView?api-version=2017-12-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2597,7 +2550,696 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDY4ODcsIm5iZiI6MTUyMDg0Njg4NywiZXhwIjoxNTIwODUwNzg3LCJhaW8iOiJZMk5nWUZqSTNsdDNLY0ZkZlpMbXF5OVZ0ZXNYQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWkdqTVpnV3dBa2lnRzg4ZzBYc2NBQSIsInZlciI6IjEuMCJ9.LrTuVc0V5NgwLKxPeVGGfEalgK2xEDJKIeWg9opVlj681I1kl-vl42Lfm3NURP8Q2jKOj8nqtogmi3SHn0wNlAEwv83DOacgSipi14Llvr4X6it8alMqx0aJDQgdYKHgyycj4KHqy9Kou2Guh6G0B0FFAJGM0Enh3D_1iKvpdORMGLBJgSG4w4A6ghO7D9J5ssbQM7XdIhvzueWtYd4wib1_hXkkA3xXUEAOPxwTl12Z6v1B431lA6jL5DG9kImdDqqjjASRqiz3amzVRzyGMHBEUTcftOONh_OWNdpDPxF-FFHAnOSVJcvYOLj8eRVJktld6CXN6OnI-5NCpFA6Wg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/GetInstanceView3Min;4797,Microsoft.Compute/GetInstanceView30Min;23915
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      X-Ms-Request-Id:
+      - 846cd650-6299-4194-a5f5-119eb18c771d
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Correlation-Request-Id:
+      - 9878cf87-f0a8-4e4e-9c39-a5a1cbef7d86
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T093323Z:9878cf87-f0a8-4e4e-9c39-a5a1cbef7d86
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:33:23 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"miqazure-linux-managed_OsDisk_1_7b2bdf790a7d4379ace2846d307730cd\",\r\n
+        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
+        succeeded\",\r\n          \"time\": \"2018-01-23T20:06:17.9818931+00:00\"\r\n
+        \       }\r\n      ]\r\n    },\r\n    {\r\n      \"name\": \"miqazure-linux-managed-data-disk\",\r\n
+        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
+        succeeded\",\r\n          \"time\": \"2018-01-23T20:06:17.9818931+00:00\"\r\n
+        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\":
+        \"ProvisioningState/succeeded\",\r\n      \"level\": \"Info\",\r\n      \"displayStatus\":
+        \"Provisioning succeeded\",\r\n      \"time\": \"2018-01-23T20:06:17.9975145+00:00\"\r\n
+        \   },\r\n    {\r\n      \"code\": \"PowerState/deallocated\",\r\n      \"level\":
+        \"Info\",\r\n      \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:33:28 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups/miq-azure-test4?api-version=2017-08-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDY4ODcsIm5iZiI6MTUyMDg0Njg4NywiZXhwIjoxNTIwODUwNzg3LCJhaW8iOiJZMk5nWUZqSTNsdDNLY0ZkZlpMbXF5OVZ0ZXNYQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWkdqTVpnV3dBa2lnRzg4ZzBYc2NBQSIsInZlciI6IjEuMCJ9.LrTuVc0V5NgwLKxPeVGGfEalgK2xEDJKIeWg9opVlj681I1kl-vl42Lfm3NURP8Q2jKOj8nqtogmi3SHn0wNlAEwv83DOacgSipi14Llvr4X6it8alMqx0aJDQgdYKHgyycj4KHqy9Kou2Guh6G0B0FFAJGM0Enh3D_1iKvpdORMGLBJgSG4w4A6ghO7D9J5ssbQM7XdIhvzueWtYd4wib1_hXkkA3xXUEAOPxwTl12Z6v1B431lA6jL5DG9kImdDqqjjASRqiz3amzVRzyGMHBEUTcftOONh_OWNdpDPxF-FFHAnOSVJcvYOLj8eRVJktld6CXN6OnI-5NCpFA6Wg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Request-Id:
+      - d0042511-3cc6-4888-863a-d3cf3a4ed1be
+      X-Ms-Correlation-Request-Id:
+      - d0042511-3cc6-4888-863a-d3cf3a4ed1be
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T093324Z:d0042511-3cc6-4888-863a-d3cf3a4ed1be
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:33:24 GMT
+      Content-Length:
+      - '183'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4","name":"miq-azure-test4","location":"eastus","properties":{"provisioningState":"Succeeded"}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:33:29 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute/locations/eastus/vmSizes?api-version=2017-12-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDY4ODcsIm5iZiI6MTUyMDg0Njg4NywiZXhwIjoxNTIwODUwNzg3LCJhaW8iOiJZMk5nWUZqSTNsdDNLY0ZkZlpMbXF5OVZ0ZXNYQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWkdqTVpnV3dBa2lnRzg4ZzBYc2NBQSIsInZlciI6IjEuMCJ9.LrTuVc0V5NgwLKxPeVGGfEalgK2xEDJKIeWg9opVlj681I1kl-vl42Lfm3NURP8Q2jKOj8nqtogmi3SHn0wNlAEwv83DOacgSipi14Llvr4X6it8alMqx0aJDQgdYKHgyycj4KHqy9Kou2Guh6G0B0FFAJGM0Enh3D_1iKvpdORMGLBJgSG4w4A6ghO7D9J5ssbQM7XdIhvzueWtYd4wib1_hXkkA3xXUEAOPxwTl12Z6v1B431lA6jL5DG9kImdDqqjjASRqiz3amzVRzyGMHBEUTcftOONh_OWNdpDPxF-FFHAnOSVJcvYOLj8eRVJktld6CXN6OnI-5NCpFA6Wg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/LowCostGet3Min;4741,Microsoft.Compute/LowCostGet30Min;37864
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      X-Ms-Request-Id:
+      - e14b0351-ca48-4256-891c-bcc2f2b1eba3
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Correlation-Request-Id:
+      - e8bdd5b2-8f71-42fd-a5fd-3f22d0bcaf81
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T093325Z:e8bdd5b2-8f71-42fd-a5fd-3f22d0bcaf81
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:33:24 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"Standard_B1ms\",\r\n
+        \     \"numberOfCores\": 1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        4096,\r\n      \"memoryInMB\": 2048,\r\n      \"maxDataDiskCount\": 2\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_B1s\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        2048,\r\n      \"memoryInMB\": 1024,\r\n      \"maxDataDiskCount\": 2\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_B2ms\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        16384,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_B2s\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        8192,\r\n      \"memoryInMB\": 4096,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_B4ms\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        32768,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_B8ms\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS1_v2\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        7168,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS2_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        14336,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS3_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS4_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS5_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS11-1_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS11_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS12-1_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS12-2_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS12_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS13-2_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS13-4_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS13_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS14-4_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        229376,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS14-8_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        229376,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS14_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        229376,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS15_v2\",\r\n      \"numberOfCores\":
+        20,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        286720,\r\n      \"memoryInMB\": 143360,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS2_v2_Promo\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        14336,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS3_v2_Promo\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS4_v2_Promo\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS5_v2_Promo\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS11_v2_Promo\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS12_v2_Promo\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS13_v2_Promo\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS14_v2_Promo\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        229376,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F1s\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        4096,\r\n      \"memoryInMB\": 2048,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F2s\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        8192,\r\n      \"memoryInMB\": 4096,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F4s\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        16384,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F8s\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        32768,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F16s\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D2s_v3\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        16384,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D4s_v3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        32768,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D8s_v3\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D16s_v3\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        131072,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D32s_v3\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        262144,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A0\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        20480,\r\n      \"memoryInMB\": 768,\r\n      \"maxDataDiskCount\": 1\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A1\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        71680,\r\n      \"memoryInMB\": 1792,\r\n      \"maxDataDiskCount\": 2\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        138240,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        291840,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A5\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        138240,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A4\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        619520,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A6\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        291840,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A7\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        619520,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Basic_A0\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        20480,\r\n      \"memoryInMB\": 768,\r\n      \"maxDataDiskCount\": 1\r\n
+        \   },\r\n    {\r\n      \"name\": \"Basic_A1\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        40960,\r\n      \"memoryInMB\": 1792,\r\n      \"maxDataDiskCount\": 2\r\n
+        \   },\r\n    {\r\n      \"name\": \"Basic_A2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        61440,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Basic_A3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        122880,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Basic_A4\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        245760,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D1_v2\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        51200,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D2_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D3_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D4_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D5_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D11_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D12_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D13_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D14_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D15_v2\",\r\n      \"numberOfCores\":
+        20,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        286720,\r\n      \"memoryInMB\": 143360,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D2_v2_Promo\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D3_v2_Promo\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D4_v2_Promo\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D5_v2_Promo\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D11_v2_Promo\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D12_v2_Promo\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D13_v2_Promo\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D14_v2_Promo\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F1\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        16384,\r\n      \"memoryInMB\": 2048,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        32768,\r\n      \"memoryInMB\": 4096,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F4\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F8\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        131072,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F16\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        262144,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A1_v2\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        10240,\r\n      \"memoryInMB\": 2048,\r\n      \"maxDataDiskCount\": 2\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A2m_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        20480,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A2_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        20480,\r\n      \"memoryInMB\": 4096,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A4m_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        40960,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A4_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        40960,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A8m_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        81920,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A8_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        81920,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D2_v3\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        51200,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D4_v3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D8_v3\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D16_v3\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 65636,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D32_v3\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_H8\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1024000,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_H16\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        2048000,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_H8m\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1024000,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_H16m\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        2048000,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_H16r\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        2048000,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_H16mr\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        2048000,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D1\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        51200,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D4\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D11\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D12\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D13\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D14\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NV6\",\r\n      \"numberOfCores\":
+        6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        389120,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 24\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NV12\",\r\n      \"numberOfCores\":
+        12,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        696320,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 48\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NV24\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1474560,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC6s_v2\",\r\n      \"numberOfCores\":
+        6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        344064,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 12\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC12s_v2\",\r\n      \"numberOfCores\":
+        12,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        688128,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 24\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC24rs_v2\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1376256,\r\n      \"memoryInMB\": 458752,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC24s_v2\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1376256,\r\n      \"memoryInMB\": 458752,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC6\",\r\n      \"numberOfCores\":
+        6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        389120,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 24\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC12\",\r\n      \"numberOfCores\":
+        12,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        696320,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 48\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC24\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1474560,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC24r\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1474560,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS1\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        7168,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        14336,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS4\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS11\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS12\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS13\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS14\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        229376,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC6s_v3\",\r\n      \"numberOfCores\":
+        6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        344064,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 12\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC12s_v3\",\r\n      \"numberOfCores\":
+        12,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        688128,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 24\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC24rs_v3\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1376256,\r\n      \"memoryInMB\": 458752,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC24s_v3\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1376256,\r\n      \"memoryInMB\": 458752,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D64_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1638400,\r\n      \"memoryInMB\": 262144,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D64s_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        524288,\r\n      \"memoryInMB\": 262144,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E2_v3\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        51200,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E4_v3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E8_v3\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E16_v3\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E32_v3\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 262144,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E64i_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1638400,\r\n      \"memoryInMB\": 442368,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E64_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1638400,\r\n      \"memoryInMB\": 442368,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E2s_v3\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        32768,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E4-2s_v3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E4s_v3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E8-2s_v3\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        131072,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E8-4s_v3\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        131072,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E8s_v3\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        131072,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E16-4s_v3\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        262144,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E16-8s_v3\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        262144,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E16s_v3\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        262144,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E32-8s_v3\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        524288,\r\n      \"memoryInMB\": 262144,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E32-16s_v3\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        524288,\r\n      \"memoryInMB\": 262144,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E32s_v3\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        524288,\r\n      \"memoryInMB\": 262144,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E64-16s_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        884736,\r\n      \"memoryInMB\": 442368,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E64-32s_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        884736,\r\n      \"memoryInMB\": 442368,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E64is_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        884736,\r\n      \"memoryInMB\": 442368,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E64s_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        884736,\r\n      \"memoryInMB\": 442368,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F2s_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        16384,\r\n      \"memoryInMB\": 4096,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F4s_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        32768,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F8s_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F16s_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        131072,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F32s_v2\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        262144,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F64s_v2\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        524288,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F72s_v2\",\r\n      \"numberOfCores\":
+        72,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        589824,\r\n      \"memoryInMB\": 147456,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_L8s_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1811981,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_L16s_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        3623962,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_ND6s\",\r\n      \"numberOfCores\":
+        6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        344064,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 12\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_ND12s\",\r\n      \"numberOfCores\":
+        12,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        688128,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 24\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_ND24rs\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1376256,\r\n      \"memoryInMB\": 458752,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_ND24s\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1376256,\r\n      \"memoryInMB\": 458752,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A8\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        391168,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A9\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        391168,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A10\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        391168,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A11\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        391168,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   }\r\n  ]\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:33:29 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqazure-linux-managed-ip?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDY4ODcsIm5iZiI6MTUyMDg0Njg4NywiZXhwIjoxNTIwODUwNzg3LCJhaW8iOiJZMk5nWUZqSTNsdDNLY0ZkZlpMbXF5OVZ0ZXNYQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWkdqTVpnV3dBa2lnRzg4ZzBYc2NBQSIsInZlciI6IjEuMCJ9.LrTuVc0V5NgwLKxPeVGGfEalgK2xEDJKIeWg9opVlj681I1kl-vl42Lfm3NURP8Q2jKOj8nqtogmi3SHn0wNlAEwv83DOacgSipi14Llvr4X6it8alMqx0aJDQgdYKHgyycj4KHqy9Kou2Guh6G0B0FFAJGM0Enh3D_1iKvpdORMGLBJgSG4w4A6ghO7D9J5ssbQM7XdIhvzueWtYd4wib1_hXkkA3xXUEAOPxwTl12Z6v1B431lA6jL5DG9kImdDqqjjASRqiz3amzVRzyGMHBEUTcftOONh_OWNdpDPxF-FFHAnOSVJcvYOLj8eRVJktld6CXN6OnI-5NCpFA6Wg
   response:
     status:
       code: 200
@@ -2614,36 +3256,381 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"cddd97d1-6111-4477-8a00-3dc885237a1d"
+      - W/"0efc9684-fb7d-4fb7-b9b9-f33dbac04a28"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 1403e5b6-8fa0-4cd3-89b1-76b6c4fd805b
+      - 4b6e873f-b8e7-4435-8ab2-eb6a4073f546
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - '14995'
       X-Ms-Correlation-Request-Id:
-      - e4a5f369-a742-466f-bd8f-42e17eaaf9c9
+      - dc111561-cfc4-4971-b3a7-0565e244db3d
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102421Z:e4a5f369-a742-466f-bd8f-42e17eaaf9c9
+      - WESTEUROPE:20180312T093326Z:dc111561-cfc4-4971-b3a7-0565e244db3d
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:21 GMT
+      - Mon, 12 Mar 2018 09:33:25 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb2-publicip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\",\r\n
-        \ \"etag\": \"W/\\\"cddd97d1-6111-4477-8a00-3dc885237a1d\\\"\",\r\n  \"location\":
+      string: "{\r\n  \"name\": \"miqazure-linux-managed-ip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqazure-linux-managed-ip\",\r\n
+        \ \"etag\": \"W/\\\"0efc9684-fb7d-4fb7-b9b9-f33dbac04a28\\\"\",\r\n  \"location\":
         \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"83e7257d-ab94-4229-8eb5-4798f37ef28d\",\r\n    \"publicIPAddressVersion\":
+        \   \"resourceGuid\": \"6a2a9142-26e8-45cd-93bf-7318192f3528\",\r\n    \"publicIPAddressVersion\":
         \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
-        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
+        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944/ipConfigurations/ipconfig1\"\r\n
         \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
         \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:26 GMT
+  recorded_at: Mon, 12 Mar 2018 09:33:30 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/disks/miqazure-linux-managed-data-disk?api-version=2017-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDY4ODcsIm5iZiI6MTUyMDg0Njg4NywiZXhwIjoxNTIwODUwNzg3LCJhaW8iOiJZMk5nWUZqSTNsdDNLY0ZkZlpMbXF5OVZ0ZXNYQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWkdqTVpnV3dBa2lnRzg4ZzBYc2NBQSIsInZlciI6IjEuMCJ9.LrTuVc0V5NgwLKxPeVGGfEalgK2xEDJKIeWg9opVlj681I1kl-vl42Lfm3NURP8Q2jKOj8nqtogmi3SHn0wNlAEwv83DOacgSipi14Llvr4X6it8alMqx0aJDQgdYKHgyycj4KHqy9Kou2Guh6G0B0FFAJGM0Enh3D_1iKvpdORMGLBJgSG4w4A6ghO7D9J5ssbQM7XdIhvzueWtYd4wib1_hXkkA3xXUEAOPxwTl12Z6v1B431lA6jL5DG9kImdDqqjjASRqiz3amzVRzyGMHBEUTcftOONh_OWNdpDPxF-FFHAnOSVJcvYOLj8eRVJktld6CXN6OnI-5NCpFA6Wg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/LowCostGet3Min;4996,Microsoft.Compute/LowCostGet30Min;19992
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131626781321631045
+      X-Ms-Request-Id:
+      - 175a224d-9f99-4487-8584-340cb13b72dd
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Correlation-Request-Id:
+      - 3e154f80-3c59-41da-aa3c-e7569445f4a3
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T093327Z:3e154f80-3c59-41da-aa3c-e7569445f4a3
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:33:26 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"managedBy\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed\",\r\n
+        \ \"sku\": {\r\n    \"name\": \"Standard_LRS\",\r\n    \"tier\": \"Standard\"\r\n
+        \ },\r\n  \"properties\": {\r\n    \"creationData\": {\r\n      \"createOption\":
+        \"Empty\"\r\n    },\r\n    \"diskSizeGB\": 1,\r\n    \"timeCreated\": \"2017-10-23T17:34:14.7022771+00:00\",\r\n
+        \   \"provisioningState\": \"Succeeded\",\r\n    \"diskState\": \"Reserved\"\r\n
+        \ },\r\n  \"type\": \"Microsoft.Compute/disks\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/disks/miqazure-linux-managed-data-disk\",\r\n
+        \ \"name\": \"miqazure-linux-managed-data-disk\"\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:33:31 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/disks/miqazure-linux-managed_OsDisk_1_7b2bdf790a7d4379ace2846d307730cd?api-version=2017-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDY4ODcsIm5iZiI6MTUyMDg0Njg4NywiZXhwIjoxNTIwODUwNzg3LCJhaW8iOiJZMk5nWUZqSTNsdDNLY0ZkZlpMbXF5OVZ0ZXNYQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWkdqTVpnV3dBa2lnRzg4ZzBYc2NBQSIsInZlciI6IjEuMCJ9.LrTuVc0V5NgwLKxPeVGGfEalgK2xEDJKIeWg9opVlj681I1kl-vl42Lfm3NURP8Q2jKOj8nqtogmi3SHn0wNlAEwv83DOacgSipi14Llvr4X6it8alMqx0aJDQgdYKHgyycj4KHqy9Kou2Guh6G0B0FFAJGM0Enh3D_1iKvpdORMGLBJgSG4w4A6ghO7D9J5ssbQM7XdIhvzueWtYd4wib1_hXkkA3xXUEAOPxwTl12Z6v1B431lA6jL5DG9kImdDqqjjASRqiz3amzVRzyGMHBEUTcftOONh_OWNdpDPxF-FFHAnOSVJcvYOLj8eRVJktld6CXN6OnI-5NCpFA6Wg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/LowCostGet3Min;4995,Microsoft.Compute/LowCostGet30Min;19991
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131626781321631045
+      X-Ms-Request-Id:
+      - c6de7a76-5b2b-4e06-94b2-41dde6760b9a
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14993'
+      X-Ms-Correlation-Request-Id:
+      - 0057fef3-8578-425f-baac-5af2268e1158
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T093328Z:0057fef3-8578-425f-baac-5af2268e1158
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:33:27 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"managedBy\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed\",\r\n
+        \ \"sku\": {\r\n    \"name\": \"Standard_LRS\",\r\n    \"tier\": \"Standard\"\r\n
+        \ },\r\n  \"properties\": {\r\n    \"osType\": \"Linux\",\r\n    \"creationData\":
+        {\r\n      \"createOption\": \"FromImage\",\r\n      \"imageReference\": {\r\n
+        \       \"id\": \"/Subscriptions/AZURE_SUBSCRIPTION_ID/Providers/Microsoft.Compute/Locations/eastus/Publishers/RedHat/ArtifactTypes/VMImage/Offers/RHEL/Skus/7.3/Versions/latest\"\r\n
+        \     }\r\n    },\r\n    \"diskSizeGB\": 32,\r\n    \"timeCreated\": \"2017-05-04T21:21:55.7801928+00:00\",\r\n
+        \   \"provisioningState\": \"Succeeded\",\r\n    \"diskState\": \"Reserved\"\r\n
+        \ },\r\n  \"type\": \"Microsoft.Compute/disks\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"tags\": {\r\n    \"delete\": \"false\"\r\n  },\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/disks/miqazure-linux-managed_OsDisk_1_7b2bdf790a7d4379ace2846d307730cd\",\r\n
+        \ \"name\": \"miqazure-linux-managed_OsDisk_1_7b2bdf790a7d4379ace2846d307730cd\"\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:33:32 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDY4ODcsIm5iZiI6MTUyMDg0Njg4NywiZXhwIjoxNTIwODUwNzg3LCJhaW8iOiJZMk5nWUZqSTNsdDNLY0ZkZlpMbXF5OVZ0ZXNYQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWkdqTVpnV3dBa2lnRzg4ZzBYc2NBQSIsInZlciI6IjEuMCJ9.LrTuVc0V5NgwLKxPeVGGfEalgK2xEDJKIeWg9opVlj681I1kl-vl42Lfm3NURP8Q2jKOj8nqtogmi3SHn0wNlAEwv83DOacgSipi14Llvr4X6it8alMqx0aJDQgdYKHgyycj4KHqy9Kou2Guh6G0B0FFAJGM0Enh3D_1iKvpdORMGLBJgSG4w4A6ghO7D9J5ssbQM7XdIhvzueWtYd4wib1_hXkkA3xXUEAOPxwTl12Z6v1B431lA6jL5DG9kImdDqqjjASRqiz3amzVRzyGMHBEUTcftOONh_OWNdpDPxF-FFHAnOSVJcvYOLj8eRVJktld6CXN6OnI-5NCpFA6Wg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - bddbc12b-91e4-4996-ab94-1c13872d2c6a
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14992'
+      X-Ms-Correlation-Request-Id:
+      - fa36d32e-27d3-4ec3-823a-0b9ab5054a99
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T093328Z:fa36d32e-27d3-4ec3-823a-0b9ab5054a99
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:33:28 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"miqazure-linux-managed-nsg\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg\",\r\n
+        \ \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/networkSecurityGroups\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
+        \"b4611f96-94a8-4486-94c5-16bb6c7a5c84\",\r\n    \"securityRules\": [\r\n
+        \     {\r\n        \"name\": \"default-allow-ssh\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/securityRules/default-allow-ssh\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"protocol\": \"TCP\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"22\",\r\n          \"sourceAddressPrefix\":
+        \"*\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n          \"access\":
+        \"Allow\",\r\n          \"priority\": 1000,\r\n          \"direction\": \"Inbound\",\r\n
+        \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      }\r\n    ],\r\n    \"defaultSecurityRules\": [\r\n
+        \     {\r\n        \"name\": \"AllowVnetInBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/AllowVnetInBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow inbound traffic from all VMs in VNET\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"VirtualNetwork\",\r\n          \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n          \"direction\":
+        \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowAzureLoadBalancerInBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/AllowAzureLoadBalancerInBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow inbound traffic from azure load balancer\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"AzureLoadBalancer\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65001,\r\n          \"direction\":
+        \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllInBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/DenyAllInBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Deny all inbound traffic\",\r\n          \"protocol\":
+        \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\":
+        \"*\",\r\n          \"sourceAddressPrefix\": \"*\",\r\n          \"destinationAddressPrefix\":
+        \"*\",\r\n          \"access\": \"Deny\",\r\n          \"priority\": 65500,\r\n
+        \         \"direction\": \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n
+        \         \"destinationPortRanges\": [],\r\n          \"sourceAddressPrefixes\":
+        [],\r\n          \"destinationAddressPrefixes\": []\r\n        }\r\n      },\r\n
+        \     {\r\n        \"name\": \"AllowVnetOutBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/AllowVnetOutBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow outbound traffic from all VMs to all VMs
+        in VNET\",\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\":
+        \"*\",\r\n          \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"VirtualNetwork\",\r\n          \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n          \"direction\":
+        \"Outbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowInternetOutBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/AllowInternetOutBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow outbound traffic from all VMs to Internet\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"*\",\r\n          \"destinationAddressPrefix\": \"Internet\",\r\n          \"access\":
+        \"Allow\",\r\n          \"priority\": 65001,\r\n          \"direction\": \"Outbound\",\r\n
+        \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllOutBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/DenyAllOutBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Deny all outbound traffic\",\r\n          \"protocol\":
+        \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\":
+        \"*\",\r\n          \"sourceAddressPrefix\": \"*\",\r\n          \"destinationAddressPrefix\":
+        \"*\",\r\n          \"access\": \"Deny\",\r\n          \"priority\": 65500,\r\n
+        \         \"direction\": \"Outbound\",\r\n          \"sourcePortRanges\":
+        [],\r\n          \"destinationPortRanges\": [],\r\n          \"sourceAddressPrefixes\":
+        [],\r\n          \"destinationAddressPrefixes\": []\r\n        }\r\n      }\r\n
+        \   ],\r\n    \"networkInterfaces\": [\r\n      {\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944\"\r\n
+        \     }\r\n    ]\r\n  }\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:33:33 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDY4ODcsIm5iZiI6MTUyMDg0Njg4NywiZXhwIjoxNTIwODUwNzg3LCJhaW8iOiJZMk5nWUZqSTNsdDNLY0ZkZlpMbXF5OVZ0ZXNYQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWkdqTVpnV3dBa2lnRzg4ZzBYc2NBQSIsInZlciI6IjEuMCJ9.LrTuVc0V5NgwLKxPeVGGfEalgK2xEDJKIeWg9opVlj681I1kl-vl42Lfm3NURP8Q2jKOj8nqtogmi3SHn0wNlAEwv83DOacgSipi14Llvr4X6it8alMqx0aJDQgdYKHgyycj4KHqy9Kou2Guh6G0B0FFAJGM0Enh3D_1iKvpdORMGLBJgSG4w4A6ghO7D9J5ssbQM7XdIhvzueWtYd4wib1_hXkkA3xXUEAOPxwTl12Z6v1B431lA6jL5DG9kImdDqqjjASRqiz3amzVRzyGMHBEUTcftOONh_OWNdpDPxF-FFHAnOSVJcvYOLj8eRVJktld6CXN6OnI-5NCpFA6Wg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"f5bbd20f-7ae4-4b6d-89c8-eb3481fcbe05"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - cb69084a-a1f4-435e-af64-2eff5f4f11d1
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14999'
+      X-Ms-Correlation-Request-Id:
+      - f9c443b1-e597-46c1-a1b9-d2491cbcb200
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T093329Z:f9c443b1-e597-46c1-a1b9-d2491cbcb200
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 09:33:29 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"miq-azure-test2\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2\",\r\n
+        \ \"etag\": \"W/\\\"f5bbd20f-7ae4-4b6d-89c8-eb3481fcbe05\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
+        \"f950a3cf-749a-49d5-a7fb-33a400b0e93c\",\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\":
+        [\r\n        \"172.25.0.0/16\"\r\n      ]\r\n    },\r\n    \"subnets\": [\r\n
+        \     {\r\n        \"name\": \"default\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2/subnets/default\",\r\n
+        \       \"etag\": \"W/\\\"f5bbd20f-7ae4-4b6d-89c8-eb3481fcbe05\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"addressPrefix\": \"172.25.0.0/24\",\r\n          \"ipConfigurations\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944/ipConfigurations/ipconfig1\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"virtualNetworkPeerings\":
+        [],\r\n    \"enableDdosProtection\": false,\r\n    \"enableVmProtection\":
+        false\r\n  }\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 09:33:34 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted_scope/cloud_network_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted_scope/cloud_network_refresh.yml
@@ -1,6 +1,62 @@
 ---
 http_interactions:
 - request:
+    method: post
+    uri: https://login.microsoftonline.com/AZURE_TENANT_ID/oauth2/token
+    body:
+      encoding: UTF-8
+      string: grant_type=client_credentials&client_id=AZURE_CLIENT_ID&client_secret=AZURE_CLIENT_SECRET&resource=https%3A%2F%2Fmanagement.azure.com%2F
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Server:
+      - Microsoft-IIS/10.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Request-Id:
+      - 2212ce19-3186-4adf-a7fc-eb3a19d63700
+      P3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Set-Cookie:
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHz-8wNivUjI8AN_tzUiwMSdjLFe2FkF41o-ujqoKlZFIgU6jSvHi9LBdcy2kK6zQtzteGULSXmmEWerrwXbjrDI2s7IfMLIFJ9jWms2n5-8hz3jOAc9Wjj7CdC0Bt6MwdTdFyCsZ69sLled2cdXlfoUVTlOn8y0aPwMrfqLyRB00wgAA;
+        domain=.login.microsoftonline.com; path=/; secure; HttpOnly
+      - stsservicecookie=ests; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=008; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Tue, 13 Mar 2018 09:05:19 GMT
+      Content-Length:
+      - '1505'
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1520935519","not_before":"1520931619","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA5MzE2MTksIm5iZiI6MTUyMDkzMTYxOSwiZXhwIjoxNTIwOTM1NTE5LCJhaW8iOiJZMk5nWU9BNzd0MVE5WExDVWhQalA5eGZ4WHhmQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiR2M0U0lvWXgzMHFuX09zNkdkWTNBQSIsInZlciI6IjEuMCJ9.Ey0BUtVO7lFOhjnT3qK65WJOYjKL-c-SBatX3KVJ2eLOdUv9i7HeRpjmmhzIw_jF2-8vmSAP5P8O7hdQgCHA23Cq6hfYeFNdc2O72RZW41YawscIiNFSOsWYjAvpQZ1joV8N67yVgltnoC3loOewrSiiWfMSGnsGkvMrqaUbrnHJ1ciIyRxOFYoFZJZUnbHpZuj2ixi16peebmoqGVcC4JELx1UgXx7w5wbzHJda3-ovfKNOD2pvb2IivfmMO1CgK3oSRhA2ekVagVYQHPraa6tjGAvL9tlA9oTMqa2bR5sLTzvnRo3hz1PgUlN8lkreeFMX6cHE2GEOOGlTj1CIFw"}'
+    http_version: 
+  recorded_at: Tue, 13 Mar 2018 09:05:19 GMT
+- request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
     body:
@@ -16,7 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA5MzE2MTksIm5iZiI6MTUyMDkzMTYxOSwiZXhwIjoxNTIwOTM1NTE5LCJhaW8iOiJZMk5nWU9BNzd0MVE5WExDVWhQalA5eGZ4WHhmQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiR2M0U0lvWXgzMHFuX09zNkdkWTNBQSIsInZlciI6IjEuMCJ9.Ey0BUtVO7lFOhjnT3qK65WJOYjKL-c-SBatX3KVJ2eLOdUv9i7HeRpjmmhzIw_jF2-8vmSAP5P8O7hdQgCHA23Cq6hfYeFNdc2O72RZW41YawscIiNFSOsWYjAvpQZ1joV8N67yVgltnoC3loOewrSiiWfMSGnsGkvMrqaUbrnHJ1ciIyRxOFYoFZJZUnbHpZuj2ixi16peebmoqGVcC4JELx1UgXx7w5wbzHJda3-ovfKNOD2pvb2IivfmMO1CgK3oSRhA2ekVagVYQHPraa6tjGAvL9tlA9oTMqa2bR5sLTzvnRo3hz1PgUlN8lkreeFMX6cHE2GEOOGlTj1CIFw
   response:
     status:
       code: 200
@@ -35,26 +91,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14997'
+      - '14998'
       X-Ms-Request-Id:
-      - cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - 7a92d35f-73cb-4f2f-b2b6-63840e4ba0a0
       X-Ms-Correlation-Request-Id:
-      - cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - 7a92d35f-73cb-4f2f-b2b6-63840e4ba0a0
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102417Z:cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - WESTEUROPE:20180313T090521Z:7a92d35f-73cb-4f2f-b2b6-63840e4ba0a0
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:17 GMT
+      - Tue, 13 Mar 2018 09:05:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID","subscriptionId":"AZURE_SUBSCRIPTION_ID","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:22 GMT
+  recorded_at: Tue, 13 Mar 2018 09:05:21 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers?api-version=2015-01-01
@@ -71,7 +127,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA5MzE2MTksIm5iZiI6MTUyMDkzMTYxOSwiZXhwIjoxNTIwOTM1NTE5LCJhaW8iOiJZMk5nWU9BNzd0MVE5WExDVWhQalA5eGZ4WHhmQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiR2M0U0lvWXgzMHFuX09zNkdkWTNBQSIsInZlciI6IjEuMCJ9.Ey0BUtVO7lFOhjnT3qK65WJOYjKL-c-SBatX3KVJ2eLOdUv9i7HeRpjmmhzIw_jF2-8vmSAP5P8O7hdQgCHA23Cq6hfYeFNdc2O72RZW41YawscIiNFSOsWYjAvpQZ1joV8N67yVgltnoC3loOewrSiiWfMSGnsGkvMrqaUbrnHJ1ciIyRxOFYoFZJZUnbHpZuj2ixi16peebmoqGVcC4JELx1UgXx7w5wbzHJda3-ovfKNOD2pvb2IivfmMO1CgK3oSRhA2ekVagVYQHPraa6tjGAvL9tlA9oTMqa2bR5sLTzvnRo3hz1PgUlN8lkreeFMX6cHE2GEOOGlTj1CIFw
   response:
     status:
       code: 200
@@ -88,21 +144,21 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - '14828'
       X-Ms-Request-Id:
-      - fe3532ca-59a2-474e-9094-8a3697b82bef
+      - fa233458-37db-46cc-99b5-a225c0c8bfae
       X-Ms-Correlation-Request-Id:
-      - fe3532ca-59a2-474e-9094-8a3697b82bef
+      - fa233458-37db-46cc-99b5-a225c0c8bfae
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102419Z:fe3532ca-59a2-474e-9094-8a3697b82bef
+      - WESTEUROPE:20180313T090522Z:fa233458-37db-46cc-99b5-a225c0c8bfae
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:18 GMT
+      - Tue, 13 Mar 2018 09:05:22 GMT
       Content-Length:
-      - '320853'
+      - '322992'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"},{"applicationId":"d87dcbc6-a371-462e-88e3-28ad15ec4e64","roleDefinitionId":"861776c5-e0df-4f95-be4f-ac1eec193323"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["East
@@ -442,7 +498,10 @@ http_interactions:
         Central US","West Europe","North Europe","East US","UK West","UK South","West
         Central US","West US 2","South India","Central India","West India","Canada
         East","Canada Central","Korea South","Korea Central"],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"managedClusters","locations":["East
-        US","West Europe","Central US","Canada Central","Canada East"],"apiVersions":["2017-08-31"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
+        US","West Europe","Central US","Canada Central","Canada East"],"apiVersions":["2017-08-31"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operationresults","locations":["East
+        US","West Europe","Central US","UK West","UK South","West Central US","West
+        US 2","South India","Central India","West India","Canada East","Canada Central","Korea
+        South","Korea Central"],"apiVersions":["2017-08-31","2016-03-30"]},{"resourceType":"locations/operations","locations":["Japan
         East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
@@ -510,7 +569,7 @@ http_interactions:
         US","South Central US","North Europe","West Europe","Southeast Asia","West
         US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"listMigrationdate","locations":["East
         US","South Central US","North Europe","West Europe","Southeast Asia","West
-        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2018-03-01","2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
@@ -612,47 +671,47 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"networkWatchers/lenses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"networkWatchers/lenses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -662,47 +721,52 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2018-02-01","2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"ddosProtectionPlans","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","West
         US 2","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
@@ -1438,57 +1502,57 @@ http_interactions:
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/asyncoperations","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/asyncoperations","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/listAccountSas","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/listAccountSas","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/listServiceSas","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/listServiceSas","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/blobServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/blobServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/tableServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/tableServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/queueServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/queueServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/fileServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/fileServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01","2016-01-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01","2016-01-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
         US","West US","West Europe","North Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":["East
         US","West US","West Europe","North Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.visualstudio","namespace":"microsoft.visualstudio","authorization":{"applicationId":"499b84ac-1321-427f-aa17-267ca6975798","roleDefinitionId":"6a18f445-86f0-4e2e-b8a9-6b9b5677e3d8"},"resourceTypes":[{"resourceType":"account","locations":["North
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.visualstudio","namespace":"microsoft.visualstudio","authorization":{"applicationId":"499b84ac-1321-427f-aa17-267ca6975798","roleDefinitionId":"6a18f445-86f0-4e2e-b8a9-6b9b5677e3d8"},"resourceTypes":[{"resourceType":"account","locations":["North
         Central US","South Central US","East US","West US","Central US","North Europe","West
         Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
         East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/project","locations":["North
@@ -2173,7 +2237,8 @@ http_interactions:
         US","West US 2","East US","East US 2","North Europe","West Europe","Southeast
         Asia","East Asia","North Central US","South Central US","Japan West","Australia
         East","Brazil South","Central India","West Central US","Canada Central","UK
-        South"],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ServiceBus","namespace":"Microsoft.ServiceBus","authorization":{"applicationId":"80a10ef9-8168-493d-abf9-3297c4ef6e3c","roleDefinitionId":"2b7763f7-bbe2-4e19-befe-28c79f1cf7f7"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        South"],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.SecurityGraph","namespace":"Microsoft.SecurityGraph","resourceTypes":[{"resourceType":"operations","locations":["West
+        US"],"apiVersions":["2017-04-01-preview"]},{"resourceType":"diagnosticSettings","locations":[],"apiVersions":["2017-04-01-preview"]},{"resourceType":"diagnosticSettingsCategories","locations":[],"apiVersions":["2017-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ServiceBus","namespace":"Microsoft.ServiceBus","authorization":{"applicationId":"80a10ef9-8168-493d-abf9-3297c4ef6e3c","roleDefinitionId":"2b7763f7-bbe2-4e19-befe-28c79f1cf7f7"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US 2","West
         US","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
@@ -2322,10 +2387,10 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:23 GMT
+  recorded_at: Tue, 13 Mar 2018 09:05:23 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2?api-version=2018-03-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2339,7 +2404,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA5MzE2MTksIm5iZiI6MTUyMDkzMTYxOSwiZXhwIjoxNTIwOTM1NTE5LCJhaW8iOiJZMk5nWU9BNzd0MVE5WExDVWhQalA5eGZ4WHhmQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiR2M0U0lvWXgzMHFuX09zNkdkWTNBQSIsInZlciI6IjEuMCJ9.Ey0BUtVO7lFOhjnT3qK65WJOYjKL-c-SBatX3KVJ2eLOdUv9i7HeRpjmmhzIw_jF2-8vmSAP5P8O7hdQgCHA23Cq6hfYeFNdc2O72RZW41YawscIiNFSOsWYjAvpQZ1joV8N67yVgltnoC3loOewrSiiWfMSGnsGkvMrqaUbrnHJ1ciIyRxOFYoFZJZUnbHpZuj2ixi16peebmoqGVcC4JELx1UgXx7w5wbzHJda3-ovfKNOD2pvb2IivfmMO1CgK3oSRhA2ekVagVYQHPraa6tjGAvL9tlA9oTMqa2bR5sLTzvnRo3hz1PgUlN8lkreeFMX6cHE2GEOOGlTj1CIFw
   response:
     status:
       code: 200
@@ -2356,294 +2421,42 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67"
+      - W/"f5bbd20f-7ae4-4b6d-89c8-eb3481fcbe05"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - '080de667-081e-4d58-9e94-9e7243d4200e'
+      - ae101acb-7033-4ab2-a674-cebca5b1f85a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
+      - '14938'
       X-Ms-Correlation-Request-Id:
-      - '093d49ac-c85f-440e-956b-955b6698dd19'
+      - af6dba5c-dddd-429d-aaa5-a3d442d16314
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102419Z:093d49ac-c85f-440e-956b-955b6698dd19
+      - WESTEUROPE:20180313T090524Z:af6dba5c-dddd-429d-aaa5-a3d442d16314
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:19 GMT
+      - Tue, 13 Mar 2018 09:05:24 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1\",\r\n
-        \ \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"7ab88756-810f-4083-95db-8b05d50e38f2\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
+      string: "{\r\n  \"name\": \"miq-azure-test2\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2\",\r\n
+        \ \"etag\": \"W/\\\"f5bbd20f-7ae4-4b6d-89c8-eb3481fcbe05\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
+        \"f950a3cf-749a-49d5-a7fb-33a400b0e93c\",\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\":
+        [\r\n        \"172.25.0.0/16\"\r\n      ]\r\n    },\r\n    \"subnets\": [\r\n
+        \     {\r\n        \"name\": \"default\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2/subnets/default\",\r\n
+        \       \"etag\": \"W/\\\"f5bbd20f-7ae4-4b6d-89c8-eb3481fcbe05\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ],\r\n          \"inboundNatRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"backendIPConfigurations\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\"\r\n
-        \           }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-rule\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\":
-        80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\"\r\n
-        \         },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n
-        \       \"name\": \"rspec-lb-probe\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-NAT\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 3441,\r\n          \"backendPort\":
-        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
+        \         \"addressPrefix\": \"172.25.0.0/24\",\r\n          \"ipConfigurations\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944/ipConfigurations/ipconfig1\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"virtualNetworkPeerings\":
+        [],\r\n    \"enableDdosProtection\": false,\r\n    \"enableVmProtection\":
+        false\r\n  }\r\n}"
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:24 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"7a8e5fe7-f777-4435-992b-a54f28c2f28c"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - bd22ca22-a01f-4ecf-9230-a4558fb66931
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Correlation-Request-Id:
-      - 19c674a8-c8da-4b5e-8265-5ebc21926459
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102420Z:19c674a8-c8da-4b5e-8265-5ebc21926459
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Mon, 12 Mar 2018 10:24:19 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb2\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2\",\r\n
-        \ \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"e2e30a77-f81b-43fc-9693-08303e43deed\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/backendAddressPools/rspec-lb2-pool\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\r\n
-        \       }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\": [],\r\n    \"probes\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-probe\",\r\n        \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/probes/rspec-lb2-probe\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\": [],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:25 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"a38434c8-7b23-4092-b7c6-402238eac0dc"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 0fd15240-6a1c-4b39-a4f6-aa53fd8591c2
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Correlation-Request-Id:
-      - 5cc03163-922e-41a1-9601-dba2d7cf2a81
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102421Z:5cc03163-922e-41a1-9601-dba2d7cf2a81
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Mon, 12 Mar 2018 10:24:20 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb1-LoadBalancerFrontEnd\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\",\r\n
-        \ \"etag\": \"W/\\\"a38434c8-7b23-4092-b7c6-402238eac0dc\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"f28e0f25-b372-4edf-97d9-13a9e3b4ba2d\",\r\n    \"ipAddress\":
-        \"40.71.82.83\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\":
-        \"Static\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipTags\": [],\r\n
-        \   \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
-        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:25 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"cddd97d1-6111-4477-8a00-3dc885237a1d"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 1403e5b6-8fa0-4cd3-89b1-76b6c4fd805b
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
-      X-Ms-Correlation-Request-Id:
-      - e4a5f369-a742-466f-bd8f-42e17eaaf9c9
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102421Z:e4a5f369-a742-466f-bd8f-42e17eaaf9c9
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Mon, 12 Mar 2018 10:24:21 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb2-publicip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\",\r\n
-        \ \"etag\": \"W/\\\"cddd97d1-6111-4477-8a00-3dc885237a1d\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"83e7257d-ab94-4229-8eb5-4798f37ef28d\",\r\n    \"publicIPAddressVersion\":
-        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
-        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
-        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:26 GMT
+  recorded_at: Tue, 13 Mar 2018 09:05:24 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted_scope/lb_created_by_stack_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted_scope/lb_created_by_stack_refresh.yml
@@ -37,25 +37,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 6f04a006-fd32-4582-b694-f4acc2720000
+      - 76d0085e-85b2-4773-8d11-3ff742f40000
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzAUQhwtvkldaDyevTOyqpz1z60SL3INUs5LYtxJvjoIPKwfzIVJZkfTsQMSd48_X7y2lKagRB99INm-jT1Tc-e-ZYviPb33N1h0mi3MqgcN9xEwaGDVeFYZNU_dKJ0o-C3yrEaNDNchTdcu9F7kM11BVRX9hfowKDppICgEM_U4EgAA;
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzytbHKrQ0D715x0Y9mJHXAtPrcolaOmHYdUDHzYS12UjES3ubvKCysjcB7TKw2G8tkDi5SZtu8Bw1Stej0H2zmARg5-48iCH9RqxT2_N9X-VEx9-iE39T08T4wrE7-83CCXB_CTtKQEUvxmL-K2zPitQgrc_R19O1_rAVDRz7sX0gAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=003; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=006; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Wed, 07 Mar 2018 20:22:28 GMT
+      - Mon, 12 Mar 2018 10:27:15 GMT
       Content-Length:
       - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1520457748","not_before":"1520453848","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM4NDgsIm5iZiI6MTUyMDQ1Mzg0OCwiZXhwIjoxNTIwNDU3NzQ4LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQnFBRWJ6TDlna1cybFBTc3duSUFBQSIsInZlciI6IjEuMCJ9.kbHraUxJtbINcGjd0a7Rjty4aVD_0kqBY179kuYiZec3QlDRtv91O3QNyCV_NG0K5OF6iNP4_zCDWExgEUJF7HJlle9w-BUQ5pCOVC7yj5jydCIsnGdUJ2S1fs3SBXwngoPNk3KDEEC45NuFIVTZECRAYmMt-ocWAN8bOOHvMKfDuxHGH73IgYKfV5knA5GPYJ6cVGbKxdxNURSvqlm2_vZEHVFhnG3bCh88za8zI-XTanUkxrU4ufYga__Kgfq8rnI_WG-fM37j2yD2sE-TkZdiEPHoQyBaTLoVqxSs6Mo4bWXVl2M1xzgEWqJ2ieSjH2MPerpECBqLXddiWQ326A"}'
+      string: '{"token_type":"Bearer","expires_in":"3600","ext_expires_in":"0","expires_on":"1520854036","not_before":"1520850136","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAxMzYsIm5iZiI6MTUyMDg1MDEzNiwiZXhwIjoxNTIwODU0MDM2LCJhaW8iOiJZMk5nWURBTjFDdDJkcHEzYjE1K2V1Lys2UnRMQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWGdqUWRyS0ZjMGVORVRfM1F2UUFBQSIsInZlciI6IjEuMCJ9.k92gx8N-NZGR-v3MZ8XE1kfP-c7zuwCBuEg8dlZhf-rHDb0Jx2j9qxg9F-GM6E5KspT6iLrchrdHoe0OD_08-v-wPrt0k2ywO3k8GrQrRG9SQUUrjmhB75BxoWhHoY7UtYgEsuEMnqCZexjKpbBEgP04zCuRtUmCSmpfZ7WKBezA8HkONVXVw-KakN5irfVjEWUNqdN016R8kuvMt3-zUsX00swvfLuvv8Py3wIoUjxWZ8P48GNlkjv3CZZHh5sOPbLDY-4XC_yAA9w0xadA_R9Z8--0wBEqz9fv8pqdybxK0PIXR017_G8TF1ts-YGpi2g3Nl4jLbKzAV8OatT5yA"}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:22:29 GMT
+  recorded_at: Mon, 12 Mar 2018 10:27:21 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -72,7 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM4NDgsIm5iZiI6MTUyMDQ1Mzg0OCwiZXhwIjoxNTIwNDU3NzQ4LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQnFBRWJ6TDlna1cybFBTc3duSUFBQSIsInZlciI6IjEuMCJ9.kbHraUxJtbINcGjd0a7Rjty4aVD_0kqBY179kuYiZec3QlDRtv91O3QNyCV_NG0K5OF6iNP4_zCDWExgEUJF7HJlle9w-BUQ5pCOVC7yj5jydCIsnGdUJ2S1fs3SBXwngoPNk3KDEEC45NuFIVTZECRAYmMt-ocWAN8bOOHvMKfDuxHGH73IgYKfV5knA5GPYJ6cVGbKxdxNURSvqlm2_vZEHVFhnG3bCh88za8zI-XTanUkxrU4ufYga__Kgfq8rnI_WG-fM37j2yD2sE-TkZdiEPHoQyBaTLoVqxSs6Mo4bWXVl2M1xzgEWqJ2ieSjH2MPerpECBqLXddiWQ326A
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAxMzYsIm5iZiI6MTUyMDg1MDEzNiwiZXhwIjoxNTIwODU0MDM2LCJhaW8iOiJZMk5nWURBTjFDdDJkcHEzYjE1K2V1Lys2UnRMQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWGdqUWRyS0ZjMGVORVRfM1F2UUFBQSIsInZlciI6IjEuMCJ9.k92gx8N-NZGR-v3MZ8XE1kfP-c7zuwCBuEg8dlZhf-rHDb0Jx2j9qxg9F-GM6E5KspT6iLrchrdHoe0OD_08-v-wPrt0k2ywO3k8GrQrRG9SQUUrjmhB75BxoWhHoY7UtYgEsuEMnqCZexjKpbBEgP04zCuRtUmCSmpfZ7WKBezA8HkONVXVw-KakN5irfVjEWUNqdN016R8kuvMt3-zUsX00swvfLuvv8Py3wIoUjxWZ8P48GNlkjv3CZZHh5sOPbLDY-4XC_yAA9w0xadA_R9Z8--0wBEqz9fv8pqdybxK0PIXR017_G8TF1ts-YGpi2g3Nl4jLbKzAV8OatT5yA
   response:
     status:
       code: 200
@@ -93,24 +93,24 @@ http_interactions:
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
       - '14998'
       X-Ms-Request-Id:
-      - c434e6fa-3cf6-4b4b-8b5c-65f0c765beb7
+      - dd956607-e6eb-4db3-89c6-d32b45dc1740
       X-Ms-Correlation-Request-Id:
-      - c434e6fa-3cf6-4b4b-8b5c-65f0c765beb7
+      - dd956607-e6eb-4db3-89c6-d32b45dc1740
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202229Z:c434e6fa-3cf6-4b4b-8b5c-65f0c765beb7
+      - WESTEUROPE:20180312T102716Z:dd956607-e6eb-4db3-89c6-d32b45dc1740
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:22:29 GMT
+      - Mon, 12 Mar 2018 10:27:16 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID","subscriptionId":"AZURE_SUBSCRIPTION_ID","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:22:29 GMT
+  recorded_at: Mon, 12 Mar 2018 10:27:21 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers?api-version=2015-01-01
@@ -127,7 +127,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM4NDgsIm5iZiI6MTUyMDQ1Mzg0OCwiZXhwIjoxNTIwNDU3NzQ4LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQnFBRWJ6TDlna1cybFBTc3duSUFBQSIsInZlciI6IjEuMCJ9.kbHraUxJtbINcGjd0a7Rjty4aVD_0kqBY179kuYiZec3QlDRtv91O3QNyCV_NG0K5OF6iNP4_zCDWExgEUJF7HJlle9w-BUQ5pCOVC7yj5jydCIsnGdUJ2S1fs3SBXwngoPNk3KDEEC45NuFIVTZECRAYmMt-ocWAN8bOOHvMKfDuxHGH73IgYKfV5knA5GPYJ6cVGbKxdxNURSvqlm2_vZEHVFhnG3bCh88za8zI-XTanUkxrU4ufYga__Kgfq8rnI_WG-fM37j2yD2sE-TkZdiEPHoQyBaTLoVqxSs6Mo4bWXVl2M1xzgEWqJ2ieSjH2MPerpECBqLXddiWQ326A
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAxMzYsIm5iZiI6MTUyMDg1MDEzNiwiZXhwIjoxNTIwODU0MDM2LCJhaW8iOiJZMk5nWURBTjFDdDJkcHEzYjE1K2V1Lys2UnRMQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWGdqUWRyS0ZjMGVORVRfM1F2UUFBQSIsInZlciI6IjEuMCJ9.k92gx8N-NZGR-v3MZ8XE1kfP-c7zuwCBuEg8dlZhf-rHDb0Jx2j9qxg9F-GM6E5KspT6iLrchrdHoe0OD_08-v-wPrt0k2ywO3k8GrQrRG9SQUUrjmhB75BxoWhHoY7UtYgEsuEMnqCZexjKpbBEgP04zCuRtUmCSmpfZ7WKBezA8HkONVXVw-KakN5irfVjEWUNqdN016R8kuvMt3-zUsX00swvfLuvv8Py3wIoUjxWZ8P48GNlkjv3CZZHh5sOPbLDY-4XC_yAA9w0xadA_R9Z8--0wBEqz9fv8pqdybxK0PIXR017_G8TF1ts-YGpi2g3Nl4jLbKzAV8OatT5yA
   response:
     status:
       code: 200
@@ -144,39 +144,37 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14979'
+      - '14981'
       X-Ms-Request-Id:
-      - fd3368d7-a526-4752-9bfb-81bae755a711
+      - 964b03ef-e9dd-4ac9-911e-4c7dbca44199
       X-Ms-Correlation-Request-Id:
-      - fd3368d7-a526-4752-9bfb-81bae755a711
+      - 964b03ef-e9dd-4ac9-911e-4c7dbca44199
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202231Z:fd3368d7-a526-4752-9bfb-81bae755a711
+      - WESTEUROPE:20180312T102718Z:964b03ef-e9dd-4ac9-911e-4c7dbca44199
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:22:30 GMT
+      - Mon, 12 Mar 2018 10:27:17 GMT
       Content-Length:
-      - '310901'
+      - '320853'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"},{"applicationId":"d87dcbc6-a371-462e-88e3-28ad15ec4e64","roleDefinitionId":"861776c5-e0df-4f95-be4f-ac1eec193323"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
+      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"},{"applicationId":"d87dcbc6-a371-462e-88e3-28ad15ec4e64","roleDefinitionId":"861776c5-e0df-4f95-be4f-ac1eec193323"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["East
+        Asia","Southeast Asia","Australia East","Australia Southeast","Japan East","Japan
+        West","Central India","South India","West India","West Europe","North Europe","Canada
+        Central","Canada East","Brazil South","West US","Central US","East US","South
+        Central US","East US 2","West Central US","North Central US","West US 2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
         US","Central US","East US","South Central US","West Europe","North Europe","East
         Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
         Central US","North Central US","Japan East","Japan West","Brazil South","Central
         India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"operations","locations":["West
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["East
+        Asia","Southeast Asia","Australia East","Australia Southeast","Japan East","Japan
+        West","Central India","South India","West India","West Europe","North Europe","Canada
+        Central","Canada East","Brazil South","West US","Central US","East US","South
+        Central US","East US 2","West Central US","North Central US","West US 2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"operations","locations":["West
         US","Central US","East US","South Central US","West Europe","North Europe","East
         Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
         Central US","North Central US","Japan East","Japan West","Brazil South","Central
@@ -232,177 +230,177 @@ http_interactions:
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/internalLoadBalancers","locations":[],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"domainNames/slots/roles/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"domainNames/slots/roles/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"domainNames/capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"domainNames/serviceCertificates","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
         US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
         Central","Canada East","UK South","UK West","West US","Central US","South
         Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
-        East","Australia Southeast","West US 2","West Central US","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        East","Australia Southeast","West US 2","West Central US","France Central","South
+        India","Central India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
         US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
         Central","Canada East","UK South","UK West","West US","Central US","South
         Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
-        East","Australia Southeast","West US 2","West Central US","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metrics","locations":["North
+        East","Australia Southeast","West US 2","West Central US","France Central","South
+        India","Central India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metrics","locations":["North
         Central US","South Central US","East US","East US 2","Canada Central","Canada
         East","West US","West US 2","West Central US","Central US","East Asia","Southeast
         Asia","North Europe","West Europe","UK South","UK West","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"resourceTypes","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"moveSubscriptionResources","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"validateSubscriptionMoveAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operationStatuses","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operatingSystems","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"operatingSystemFamilies","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicNetwork","namespace":"Microsoft.ClassicNetwork","resourceTypes":[{"resourceType":"virtualNetworks","locations":["East
+        India","West India","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"resourceTypes","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"moveSubscriptionResources","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"validateSubscriptionMoveAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operationStatuses","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operatingSystems","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"operatingSystemFamilies","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicNetwork","namespace":"Microsoft.ClassicNetwork","resourceTypes":[{"resourceType":"virtualNetworks","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"virtualNetworks/remoteVirtualNetworkPeeringProxies","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01"]},{"resourceType":"virtualNetworks/remoteVirtualNetworkPeeringProxies","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"reservedIps","locations":["East
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01"]},{"resourceType":"reservedIps","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"gatewaySupportedDevices","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"networkSecurityGroups","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"gatewaySupportedDevices","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"networkSecurityGroups","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicStorage","namespace":"Microsoft.ClassicStorage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"expressRouteCrossConnections","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"expressRouteCrossConnections/peerings","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicStorage","namespace":"Microsoft.ClassicStorage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkStorageAccountAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"storageAccounts/services","locations":["West
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkStorageAccountAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"storageAccounts/services","locations":["West
         US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
         Asia","Australia East","Australia Southeast","South India","Central India","West
         India","West US 2","West Central US","East US","East US 2","North Central
         US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
-        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/diagnosticSettings","locations":["West
+        South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/diagnosticSettings","locations":["West
         US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
         Asia","Australia East","Australia Southeast","South India","Central India","West
         India","West US 2","West Central US","East US","East US 2","North Central
         US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
-        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"disks","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"images","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"vmImages","locations":[],"apiVersions":["2016-11-01"]},{"resourceType":"publicImages","locations":[],"apiVersions":["2016-11-01","2016-04-01"]},{"resourceType":"osImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"osPlatformImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute","namespace":"Microsoft.Compute","authorizations":[{"applicationId":"60e6cd67-9c8c-4951-9b3c-23c25a2169af","roleDefinitionId":"e4770acb-272e-4dc8-87f3-12f44a612224"},{"applicationId":"a303894e-f1d8-4a37-bf10-67aa654a0596","roleDefinitionId":"903ac751-8ad5-4e5a-bfc2-5e49f450a241"},{"applicationId":"a8b6bf88-1d1a-4626-b040-9a729ea93c65","roleDefinitionId":"45c8267c-80ba-4b96-9a43-115b8f49fccd"}],"resourceTypes":[{"resourceType":"availabilitySets","locations":["East
+        South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"disks","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"images","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"vmImages","locations":[],"apiVersions":["2016-11-01"]},{"resourceType":"storageAccounts/vmImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"publicImages","locations":[],"apiVersions":["2016-11-01","2016-04-01"]},{"resourceType":"osImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"osPlatformImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute","namespace":"Microsoft.Compute","authorizations":[{"applicationId":"60e6cd67-9c8c-4951-9b3c-23c25a2169af","roleDefinitionId":"e4770acb-272e-4dc8-87f3-12f44a612224"},{"applicationId":"a303894e-f1d8-4a37-bf10-67aa654a0596","roleDefinitionId":"903ac751-8ad5-4e5a-bfc2-5e49f450a241"},{"applicationId":"a8b6bf88-1d1a-4626-b040-9a729ea93c65","roleDefinitionId":"45c8267c-80ba-4b96-9a43-115b8f49fccd"}],"resourceTypes":[{"resourceType":"availabilitySets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations/usages","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations/usages","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"sharedVMImages","locations":["West
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"sharedVMImages","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"sharedVMImages/versions","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"locations/capsoperations","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"disks","locations":["Southeast
@@ -410,27 +408,27 @@ http_interactions:
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"snapshots","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"snapshots","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"locations/diskoperations","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"locations/diskoperations","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"images","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"images","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"]},{"resourceType":"locations/logAnalytics","locations":["East
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"]},{"resourceType":"locations/logAnalytics","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
         US","East US","South Central US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
@@ -547,7 +545,12 @@ http_interactions:
         US","East Asia","East US","East US 2","Japan East","Japan West","North Central
         US","North Europe","South Central US","South India","Southeast Asia","West
         Central US","West Europe","West India","West US","West US 2","UK West","UK
-        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"},{"applicationId":"f5c26e74-f226-4ae8-85f0-b4af0080ac9e","roleDefinitionId":"529d7ae6-e892-4d43-809d-8547aeb90643"}],"resourceTypes":[{"resourceType":"components","locations":["East
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/consumergroups","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/disasterrecoveryconfigs","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"},{"applicationId":"f5c26e74-f226-4ae8-85f0-b4af0080ac9e","roleDefinitionId":"529d7ae6-e892-4d43-809d-8547aeb90643"}],"resourceTypes":[{"resourceType":"components","locations":["East
         US","South Central US","North Europe","West Europe","Southeast Asia","West
         US 2"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
         US","South Central US","North Europe","West Europe","Southeast Asia","West
@@ -614,32 +617,32 @@ http_interactions:
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/accessPolicies","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"vaults/accessPolicies","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-10-01","2015-06-01","2014-12-19-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"deletedVaults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01","2014-12-19-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"deletedVaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-10-01"]},{"resourceType":"locations/deletedVaults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations/deletedVaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
         Central US","West Europe","Southeast Asia","Japan East","West Central US"],"apiVersions":["2016-04-01"]},{"resourceType":"webServices","locations":["South
         Central US","West Europe","Southeast Asia","Japan East","East US 2","West
         Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"operations","locations":["South
@@ -665,97 +668,97 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"networkWatchers/lenses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"networkWatchers/lenses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","West
         US 2","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
@@ -846,7 +849,7 @@ http_interactions:
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
         West","Korea Central","Korea South"],"apiVersions":["2017-07-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ResourceHealth","namespace":"Microsoft.ResourceHealth","authorizations":[{"applicationId":"8bdebf23-c0fe-4187-a378-717ad86f6a53","roleDefinitionId":"cc026344-c8b1-4561-83ba-59eba84b27cc"}],"resourceTypes":[{"resourceType":"availabilityStatuses","locations":[],"apiVersions":["2017-07-01","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"notifications","locations":["Australia
-        Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Security","namespace":"Microsoft.Security","authorization":{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
+        Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Security","namespace":"Microsoft.Security","authorizations":[{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},{"applicationId":"fc780465-2017-40d4-a0c5-307022471b92"}],"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatuses","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/virtualMachines","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/endpoints","locations":["Central
@@ -898,565 +901,595 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Central India","South
         India"],"apiVersions":["2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Sql","namespace":"Microsoft.Sql","authorizations":[{"applicationId":"e4ab13ed-33cb-41b4-9140-6e264582cf85","roleDefinitionId":"ec3ddc95-44dc-47a2-9926-5e9f5ffd44ec"},{"applicationId":"0130cc9f-7ac5-4026-bd5f-80a08a54e6d9","roleDefinitionId":"45e8abf8-0ec4-44f3-9c37-cff4f7779302"},{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},{"applicationId":"76c7f279-7959-468f-8943-3954880e0d8c","roleDefinitionId":"7f7513a8-73f9-4c5f-97a2-c41f0ea783ef"}],"resourceTypes":[{"resourceType":"operations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/capabilities","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/databaseAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/databaseOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverKeyOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/keys","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/encryptionProtector","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/usages","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01","2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/communicationLinks","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administrators","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administratorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/restorableDroppedDatabases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recoverableDatabases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/geoBackupPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/importExportOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/operationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/backupLongTermRetentionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/automaticTuning","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/automaticTuning","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/databases/transparentDataEncryption","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recommendedElasticPools","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/auditingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/connectionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/connectionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies/rules","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/securityAlertPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/securityAlertPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/auditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/extendedAuditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/elasticpools","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-09-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/jobAgentOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/jobAgentAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/disasterRecoveryConfiguration","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/dnsAliases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/failoverGroups","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/virtualNetworkRules","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/virtualNetworkRulesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/virtualNetworkRulesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/databaseRestoreAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metricDefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/aggregatedDatabaseMetrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metricdefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries/queryText","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPools/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/extensions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPoolEstimates","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditRecords","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentScans","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/vulnerabilityAssessments","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessment","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/syncGroups","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups/syncMembers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/syncAgents","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"managedInstances/administrators","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/databases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metricDefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/administratorAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/administratorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncMemberOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncAgentOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncDatabaseIds","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorizations":[{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},{"applicationId":"e406a681-f3d4-42a8-90b6-c2b029497af1"}],"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/capabilities","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/databaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"locations/databaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverKeyOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/keys","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/encryptionProtector","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01","2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/communicationLinks","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/restorableDroppedDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recoverableDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/geoBackupPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/importExportOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/operationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/backupLongTermRetentionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/databases/transparentDataEncryption","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recommendedElasticPools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies/rules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/extendedAuditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/elasticPoolAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/elasticPoolOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/elasticpools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-09-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/jobAgentOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/jobAgentAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/disasterRecoveryConfiguration","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/dnsAliases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/failoverGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/virtualNetworkRules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/virtualNetworkRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/virtualNetworkRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/databaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/aggregatedDatabaseMetrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metricdefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries/queryText","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPools/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/extensions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPoolEstimates","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditRecords","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentScans","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/vulnerabilityAssessments","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessment","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/syncGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups/syncMembers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/syncAgents","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"managedInstances/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/administratorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncMemberOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncAgentOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncDatabaseIds","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/longTermRetentionPolicyOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionPolicyAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionBackupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionBackupAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorizations":[{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},{"applicationId":"e406a681-f3d4-42a8-90b6-c2b029497af1"}],"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
@@ -1795,12 +1828,12 @@ http_interactions:
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","Canada Central","Canada East","UK South","UK West","West US 2","West
-        Central US","South India","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","South India","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","South India","Canada Central","Canada East","UK South","UK West","West
-        US 2","West Central US","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Capacity","namespace":"Microsoft.Capacity","authorization":{"applicationId":"4d0ad6c7-f6c3-46d8-ab0d-1406d5e6c86b","roleDefinitionId":"FD9C0A9A-4DB9-4F41-8A61-98385DEB6E2D"},"resourceTypes":[{"resourceType":"resources","locations":["South
+        US 2","West Central US","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Capacity","namespace":"Microsoft.Capacity","authorization":{"applicationId":"4d0ad6c7-f6c3-46d8-ab0d-1406d5e6c86b","roleDefinitionId":"FD9C0A9A-4DB9-4F41-8A61-98385DEB6E2D"},"resourceTypes":[{"resourceType":"resources","locations":["South
         Central US"],"apiVersions":["2017-11-01"]},{"resourceType":"reservationOrders","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/reservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/reservations/revisions","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"catalogs","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"appliedReservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"checkOffers","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"checkScopes","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"calculatePrice","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/calculateRefund","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/return","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/split","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/merge","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"validateReservationOrder","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/availableScopes","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Cdn","namespace":"Microsoft.Cdn","resourceTypes":[{"resourceType":"profiles","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
@@ -1876,9 +1909,9 @@ http_interactions:
         2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/updateAccountsCreationSettings","locations":["West
         US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/accountsCreationSettings","locations":["West
         US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2016-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Commerce","namespace":"Microsoft.Commerce","resourceTypes":[{"resourceType":"UsageAggregates","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]},{"resourceType":"RateCard","locations":[],"apiVersions":["2016-08-31-preview","2015-06-01-preview","2015-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Consumption","namespace":"Microsoft.Consumption","resourceTypes":[{"resourceType":"ReservationSummaries","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationTransactions","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Balances","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Marketplaces","locations":[],"apiVersions":["2018-01-31"]},{"resourceType":"Pricesheets","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationDetails","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Budgets","locations":[],"apiVersions":["2018-01-31","2017-12-30-preview"]},{"resourceType":"Terms","locations":[],"apiVersions":["2018-01-31","2017-12-30-preview"]},{"resourceType":"UsageDetails","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview","2017-04-24-preview"]},{"resourceType":"Operations","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview","2017-04-24-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerInstance","namespace":"Microsoft.ContainerInstance","resourceTypes":[{"resourceType":"containerGroups","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/usages","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/operations","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/operations","locations":["West
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
         US"],"apiVersions":["2016-04-08"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.CustomerInsights","namespace":"Microsoft.CustomerInsights","authorization":{"applicationId":"38c77d00-5fcb-4cce-9d93-af4738258e3c","roleDefinitionId":"E006F9C7-F333-477C-8AD6-1F3A9FE87F55"},"resourceTypes":[{"resourceType":"hubs","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/profiles","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/interactions","locations":["East
@@ -1895,7 +1928,9 @@ http_interactions:
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"operations","locations":["East
         US 2"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Databricks","namespace":"Microsoft.Databricks","authorizations":[{"applicationId":"d9327919-6775-4843-9037-3fb0fb0473cb","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},{"applicationId":"2ff814a6-3304-4ab8-85cb-cd0e6f879c1d","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"}],"resourceTypes":[{"resourceType":"workspaces","locations":["West
         US","East US 2","West Europe","East US","North Europe","Southeast Asia","East
-        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]},{"resourceType":"locations","locations":["West
+        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2017-09-01-preview"]},{"resourceType":"workspaces/virtualNetworkPeerings","locations":["West
+        US","East US 2","West Europe","North Europe","East US","Southeast Asia","East
+        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01"]},{"resourceType":"locations","locations":["West
         US","East US 2","West Europe","North Europe","East US","Southeast Asia"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
         US","East US 2","West Europe","East US","North Europe","Southeast Asia","East
         Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataCatalog","namespace":"Microsoft.DataCatalog","resourceTypes":[{"resourceType":"catalogs","locations":["East
@@ -1919,23 +1954,26 @@ http_interactions:
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers/listSasTokens","locations":["East
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataLakeStore","namespace":"Microsoft.DataLakeStore","authorization":{"applicationId":"e9f49c6b-5ce5-44c8-925d-015017e9f7ad","roleDefinitionId":"17eb9cca-f08a-4499-b2d3-852d175f614f"},"resourceTypes":[{"resourceType":"accounts","locations":["East
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/firewallRules","locations":["East
-        US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataMigration","namespace":"Microsoft.DataMigration","authorization":{"applicationId":"a4bad4aa-bf02-4631-9f78-a64ffdba8150","roleDefinitionId":"b831a21d-db98-4760-89cb-bef871952df1","managedByRoleDefinitionId":"6256fb55-9e59-4018-a9e1-76b11c0a4c89"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services/projects","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationStatuses","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
+        US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataMigration","namespace":"Microsoft.DataMigration","authorization":{"applicationId":"a4bad4aa-bf02-4631-9f78-a64ffdba8150","roleDefinitionId":"b831a21d-db98-4760-89cb-bef871952df1","managedByRoleDefinitionId":"6256fb55-9e59-4018-a9e1-76b11c0a4c89"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services/projects","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationStatuses","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
-        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/recoverableServers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
@@ -1959,7 +1997,10 @@ http_interactions:
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
-        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/recoverableServers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
@@ -2015,12 +2056,7 @@ http_interactions:
         US 2","East US","West US","Central US","East US 2","West Central US","West
         Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
         US 2","East US","West US","Central US","East US 2","West Central US","West
-        Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","West
-        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
-        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
-        India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/consumergroups","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/disasterrecoveryconfigs","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
         US 2","South Central US","Central US","Australia Southeast","Central India","West
         Central US","West US 2","Canada East","Canada Central","Brazil South","UK
         South","UK West","East Asia","Australia East","Japan East","Japan West","North
@@ -2131,7 +2167,7 @@ http_interactions:
         West","Japan East","East Asia","Southeast Asia","West Europe","North Europe","East
         US","West US","Australia East","Australia Southeast","Central US","Brazil
         South","Central India","West India","South India","South Central US","Canada
-        Central","Canada East","West Central US","West US 2"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
+        Central","Canada East","West Central US","West US 2"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-05","2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
         Central US","East US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"operations","locations":["West
         Central US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
         Central US","East US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.PolicyInsights","namespace":"Microsoft.PolicyInsights","authorization":{"applicationId":"1d78a85d-813d-46f0-b496-dd72f50a3ec0","roleDefinitionId":"63d2b225-4c34-4641-8768-21a1f7c68ce8"},"resourceTypes":[{"resourceType":"policyEvents","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"policyStates","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
@@ -2163,12 +2199,12 @@ http_interactions:
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
         Central US","South Central US","North Europe","West Europe","East Asia","Southeast
         Asia","West US","East US","Japan West","Japan East","Brazil South","Central
         US","East US 2","Australia East","Australia Southeast","South India","Central
@@ -2208,40 +2244,50 @@ http_interactions:
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/clusterVersions","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"clusters/applications","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operations","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/clusterVersions","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/environments","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operations","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
         Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applianceDefinitions","locations":["West
         Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applications","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
-        Central US"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
+        Central US"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
         US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
         US","Canada Central","Canada East","Central US","East US 2","UK South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups","locations":["West
         US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
@@ -2332,7 +2378,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:22:31 GMT
+  recorded_at: Mon, 12 Mar 2018 10:27:23 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb?api-version=2018-01-01
@@ -2349,7 +2395,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM4NDgsIm5iZiI6MTUyMDQ1Mzg0OCwiZXhwIjoxNTIwNDU3NzQ4LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQnFBRWJ6TDlna1cybFBTc3duSUFBQSIsInZlciI6IjEuMCJ9.kbHraUxJtbINcGjd0a7Rjty4aVD_0kqBY179kuYiZec3QlDRtv91O3QNyCV_NG0K5OF6iNP4_zCDWExgEUJF7HJlle9w-BUQ5pCOVC7yj5jydCIsnGdUJ2S1fs3SBXwngoPNk3KDEEC45NuFIVTZECRAYmMt-ocWAN8bOOHvMKfDuxHGH73IgYKfV5knA5GPYJ6cVGbKxdxNURSvqlm2_vZEHVFhnG3bCh88za8zI-XTanUkxrU4ufYga__Kgfq8rnI_WG-fM37j2yD2sE-TkZdiEPHoQyBaTLoVqxSs6Mo4bWXVl2M1xzgEWqJ2ieSjH2MPerpECBqLXddiWQ326A
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAxMzYsIm5iZiI6MTUyMDg1MDEzNiwiZXhwIjoxNTIwODU0MDM2LCJhaW8iOiJZMk5nWURBTjFDdDJkcHEzYjE1K2V1Lys2UnRMQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWGdqUWRyS0ZjMGVORVRfM1F2UUFBQSIsInZlciI6IjEuMCJ9.k92gx8N-NZGR-v3MZ8XE1kfP-c7zuwCBuEg8dlZhf-rHDb0Jx2j9qxg9F-GM6E5KspT6iLrchrdHoe0OD_08-v-wPrt0k2ywO3k8GrQrRG9SQUUrjmhB75BxoWhHoY7UtYgEsuEMnqCZexjKpbBEgP04zCuRtUmCSmpfZ7WKBezA8HkONVXVw-KakN5irfVjEWUNqdN016R8kuvMt3-zUsX00swvfLuvv8Py3wIoUjxWZ8P48GNlkjv3CZZHh5sOPbLDY-4XC_yAA9w0xadA_R9Z8--0wBEqz9fv8pqdybxK0PIXR017_G8TF1ts-YGpi2g3Nl4jLbKzAV8OatT5yA
   response:
     status:
       code: 200
@@ -2370,22 +2416,22 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - b9704ac1-af7a-4fb8-b622-6da2862680ed
+      - 9a899f7a-0f6c-4353-89b5-7919197716ab
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14965'
+      - '14985'
       X-Ms-Correlation-Request-Id:
-      - df8c7dad-736b-42c8-9513-bdd261576090
+      - 132a7f84-9c46-4607-aab1-bc633033e593
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202232Z:df8c7dad-736b-42c8-9513-bdd261576090
+      - WESTEUROPE:20180312T102722Z:132a7f84-9c46-4607-aab1-bc633033e593
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:22:31 GMT
+      - Mon, 12 Mar 2018 10:27:22 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"spec0deply1lb\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb\",\r\n
@@ -2452,247 +2498,7 @@ http_interactions:
         [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
         \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:22:32 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM4NDgsIm5iZiI6MTUyMDQ1Mzg0OCwiZXhwIjoxNTIwNDU3NzQ4LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQnFBRWJ6TDlna1cybFBTc3duSUFBQSIsInZlciI6IjEuMCJ9.kbHraUxJtbINcGjd0a7Rjty4aVD_0kqBY179kuYiZec3QlDRtv91O3QNyCV_NG0K5OF6iNP4_zCDWExgEUJF7HJlle9w-BUQ5pCOVC7yj5jydCIsnGdUJ2S1fs3SBXwngoPNk3KDEEC45NuFIVTZECRAYmMt-ocWAN8bOOHvMKfDuxHGH73IgYKfV5knA5GPYJ6cVGbKxdxNURSvqlm2_vZEHVFhnG3bCh88za8zI-XTanUkxrU4ufYga__Kgfq8rnI_WG-fM37j2yD2sE-TkZdiEPHoQyBaTLoVqxSs6Mo4bWXVl2M1xzgEWqJ2ieSjH2MPerpECBqLXddiWQ326A
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"92982330-0f29-406e-bba9-ad19198579a5"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 27f51066-a5df-47fb-b05f-59d43baaa1e1
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14962'
-      X-Ms-Correlation-Request-Id:
-      - 7079a89d-3fe7-456e-b903-0b9e12ca7b64
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202232Z:7079a89d-3fe7-456e-b903-0b9e12ca7b64
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:22:32 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"spec0deply1lb\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb\",\r\n
-        \ \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"8cd72f7c-03bd-4584-abc6-d9ce77ae6202\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip\"\r\n
-        \         },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
-        \           }\r\n          ],\r\n          \"inboundNatRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"BackendPool1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"backendIPConfigurations\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1\"\r\n
-        \           }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\":
-        [\r\n      {\r\n        \"name\": \"LBRule\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\":
-        80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        5,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\"\r\n
-        \         },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/probes/tcpProbe\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n
-        \       \"name\": \"tcpProbe\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/probes/tcpProbe\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Tcp\",\r\n          \"port\": 80,\r\n          \"intervalInSeconds\":
-        5,\r\n          \"numberOfProbes\": 2,\r\n          \"loadBalancingRules\":
-        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\":
-        [\r\n      {\r\n        \"name\": \"RDP-VM0\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 50001,\r\n          \"backendPort\":
-        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1\"\r\n
-        \         }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"RDP-VM1\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 50002,\r\n          \"backendPort\":
-        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:22:32 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM4NDgsIm5iZiI6MTUyMDQ1Mzg0OCwiZXhwIjoxNTIwNDU3NzQ4LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQnFBRWJ6TDlna1cybFBTc3duSUFBQSIsInZlciI6IjEuMCJ9.kbHraUxJtbINcGjd0a7Rjty4aVD_0kqBY179kuYiZec3QlDRtv91O3QNyCV_NG0K5OF6iNP4_zCDWExgEUJF7HJlle9w-BUQ5pCOVC7yj5jydCIsnGdUJ2S1fs3SBXwngoPNk3KDEEC45NuFIVTZECRAYmMt-ocWAN8bOOHvMKfDuxHGH73IgYKfV5knA5GPYJ6cVGbKxdxNURSvqlm2_vZEHVFhnG3bCh88za8zI-XTanUkxrU4ufYga__Kgfq8rnI_WG-fM37j2yD2sE-TkZdiEPHoQyBaTLoVqxSs6Mo4bWXVl2M1xzgEWqJ2ieSjH2MPerpECBqLXddiWQ326A
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"92982330-0f29-406e-bba9-ad19198579a5"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 333d2a39-b3d9-4186-811c-ae684caaf8f7
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14967'
-      X-Ms-Correlation-Request-Id:
-      - b0683f24-2899-4c4a-aa6e-0339485dbf95
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202233Z:b0683f24-2899-4c4a-aa6e-0339485dbf95
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:22:33 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"spec0deply1lb\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb\",\r\n
-        \ \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"8cd72f7c-03bd-4584-abc6-d9ce77ae6202\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip\"\r\n
-        \         },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
-        \           }\r\n          ],\r\n          \"inboundNatRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"BackendPool1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"backendIPConfigurations\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1\"\r\n
-        \           }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\":
-        [\r\n      {\r\n        \"name\": \"LBRule\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\":
-        80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        5,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\"\r\n
-        \         },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/probes/tcpProbe\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n
-        \       \"name\": \"tcpProbe\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/probes/tcpProbe\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Tcp\",\r\n          \"port\": 80,\r\n          \"intervalInSeconds\":
-        5,\r\n          \"numberOfProbes\": 2,\r\n          \"loadBalancingRules\":
-        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\":
-        [\r\n      {\r\n        \"name\": \"RDP-VM0\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 50001,\r\n          \"backendPort\":
-        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1\"\r\n
-        \         }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"RDP-VM1\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 50002,\r\n          \"backendPort\":
-        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:22:33 GMT
+  recorded_at: Mon, 12 Mar 2018 10:27:27 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip?api-version=2018-01-01
@@ -2709,7 +2515,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM4NDgsIm5iZiI6MTUyMDQ1Mzg0OCwiZXhwIjoxNTIwNDU3NzQ4LCJhaW8iOiJZMk5nWUpoVUZzTGYyVlNzMUhoTjFhbnUvNjBBQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQnFBRWJ6TDlna1cybFBTc3duSUFBQSIsInZlciI6IjEuMCJ9.kbHraUxJtbINcGjd0a7Rjty4aVD_0kqBY179kuYiZec3QlDRtv91O3QNyCV_NG0K5OF6iNP4_zCDWExgEUJF7HJlle9w-BUQ5pCOVC7yj5jydCIsnGdUJ2S1fs3SBXwngoPNk3KDEEC45NuFIVTZECRAYmMt-ocWAN8bOOHvMKfDuxHGH73IgYKfV5knA5GPYJ6cVGbKxdxNURSvqlm2_vZEHVFhnG3bCh88za8zI-XTanUkxrU4ufYga__Kgfq8rnI_WG-fM37j2yD2sE-TkZdiEPHoQyBaTLoVqxSs6Mo4bWXVl2M1xzgEWqJ2ieSjH2MPerpECBqLXddiWQ326A
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAxMzYsIm5iZiI6MTUyMDg1MDEzNiwiZXhwIjoxNTIwODU0MDM2LCJhaW8iOiJZMk5nWURBTjFDdDJkcHEzYjE1K2V1Lys2UnRMQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiWGdqUWRyS0ZjMGVORVRfM1F2UUFBQSIsInZlciI6IjEuMCJ9.k92gx8N-NZGR-v3MZ8XE1kfP-c7zuwCBuEg8dlZhf-rHDb0Jx2j9qxg9F-GM6E5KspT6iLrchrdHoe0OD_08-v-wPrt0k2ywO3k8GrQrRG9SQUUrjmhB75BxoWhHoY7UtYgEsuEMnqCZexjKpbBEgP04zCuRtUmCSmpfZ7WKBezA8HkONVXVw-KakN5irfVjEWUNqdN016R8kuvMt3-zUsX00swvfLuvv8Py3wIoUjxWZ8P48GNlkjv3CZZHh5sOPbLDY-4XC_yAA9w0xadA_R9Z8--0wBEqz9fv8pqdybxK0PIXR017_G8TF1ts-YGpi2g3Nl4jLbKzAV8OatT5yA
   response:
     status:
       code: 200
@@ -2730,22 +2536,22 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - c8d2afc3-a8fb-4742-b9d6-22157c578cd5
+      - c760ae8a-6ca1-48f4-8b2e-27195a8d0c8c
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14765'
+      - '14985'
       X-Ms-Correlation-Request-Id:
-      - 683b4921-0f52-4a8d-9e73-11ff84177be4
+      - 72d34090-1bd0-4f10-ac9a-babbd461e93f
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202233Z:683b4921-0f52-4a8d-9e73-11ff84177be4
+      - WESTEUROPE:20180312T102723Z:72d34090-1bd0-4f10-ac9a-babbd461e93f
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:22:33 GMT
+      - Mon, 12 Mar 2018 10:27:22 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"spec0deply1ip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip\",\r\n
@@ -2759,5 +2565,5 @@ http_interactions:
         \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
         \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:22:33 GMT
+  recorded_at: Mon, 12 Mar 2018 10:27:28 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted_scope/lb_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted_scope/lb_refresh.yml
@@ -37,25 +37,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - f2bccd07-9fd7-4a0a-9c31-26e78f6d0000
+      - db1092f2-ff1f-49cf-92a4-645258611700
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHz52WGfmIwXttVuNT_nLBPDxRcDht02wZLvwo8OICWrw3G3nNgJh3jX7yUNEwTyt1Gaf0z-5r_vUvV5AKTueJg2MVcGUNfj6if-6Yoq-B7mgir7zynTsuiYOuyuVH1zZbKXA80cpYJlYDcl4ZToF85dlS84aYc5sJjZ8gXng3EUx0gAA;
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzAmNeukm7KWOiISe84SkBo6psvqHyBN1LpzpE87_ZtVTBorAJNSAFsg5qOOPX4iWipKHkPZbIUZaIJx-C4_Y6eKkagWbl4LFBs6eewckzmOzLFXkucc14mFXzlB7kMPeKQLs6z-NNEp6KmEGzhzEpA7dTTxtIRIZyw4-6lmh4nd8gAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=005; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=007; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Wed, 07 Mar 2018 20:18:46 GMT
+      - Mon, 12 Mar 2018 10:24:30 GMT
       Content-Length:
       - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1520457527","not_before":"1520453627","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2MjcsIm5iZiI6MTUyMDQ1MzYyNywiZXhwIjoxNTIwNDU3NTI3LCJhaW8iOiJZMk5nWURBTjFDdDJkcHEzYjE1K2V1Lys2UnRMQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQjgyODh0ZWZDa3FjTVNibmoyMEFBQSIsInZlciI6IjEuMCJ9.a33YVEj1f8OO84ni3lxC6dL8HdTlV5miQpI3UT2Om6E4VG0_7R9KD-vyxxUZYFeTNr6y9MzH3JQUZqsuuuumDt9Vzxl_P7ZrMI8AW541wZREpKKnHaSKX8tsDzk41t9F64e9B7ZUyovHBmazhowxQhW5uhDSJL2k8spFOKBIaRzaCe7jsy4lraeY2NDkKRuIFr4ku6yW00U8XeqQ2DtihEgMPbr6ckBef0jDXPetZJ9WKKAksRVMHbKhixBpxLSDvHrm-IYfFuQQh7VbCabZQRkwXPAgVZDHKiZCUKkhvtnzS5ZRTBvdV0obNdTFyO9s8wuGbljCm0q1i2S5FX5ASw"}'
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1520853870","not_before":"1520849970","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5NzAsIm5iZiI6MTUyMDg0OTk3MCwiZXhwIjoxNTIwODUzODcwLCJhaW8iOiJZMk5nWUZCTzNGYjNsL3ZQM3pXbkd3d1dlcjVhQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiOHBJUTJ4X196MG1TcEdSU1dHRVhBQSIsInZlciI6IjEuMCJ9.R4haEyoof1avup5BefTy1B4S1yIQteJi1K7r6TfDwAJJl76g2HHdKnK0E4OWRh05yNXdOYdYyqnP5XmAgm1s6nVH62QwTgx6xrVOhqlQb60LRhN-jeZg4xrRH4XIQRF_hzNOA_QHlpZQzQ5tqbAYqTonFYwRW_2YuuNNlNAwNZmNqxyl0zExhHRK68pF04oUNMZrplqM6wPRRPCeB-XJ3170z9-VBDCMWrK1vbYwhjD5Kr08YDcnGtcrV2pgiifAT7rvPfjSMqa-YpB7NXz07WdYKWq6b9pRb5l06THpFKaq7PNpPAeMRfMCq3d6REuqo1I7VUECTxej3HhNKftPwg"}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:47 GMT
+  recorded_at: Mon, 12 Mar 2018 10:24:35 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -72,7 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2MjcsIm5iZiI6MTUyMDQ1MzYyNywiZXhwIjoxNTIwNDU3NTI3LCJhaW8iOiJZMk5nWURBTjFDdDJkcHEzYjE1K2V1Lys2UnRMQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQjgyODh0ZWZDa3FjTVNibmoyMEFBQSIsInZlciI6IjEuMCJ9.a33YVEj1f8OO84ni3lxC6dL8HdTlV5miQpI3UT2Om6E4VG0_7R9KD-vyxxUZYFeTNr6y9MzH3JQUZqsuuuumDt9Vzxl_P7ZrMI8AW541wZREpKKnHaSKX8tsDzk41t9F64e9B7ZUyovHBmazhowxQhW5uhDSJL2k8spFOKBIaRzaCe7jsy4lraeY2NDkKRuIFr4ku6yW00U8XeqQ2DtihEgMPbr6ckBef0jDXPetZJ9WKKAksRVMHbKhixBpxLSDvHrm-IYfFuQQh7VbCabZQRkwXPAgVZDHKiZCUKkhvtnzS5ZRTBvdV0obNdTFyO9s8wuGbljCm0q1i2S5FX5ASw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5NzAsIm5iZiI6MTUyMDg0OTk3MCwiZXhwIjoxNTIwODUzODcwLCJhaW8iOiJZMk5nWUZCTzNGYjNsL3ZQM3pXbkd3d1dlcjVhQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiOHBJUTJ4X196MG1TcEdSU1dHRVhBQSIsInZlciI6IjEuMCJ9.R4haEyoof1avup5BefTy1B4S1yIQteJi1K7r6TfDwAJJl76g2HHdKnK0E4OWRh05yNXdOYdYyqnP5XmAgm1s6nVH62QwTgx6xrVOhqlQb60LRhN-jeZg4xrRH4XIQRF_hzNOA_QHlpZQzQ5tqbAYqTonFYwRW_2YuuNNlNAwNZmNqxyl0zExhHRK68pF04oUNMZrplqM6wPRRPCeB-XJ3170z9-VBDCMWrK1vbYwhjD5Kr08YDcnGtcrV2pgiifAT7rvPfjSMqa-YpB7NXz07WdYKWq6b9pRb5l06THpFKaq7PNpPAeMRfMCq3d6REuqo1I7VUECTxej3HhNKftPwg
   response:
     status:
       code: 200
@@ -91,26 +91,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14997'
+      - '14999'
       X-Ms-Request-Id:
-      - 8f6d09c6-ea37-4342-b995-6057b2832c1c
+      - 45abb945-86de-457d-811d-8ed4c7ab22a4
       X-Ms-Correlation-Request-Id:
-      - 8f6d09c6-ea37-4342-b995-6057b2832c1c
+      - 45abb945-86de-457d-811d-8ed4c7ab22a4
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201847Z:8f6d09c6-ea37-4342-b995-6057b2832c1c
+      - WESTEUROPE:20180312T102431Z:45abb945-86de-457d-811d-8ed4c7ab22a4
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:18:46 GMT
+      - Mon, 12 Mar 2018 10:24:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID","subscriptionId":"AZURE_SUBSCRIPTION_ID","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:47 GMT
+  recorded_at: Mon, 12 Mar 2018 10:24:35 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers?api-version=2015-01-01
@@ -127,7 +127,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2MjcsIm5iZiI6MTUyMDQ1MzYyNywiZXhwIjoxNTIwNDU3NTI3LCJhaW8iOiJZMk5nWURBTjFDdDJkcHEzYjE1K2V1Lys2UnRMQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQjgyODh0ZWZDa3FjTVNibmoyMEFBQSIsInZlciI6IjEuMCJ9.a33YVEj1f8OO84ni3lxC6dL8HdTlV5miQpI3UT2Om6E4VG0_7R9KD-vyxxUZYFeTNr6y9MzH3JQUZqsuuuumDt9Vzxl_P7ZrMI8AW541wZREpKKnHaSKX8tsDzk41t9F64e9B7ZUyovHBmazhowxQhW5uhDSJL2k8spFOKBIaRzaCe7jsy4lraeY2NDkKRuIFr4ku6yW00U8XeqQ2DtihEgMPbr6ckBef0jDXPetZJ9WKKAksRVMHbKhixBpxLSDvHrm-IYfFuQQh7VbCabZQRkwXPAgVZDHKiZCUKkhvtnzS5ZRTBvdV0obNdTFyO9s8wuGbljCm0q1i2S5FX5ASw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5NzAsIm5iZiI6MTUyMDg0OTk3MCwiZXhwIjoxNTIwODUzODcwLCJhaW8iOiJZMk5nWUZCTzNGYjNsL3ZQM3pXbkd3d1dlcjVhQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiOHBJUTJ4X196MG1TcEdSU1dHRVhBQSIsInZlciI6IjEuMCJ9.R4haEyoof1avup5BefTy1B4S1yIQteJi1K7r6TfDwAJJl76g2HHdKnK0E4OWRh05yNXdOYdYyqnP5XmAgm1s6nVH62QwTgx6xrVOhqlQb60LRhN-jeZg4xrRH4XIQRF_hzNOA_QHlpZQzQ5tqbAYqTonFYwRW_2YuuNNlNAwNZmNqxyl0zExhHRK68pF04oUNMZrplqM6wPRRPCeB-XJ3170z9-VBDCMWrK1vbYwhjD5Kr08YDcnGtcrV2pgiifAT7rvPfjSMqa-YpB7NXz07WdYKWq6b9pRb5l06THpFKaq7PNpPAeMRfMCq3d6REuqo1I7VUECTxej3HhNKftPwg
   response:
     status:
       code: 200
@@ -144,39 +144,37 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14970'
+      - '14988'
       X-Ms-Request-Id:
-      - e4b4d8d4-d839-4557-a51a-4af29d9f6e83
+      - ddf16916-02ac-4ff4-8d5d-c0415ed42e3f
       X-Ms-Correlation-Request-Id:
-      - e4b4d8d4-d839-4557-a51a-4af29d9f6e83
+      - ddf16916-02ac-4ff4-8d5d-c0415ed42e3f
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201848Z:e4b4d8d4-d839-4557-a51a-4af29d9f6e83
+      - WESTEUROPE:20180312T102432Z:ddf16916-02ac-4ff4-8d5d-c0415ed42e3f
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:18:48 GMT
+      - Mon, 12 Mar 2018 10:24:32 GMT
       Content-Length:
-      - '310901'
+      - '320853'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"},{"applicationId":"d87dcbc6-a371-462e-88e3-28ad15ec4e64","roleDefinitionId":"861776c5-e0df-4f95-be4f-ac1eec193323"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
+      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"},{"applicationId":"d87dcbc6-a371-462e-88e3-28ad15ec4e64","roleDefinitionId":"861776c5-e0df-4f95-be4f-ac1eec193323"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["East
+        Asia","Southeast Asia","Australia East","Australia Southeast","Japan East","Japan
+        West","Central India","South India","West India","West Europe","North Europe","Canada
+        Central","Canada East","Brazil South","West US","Central US","East US","South
+        Central US","East US 2","West Central US","North Central US","West US 2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
         US","Central US","East US","South Central US","West Europe","North Europe","East
         Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
         Central US","North Central US","Japan East","Japan West","Brazil South","Central
         India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"operations","locations":["West
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["East
+        Asia","Southeast Asia","Australia East","Australia Southeast","Japan East","Japan
+        West","Central India","South India","West India","West Europe","North Europe","Canada
+        Central","Canada East","Brazil South","West US","Central US","East US","South
+        Central US","East US 2","West Central US","North Central US","West US 2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"operations","locations":["West
         US","Central US","East US","South Central US","West Europe","North Europe","East
         Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
         Central US","North Central US","Japan East","Japan West","Brazil South","Central
@@ -232,177 +230,177 @@ http_interactions:
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/internalLoadBalancers","locations":[],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"domainNames/slots/roles/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"domainNames/slots/roles/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"domainNames/capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"domainNames/serviceCertificates","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
         US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
         Central","Canada East","UK South","UK West","West US","Central US","South
         Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
-        East","Australia Southeast","West US 2","West Central US","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        East","Australia Southeast","West US 2","West Central US","France Central","South
+        India","Central India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
         US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
         Central","Canada East","UK South","UK West","West US","Central US","South
         Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
-        East","Australia Southeast","West US 2","West Central US","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metrics","locations":["North
+        East","Australia Southeast","West US 2","West Central US","France Central","South
+        India","Central India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metrics","locations":["North
         Central US","South Central US","East US","East US 2","Canada Central","Canada
         East","West US","West US 2","West Central US","Central US","East Asia","Southeast
         Asia","North Europe","West Europe","UK South","UK West","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"resourceTypes","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"moveSubscriptionResources","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"validateSubscriptionMoveAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operationStatuses","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operatingSystems","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"operatingSystemFamilies","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicNetwork","namespace":"Microsoft.ClassicNetwork","resourceTypes":[{"resourceType":"virtualNetworks","locations":["East
+        India","West India","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"resourceTypes","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"moveSubscriptionResources","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"validateSubscriptionMoveAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operationStatuses","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operatingSystems","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"operatingSystemFamilies","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicNetwork","namespace":"Microsoft.ClassicNetwork","resourceTypes":[{"resourceType":"virtualNetworks","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"virtualNetworks/remoteVirtualNetworkPeeringProxies","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01"]},{"resourceType":"virtualNetworks/remoteVirtualNetworkPeeringProxies","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"reservedIps","locations":["East
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01"]},{"resourceType":"reservedIps","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"gatewaySupportedDevices","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"networkSecurityGroups","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"gatewaySupportedDevices","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"networkSecurityGroups","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicStorage","namespace":"Microsoft.ClassicStorage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"expressRouteCrossConnections","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"expressRouteCrossConnections/peerings","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicStorage","namespace":"Microsoft.ClassicStorage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkStorageAccountAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"storageAccounts/services","locations":["West
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkStorageAccountAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"storageAccounts/services","locations":["West
         US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
         Asia","Australia East","Australia Southeast","South India","Central India","West
         India","West US 2","West Central US","East US","East US 2","North Central
         US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
-        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/diagnosticSettings","locations":["West
+        South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/diagnosticSettings","locations":["West
         US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
         Asia","Australia East","Australia Southeast","South India","Central India","West
         India","West US 2","West Central US","East US","East US 2","North Central
         US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
-        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"disks","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"images","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"vmImages","locations":[],"apiVersions":["2016-11-01"]},{"resourceType":"publicImages","locations":[],"apiVersions":["2016-11-01","2016-04-01"]},{"resourceType":"osImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"osPlatformImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute","namespace":"Microsoft.Compute","authorizations":[{"applicationId":"60e6cd67-9c8c-4951-9b3c-23c25a2169af","roleDefinitionId":"e4770acb-272e-4dc8-87f3-12f44a612224"},{"applicationId":"a303894e-f1d8-4a37-bf10-67aa654a0596","roleDefinitionId":"903ac751-8ad5-4e5a-bfc2-5e49f450a241"},{"applicationId":"a8b6bf88-1d1a-4626-b040-9a729ea93c65","roleDefinitionId":"45c8267c-80ba-4b96-9a43-115b8f49fccd"}],"resourceTypes":[{"resourceType":"availabilitySets","locations":["East
+        South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"disks","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"images","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"vmImages","locations":[],"apiVersions":["2016-11-01"]},{"resourceType":"storageAccounts/vmImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"publicImages","locations":[],"apiVersions":["2016-11-01","2016-04-01"]},{"resourceType":"osImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"osPlatformImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute","namespace":"Microsoft.Compute","authorizations":[{"applicationId":"60e6cd67-9c8c-4951-9b3c-23c25a2169af","roleDefinitionId":"e4770acb-272e-4dc8-87f3-12f44a612224"},{"applicationId":"a303894e-f1d8-4a37-bf10-67aa654a0596","roleDefinitionId":"903ac751-8ad5-4e5a-bfc2-5e49f450a241"},{"applicationId":"a8b6bf88-1d1a-4626-b040-9a729ea93c65","roleDefinitionId":"45c8267c-80ba-4b96-9a43-115b8f49fccd"}],"resourceTypes":[{"resourceType":"availabilitySets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations/usages","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations/usages","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"sharedVMImages","locations":["West
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"sharedVMImages","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"sharedVMImages/versions","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"locations/capsoperations","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"disks","locations":["Southeast
@@ -410,27 +408,27 @@ http_interactions:
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"snapshots","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"snapshots","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"locations/diskoperations","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"locations/diskoperations","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"images","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"images","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"]},{"resourceType":"locations/logAnalytics","locations":["East
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"]},{"resourceType":"locations/logAnalytics","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
         US","East US","South Central US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
@@ -547,7 +545,12 @@ http_interactions:
         US","East Asia","East US","East US 2","Japan East","Japan West","North Central
         US","North Europe","South Central US","South India","Southeast Asia","West
         Central US","West Europe","West India","West US","West US 2","UK West","UK
-        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"},{"applicationId":"f5c26e74-f226-4ae8-85f0-b4af0080ac9e","roleDefinitionId":"529d7ae6-e892-4d43-809d-8547aeb90643"}],"resourceTypes":[{"resourceType":"components","locations":["East
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/consumergroups","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/disasterrecoveryconfigs","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"},{"applicationId":"f5c26e74-f226-4ae8-85f0-b4af0080ac9e","roleDefinitionId":"529d7ae6-e892-4d43-809d-8547aeb90643"}],"resourceTypes":[{"resourceType":"components","locations":["East
         US","South Central US","North Europe","West Europe","Southeast Asia","West
         US 2"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
         US","South Central US","North Europe","West Europe","Southeast Asia","West
@@ -614,32 +617,32 @@ http_interactions:
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/accessPolicies","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"vaults/accessPolicies","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-10-01","2015-06-01","2014-12-19-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"deletedVaults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01","2014-12-19-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"deletedVaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-10-01"]},{"resourceType":"locations/deletedVaults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations/deletedVaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
         Central US","West Europe","Southeast Asia","Japan East","West Central US"],"apiVersions":["2016-04-01"]},{"resourceType":"webServices","locations":["South
         Central US","West Europe","Southeast Asia","Japan East","East US 2","West
         Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"operations","locations":["South
@@ -665,97 +668,97 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"networkWatchers/lenses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"networkWatchers/lenses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","West
         US 2","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
@@ -846,7 +849,7 @@ http_interactions:
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
         West","Korea Central","Korea South"],"apiVersions":["2017-07-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ResourceHealth","namespace":"Microsoft.ResourceHealth","authorizations":[{"applicationId":"8bdebf23-c0fe-4187-a378-717ad86f6a53","roleDefinitionId":"cc026344-c8b1-4561-83ba-59eba84b27cc"}],"resourceTypes":[{"resourceType":"availabilityStatuses","locations":[],"apiVersions":["2017-07-01","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"notifications","locations":["Australia
-        Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Security","namespace":"Microsoft.Security","authorization":{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
+        Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Security","namespace":"Microsoft.Security","authorizations":[{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},{"applicationId":"fc780465-2017-40d4-a0c5-307022471b92"}],"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatuses","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/virtualMachines","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/endpoints","locations":["Central
@@ -898,565 +901,595 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Central India","South
         India"],"apiVersions":["2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Sql","namespace":"Microsoft.Sql","authorizations":[{"applicationId":"e4ab13ed-33cb-41b4-9140-6e264582cf85","roleDefinitionId":"ec3ddc95-44dc-47a2-9926-5e9f5ffd44ec"},{"applicationId":"0130cc9f-7ac5-4026-bd5f-80a08a54e6d9","roleDefinitionId":"45e8abf8-0ec4-44f3-9c37-cff4f7779302"},{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},{"applicationId":"76c7f279-7959-468f-8943-3954880e0d8c","roleDefinitionId":"7f7513a8-73f9-4c5f-97a2-c41f0ea783ef"}],"resourceTypes":[{"resourceType":"operations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/capabilities","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/databaseAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/databaseOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverKeyOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/keys","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/encryptionProtector","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/usages","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01","2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/communicationLinks","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administrators","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administratorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/restorableDroppedDatabases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recoverableDatabases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/geoBackupPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/importExportOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/operationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/backupLongTermRetentionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/automaticTuning","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/automaticTuning","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/databases/transparentDataEncryption","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recommendedElasticPools","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/auditingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/connectionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/connectionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies/rules","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/securityAlertPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/securityAlertPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/auditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/extendedAuditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/elasticpools","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-09-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/jobAgentOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/jobAgentAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/disasterRecoveryConfiguration","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/dnsAliases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/failoverGroups","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/virtualNetworkRules","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/virtualNetworkRulesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/virtualNetworkRulesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/databaseRestoreAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metricDefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/aggregatedDatabaseMetrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metricdefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries/queryText","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPools/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/extensions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPoolEstimates","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditRecords","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentScans","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/vulnerabilityAssessments","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessment","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/syncGroups","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups/syncMembers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/syncAgents","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"managedInstances/administrators","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/databases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metricDefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/administratorAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/administratorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncMemberOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncAgentOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncDatabaseIds","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorizations":[{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},{"applicationId":"e406a681-f3d4-42a8-90b6-c2b029497af1"}],"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/capabilities","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/databaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"locations/databaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverKeyOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/keys","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/encryptionProtector","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01","2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/communicationLinks","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/restorableDroppedDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recoverableDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/geoBackupPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/importExportOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/operationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/backupLongTermRetentionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/databases/transparentDataEncryption","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recommendedElasticPools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies/rules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/extendedAuditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/elasticPoolAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/elasticPoolOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/elasticpools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-09-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/jobAgentOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/jobAgentAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/disasterRecoveryConfiguration","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/dnsAliases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/failoverGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/virtualNetworkRules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/virtualNetworkRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/virtualNetworkRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/databaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/aggregatedDatabaseMetrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metricdefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries/queryText","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPools/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/extensions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPoolEstimates","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditRecords","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentScans","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/vulnerabilityAssessments","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessment","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/syncGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups/syncMembers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/syncAgents","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"managedInstances/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/administratorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncMemberOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncAgentOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncDatabaseIds","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/longTermRetentionPolicyOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionPolicyAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionBackupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionBackupAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorizations":[{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},{"applicationId":"e406a681-f3d4-42a8-90b6-c2b029497af1"}],"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
@@ -1795,12 +1828,12 @@ http_interactions:
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","Canada Central","Canada East","UK South","UK West","West US 2","West
-        Central US","South India","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","South India","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","South India","Canada Central","Canada East","UK South","UK West","West
-        US 2","West Central US","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Capacity","namespace":"Microsoft.Capacity","authorization":{"applicationId":"4d0ad6c7-f6c3-46d8-ab0d-1406d5e6c86b","roleDefinitionId":"FD9C0A9A-4DB9-4F41-8A61-98385DEB6E2D"},"resourceTypes":[{"resourceType":"resources","locations":["South
+        US 2","West Central US","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Capacity","namespace":"Microsoft.Capacity","authorization":{"applicationId":"4d0ad6c7-f6c3-46d8-ab0d-1406d5e6c86b","roleDefinitionId":"FD9C0A9A-4DB9-4F41-8A61-98385DEB6E2D"},"resourceTypes":[{"resourceType":"resources","locations":["South
         Central US"],"apiVersions":["2017-11-01"]},{"resourceType":"reservationOrders","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/reservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/reservations/revisions","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"catalogs","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"appliedReservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"checkOffers","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"checkScopes","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"calculatePrice","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/calculateRefund","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/return","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/split","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/merge","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"validateReservationOrder","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/availableScopes","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Cdn","namespace":"Microsoft.Cdn","resourceTypes":[{"resourceType":"profiles","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
@@ -1876,9 +1909,9 @@ http_interactions:
         2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/updateAccountsCreationSettings","locations":["West
         US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/accountsCreationSettings","locations":["West
         US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2016-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Commerce","namespace":"Microsoft.Commerce","resourceTypes":[{"resourceType":"UsageAggregates","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]},{"resourceType":"RateCard","locations":[],"apiVersions":["2016-08-31-preview","2015-06-01-preview","2015-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Consumption","namespace":"Microsoft.Consumption","resourceTypes":[{"resourceType":"ReservationSummaries","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationTransactions","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Balances","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Marketplaces","locations":[],"apiVersions":["2018-01-31"]},{"resourceType":"Pricesheets","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationDetails","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Budgets","locations":[],"apiVersions":["2018-01-31","2017-12-30-preview"]},{"resourceType":"Terms","locations":[],"apiVersions":["2018-01-31","2017-12-30-preview"]},{"resourceType":"UsageDetails","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview","2017-04-24-preview"]},{"resourceType":"Operations","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview","2017-04-24-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerInstance","namespace":"Microsoft.ContainerInstance","resourceTypes":[{"resourceType":"containerGroups","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/usages","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/operations","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/operations","locations":["West
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
         US"],"apiVersions":["2016-04-08"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.CustomerInsights","namespace":"Microsoft.CustomerInsights","authorization":{"applicationId":"38c77d00-5fcb-4cce-9d93-af4738258e3c","roleDefinitionId":"E006F9C7-F333-477C-8AD6-1F3A9FE87F55"},"resourceTypes":[{"resourceType":"hubs","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/profiles","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/interactions","locations":["East
@@ -1895,7 +1928,9 @@ http_interactions:
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"operations","locations":["East
         US 2"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Databricks","namespace":"Microsoft.Databricks","authorizations":[{"applicationId":"d9327919-6775-4843-9037-3fb0fb0473cb","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},{"applicationId":"2ff814a6-3304-4ab8-85cb-cd0e6f879c1d","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"}],"resourceTypes":[{"resourceType":"workspaces","locations":["West
         US","East US 2","West Europe","East US","North Europe","Southeast Asia","East
-        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]},{"resourceType":"locations","locations":["West
+        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2017-09-01-preview"]},{"resourceType":"workspaces/virtualNetworkPeerings","locations":["West
+        US","East US 2","West Europe","North Europe","East US","Southeast Asia","East
+        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01"]},{"resourceType":"locations","locations":["West
         US","East US 2","West Europe","North Europe","East US","Southeast Asia"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
         US","East US 2","West Europe","East US","North Europe","Southeast Asia","East
         Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataCatalog","namespace":"Microsoft.DataCatalog","resourceTypes":[{"resourceType":"catalogs","locations":["East
@@ -1919,23 +1954,26 @@ http_interactions:
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers/listSasTokens","locations":["East
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataLakeStore","namespace":"Microsoft.DataLakeStore","authorization":{"applicationId":"e9f49c6b-5ce5-44c8-925d-015017e9f7ad","roleDefinitionId":"17eb9cca-f08a-4499-b2d3-852d175f614f"},"resourceTypes":[{"resourceType":"accounts","locations":["East
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/firewallRules","locations":["East
-        US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataMigration","namespace":"Microsoft.DataMigration","authorization":{"applicationId":"a4bad4aa-bf02-4631-9f78-a64ffdba8150","roleDefinitionId":"b831a21d-db98-4760-89cb-bef871952df1","managedByRoleDefinitionId":"6256fb55-9e59-4018-a9e1-76b11c0a4c89"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services/projects","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationStatuses","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
+        US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataMigration","namespace":"Microsoft.DataMigration","authorization":{"applicationId":"a4bad4aa-bf02-4631-9f78-a64ffdba8150","roleDefinitionId":"b831a21d-db98-4760-89cb-bef871952df1","managedByRoleDefinitionId":"6256fb55-9e59-4018-a9e1-76b11c0a4c89"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services/projects","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationStatuses","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
-        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/recoverableServers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
@@ -1959,7 +1997,10 @@ http_interactions:
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
-        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/recoverableServers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
@@ -2015,12 +2056,7 @@ http_interactions:
         US 2","East US","West US","Central US","East US 2","West Central US","West
         Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
         US 2","East US","West US","Central US","East US 2","West Central US","West
-        Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","West
-        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
-        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
-        India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/consumergroups","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/disasterrecoveryconfigs","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
         US 2","South Central US","Central US","Australia Southeast","Central India","West
         Central US","West US 2","Canada East","Canada Central","Brazil South","UK
         South","UK West","East Asia","Australia East","Japan East","Japan West","North
@@ -2131,7 +2167,7 @@ http_interactions:
         West","Japan East","East Asia","Southeast Asia","West Europe","North Europe","East
         US","West US","Australia East","Australia Southeast","Central US","Brazil
         South","Central India","West India","South India","South Central US","Canada
-        Central","Canada East","West Central US","West US 2"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
+        Central","Canada East","West Central US","West US 2"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-05","2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
         Central US","East US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"operations","locations":["West
         Central US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
         Central US","East US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.PolicyInsights","namespace":"Microsoft.PolicyInsights","authorization":{"applicationId":"1d78a85d-813d-46f0-b496-dd72f50a3ec0","roleDefinitionId":"63d2b225-4c34-4641-8768-21a1f7c68ce8"},"resourceTypes":[{"resourceType":"policyEvents","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"policyStates","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
@@ -2163,12 +2199,12 @@ http_interactions:
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
         Central US","South Central US","North Europe","West Europe","East Asia","Southeast
         Asia","West US","East US","Japan West","Japan East","Brazil South","Central
         US","East US 2","Australia East","Australia Southeast","South India","Central
@@ -2208,40 +2244,50 @@ http_interactions:
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/clusterVersions","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"clusters/applications","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operations","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/clusterVersions","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/environments","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operations","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
         Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applianceDefinitions","locations":["West
         Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applications","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
-        Central US"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
+        Central US"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
         US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
         US","Canada Central","Canada East","Central US","East US 2","UK South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups","locations":["West
         US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
@@ -2332,7 +2378,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:49 GMT
+  recorded_at: Mon, 12 Mar 2018 10:24:38 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1?api-version=2018-01-01
@@ -2349,7 +2395,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2MjcsIm5iZiI6MTUyMDQ1MzYyNywiZXhwIjoxNTIwNDU3NTI3LCJhaW8iOiJZMk5nWURBTjFDdDJkcHEzYjE1K2V1Lys2UnRMQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQjgyODh0ZWZDa3FjTVNibmoyMEFBQSIsInZlciI6IjEuMCJ9.a33YVEj1f8OO84ni3lxC6dL8HdTlV5miQpI3UT2Om6E4VG0_7R9KD-vyxxUZYFeTNr6y9MzH3JQUZqsuuuumDt9Vzxl_P7ZrMI8AW541wZREpKKnHaSKX8tsDzk41t9F64e9B7ZUyovHBmazhowxQhW5uhDSJL2k8spFOKBIaRzaCe7jsy4lraeY2NDkKRuIFr4ku6yW00U8XeqQ2DtihEgMPbr6ckBef0jDXPetZJ9WKKAksRVMHbKhixBpxLSDvHrm-IYfFuQQh7VbCabZQRkwXPAgVZDHKiZCUKkhvtnzS5ZRTBvdV0obNdTFyO9s8wuGbljCm0q1i2S5FX5ASw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5NzAsIm5iZiI6MTUyMDg0OTk3MCwiZXhwIjoxNTIwODUzODcwLCJhaW8iOiJZMk5nWUZCTzNGYjNsL3ZQM3pXbkd3d1dlcjVhQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiOHBJUTJ4X196MG1TcEdSU1dHRVhBQSIsInZlciI6IjEuMCJ9.R4haEyoof1avup5BefTy1B4S1yIQteJi1K7r6TfDwAJJl76g2HHdKnK0E4OWRh05yNXdOYdYyqnP5XmAgm1s6nVH62QwTgx6xrVOhqlQb60LRhN-jeZg4xrRH4XIQRF_hzNOA_QHlpZQzQ5tqbAYqTonFYwRW_2YuuNNlNAwNZmNqxyl0zExhHRK68pF04oUNMZrplqM6wPRRPCeB-XJ3170z9-VBDCMWrK1vbYwhjD5Kr08YDcnGtcrV2pgiifAT7rvPfjSMqa-YpB7NXz07WdYKWq6b9pRb5l06THpFKaq7PNpPAeMRfMCq3d6REuqo1I7VUECTxej3HhNKftPwg
   response:
     status:
       code: 200
@@ -2370,22 +2416,22 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 34dca3f9-00a0-46a9-98f1-beaa9dfc61a7
+      - 2a450f00-9f6a-431b-9e99-2bd1ff7309b8
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14980'
+      - '14984'
       X-Ms-Correlation-Request-Id:
-      - d431baea-60ec-490f-a62b-8180a23277fa
+      - 42d2c5e5-f7cd-4430-9807-691422cc768a
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201849Z:d431baea-60ec-490f-a62b-8180a23277fa
+      - WESTEUROPE:20180312T102434Z:42d2c5e5-f7cd-4430-9807-691422cc768a
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:18:49 GMT
+      - Mon, 12 Mar 2018 10:24:33 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"rspec-lb1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1\",\r\n
@@ -2443,229 +2489,7 @@ http_interactions:
         [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
         \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:49 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2MjcsIm5iZiI6MTUyMDQ1MzYyNywiZXhwIjoxNTIwNDU3NTI3LCJhaW8iOiJZMk5nWURBTjFDdDJkcHEzYjE1K2V1Lys2UnRMQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQjgyODh0ZWZDa3FjTVNibmoyMEFBQSIsInZlciI6IjEuMCJ9.a33YVEj1f8OO84ni3lxC6dL8HdTlV5miQpI3UT2Om6E4VG0_7R9KD-vyxxUZYFeTNr6y9MzH3JQUZqsuuuumDt9Vzxl_P7ZrMI8AW541wZREpKKnHaSKX8tsDzk41t9F64e9B7ZUyovHBmazhowxQhW5uhDSJL2k8spFOKBIaRzaCe7jsy4lraeY2NDkKRuIFr4ku6yW00U8XeqQ2DtihEgMPbr6ckBef0jDXPetZJ9WKKAksRVMHbKhixBpxLSDvHrm-IYfFuQQh7VbCabZQRkwXPAgVZDHKiZCUKkhvtnzS5ZRTBvdV0obNdTFyO9s8wuGbljCm0q1i2S5FX5ASw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - e6e34e22-32e3-4985-938f-9186dda7823d
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14969'
-      X-Ms-Correlation-Request-Id:
-      - '0836e522-5af8-4a64-a7e3-b3953fe4fa0e'
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201850Z:0836e522-5af8-4a64-a7e3-b3953fe4fa0e
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:18:49 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1\",\r\n
-        \ \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"7ab88756-810f-4083-95db-8b05d50e38f2\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ],\r\n          \"inboundNatRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"backendIPConfigurations\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\"\r\n
-        \           }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-rule\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\":
-        80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\"\r\n
-        \         },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n
-        \       \"name\": \"rspec-lb-probe\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-NAT\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 3441,\r\n          \"backendPort\":
-        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:50 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2MjcsIm5iZiI6MTUyMDQ1MzYyNywiZXhwIjoxNTIwNDU3NTI3LCJhaW8iOiJZMk5nWURBTjFDdDJkcHEzYjE1K2V1Lys2UnRMQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQjgyODh0ZWZDa3FjTVNibmoyMEFBQSIsInZlciI6IjEuMCJ9.a33YVEj1f8OO84ni3lxC6dL8HdTlV5miQpI3UT2Om6E4VG0_7R9KD-vyxxUZYFeTNr6y9MzH3JQUZqsuuuumDt9Vzxl_P7ZrMI8AW541wZREpKKnHaSKX8tsDzk41t9F64e9B7ZUyovHBmazhowxQhW5uhDSJL2k8spFOKBIaRzaCe7jsy4lraeY2NDkKRuIFr4ku6yW00U8XeqQ2DtihEgMPbr6ckBef0jDXPetZJ9WKKAksRVMHbKhixBpxLSDvHrm-IYfFuQQh7VbCabZQRkwXPAgVZDHKiZCUKkhvtnzS5ZRTBvdV0obNdTFyO9s8wuGbljCm0q1i2S5FX5ASw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 1587065d-461e-4c4f-9806-1a2264ad9163
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14972'
-      X-Ms-Correlation-Request-Id:
-      - 887a5950-abfb-4d7c-8a7d-6ef8e66a170e
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201850Z:887a5950-abfb-4d7c-8a7d-6ef8e66a170e
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:18:50 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1\",\r\n
-        \ \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"7ab88756-810f-4083-95db-8b05d50e38f2\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ],\r\n          \"inboundNatRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"backendIPConfigurations\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\"\r\n
-        \           }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-rule\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\":
-        80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\"\r\n
-        \         },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n
-        \       \"name\": \"rspec-lb-probe\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-NAT\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 3441,\r\n          \"backendPort\":
-        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:50 GMT
+  recorded_at: Mon, 12 Mar 2018 10:24:39 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd?api-version=2018-01-01
@@ -2682,7 +2506,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2MjcsIm5iZiI6MTUyMDQ1MzYyNywiZXhwIjoxNTIwNDU3NTI3LCJhaW8iOiJZMk5nWURBTjFDdDJkcHEzYjE1K2V1Lys2UnRMQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQjgyODh0ZWZDa3FjTVNibmoyMEFBQSIsInZlciI6IjEuMCJ9.a33YVEj1f8OO84ni3lxC6dL8HdTlV5miQpI3UT2Om6E4VG0_7R9KD-vyxxUZYFeTNr6y9MzH3JQUZqsuuuumDt9Vzxl_P7ZrMI8AW541wZREpKKnHaSKX8tsDzk41t9F64e9B7ZUyovHBmazhowxQhW5uhDSJL2k8spFOKBIaRzaCe7jsy4lraeY2NDkKRuIFr4ku6yW00U8XeqQ2DtihEgMPbr6ckBef0jDXPetZJ9WKKAksRVMHbKhixBpxLSDvHrm-IYfFuQQh7VbCabZQRkwXPAgVZDHKiZCUKkhvtnzS5ZRTBvdV0obNdTFyO9s8wuGbljCm0q1i2S5FX5ASw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5NzAsIm5iZiI6MTUyMDg0OTk3MCwiZXhwIjoxNTIwODUzODcwLCJhaW8iOiJZMk5nWUZCTzNGYjNsL3ZQM3pXbkd3d1dlcjVhQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiOHBJUTJ4X196MG1TcEdSU1dHRVhBQSIsInZlciI6IjEuMCJ9.R4haEyoof1avup5BefTy1B4S1yIQteJi1K7r6TfDwAJJl76g2HHdKnK0E4OWRh05yNXdOYdYyqnP5XmAgm1s6nVH62QwTgx6xrVOhqlQb60LRhN-jeZg4xrRH4XIQRF_hzNOA_QHlpZQzQ5tqbAYqTonFYwRW_2YuuNNlNAwNZmNqxyl0zExhHRK68pF04oUNMZrplqM6wPRRPCeB-XJ3170z9-VBDCMWrK1vbYwhjD5Kr08YDcnGtcrV2pgiifAT7rvPfjSMqa-YpB7NXz07WdYKWq6b9pRb5l06THpFKaq7PNpPAeMRfMCq3d6REuqo1I7VUECTxej3HhNKftPwg
   response:
     status:
       code: 200
@@ -2703,22 +2527,22 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - bed4a844-c3d4-4adb-8253-f015950a5efe
+      - c152acbf-0a4d-4c82-abda-52f71b9406d7
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14978'
+      - '14985'
       X-Ms-Correlation-Request-Id:
-      - a86816ca-1424-449f-a9ea-950180600b8c
+      - d4f56c8d-b13c-4a53-81a2-ffb2c6e6b292
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201855Z:a86816ca-1424-449f-a9ea-950180600b8c
+      - WESTEUROPE:20180312T102435Z:d4f56c8d-b13c-4a53-81a2-ffb2c6e6b292
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:18:54 GMT
+      - Mon, 12 Mar 2018 10:24:34 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"rspec-lb1-LoadBalancerFrontEnd\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\",\r\n
@@ -2731,5 +2555,5 @@ http_interactions:
         \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
         \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:55 GMT
+  recorded_at: Mon, 12 Mar 2018 10:24:39 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted_scope/lb_vms_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted_scope/lb_vms_refresh.yml
@@ -37,25 +37,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - f1b02694-5014-41b0-b9a2-dde770740000
+      - e55a7697-48dd-4fe3-9a26-2ef05cdf2400
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzyiZBPbskTKWQooPHxh5Bme21NNPK9shD1mSPEy3hh5P2QzO3mxZBysygzz8PVc5YiOn_GUEzJbIZNMPN0F3qAd-QwMIp_Z4UEiHEKAsvUuaaoEptzuov1IBp1BUolr8ZhNQT5ssQx1vadhUAnCgu2iP0CzoworEUgfyFEKul4wQgAA;
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzYNg2vkqPylyfCjxD3AMYVzyEe6m3dF8hOe6sOw4Uitl4oahhvSFoEodjrshGvcoBtDYJx8159Vv7K5fn7CvgmJz7tbxOe-TjYqxYuHpC2bvqNeAuCGFmdbQN8HESdaXaIpZ-dX812jsM6x9UUt7NDuE7ABs-t7pfjJcE_NacQdAgAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=006; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=005; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Wed, 07 Mar 2018 20:21:29 GMT
+      - Mon, 12 Mar 2018 10:23:44 GMT
       Content-Length:
       - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1520457689","not_before":"1520453789","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3ODksIm5iZiI6MTUyMDQ1Mzc4OSwiZXhwIjoxNTIwNDU3Njg5LCJhaW8iOiJZMk5nWUdBTzluZzJLY25wRWNmV20xS1NCOXJmQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibENhdzhSUlFzRUc1b3QzbmNIUUFBQSIsInZlciI6IjEuMCJ9.NjJPw1ksaOk2iyA699o9MPbQPQzcldpuJcvgMO2D851_sHs8aIbEejVf7P9Ea_F33pyoJTwYfa22s4vK3mI3-6WWOfdOmzwoMPVJAZ_uwYU9SM-idZOUKEQjQiMzI9Rhp9dk0xhs4tcwU_u6m4k2UUzfXtEnHQlC6sCQ_H1P4jZvfnygqQy5z-hxaJm33e71ogox7lnCxtQJ2S6kpVnflD-C-RW2X-g7A9yxmDe7yOG1MR3kZpilCs2HqqXzTzl0TOc91Xfdo9avET2GqN0t4WutUsVKEEbqAuSWUzsWzLQOz3EJ8OZG_PCiDpF4QAE5DtiZQyIgGIYwRWtBhE-tqQ"}'
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1520853824","not_before":"1520849924","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ"}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:30 GMT
+  recorded_at: Mon, 12 Mar 2018 10:23:49 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -72,7 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3ODksIm5iZiI6MTUyMDQ1Mzc4OSwiZXhwIjoxNTIwNDU3Njg5LCJhaW8iOiJZMk5nWUdBTzluZzJLY25wRWNmV20xS1NCOXJmQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibENhdzhSUlFzRUc1b3QzbmNIUUFBQSIsInZlciI6IjEuMCJ9.NjJPw1ksaOk2iyA699o9MPbQPQzcldpuJcvgMO2D851_sHs8aIbEejVf7P9Ea_F33pyoJTwYfa22s4vK3mI3-6WWOfdOmzwoMPVJAZ_uwYU9SM-idZOUKEQjQiMzI9Rhp9dk0xhs4tcwU_u6m4k2UUzfXtEnHQlC6sCQ_H1P4jZvfnygqQy5z-hxaJm33e71ogox7lnCxtQJ2S6kpVnflD-C-RW2X-g7A9yxmDe7yOG1MR3kZpilCs2HqqXzTzl0TOc91Xfdo9avET2GqN0t4WutUsVKEEbqAuSWUzsWzLQOz3EJ8OZG_PCiDpF4QAE5DtiZQyIgGIYwRWtBhE-tqQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
   response:
     status:
       code: 200
@@ -91,26 +91,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14995'
+      - '14998'
       X-Ms-Request-Id:
-      - 48ab896a-e6fa-427b-bcba-d2f9577a02d0
+      - 543f69f7-efc2-433a-a2fd-93d6eeaae969
       X-Ms-Correlation-Request-Id:
-      - 48ab896a-e6fa-427b-bcba-d2f9577a02d0
+      - 543f69f7-efc2-433a-a2fd-93d6eeaae969
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202130Z:48ab896a-e6fa-427b-bcba-d2f9577a02d0
+      - WESTEUROPE:20180312T102344Z:543f69f7-efc2-433a-a2fd-93d6eeaae969
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:21:29 GMT
+      - Mon, 12 Mar 2018 10:23:44 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID","subscriptionId":"AZURE_SUBSCRIPTION_ID","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:30 GMT
+  recorded_at: Mon, 12 Mar 2018 10:23:49 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers?api-version=2015-01-01
@@ -127,7 +127,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3ODksIm5iZiI6MTUyMDQ1Mzc4OSwiZXhwIjoxNTIwNDU3Njg5LCJhaW8iOiJZMk5nWUdBTzluZzJLY25wRWNmV20xS1NCOXJmQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibENhdzhSUlFzRUc1b3QzbmNIUUFBQSIsInZlciI6IjEuMCJ9.NjJPw1ksaOk2iyA699o9MPbQPQzcldpuJcvgMO2D851_sHs8aIbEejVf7P9Ea_F33pyoJTwYfa22s4vK3mI3-6WWOfdOmzwoMPVJAZ_uwYU9SM-idZOUKEQjQiMzI9Rhp9dk0xhs4tcwU_u6m4k2UUzfXtEnHQlC6sCQ_H1P4jZvfnygqQy5z-hxaJm33e71ogox7lnCxtQJ2S6kpVnflD-C-RW2X-g7A9yxmDe7yOG1MR3kZpilCs2HqqXzTzl0TOc91Xfdo9avET2GqN0t4WutUsVKEEbqAuSWUzsWzLQOz3EJ8OZG_PCiDpF4QAE5DtiZQyIgGIYwRWtBhE-tqQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
   response:
     status:
       code: 200
@@ -144,39 +144,37 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14971'
+      - '14989'
       X-Ms-Request-Id:
-      - 72b25401-ad36-4930-b352-1c2876283e49
+      - 075d07c7-de25-48a8-9a83-66f71bc4d90d
       X-Ms-Correlation-Request-Id:
-      - 72b25401-ad36-4930-b352-1c2876283e49
+      - 075d07c7-de25-48a8-9a83-66f71bc4d90d
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202131Z:72b25401-ad36-4930-b352-1c2876283e49
+      - WESTEUROPE:20180312T102346Z:075d07c7-de25-48a8-9a83-66f71bc4d90d
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:21:30 GMT
+      - Mon, 12 Mar 2018 10:23:46 GMT
       Content-Length:
-      - '310901'
+      - '320853'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"},{"applicationId":"d87dcbc6-a371-462e-88e3-28ad15ec4e64","roleDefinitionId":"861776c5-e0df-4f95-be4f-ac1eec193323"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
+      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"},{"applicationId":"d87dcbc6-a371-462e-88e3-28ad15ec4e64","roleDefinitionId":"861776c5-e0df-4f95-be4f-ac1eec193323"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["East
+        Asia","Southeast Asia","Australia East","Australia Southeast","Japan East","Japan
+        West","Central India","South India","West India","West Europe","North Europe","Canada
+        Central","Canada East","Brazil South","West US","Central US","East US","South
+        Central US","East US 2","West Central US","North Central US","West US 2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
         US","Central US","East US","South Central US","West Europe","North Europe","East
         Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
         Central US","North Central US","Japan East","Japan West","Brazil South","Central
         India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"operations","locations":["West
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["East
+        Asia","Southeast Asia","Australia East","Australia Southeast","Japan East","Japan
+        West","Central India","South India","West India","West Europe","North Europe","Canada
+        Central","Canada East","Brazil South","West US","Central US","East US","South
+        Central US","East US 2","West Central US","North Central US","West US 2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"operations","locations":["West
         US","Central US","East US","South Central US","West Europe","North Europe","East
         Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
         Central US","North Central US","Japan East","Japan West","Brazil South","Central
@@ -232,177 +230,177 @@ http_interactions:
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/internalLoadBalancers","locations":[],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"domainNames/slots/roles/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"domainNames/slots/roles/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"domainNames/capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"domainNames/serviceCertificates","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
         US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
         Central","Canada East","UK South","UK West","West US","Central US","South
         Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
-        East","Australia Southeast","West US 2","West Central US","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        East","Australia Southeast","West US 2","West Central US","France Central","South
+        India","Central India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
         US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
         Central","Canada East","UK South","UK West","West US","Central US","South
         Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
-        East","Australia Southeast","West US 2","West Central US","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metrics","locations":["North
+        East","Australia Southeast","West US 2","West Central US","France Central","South
+        India","Central India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metrics","locations":["North
         Central US","South Central US","East US","East US 2","Canada Central","Canada
         East","West US","West US 2","West Central US","Central US","East Asia","Southeast
         Asia","North Europe","West Europe","UK South","UK West","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"resourceTypes","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"moveSubscriptionResources","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"validateSubscriptionMoveAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operationStatuses","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operatingSystems","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"operatingSystemFamilies","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicNetwork","namespace":"Microsoft.ClassicNetwork","resourceTypes":[{"resourceType":"virtualNetworks","locations":["East
+        India","West India","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"resourceTypes","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"moveSubscriptionResources","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"validateSubscriptionMoveAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operationStatuses","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operatingSystems","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"operatingSystemFamilies","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicNetwork","namespace":"Microsoft.ClassicNetwork","resourceTypes":[{"resourceType":"virtualNetworks","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"virtualNetworks/remoteVirtualNetworkPeeringProxies","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01"]},{"resourceType":"virtualNetworks/remoteVirtualNetworkPeeringProxies","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"reservedIps","locations":["East
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01"]},{"resourceType":"reservedIps","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"gatewaySupportedDevices","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"networkSecurityGroups","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"gatewaySupportedDevices","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"networkSecurityGroups","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicStorage","namespace":"Microsoft.ClassicStorage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"expressRouteCrossConnections","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"expressRouteCrossConnections/peerings","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicStorage","namespace":"Microsoft.ClassicStorage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkStorageAccountAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"storageAccounts/services","locations":["West
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkStorageAccountAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"storageAccounts/services","locations":["West
         US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
         Asia","Australia East","Australia Southeast","South India","Central India","West
         India","West US 2","West Central US","East US","East US 2","North Central
         US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
-        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/diagnosticSettings","locations":["West
+        South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/diagnosticSettings","locations":["West
         US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
         Asia","Australia East","Australia Southeast","South India","Central India","West
         India","West US 2","West Central US","East US","East US 2","North Central
         US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
-        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"disks","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"images","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"vmImages","locations":[],"apiVersions":["2016-11-01"]},{"resourceType":"publicImages","locations":[],"apiVersions":["2016-11-01","2016-04-01"]},{"resourceType":"osImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"osPlatformImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute","namespace":"Microsoft.Compute","authorizations":[{"applicationId":"60e6cd67-9c8c-4951-9b3c-23c25a2169af","roleDefinitionId":"e4770acb-272e-4dc8-87f3-12f44a612224"},{"applicationId":"a303894e-f1d8-4a37-bf10-67aa654a0596","roleDefinitionId":"903ac751-8ad5-4e5a-bfc2-5e49f450a241"},{"applicationId":"a8b6bf88-1d1a-4626-b040-9a729ea93c65","roleDefinitionId":"45c8267c-80ba-4b96-9a43-115b8f49fccd"}],"resourceTypes":[{"resourceType":"availabilitySets","locations":["East
+        South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"disks","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"images","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"vmImages","locations":[],"apiVersions":["2016-11-01"]},{"resourceType":"storageAccounts/vmImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"publicImages","locations":[],"apiVersions":["2016-11-01","2016-04-01"]},{"resourceType":"osImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"osPlatformImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute","namespace":"Microsoft.Compute","authorizations":[{"applicationId":"60e6cd67-9c8c-4951-9b3c-23c25a2169af","roleDefinitionId":"e4770acb-272e-4dc8-87f3-12f44a612224"},{"applicationId":"a303894e-f1d8-4a37-bf10-67aa654a0596","roleDefinitionId":"903ac751-8ad5-4e5a-bfc2-5e49f450a241"},{"applicationId":"a8b6bf88-1d1a-4626-b040-9a729ea93c65","roleDefinitionId":"45c8267c-80ba-4b96-9a43-115b8f49fccd"}],"resourceTypes":[{"resourceType":"availabilitySets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations/usages","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations/usages","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"sharedVMImages","locations":["West
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"sharedVMImages","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"sharedVMImages/versions","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"locations/capsoperations","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"disks","locations":["Southeast
@@ -410,27 +408,27 @@ http_interactions:
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"snapshots","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"snapshots","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"locations/diskoperations","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"locations/diskoperations","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"images","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"images","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"]},{"resourceType":"locations/logAnalytics","locations":["East
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"]},{"resourceType":"locations/logAnalytics","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
         US","East US","South Central US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
@@ -547,7 +545,12 @@ http_interactions:
         US","East Asia","East US","East US 2","Japan East","Japan West","North Central
         US","North Europe","South Central US","South India","Southeast Asia","West
         Central US","West Europe","West India","West US","West US 2","UK West","UK
-        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"},{"applicationId":"f5c26e74-f226-4ae8-85f0-b4af0080ac9e","roleDefinitionId":"529d7ae6-e892-4d43-809d-8547aeb90643"}],"resourceTypes":[{"resourceType":"components","locations":["East
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/consumergroups","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/disasterrecoveryconfigs","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"},{"applicationId":"f5c26e74-f226-4ae8-85f0-b4af0080ac9e","roleDefinitionId":"529d7ae6-e892-4d43-809d-8547aeb90643"}],"resourceTypes":[{"resourceType":"components","locations":["East
         US","South Central US","North Europe","West Europe","Southeast Asia","West
         US 2"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
         US","South Central US","North Europe","West Europe","Southeast Asia","West
@@ -614,32 +617,32 @@ http_interactions:
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/accessPolicies","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"vaults/accessPolicies","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-10-01","2015-06-01","2014-12-19-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"deletedVaults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01","2014-12-19-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"deletedVaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-10-01"]},{"resourceType":"locations/deletedVaults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations/deletedVaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
         Central US","West Europe","Southeast Asia","Japan East","West Central US"],"apiVersions":["2016-04-01"]},{"resourceType":"webServices","locations":["South
         Central US","West Europe","Southeast Asia","Japan East","East US 2","West
         Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"operations","locations":["South
@@ -665,97 +668,97 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"networkWatchers/lenses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"networkWatchers/lenses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","West
         US 2","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
@@ -846,7 +849,7 @@ http_interactions:
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
         West","Korea Central","Korea South"],"apiVersions":["2017-07-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ResourceHealth","namespace":"Microsoft.ResourceHealth","authorizations":[{"applicationId":"8bdebf23-c0fe-4187-a378-717ad86f6a53","roleDefinitionId":"cc026344-c8b1-4561-83ba-59eba84b27cc"}],"resourceTypes":[{"resourceType":"availabilityStatuses","locations":[],"apiVersions":["2017-07-01","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"notifications","locations":["Australia
-        Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Security","namespace":"Microsoft.Security","authorization":{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
+        Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Security","namespace":"Microsoft.Security","authorizations":[{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},{"applicationId":"fc780465-2017-40d4-a0c5-307022471b92"}],"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatuses","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/virtualMachines","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/endpoints","locations":["Central
@@ -898,565 +901,595 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Central India","South
         India"],"apiVersions":["2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Sql","namespace":"Microsoft.Sql","authorizations":[{"applicationId":"e4ab13ed-33cb-41b4-9140-6e264582cf85","roleDefinitionId":"ec3ddc95-44dc-47a2-9926-5e9f5ffd44ec"},{"applicationId":"0130cc9f-7ac5-4026-bd5f-80a08a54e6d9","roleDefinitionId":"45e8abf8-0ec4-44f3-9c37-cff4f7779302"},{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},{"applicationId":"76c7f279-7959-468f-8943-3954880e0d8c","roleDefinitionId":"7f7513a8-73f9-4c5f-97a2-c41f0ea783ef"}],"resourceTypes":[{"resourceType":"operations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/capabilities","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/databaseAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/databaseOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverKeyOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/keys","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/encryptionProtector","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/usages","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01","2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/communicationLinks","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administrators","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administratorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/restorableDroppedDatabases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recoverableDatabases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/geoBackupPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/importExportOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/operationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/backupLongTermRetentionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/automaticTuning","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/automaticTuning","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/databases/transparentDataEncryption","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recommendedElasticPools","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/auditingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/connectionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/connectionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies/rules","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/securityAlertPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/securityAlertPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/auditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/extendedAuditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/elasticpools","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-09-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/jobAgentOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/jobAgentAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/disasterRecoveryConfiguration","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/dnsAliases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/failoverGroups","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/virtualNetworkRules","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/virtualNetworkRulesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/virtualNetworkRulesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/databaseRestoreAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metricDefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/aggregatedDatabaseMetrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metricdefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries/queryText","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPools/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/extensions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPoolEstimates","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditRecords","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentScans","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/vulnerabilityAssessments","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessment","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/syncGroups","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups/syncMembers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/syncAgents","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"managedInstances/administrators","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/databases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metricDefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/administratorAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/administratorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncMemberOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncAgentOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncDatabaseIds","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorizations":[{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},{"applicationId":"e406a681-f3d4-42a8-90b6-c2b029497af1"}],"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/capabilities","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/databaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"locations/databaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverKeyOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/keys","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/encryptionProtector","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01","2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/communicationLinks","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/restorableDroppedDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recoverableDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/geoBackupPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/importExportOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/operationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/backupLongTermRetentionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/databases/transparentDataEncryption","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recommendedElasticPools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies/rules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/extendedAuditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/elasticPoolAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/elasticPoolOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/elasticpools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-09-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/jobAgentOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/jobAgentAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/disasterRecoveryConfiguration","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/dnsAliases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/failoverGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/virtualNetworkRules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/virtualNetworkRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/virtualNetworkRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/databaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/aggregatedDatabaseMetrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metricdefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries/queryText","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPools/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/extensions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPoolEstimates","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditRecords","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentScans","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/vulnerabilityAssessments","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessment","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/syncGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups/syncMembers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/syncAgents","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"managedInstances/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/administratorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncMemberOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncAgentOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncDatabaseIds","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/longTermRetentionPolicyOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionPolicyAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionBackupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionBackupAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorizations":[{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},{"applicationId":"e406a681-f3d4-42a8-90b6-c2b029497af1"}],"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
@@ -1795,12 +1828,12 @@ http_interactions:
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","Canada Central","Canada East","UK South","UK West","West US 2","West
-        Central US","South India","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","South India","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","South India","Canada Central","Canada East","UK South","UK West","West
-        US 2","West Central US","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Capacity","namespace":"Microsoft.Capacity","authorization":{"applicationId":"4d0ad6c7-f6c3-46d8-ab0d-1406d5e6c86b","roleDefinitionId":"FD9C0A9A-4DB9-4F41-8A61-98385DEB6E2D"},"resourceTypes":[{"resourceType":"resources","locations":["South
+        US 2","West Central US","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Capacity","namespace":"Microsoft.Capacity","authorization":{"applicationId":"4d0ad6c7-f6c3-46d8-ab0d-1406d5e6c86b","roleDefinitionId":"FD9C0A9A-4DB9-4F41-8A61-98385DEB6E2D"},"resourceTypes":[{"resourceType":"resources","locations":["South
         Central US"],"apiVersions":["2017-11-01"]},{"resourceType":"reservationOrders","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/reservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/reservations/revisions","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"catalogs","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"appliedReservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"checkOffers","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"checkScopes","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"calculatePrice","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/calculateRefund","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/return","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/split","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/merge","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"validateReservationOrder","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/availableScopes","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Cdn","namespace":"Microsoft.Cdn","resourceTypes":[{"resourceType":"profiles","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
@@ -1876,9 +1909,9 @@ http_interactions:
         2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/updateAccountsCreationSettings","locations":["West
         US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/accountsCreationSettings","locations":["West
         US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2016-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Commerce","namespace":"Microsoft.Commerce","resourceTypes":[{"resourceType":"UsageAggregates","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]},{"resourceType":"RateCard","locations":[],"apiVersions":["2016-08-31-preview","2015-06-01-preview","2015-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Consumption","namespace":"Microsoft.Consumption","resourceTypes":[{"resourceType":"ReservationSummaries","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationTransactions","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Balances","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Marketplaces","locations":[],"apiVersions":["2018-01-31"]},{"resourceType":"Pricesheets","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationDetails","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Budgets","locations":[],"apiVersions":["2018-01-31","2017-12-30-preview"]},{"resourceType":"Terms","locations":[],"apiVersions":["2018-01-31","2017-12-30-preview"]},{"resourceType":"UsageDetails","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview","2017-04-24-preview"]},{"resourceType":"Operations","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview","2017-04-24-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerInstance","namespace":"Microsoft.ContainerInstance","resourceTypes":[{"resourceType":"containerGroups","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/usages","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/operations","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/operations","locations":["West
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
         US"],"apiVersions":["2016-04-08"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.CustomerInsights","namespace":"Microsoft.CustomerInsights","authorization":{"applicationId":"38c77d00-5fcb-4cce-9d93-af4738258e3c","roleDefinitionId":"E006F9C7-F333-477C-8AD6-1F3A9FE87F55"},"resourceTypes":[{"resourceType":"hubs","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/profiles","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/interactions","locations":["East
@@ -1895,7 +1928,9 @@ http_interactions:
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"operations","locations":["East
         US 2"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Databricks","namespace":"Microsoft.Databricks","authorizations":[{"applicationId":"d9327919-6775-4843-9037-3fb0fb0473cb","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},{"applicationId":"2ff814a6-3304-4ab8-85cb-cd0e6f879c1d","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"}],"resourceTypes":[{"resourceType":"workspaces","locations":["West
         US","East US 2","West Europe","East US","North Europe","Southeast Asia","East
-        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]},{"resourceType":"locations","locations":["West
+        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2017-09-01-preview"]},{"resourceType":"workspaces/virtualNetworkPeerings","locations":["West
+        US","East US 2","West Europe","North Europe","East US","Southeast Asia","East
+        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01"]},{"resourceType":"locations","locations":["West
         US","East US 2","West Europe","North Europe","East US","Southeast Asia"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
         US","East US 2","West Europe","East US","North Europe","Southeast Asia","East
         Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataCatalog","namespace":"Microsoft.DataCatalog","resourceTypes":[{"resourceType":"catalogs","locations":["East
@@ -1919,23 +1954,26 @@ http_interactions:
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers/listSasTokens","locations":["East
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataLakeStore","namespace":"Microsoft.DataLakeStore","authorization":{"applicationId":"e9f49c6b-5ce5-44c8-925d-015017e9f7ad","roleDefinitionId":"17eb9cca-f08a-4499-b2d3-852d175f614f"},"resourceTypes":[{"resourceType":"accounts","locations":["East
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/firewallRules","locations":["East
-        US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataMigration","namespace":"Microsoft.DataMigration","authorization":{"applicationId":"a4bad4aa-bf02-4631-9f78-a64ffdba8150","roleDefinitionId":"b831a21d-db98-4760-89cb-bef871952df1","managedByRoleDefinitionId":"6256fb55-9e59-4018-a9e1-76b11c0a4c89"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services/projects","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationStatuses","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
+        US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataMigration","namespace":"Microsoft.DataMigration","authorization":{"applicationId":"a4bad4aa-bf02-4631-9f78-a64ffdba8150","roleDefinitionId":"b831a21d-db98-4760-89cb-bef871952df1","managedByRoleDefinitionId":"6256fb55-9e59-4018-a9e1-76b11c0a4c89"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services/projects","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationStatuses","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
-        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/recoverableServers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
@@ -1959,7 +1997,10 @@ http_interactions:
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
-        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/recoverableServers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
@@ -2015,12 +2056,7 @@ http_interactions:
         US 2","East US","West US","Central US","East US 2","West Central US","West
         Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
         US 2","East US","West US","Central US","East US 2","West Central US","West
-        Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","West
-        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
-        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
-        India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/consumergroups","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/disasterrecoveryconfigs","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
         US 2","South Central US","Central US","Australia Southeast","Central India","West
         Central US","West US 2","Canada East","Canada Central","Brazil South","UK
         South","UK West","East Asia","Australia East","Japan East","Japan West","North
@@ -2131,7 +2167,7 @@ http_interactions:
         West","Japan East","East Asia","Southeast Asia","West Europe","North Europe","East
         US","West US","Australia East","Australia Southeast","Central US","Brazil
         South","Central India","West India","South India","South Central US","Canada
-        Central","Canada East","West Central US","West US 2"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
+        Central","Canada East","West Central US","West US 2"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-05","2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
         Central US","East US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"operations","locations":["West
         Central US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
         Central US","East US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.PolicyInsights","namespace":"Microsoft.PolicyInsights","authorization":{"applicationId":"1d78a85d-813d-46f0-b496-dd72f50a3ec0","roleDefinitionId":"63d2b225-4c34-4641-8768-21a1f7c68ce8"},"resourceTypes":[{"resourceType":"policyEvents","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"policyStates","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
@@ -2163,12 +2199,12 @@ http_interactions:
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
         Central US","South Central US","North Europe","West Europe","East Asia","Southeast
         Asia","West US","East US","Japan West","Japan East","Brazil South","Central
         US","East US 2","Australia East","Australia Southeast","South India","Central
@@ -2208,40 +2244,50 @@ http_interactions:
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/clusterVersions","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"clusters/applications","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operations","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/clusterVersions","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/environments","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operations","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
         Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applianceDefinitions","locations":["West
         Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applications","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
-        Central US"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
+        Central US"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
         US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
         US","Canada Central","Canada East","Central US","East US 2","UK South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups","locations":["West
         US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
@@ -2332,7 +2378,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:31 GMT
+  recorded_at: Mon, 12 Mar 2018 10:23:51 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a?api-version=2017-12-01
@@ -2349,7 +2395,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3ODksIm5iZiI6MTUyMDQ1Mzc4OSwiZXhwIjoxNTIwNDU3Njg5LCJhaW8iOiJZMk5nWUdBTzluZzJLY25wRWNmV20xS1NCOXJmQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibENhdzhSUlFzRUc1b3QzbmNIUUFBQSIsInZlciI6IjEuMCJ9.NjJPw1ksaOk2iyA699o9MPbQPQzcldpuJcvgMO2D851_sHs8aIbEejVf7P9Ea_F33pyoJTwYfa22s4vK3mI3-6WWOfdOmzwoMPVJAZ_uwYU9SM-idZOUKEQjQiMzI9Rhp9dk0xhs4tcwU_u6m4k2UUzfXtEnHQlC6sCQ_H1P4jZvfnygqQy5z-hxaJm33e71ogox7lnCxtQJ2S6kpVnflD-C-RW2X-g7A9yxmDe7yOG1MR3kZpilCs2HqqXzTzl0TOc91Xfdo9avET2GqN0t4WutUsVKEEbqAuSWUzsWzLQOz3EJ8OZG_PCiDpF4QAE5DtiZQyIgGIYwRWtBhE-tqQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
   response:
     status:
       code: 200
@@ -2368,26 +2414,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/LowCostGet3Min;4706,Microsoft.Compute/LowCostGet30Min;37847
+      - Microsoft.Compute/LowCostGet3Min;4740,Microsoft.Compute/LowCostGet30Min;37758
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344652126238
       X-Ms-Request-Id:
-      - e05f4774-72aa-4dd5-9556-bca0bb8783f7
+      - 77185ae6-edd2-4758-a6f3-67bb9d0b2874
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14969'
+      - '14990'
       X-Ms-Correlation-Request-Id:
-      - 7979e62b-dbf9-4acb-9efc-15cb0ddaf0c3
+      - 9a20f5da-6a36-46bf-8d2f-ca02d7042ce7
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202131Z:7979e62b-dbf9-4acb-9efc-15cb0ddaf0c3
+      - WESTEUROPE:20180312T102350Z:9a20f5da-6a36-46bf-8d2f-ca02d7042ce7
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:21:31 GMT
+      - Mon, 12 Mar 2018 10:23:49 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"23b0beab-16d2-4135-a01f-2fe713217fd0\",\r\n
@@ -2418,7 +2464,7 @@ http_interactions:
         \"eastus\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a\",\r\n
         \ \"name\": \"rspec-lb-a\"\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:32 GMT
+  recorded_at: Mon, 12 Mar 2018 10:23:54 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b?api-version=2017-12-01
@@ -2435,7 +2481,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3ODksIm5iZiI6MTUyMDQ1Mzc4OSwiZXhwIjoxNTIwNDU3Njg5LCJhaW8iOiJZMk5nWUdBTzluZzJLY25wRWNmV20xS1NCOXJmQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibENhdzhSUlFzRUc1b3QzbmNIUUFBQSIsInZlciI6IjEuMCJ9.NjJPw1ksaOk2iyA699o9MPbQPQzcldpuJcvgMO2D851_sHs8aIbEejVf7P9Ea_F33pyoJTwYfa22s4vK3mI3-6WWOfdOmzwoMPVJAZ_uwYU9SM-idZOUKEQjQiMzI9Rhp9dk0xhs4tcwU_u6m4k2UUzfXtEnHQlC6sCQ_H1P4jZvfnygqQy5z-hxaJm33e71ogox7lnCxtQJ2S6kpVnflD-C-RW2X-g7A9yxmDe7yOG1MR3kZpilCs2HqqXzTzl0TOc91Xfdo9avET2GqN0t4WutUsVKEEbqAuSWUzsWzLQOz3EJ8OZG_PCiDpF4QAE5DtiZQyIgGIYwRWtBhE-tqQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
   response:
     status:
       code: 200
@@ -2454,26 +2500,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/LowCostGet3Min;4705,Microsoft.Compute/LowCostGet30Min;37846
+      - Microsoft.Compute/LowCostGet3Min;4738,Microsoft.Compute/LowCostGet30Min;37756
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344652126238
       X-Ms-Request-Id:
-      - 62a5c57d-a9a9-4c0c-a1a8-638215551d38
+      - 615cfef0-436c-43b5-8dba-37a6953ed645
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14967'
+      - '14988'
       X-Ms-Correlation-Request-Id:
-      - 1f68e5f4-8bfe-4d0a-a9a1-619d5444f4fe
+      - a1586854-87da-4efe-aa19-e9c5756128f8
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202132Z:1f68e5f4-8bfe-4d0a-a9a1-619d5444f4fe
+      - WESTEUROPE:20180312T102350Z:a1586854-87da-4efe-aa19-e9c5756128f8
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:21:31 GMT
+      - Mon, 12 Mar 2018 10:23:50 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"834a70b5-868d-4466-9dda-14e0f6b2caaf\",\r\n
@@ -2504,7 +2550,7 @@ http_interactions:
         \"eastus\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b\",\r\n
         \ \"name\": \"rspec-lb-b\"\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:32 GMT
+  recorded_at: Mon, 12 Mar 2018 10:23:55 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670?api-version=2018-01-01
@@ -2521,7 +2567,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3ODksIm5iZiI6MTUyMDQ1Mzc4OSwiZXhwIjoxNTIwNDU3Njg5LCJhaW8iOiJZMk5nWUdBTzluZzJLY25wRWNmV20xS1NCOXJmQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibENhdzhSUlFzRUc1b3QzbmNIUUFBQSIsInZlciI6IjEuMCJ9.NjJPw1ksaOk2iyA699o9MPbQPQzcldpuJcvgMO2D851_sHs8aIbEejVf7P9Ea_F33pyoJTwYfa22s4vK3mI3-6WWOfdOmzwoMPVJAZ_uwYU9SM-idZOUKEQjQiMzI9Rhp9dk0xhs4tcwU_u6m4k2UUzfXtEnHQlC6sCQ_H1P4jZvfnygqQy5z-hxaJm33e71ogox7lnCxtQJ2S6kpVnflD-C-RW2X-g7A9yxmDe7yOG1MR3kZpilCs2HqqXzTzl0TOc91Xfdo9avET2GqN0t4WutUsVKEEbqAuSWUzsWzLQOz3EJ8OZG_PCiDpF4QAE5DtiZQyIgGIYwRWtBhE-tqQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
   response:
     status:
       code: 200
@@ -2542,22 +2588,22 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - de49271d-9c00-4640-ad65-4522e3752c49
+      - d848343a-ec69-4f64-9efb-303649392214
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14970'
+      - '14988'
       X-Ms-Correlation-Request-Id:
-      - 3d0118d8-d4e2-4228-ab88-a51350e05967
+      - 1a909240-4de3-4d96-bfb7-f83eb6ded23a
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202132Z:3d0118d8-d4e2-4228-ab88-a51350e05967
+      - WESTEUROPE:20180312T102351Z:1a909240-4de3-4d96-bfb7-f83eb6ded23a
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:21:32 GMT
+      - Mon, 12 Mar 2018 10:23:50 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"rspec-lb-a670\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670\",\r\n
@@ -2585,7 +2631,7 @@ http_interactions:
         \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
         \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:33 GMT
+  recorded_at: Mon, 12 Mar 2018 10:23:56 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843?api-version=2018-01-01
@@ -2602,7 +2648,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3ODksIm5iZiI6MTUyMDQ1Mzc4OSwiZXhwIjoxNTIwNDU3Njg5LCJhaW8iOiJZMk5nWUdBTzluZzJLY25wRWNmV20xS1NCOXJmQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibENhdzhSUlFzRUc1b3QzbmNIUUFBQSIsInZlciI6IjEuMCJ9.NjJPw1ksaOk2iyA699o9MPbQPQzcldpuJcvgMO2D851_sHs8aIbEejVf7P9Ea_F33pyoJTwYfa22s4vK3mI3-6WWOfdOmzwoMPVJAZ_uwYU9SM-idZOUKEQjQiMzI9Rhp9dk0xhs4tcwU_u6m4k2UUzfXtEnHQlC6sCQ_H1P4jZvfnygqQy5z-hxaJm33e71ogox7lnCxtQJ2S6kpVnflD-C-RW2X-g7A9yxmDe7yOG1MR3kZpilCs2HqqXzTzl0TOc91Xfdo9avET2GqN0t4WutUsVKEEbqAuSWUzsWzLQOz3EJ8OZG_PCiDpF4QAE5DtiZQyIgGIYwRWtBhE-tqQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
   response:
     status:
       code: 200
@@ -2623,22 +2669,22 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 8cb873c5-d069-4467-b5e3-07bb4e08b634
+      - fdaeada7-7263-4480-8284-e5bdf89263a3
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14969'
+      - '14989'
       X-Ms-Correlation-Request-Id:
-      - ced0dfc6-16fc-42e5-9b9b-328c3af2acd9
+      - 59b0465f-c5c7-468e-8d86-c47f48532540
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202133Z:ced0dfc6-16fc-42e5-9b9b-328c3af2acd9
+      - WESTEUROPE:20180312T102352Z:59b0465f-c5c7-468e-8d86-c47f48532540
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:21:33 GMT
+      - Mon, 12 Mar 2018 10:23:51 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"rspec-lb-b843\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843\",\r\n
@@ -2663,10 +2709,10 @@ http_interactions:
         \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
         \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:33 GMT
+  recorded_at: Mon, 12 Mar 2018 10:23:56 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups/miq-azure-test1?api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a/instanceView?api-version=2017-12-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2680,60 +2726,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3ODksIm5iZiI6MTUyMDQ1Mzc4OSwiZXhwIjoxNTIwNDU3Njg5LCJhaW8iOiJZMk5nWUdBTzluZzJLY25wRWNmV20xS1NCOXJmQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibENhdzhSUlFzRUc1b3QzbmNIUUFBQSIsInZlciI6IjEuMCJ9.NjJPw1ksaOk2iyA699o9MPbQPQzcldpuJcvgMO2D851_sHs8aIbEejVf7P9Ea_F33pyoJTwYfa22s4vK3mI3-6WWOfdOmzwoMPVJAZ_uwYU9SM-idZOUKEQjQiMzI9Rhp9dk0xhs4tcwU_u6m4k2UUzfXtEnHQlC6sCQ_H1P4jZvfnygqQy5z-hxaJm33e71ogox7lnCxtQJ2S6kpVnflD-C-RW2X-g7A9yxmDe7yOG1MR3kZpilCs2HqqXzTzl0TOc91Xfdo9avET2GqN0t4WutUsVKEEbqAuSWUzsWzLQOz3EJ8OZG_PCiDpF4QAE5DtiZQyIgGIYwRWtBhE-tqQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14969'
-      X-Ms-Request-Id:
-      - 26d29e99-61d5-4a45-842b-9090bdfb5af2
-      X-Ms-Correlation-Request-Id:
-      - 26d29e99-61d5-4a45-842b-9090bdfb5af2
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202133Z:26d29e99-61d5-4a45-842b-9090bdfb5af2
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:21:33 GMT
-      Content-Length:
-      - '183'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1","name":"miq-azure-test1","location":"eastus","properties":{"provisioningState":"Succeeded"}}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:33 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute/locations/eastus/vmSizes?api-version=2017-12-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3ODksIm5iZiI6MTUyMDQ1Mzc4OSwiZXhwIjoxNTIwNDU3Njg5LCJhaW8iOiJZMk5nWUdBTzluZzJLY25wRWNmV20xS1NCOXJmQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibENhdzhSUlFzRUc1b3QzbmNIUUFBQSIsInZlciI6IjEuMCJ9.NjJPw1ksaOk2iyA699o9MPbQPQzcldpuJcvgMO2D851_sHs8aIbEejVf7P9Ea_F33pyoJTwYfa22s4vK3mI3-6WWOfdOmzwoMPVJAZ_uwYU9SM-idZOUKEQjQiMzI9Rhp9dk0xhs4tcwU_u6m4k2UUzfXtEnHQlC6sCQ_H1P4jZvfnygqQy5z-hxaJm33e71ogox7lnCxtQJ2S6kpVnflD-C-RW2X-g7A9yxmDe7yOG1MR3kZpilCs2HqqXzTzl0TOc91Xfdo9avET2GqN0t4WutUsVKEEbqAuSWUzsWzLQOz3EJ8OZG_PCiDpF4QAE5DtiZQyIgGIYwRWtBhE-tqQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
   response:
     status:
       code: 200
@@ -2752,26 +2745,233 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/LowCostGet3Min;4704,Microsoft.Compute/LowCostGet30Min;37845
+      - Microsoft.Compute/GetInstanceView3Min;4781,Microsoft.Compute/GetInstanceView30Min;23767
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344652126238
       X-Ms-Request-Id:
-      - 87dae63b-4b93-4017-b2f0-b467bae4c9b6
+      - 364e2038-0e7d-45f8-ae14-183872020be8
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14982'
+      - '14988'
       X-Ms-Correlation-Request-Id:
-      - 54f38995-5281-4543-887b-030fd68ae7de
+      - 3a426495-af5d-4a07-a41f-1572301b228b
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202134Z:54f38995-5281-4543-887b-030fd68ae7de
+      - WESTEUROPE:20180312T102402Z:3a426495-af5d-4a07-a41f-1572301b228b
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:21:34 GMT
+      - Mon, 12 Mar 2018 10:24:01 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"platformUpdateDomain\": 0,\r\n  \"platformFaultDomain\": 0,\r\n
+        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
+        [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
+        \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
+        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2018-03-12T10:23:52+00:00\"\r\n
+        \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"rspec-lb-a\",\r\n
+        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
+        succeeded\",\r\n          \"time\": \"2016-09-03T14:04:26.7359609+00:00\"\r\n
+        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
+        \"https://miqazuretest16487.blob.core.windows.net/bootdiagnostics-rspeclba-23b0beab-16d2-4135-a01f-2fe713217fd0/rspec-lb-a.23b0beab-16d2-4135-a01f-2fe713217fd0.screenshot.bmp\",\r\n
+        \   \"serialConsoleLogBlobUri\": \"https://miqazuretest16487.blob.core.windows.net/bootdiagnostics-rspeclba-23b0beab-16d2-4135-a01f-2fe713217fd0/rspec-lb-a.23b0beab-16d2-4135-a01f-2fe713217fd0.serialconsole.log\"\r\n
+        \ },\r\n  \"extensions\": [\r\n    {\r\n      \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n
+        \   }\r\n  ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n
+        \     \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n
+        \     \"time\": \"2016-09-03T14:04:26.7828345+00:00\"\r\n    },\r\n    {\r\n
+        \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
+        \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 10:24:06 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b/instanceView?api-version=2017-12-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/GetInstanceView3Min;4797,Microsoft.Compute/GetInstanceView30Min;23766
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344652126238
+      X-Ms-Request-Id:
+      - 8384957c-39ce-4bfd-89b7-908e1e4e4173
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14987'
+      X-Ms-Correlation-Request-Id:
+      - 5b99cbee-dd3c-4960-82db-ead12b3beed5
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T102402Z:5b99cbee-dd3c-4960-82db-ead12b3beed5
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 10:24:02 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"platformUpdateDomain\": 1,\r\n  \"platformFaultDomain\": 1,\r\n
+        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
+        [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
+        \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
+        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2018-03-12T10:24:02+00:00\"\r\n
+        \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"rspec-lb-b\",\r\n
+        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
+        succeeded\",\r\n          \"time\": \"2016-09-03T14:07:52.9377685+00:00\"\r\n
+        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
+        \"https://amissteastorage.blob.core.windows.net/bootdiagnostics-rspeclbb-834a70b5-868d-4466-9dda-14e0f6b2caaf/rspec-lb-b.834a70b5-868d-4466-9dda-14e0f6b2caaf.screenshot.bmp\",\r\n
+        \   \"serialConsoleLogBlobUri\": \"https://amissteastorage.blob.core.windows.net/bootdiagnostics-rspeclbb-834a70b5-868d-4466-9dda-14e0f6b2caaf/rspec-lb-b.834a70b5-868d-4466-9dda-14e0f6b2caaf.serialconsole.log\"\r\n
+        \ },\r\n  \"extensions\": [\r\n    {\r\n      \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n
+        \   }\r\n  ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n
+        \     \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n
+        \     \"time\": \"2016-09-03T14:07:52.9846158+00:00\"\r\n    },\r\n    {\r\n
+        \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
+        \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 10:24:07 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups/miq-azure-test1?api-version=2017-08-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14989'
+      X-Ms-Request-Id:
+      - 51c3828a-5fbe-4bf0-a347-673b99015eae
+      X-Ms-Correlation-Request-Id:
+      - 51c3828a-5fbe-4bf0-a347-673b99015eae
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T102403Z:51c3828a-5fbe-4bf0-a347-673b99015eae
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 10:24:03 GMT
+      Content-Length:
+      - '183'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1","name":"miq-azure-test1","location":"eastus","properties":{"provisioningState":"Succeeded"}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 10:24:08 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute/locations/eastus/vmSizes?api-version=2017-12-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/LowCostGet3Min;4747,Microsoft.Compute/LowCostGet30Min;37751
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344652126238
+      X-Ms-Request-Id:
+      - 6a77df97-de6f-4a78-832e-130d9603ecaf
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14987'
+      X-Ms-Correlation-Request-Id:
+      - 2b411d50-d8f1-408e-b8ef-900ca80f7abe
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T102404Z:2b411d50-d8f1-408e-b8ef-900ca80f7abe
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 10:24:03 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"Standard_B1ms\",\r\n
@@ -3248,6 +3448,12 @@ http_interactions:
         \   },\r\n    {\r\n      \"name\": \"Standard_F72s_v2\",\r\n      \"numberOfCores\":
         72,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
         589824,\r\n      \"memoryInMB\": 147456,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_L8s_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1811981,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_L16s_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        3623962,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
         \   },\r\n    {\r\n      \"name\": \"Standard_ND6s\",\r\n      \"numberOfCores\":
         6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
         344064,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 12\r\n
@@ -3274,7 +3480,7 @@ http_interactions:
         391168,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
         \   }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:34 GMT
+  recorded_at: Mon, 12 Mar 2018 10:24:09 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802122903?api-version=2017-08-01
@@ -3291,7 +3497,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3ODksIm5iZiI6MTUyMDQ1Mzc4OSwiZXhwIjoxNTIwNDU3Njg5LCJhaW8iOiJZMk5nWUdBTzluZzJLY25wRWNmV20xS1NCOXJmQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibENhdzhSUlFzRUc1b3QzbmNIUUFBQSIsInZlciI6IjEuMCJ9.NjJPw1ksaOk2iyA699o9MPbQPQzcldpuJcvgMO2D851_sHs8aIbEejVf7P9Ea_F33pyoJTwYfa22s4vK3mI3-6WWOfdOmzwoMPVJAZ_uwYU9SM-idZOUKEQjQiMzI9Rhp9dk0xhs4tcwU_u6m4k2UUzfXtEnHQlC6sCQ_H1P4jZvfnygqQy5z-hxaJm33e71ogox7lnCxtQJ2S6kpVnflD-C-RW2X-g7A9yxmDe7yOG1MR3kZpilCs2HqqXzTzl0TOc91Xfdo9avET2GqN0t4WutUsVKEEbqAuSWUzsWzLQOz3EJ8OZG_PCiDpF4QAE5DtiZQyIgGIYwRWtBhE-tqQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
   response:
     status:
       code: 200
@@ -3308,26 +3514,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14965'
+      - '14988'
       X-Ms-Request-Id:
-      - bda76f49-3730-474c-8bd2-7f88826a59e6
+      - 51744d52-fbc7-42a8-960f-aa3a0fb68c79
       X-Ms-Correlation-Request-Id:
-      - bda76f49-3730-474c-8bd2-7f88826a59e6
+      - 51744d52-fbc7-42a8-960f-aa3a0fb68c79
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202134Z:bda76f49-3730-474c-8bd2-7f88826a59e6
+      - WESTEUROPE:20180312T102407Z:51744d52-fbc7-42a8-960f-aa3a0fb68c79
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:21:34 GMT
+      - Mon, 12 Mar 2018 10:24:07 GMT
       Content-Length:
       - '6500'
     body:
       encoding: ASCII-8BIT
       string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802122903","name":"RedHat.RedHatEnterpriseLinux67-20160802122903","properties":{"parameters":{"location":{"type":"String","value":"eastus"},"virtualMachineName":{"type":"String","value":"rspec-lb-a"},"virtualMachineSize":{"type":"String","value":"Standard_F1s"},"adminUsername":{"type":"String","value":"bronaghs"},"storageAccountName":{"type":"String","value":"rspeclb"},"virtualNetworkName":{"type":"String","value":"miq-azure-test1"},"networkInterfaceName":{"type":"String","value":"rspec-lb-a670"},"networkSecurityGroupName":{"type":"String","value":"rspec-lb-a-nsg"},"adminPassword":{"type":"SecureString"},"availabilitySetName":{"type":"String","value":"rspec-lb"},"availabilitySetPlatformFaultDomainCount":{"type":"String","value":"3"},"availabilitySetPlatformUpdateDomainCount":{"type":"String","value":"5"},"storageAccountType":{"type":"String","value":"Premium_LRS"},"diagnosticsStorageAccountName":{"type":"String","value":"miqazuretest16487"},"diagnosticsStorageAccountId":{"type":"String","value":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487"},"subnetName":{"type":"String","value":"default"},"publicIpAddressName":{"type":"String","value":"rspec-lb-a-ip"},"publicIpAddressType":{"type":"String","value":"Dynamic"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-09-02T16:34:50.7306487Z","duration":"PT5M42.9911979S","correlationId":"8ed1d69b-1d36-4441-9d80-b07a5982a384","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]},{"resourceType":"virtualMachines/extensions","locations":["eastus"]},{"resourceType":"availabilitySets","locations":["eastus"]}]},{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkInterfaces","locations":["eastus"]},{"resourceType":"publicIpAddresses","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"rspec-lb-a670"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/rspec-lb","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"rspec-lb"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"rspeclb"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"rspeclb","apiVersion":"2015-06-15"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest16487","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"rspec-lb-a"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"rspec-lb-a"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest16487","actionName":"listKeys","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"rspec-lb-a/Microsoft.Insights.VMDiagnosticsSettings"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/rspec-lb-a-ip","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"rspec-lb-a-ip"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"rspec-lb-a-nsg"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"rspec-lb-a670"}],"outputs":{"adminUsername":{"type":"String","value":"bronaghs"}},"outputResources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/rspec-lb"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a/extensions/Microsoft.Insights.VMDiagnosticsSettings"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/rspec-lb-a-ip"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb"}]}}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:35 GMT
+  recorded_at: Mon, 12 Mar 2018 10:24:12 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802123704?api-version=2017-08-01
@@ -3344,7 +3550,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3ODksIm5iZiI6MTUyMDQ1Mzc4OSwiZXhwIjoxNTIwNDU3Njg5LCJhaW8iOiJZMk5nWUdBTzluZzJLY25wRWNmV20xS1NCOXJmQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibENhdzhSUlFzRUc1b3QzbmNIUUFBQSIsInZlciI6IjEuMCJ9.NjJPw1ksaOk2iyA699o9MPbQPQzcldpuJcvgMO2D851_sHs8aIbEejVf7P9Ea_F33pyoJTwYfa22s4vK3mI3-6WWOfdOmzwoMPVJAZ_uwYU9SM-idZOUKEQjQiMzI9Rhp9dk0xhs4tcwU_u6m4k2UUzfXtEnHQlC6sCQ_H1P4jZvfnygqQy5z-hxaJm33e71ogox7lnCxtQJ2S6kpVnflD-C-RW2X-g7A9yxmDe7yOG1MR3kZpilCs2HqqXzTzl0TOc91Xfdo9avET2GqN0t4WutUsVKEEbqAuSWUzsWzLQOz3EJ8OZG_PCiDpF4QAE5DtiZQyIgGIYwRWtBhE-tqQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
   response:
     status:
       code: 200
@@ -3361,26 +3567,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14772'
+      - '14989'
       X-Ms-Request-Id:
-      - 157566e2-dc08-4038-9a26-6303cea53241
+      - 1412f9d7-9e65-498c-b839-a0c8d0cb932d
       X-Ms-Correlation-Request-Id:
-      - 157566e2-dc08-4038-9a26-6303cea53241
+      - 1412f9d7-9e65-498c-b839-a0c8d0cb932d
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202136Z:157566e2-dc08-4038-9a26-6303cea53241
+      - WESTEUROPE:20180312T102409Z:1412f9d7-9e65-498c-b839-a0c8d0cb932d
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:21:35 GMT
+      - Mon, 12 Mar 2018 10:24:08 GMT
       Content-Length:
       - '5370'
     body:
       encoding: ASCII-8BIT
       string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802123704","name":"RedHat.RedHatEnterpriseLinux67-20160802123704","properties":{"parameters":{"location":{"type":"String","value":"eastus"},"virtualMachineName":{"type":"String","value":"rspec-lb-b"},"virtualMachineSize":{"type":"String","value":"Standard_DS1_v2"},"adminUsername":{"type":"String","value":"bronaghs"},"storageAccountName":{"type":"String","value":"rspeclb"},"virtualNetworkName":{"type":"String","value":"miq-azure-test1"},"networkInterfaceName":{"type":"String","value":"rspec-lb-b843"},"networkSecurityGroupName":{"type":"String","value":"rspec-lb-b-nsg"},"adminPassword":{"type":"SecureString"},"availabilitySetName":{"type":"String","value":"rspec-lb"},"diagnosticsStorageAccountName":{"type":"String","value":"amissteastorage"},"diagnosticsStorageAccountId":{"type":"String","value":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/amisstea-rg/providers/Microsoft.Storage/storageAccounts/amissteastorage"},"subnetName":{"type":"String","value":"default"},"publicIpAddressName":{"type":"String","value":"rspec-lb-b-ip"},"publicIpAddressType":{"type":"String","value":"Dynamic"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-09-02T16:42:20.1492177Z","duration":"PT5M12.4641651S","correlationId":"55d1443a-bd21-4f39-9411-c1e4db80945f","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]},{"resourceType":"virtualMachines/extensions","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkInterfaces","locations":["eastus"]},{"resourceType":"publicIpAddresses","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"rspec-lb-b843"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"rspeclb","apiVersion":"2015-06-15"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/amisstea-rg/providers/Microsoft.Storage/storageAccounts/amissteastorage","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"amissteastorage","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"rspec-lb-b"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"rspec-lb-b"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/amisstea-rg/providers/Microsoft.Storage/storageAccounts/amissteastorage","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"amissteastorage","actionName":"listKeys","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"rspec-lb-b/Microsoft.Insights.VMDiagnosticsSettings"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/rspec-lb-b-ip","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"rspec-lb-b-ip"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"rspec-lb-b-nsg"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"rspec-lb-b843"}],"outputs":{"adminUsername":{"type":"String","value":"bronaghs"}},"outputResources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b/extensions/Microsoft.Insights.VMDiagnosticsSettings"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/rspec-lb-b-ip"}]}}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:36 GMT
+  recorded_at: Mon, 12 Mar 2018 10:24:13 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250?api-version=2017-08-01
@@ -3397,7 +3603,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3ODksIm5iZiI6MTUyMDQ1Mzc4OSwiZXhwIjoxNTIwNDU3Njg5LCJhaW8iOiJZMk5nWUdBTzluZzJLY25wRWNmV20xS1NCOXJmQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibENhdzhSUlFzRUc1b3QzbmNIUUFBQSIsInZlciI6IjEuMCJ9.NjJPw1ksaOk2iyA699o9MPbQPQzcldpuJcvgMO2D851_sHs8aIbEejVf7P9Ea_F33pyoJTwYfa22s4vK3mI3-6WWOfdOmzwoMPVJAZ_uwYU9SM-idZOUKEQjQiMzI9Rhp9dk0xhs4tcwU_u6m4k2UUzfXtEnHQlC6sCQ_H1P4jZvfnygqQy5z-hxaJm33e71ogox7lnCxtQJ2S6kpVnflD-C-RW2X-g7A9yxmDe7yOG1MR3kZpilCs2HqqXzTzl0TOc91Xfdo9avET2GqN0t4WutUsVKEEbqAuSWUzsWzLQOz3EJ8OZG_PCiDpF4QAE5DtiZQyIgGIYwRWtBhE-tqQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
   response:
     status:
       code: 200
@@ -3414,29 +3620,29 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14977'
+      - '14987'
       X-Ms-Request-Id:
-      - '08fbc0bc-bb59-4cee-85c9-9834fe48490f'
+      - 1abc0365-0083-4414-97fb-1cf54dae28ee
       X-Ms-Correlation-Request-Id:
-      - '08fbc0bc-bb59-4cee-85c9-9834fe48490f'
+      - 1abc0365-0083-4414-97fb-1cf54dae28ee
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202137Z:08fbc0bc-bb59-4cee-85c9-9834fe48490f
+      - WESTEUROPE:20180312T102409Z:1abc0365-0083-4414-97fb-1cf54dae28ee
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:21:37 GMT
+      - Mon, 12 Mar 2018 10:24:09 GMT
       Content-Length:
       - '6266'
     body:
       encoding: ASCII-8BIT
       string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250","name":"RedHat.RedHatEnterpriseLinux72-20160218112250","properties":{"parameters":{"location":{"type":"String","value":"eastus"},"virtualMachineName":{"type":"String","value":"miq-test-rhel1"},"virtualMachineSize":{"type":"String","value":"Basic_A0"},"adminUsername":{"type":"String","value":"dberger"},"storageAccountName":{"type":"String","value":"miqazuretest18686"},"virtualNetworkName":{"type":"String","value":"miq-azure-test1"},"networkInterfaceName":{"type":"String","value":"miq-test-rhel1390"},"networkSecurityGroupName":{"type":"String","value":"miq-test-rhel1"},"adminPassword":{"type":"SecureString"},"storageAccountType":{"type":"String","value":"Standard_LRS"},"diagnosticsStorageAccountName":{"type":"String","value":"miqazuretest18686"},"diagnosticsStorageAccountId":{"type":"String","value":"Microsoft.Storage/storageAccounts/miqazuretest18686"},"diagnosticsStorageAccountType":{"type":"String","value":"Standard_LRS"},"addressPrefix":{"type":"String","value":"10.16.0.0/16"},"subnetName":{"type":"String","value":"default"},"subnetPrefix":{"type":"String","value":"10.16.0.0/24"},"publicIpAddressName":{"type":"String","value":"miq-test-rhel1"},"publicIpAddressType":{"type":"String","value":"Dynamic"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-03-18T17:28:57.6212521Z","duration":"PT6M6.1062402S","correlationId":"3222315f-f31e-4ee7-b405-4d40dfd500a3","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]},{"resourceType":"virtualMachines/extensions","locations":["eastus"]}]},{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]},{"resourceType":"publicIpAddresses","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-rhel1390"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-rhel1"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-rhel1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686","actionName":"listKeys","apiVersion":"2015-05-01-preview"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-rhel1/Microsoft.Insights.VMDiagnosticsSettings"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"miq-azure-test1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-rhel1","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-rhel1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-rhel1"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-rhel1390"}],"outputs":{"adminUsername":{"type":"String","value":"dberger"}},"outputResources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/extensions/Microsoft.Insights.VMDiagnosticsSettings"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-rhel1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686"}]}}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:37 GMT
+  recorded_at: Mon, 12 Mar 2018 10:24:14 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802122903/operations?api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-a-ip?api-version=2018-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3450,327 +3656,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3ODksIm5iZiI6MTUyMDQ1Mzc4OSwiZXhwIjoxNTIwNDU3Njg5LCJhaW8iOiJZMk5nWUdBTzluZzJLY25wRWNmV20xS1NCOXJmQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibENhdzhSUlFzRUc1b3QzbmNIUUFBQSIsInZlciI6IjEuMCJ9.NjJPw1ksaOk2iyA699o9MPbQPQzcldpuJcvgMO2D851_sHs8aIbEejVf7P9Ea_F33pyoJTwYfa22s4vK3mI3-6WWOfdOmzwoMPVJAZ_uwYU9SM-idZOUKEQjQiMzI9Rhp9dk0xhs4tcwU_u6m4k2UUzfXtEnHQlC6sCQ_H1P4jZvfnygqQy5z-hxaJm33e71ogox7lnCxtQJ2S6kpVnflD-C-RW2X-g7A9yxmDe7yOG1MR3kZpilCs2HqqXzTzl0TOc91Xfdo9avET2GqN0t4WutUsVKEEbqAuSWUzsWzLQOz3EJ8OZG_PCiDpF4QAE5DtiZQyIgGIYwRWtBhE-tqQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14967'
-      X-Ms-Request-Id:
-      - 6c00d84a-d938-43ee-b27e-79a552370bcc
-      X-Ms-Correlation-Request-Id:
-      - 6c00d84a-d938-43ee-b27e-79a552370bcc
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202138Z:6c00d84a-d938-43ee-b27e-79a552370bcc
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:21:38 GMT
-      Content-Length:
-      - '8275'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802122903/operations/48A8B19CEC64C173","operationId":"48A8B19CEC64C173","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-09-02T16:34:50.179304Z","duration":"PT3M15.9148608S","trackingId":"6621f53a-bb4c-4914-8928-a21f0fad462b","serviceRequestId":"10450de5-018f-4832-b9b2-8dbeef4329e4","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"rspec-lb-a/Microsoft.Insights.VMDiagnosticsSettings"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802122903/operations/210AB817B36AD006","operationId":"210AB817B36AD006","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-09-02T16:31:34.1720715Z","duration":"PT1M55.3321384S","trackingId":"c1abc3b5-41b7-4e66-8b78-82756e43a4f5","serviceRequestId":"3bbe3405-472e-46cd-9d0f-6eef141ad715","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"rspec-lb-a"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802122903/operations/F77424ED32CB70F0","operationId":"F77424ED32CB70F0","properties":{"provisioningOperation":"Read","provisioningState":"Succeeded","timestamp":"2016-09-02T16:29:38.772059Z","duration":"PT0.4582883S","trackingId":"d9e7d64d-f57c-4675-aa66-2f0bee040167","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"rspeclb","apiVersion":"2015-06-15"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802122903/operations/986DE70BC89CDFE7","operationId":"986DE70BC89CDFE7","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-09-02T16:29:26.4636058Z","duration":"PT2.189989S","trackingId":"7b69bca1-4e85-4722-88c0-8ee10f245beb","serviceRequestId":"0321218c-4bdd-4485-96ac-09cf4208ff7f","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"rspec-lb-a670"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802122903/operations/5064B02C668F3E98","operationId":"5064B02C668F3E98","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-09-02T16:29:38.2436278Z","duration":"PT27.64535S","trackingId":"32f4ac11-eb11-4a16-bf6c-74813d560af3","serviceRequestId":"8ed1d69b-1d36-4441-9d80-b07a5982a384","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"rspeclb"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802122903/operations/0F06C77DFE66C888","operationId":"0F06C77DFE66C888","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-09-02T16:29:24.201372Z","duration":"PT13.6021499S","trackingId":"17881050-3c7a-451a-abe2-643dba3e0dd5","serviceRequestId":"5c72198e-795a-4f1b-9d3a-1facb1e55004","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"rspec-lb-a-nsg"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802122903/operations/580FB462E46F8B3E","operationId":"580FB462E46F8B3E","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-09-02T16:29:12.2815826Z","duration":"PT1.6624975S","trackingId":"305761d4-7e14-437a-be92-42648530b875","serviceRequestId":"298bb1ba-c61a-4c3a-af00-ada3fd033cf8","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/rspec-lb","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"rspec-lb"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802122903/operations/F0FB3DED90543099","operationId":"F0FB3DED90543099","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-09-02T16:29:23.1864805Z","duration":"PT12.5622692S","trackingId":"4761ff79-3ced-4623-9187-f5c54cfb081c","serviceRequestId":"2dbe5cef-91aa-4ffb-b1d7-77baf7a9fd91","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/rspec-lb-a-ip","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"rspec-lb-a-ip"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802122903/operations/FD71B215BA4C3896","operationId":"FD71B215BA4C3896","properties":{"provisioningOperation":"Action","provisioningState":"Succeeded","timestamp":"2016-09-02T16:29:11.1330107Z","duration":"PT0.4963293S","trackingId":"b81ff5ed-ed16-4ec7-9757-aa6555ff9b44","serviceRequestId":"8ed1d69b-1d36-4441-9d80-b07a5982a384","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest16487","actionName":"listKeys","apiVersion":"2015-06-15"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802122903/operations/8FAE05273E5E7FD9","operationId":"8FAE05273E5E7FD9","properties":{"provisioningOperation":"Read","provisioningState":"Succeeded","timestamp":"2016-09-02T16:29:11.0799469Z","duration":"PT0.450359S","trackingId":"8c5a2516-fcee-4fa8-b335-41d9f3e0181a","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest16487","apiVersion":"2015-06-15"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802122903/operations/08587287731377382400","operationId":"08587287731377382400","properties":{"provisioningOperation":"EvaluateDeploymentOutput","provisioningState":"Succeeded","timestamp":"2016-09-02T16:34:50.6327712Z","duration":"PT0.3207448S","trackingId":"f365a963-c99a-4c95-8df0-384b7769036b","statusCode":"OK","statusMessage":null}}]}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:38 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802123704/operations?api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3ODksIm5iZiI6MTUyMDQ1Mzc4OSwiZXhwIjoxNTIwNDU3Njg5LCJhaW8iOiJZMk5nWUdBTzluZzJLY25wRWNmV20xS1NCOXJmQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibENhdzhSUlFzRUc1b3QzbmNIUUFBQSIsInZlciI6IjEuMCJ9.NjJPw1ksaOk2iyA699o9MPbQPQzcldpuJcvgMO2D851_sHs8aIbEejVf7P9Ea_F33pyoJTwYfa22s4vK3mI3-6WWOfdOmzwoMPVJAZ_uwYU9SM-idZOUKEQjQiMzI9Rhp9dk0xhs4tcwU_u6m4k2UUzfXtEnHQlC6sCQ_H1P4jZvfnygqQy5z-hxaJm33e71ogox7lnCxtQJ2S6kpVnflD-C-RW2X-g7A9yxmDe7yOG1MR3kZpilCs2HqqXzTzl0TOc91Xfdo9avET2GqN0t4WutUsVKEEbqAuSWUzsWzLQOz3EJ8OZG_PCiDpF4QAE5DtiZQyIgGIYwRWtBhE-tqQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14981'
-      X-Ms-Request-Id:
-      - ee660e8c-c8c4-42e6-b3a7-fa8c904b0427
-      X-Ms-Correlation-Request-Id:
-      - ee660e8c-c8c4-42e6-b3a7-fa8c904b0427
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202139Z:ee660e8c-c8c4-42e6-b3a7-fa8c904b0427
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:21:39 GMT
-      Content-Length:
-      - '6749'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802123704/operations/5980E17A3BB3BA88","operationId":"5980E17A3BB3BA88","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-09-02T16:42:19.6441784Z","duration":"PT3M12.6404681S","trackingId":"96993dcd-e9d1-4488-a583-59d2334c03fa","serviceRequestId":"7f754871-8266-4557-a0fc-d60818f78dfb","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"rspec-lb-b/Microsoft.Insights.VMDiagnosticsSettings"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802123704/operations/9B8161B7EC4A5300","operationId":"9B8161B7EC4A5300","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-09-02T16:39:06.894563Z","duration":"PT1M39.9156702S","trackingId":"17e6b4dd-7dee-4f5a-b9b5-ac21c8e6d6e3","serviceRequestId":"10e38ed0-57ce-4265-8a23-5974bc05ee4a","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"rspec-lb-b"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802123704/operations/255C04C9CEE1C896","operationId":"255C04C9CEE1C896","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-09-02T16:37:26.8548295Z","duration":"PT2.3465059S","trackingId":"0d766573-a411-44d7-8fe1-bf748a546593","serviceRequestId":"df2239b5-e982-4ecc-9a76-3d6a9e8030e1","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"rspec-lb-b843"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802123704/operations/B0AC30BF03BF196C","operationId":"B0AC30BF03BF196C","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-09-02T16:37:23.8097625Z","duration":"PT14.5526774S","trackingId":"0413ed6a-bd76-44d4-a2e0-2d7b61cbe02e","serviceRequestId":"1cd0dbe9-b117-4bd2-aa09-dc1388bae3dd","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/rspec-lb-b-ip","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"rspec-lb-b-ip"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802123704/operations/8FA4CFC0E28A6EEA","operationId":"8FA4CFC0E28A6EEA","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-09-02T16:37:24.4007807Z","duration":"PT15.1804313S","trackingId":"16bd7484-0747-49fd-a680-d50cec97d25a","serviceRequestId":"7d4ef02c-bb92-49bd-9b7f-f71d84eeac21","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"rspec-lb-b-nsg"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802123704/operations/125929E0A29D3A03","operationId":"125929E0A29D3A03","properties":{"provisioningOperation":"Action","provisioningState":"Succeeded","timestamp":"2016-09-02T16:37:10.3958766Z","duration":"PT1.2143901S","trackingId":"c97eb614-9b2b-441a-b29b-810a0267d622","serviceRequestId":"55d1443a-bd21-4f39-9411-c1e4db80945f","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/amisstea-rg/providers/Microsoft.Storage/storageAccounts/amissteastorage","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"amissteastorage","actionName":"listKeys","apiVersion":"2015-06-15"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802123704/operations/9227F7F6B387D66B","operationId":"9227F7F6B387D66B","properties":{"provisioningOperation":"Read","provisioningState":"Succeeded","timestamp":"2016-09-02T16:37:10.274491Z","duration":"PT1.0632594S","trackingId":"80cf31f4-af3e-4a5d-9ca2-836c0f0309b1","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/amisstea-rg/providers/Microsoft.Storage/storageAccounts/amissteastorage","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"amissteastorage","apiVersion":"2015-06-15"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802123704/operations/F77424ED32CB70F0","operationId":"F77424ED32CB70F0","properties":{"provisioningOperation":"Read","provisioningState":"Succeeded","timestamp":"2016-09-02T16:37:10.2732507Z","duration":"PT1.0178922S","trackingId":"5111053f-19ff-488a-b43d-ed10b7b8e2e7","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"rspeclb","apiVersion":"2015-06-15"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802123704/operations/08587287726577926452","operationId":"08587287726577926452","properties":{"provisioningOperation":"EvaluateDeploymentOutput","provisioningState":"Succeeded","timestamp":"2016-09-02T16:42:20.0050132Z","duration":"PT0.2565693S","trackingId":"8aa39138-1910-493d-84c4-cf15df5b5802","statusCode":"OK","statusMessage":null}}]}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:39 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations?api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3ODksIm5iZiI6MTUyMDQ1Mzc4OSwiZXhwIjoxNTIwNDU3Njg5LCJhaW8iOiJZMk5nWUdBTzluZzJLY25wRWNmV20xS1NCOXJmQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibENhdzhSUlFzRUc1b3QzbmNIUUFBQSIsInZlciI6IjEuMCJ9.NjJPw1ksaOk2iyA699o9MPbQPQzcldpuJcvgMO2D851_sHs8aIbEejVf7P9Ea_F33pyoJTwYfa22s4vK3mI3-6WWOfdOmzwoMPVJAZ_uwYU9SM-idZOUKEQjQiMzI9Rhp9dk0xhs4tcwU_u6m4k2UUzfXtEnHQlC6sCQ_H1P4jZvfnygqQy5z-hxaJm33e71ogox7lnCxtQJ2S6kpVnflD-C-RW2X-g7A9yxmDe7yOG1MR3kZpilCs2HqqXzTzl0TOc91Xfdo9avET2GqN0t4WutUsVKEEbqAuSWUzsWzLQOz3EJ8OZG_PCiDpF4QAE5DtiZQyIgGIYwRWtBhE-tqQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14970'
-      X-Ms-Request-Id:
-      - 3817fde1-2177-4169-8727-3ccff712a881
-      X-Ms-Correlation-Request-Id:
-      - 3817fde1-2177-4169-8727-3ccff712a881
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202140Z:3817fde1-2177-4169-8727-3ccff712a881
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:21:40 GMT
-      Content-Length:
-      - '7624'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/B42FCDF4A2A39FE2","operationId":"B42FCDF4A2A39FE2","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:28:56.9829484Z","duration":"PT3M1.9672591S","trackingId":"14feeb1c-b462-4bdc-98e0-07e3c051bc4a","serviceRequestId":"929da49c-b732-4413-8fe7-6a94ebf1b7df","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-rhel1/Microsoft.Insights.VMDiagnosticsSettings"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/90897F1FE623927D","operationId":"90897F1FE623927D","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:25:54.9100087Z","duration":"PT2M28.9316677S","trackingId":"677bf860-1814-46bf-81b8-2f40e478702f","serviceRequestId":"0d568f4d-db1a-414b-82af-8a476f4ee398","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-rhel1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/465DEB7D7737AAEB","operationId":"465DEB7D7737AAEB","properties":{"provisioningOperation":"Read","provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:25.8536981Z","duration":"PT2.5042804S","trackingId":"39bb6568-d7b8-42e4-97ed-3b32cb629561","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686","apiVersion":"2015-06-15"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/2972B36A0CF48AB3","operationId":"2972B36A0CF48AB3","properties":{"provisioningOperation":"Action","provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:23.6072605Z","duration":"PT0.2582045S","trackingId":"c5a9e298-ec4e-439b-ba11-f531388139de","serviceRequestId":"3222315f-f31e-4ee7-b405-4d40dfd500a3","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686","actionName":"listKeys","apiVersion":"2015-05-01-preview"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/E74E878C29CB66B6","operationId":"E74E878C29CB66B6","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:10.196193Z","duration":"PT1.6122458S","trackingId":"2341df4a-20e3-4fb4-b417-2f2263e009d3","serviceRequestId":"ad2b548c-e848-42f3-8834-a07996ead051","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-rhel1390"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/159B68AE177CBFD9","operationId":"159B68AE177CBFD9","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:23.2936909Z","duration":"PT30.2333245S","trackingId":"3d2daef3-03af-4017-9b52-2202b98e54c0","serviceRequestId":"3222315f-f31e-4ee7-b405-4d40dfd500a3","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/601C5CBE140F5FC4","operationId":"601C5CBE140F5FC4","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:08.4807196Z","duration":"PT15.4177267S","trackingId":"5280cb26-eed9-43e1-aff7-2c60ba0a4e32","serviceRequestId":"18d0a142-7dcb-4e5d-86ea-b8cd95ab1ff4","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-rhel1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/DDFCB6138638C2AE","operationId":"DDFCB6138638C2AE","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:06.4145604Z","duration":"PT13.2922738S","trackingId":"18bf2d19-1ef3-4026-b6c2-650bcd5a6da9","serviceRequestId":"8f6af50d-004e-4653-b263-3e2a8e85ebeb","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-rhel1","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-rhel1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/6E56D08B1E39DCCA","operationId":"6E56D08B1E39DCCA","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:05.836911Z","duration":"PT12.771463S","trackingId":"33412052-f3be-4e84-bd79-0a00abef61f4","serviceRequestId":"2252541d-7285-41d8-87d1-3a0a1d1b330a","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"miq-azure-test1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/08587432851139626716","operationId":"08587432851139626716","properties":{"provisioningOperation":"EvaluateDeploymentOutput","provisioningState":"Succeeded","timestamp":"2016-03-18T17:28:57.5892101Z","duration":"PT0.2087634S","trackingId":"85e2cf8a-3929-4515-8a51-97dbc778352e","statusCode":"OK","statusMessage":null}}]}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:41 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802122903?api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3ODksIm5iZiI6MTUyMDQ1Mzc4OSwiZXhwIjoxNTIwNDU3Njg5LCJhaW8iOiJZMk5nWUdBTzluZzJLY25wRWNmV20xS1NCOXJmQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibENhdzhSUlFzRUc1b3QzbmNIUUFBQSIsInZlciI6IjEuMCJ9.NjJPw1ksaOk2iyA699o9MPbQPQzcldpuJcvgMO2D851_sHs8aIbEejVf7P9Ea_F33pyoJTwYfa22s4vK3mI3-6WWOfdOmzwoMPVJAZ_uwYU9SM-idZOUKEQjQiMzI9Rhp9dk0xhs4tcwU_u6m4k2UUzfXtEnHQlC6sCQ_H1P4jZvfnygqQy5z-hxaJm33e71ogox7lnCxtQJ2S6kpVnflD-C-RW2X-g7A9yxmDe7yOG1MR3kZpilCs2HqqXzTzl0TOc91Xfdo9avET2GqN0t4WutUsVKEEbqAuSWUzsWzLQOz3EJ8OZG_PCiDpF4QAE5DtiZQyIgGIYwRWtBhE-tqQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14967'
-      X-Ms-Request-Id:
-      - 3407192a-4e28-448d-acf4-4b799834a618
-      X-Ms-Correlation-Request-Id:
-      - 3407192a-4e28-448d-acf4-4b799834a618
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202141Z:3407192a-4e28-448d-acf4-4b799834a618
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:21:41 GMT
-      Content-Length:
-      - '6500'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802122903","name":"RedHat.RedHatEnterpriseLinux67-20160802122903","properties":{"parameters":{"location":{"type":"String","value":"eastus"},"virtualMachineName":{"type":"String","value":"rspec-lb-a"},"virtualMachineSize":{"type":"String","value":"Standard_F1s"},"adminUsername":{"type":"String","value":"bronaghs"},"storageAccountName":{"type":"String","value":"rspeclb"},"virtualNetworkName":{"type":"String","value":"miq-azure-test1"},"networkInterfaceName":{"type":"String","value":"rspec-lb-a670"},"networkSecurityGroupName":{"type":"String","value":"rspec-lb-a-nsg"},"adminPassword":{"type":"SecureString"},"availabilitySetName":{"type":"String","value":"rspec-lb"},"availabilitySetPlatformFaultDomainCount":{"type":"String","value":"3"},"availabilitySetPlatformUpdateDomainCount":{"type":"String","value":"5"},"storageAccountType":{"type":"String","value":"Premium_LRS"},"diagnosticsStorageAccountName":{"type":"String","value":"miqazuretest16487"},"diagnosticsStorageAccountId":{"type":"String","value":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487"},"subnetName":{"type":"String","value":"default"},"publicIpAddressName":{"type":"String","value":"rspec-lb-a-ip"},"publicIpAddressType":{"type":"String","value":"Dynamic"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-09-02T16:34:50.7306487Z","duration":"PT5M42.9911979S","correlationId":"8ed1d69b-1d36-4441-9d80-b07a5982a384","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]},{"resourceType":"virtualMachines/extensions","locations":["eastus"]},{"resourceType":"availabilitySets","locations":["eastus"]}]},{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkInterfaces","locations":["eastus"]},{"resourceType":"publicIpAddresses","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"rspec-lb-a670"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/rspec-lb","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"rspec-lb"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"rspeclb"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"rspeclb","apiVersion":"2015-06-15"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest16487","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"rspec-lb-a"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"rspec-lb-a"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest16487","actionName":"listKeys","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"rspec-lb-a/Microsoft.Insights.VMDiagnosticsSettings"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/rspec-lb-a-ip","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"rspec-lb-a-ip"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"rspec-lb-a-nsg"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"rspec-lb-a670"}],"outputs":{"adminUsername":{"type":"String","value":"bronaghs"}},"outputResources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/rspec-lb"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a/extensions/Microsoft.Insights.VMDiagnosticsSettings"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/rspec-lb-a-ip"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb"}]}}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:41 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802123704?api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3ODksIm5iZiI6MTUyMDQ1Mzc4OSwiZXhwIjoxNTIwNDU3Njg5LCJhaW8iOiJZMk5nWUdBTzluZzJLY25wRWNmV20xS1NCOXJmQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibENhdzhSUlFzRUc1b3QzbmNIUUFBQSIsInZlciI6IjEuMCJ9.NjJPw1ksaOk2iyA699o9MPbQPQzcldpuJcvgMO2D851_sHs8aIbEejVf7P9Ea_F33pyoJTwYfa22s4vK3mI3-6WWOfdOmzwoMPVJAZ_uwYU9SM-idZOUKEQjQiMzI9Rhp9dk0xhs4tcwU_u6m4k2UUzfXtEnHQlC6sCQ_H1P4jZvfnygqQy5z-hxaJm33e71ogox7lnCxtQJ2S6kpVnflD-C-RW2X-g7A9yxmDe7yOG1MR3kZpilCs2HqqXzTzl0TOc91Xfdo9avET2GqN0t4WutUsVKEEbqAuSWUzsWzLQOz3EJ8OZG_PCiDpF4QAE5DtiZQyIgGIYwRWtBhE-tqQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14976'
-      X-Ms-Request-Id:
-      - fe56f5bb-bdd2-488f-800f-3b5a46d85579
-      X-Ms-Correlation-Request-Id:
-      - fe56f5bb-bdd2-488f-800f-3b5a46d85579
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202142Z:fe56f5bb-bdd2-488f-800f-3b5a46d85579
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:21:41 GMT
-      Content-Length:
-      - '5370'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802123704","name":"RedHat.RedHatEnterpriseLinux67-20160802123704","properties":{"parameters":{"location":{"type":"String","value":"eastus"},"virtualMachineName":{"type":"String","value":"rspec-lb-b"},"virtualMachineSize":{"type":"String","value":"Standard_DS1_v2"},"adminUsername":{"type":"String","value":"bronaghs"},"storageAccountName":{"type":"String","value":"rspeclb"},"virtualNetworkName":{"type":"String","value":"miq-azure-test1"},"networkInterfaceName":{"type":"String","value":"rspec-lb-b843"},"networkSecurityGroupName":{"type":"String","value":"rspec-lb-b-nsg"},"adminPassword":{"type":"SecureString"},"availabilitySetName":{"type":"String","value":"rspec-lb"},"diagnosticsStorageAccountName":{"type":"String","value":"amissteastorage"},"diagnosticsStorageAccountId":{"type":"String","value":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/amisstea-rg/providers/Microsoft.Storage/storageAccounts/amissteastorage"},"subnetName":{"type":"String","value":"default"},"publicIpAddressName":{"type":"String","value":"rspec-lb-b-ip"},"publicIpAddressType":{"type":"String","value":"Dynamic"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-09-02T16:42:20.1492177Z","duration":"PT5M12.4641651S","correlationId":"55d1443a-bd21-4f39-9411-c1e4db80945f","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]},{"resourceType":"virtualMachines/extensions","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkInterfaces","locations":["eastus"]},{"resourceType":"publicIpAddresses","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"rspec-lb-b843"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"rspeclb","apiVersion":"2015-06-15"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/amisstea-rg/providers/Microsoft.Storage/storageAccounts/amissteastorage","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"amissteastorage","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"rspec-lb-b"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"rspec-lb-b"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/amisstea-rg/providers/Microsoft.Storage/storageAccounts/amissteastorage","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"amissteastorage","actionName":"listKeys","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"rspec-lb-b/Microsoft.Insights.VMDiagnosticsSettings"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/rspec-lb-b-ip","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"rspec-lb-b-ip"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"rspec-lb-b-nsg"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"rspec-lb-b843"}],"outputs":{"adminUsername":{"type":"String","value":"bronaghs"}},"outputResources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b/extensions/Microsoft.Insights.VMDiagnosticsSettings"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/rspec-lb-b-ip"}]}}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:42 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250?api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3ODksIm5iZiI6MTUyMDQ1Mzc4OSwiZXhwIjoxNTIwNDU3Njg5LCJhaW8iOiJZMk5nWUdBTzluZzJLY25wRWNmV20xS1NCOXJmQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibENhdzhSUlFzRUc1b3QzbmNIUUFBQSIsInZlciI6IjEuMCJ9.NjJPw1ksaOk2iyA699o9MPbQPQzcldpuJcvgMO2D851_sHs8aIbEejVf7P9Ea_F33pyoJTwYfa22s4vK3mI3-6WWOfdOmzwoMPVJAZ_uwYU9SM-idZOUKEQjQiMzI9Rhp9dk0xhs4tcwU_u6m4k2UUzfXtEnHQlC6sCQ_H1P4jZvfnygqQy5z-hxaJm33e71ogox7lnCxtQJ2S6kpVnflD-C-RW2X-g7A9yxmDe7yOG1MR3kZpilCs2HqqXzTzl0TOc91Xfdo9avET2GqN0t4WutUsVKEEbqAuSWUzsWzLQOz3EJ8OZG_PCiDpF4QAE5DtiZQyIgGIYwRWtBhE-tqQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14966'
-      X-Ms-Request-Id:
-      - 86a2db93-e507-45ae-a8ae-020c9a1f6333
-      X-Ms-Correlation-Request-Id:
-      - 86a2db93-e507-45ae-a8ae-020c9a1f6333
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202142Z:86a2db93-e507-45ae-a8ae-020c9a1f6333
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:21:42 GMT
-      Content-Length:
-      - '6266'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250","name":"RedHat.RedHatEnterpriseLinux72-20160218112250","properties":{"parameters":{"location":{"type":"String","value":"eastus"},"virtualMachineName":{"type":"String","value":"miq-test-rhel1"},"virtualMachineSize":{"type":"String","value":"Basic_A0"},"adminUsername":{"type":"String","value":"dberger"},"storageAccountName":{"type":"String","value":"miqazuretest18686"},"virtualNetworkName":{"type":"String","value":"miq-azure-test1"},"networkInterfaceName":{"type":"String","value":"miq-test-rhel1390"},"networkSecurityGroupName":{"type":"String","value":"miq-test-rhel1"},"adminPassword":{"type":"SecureString"},"storageAccountType":{"type":"String","value":"Standard_LRS"},"diagnosticsStorageAccountName":{"type":"String","value":"miqazuretest18686"},"diagnosticsStorageAccountId":{"type":"String","value":"Microsoft.Storage/storageAccounts/miqazuretest18686"},"diagnosticsStorageAccountType":{"type":"String","value":"Standard_LRS"},"addressPrefix":{"type":"String","value":"10.16.0.0/16"},"subnetName":{"type":"String","value":"default"},"subnetPrefix":{"type":"String","value":"10.16.0.0/24"},"publicIpAddressName":{"type":"String","value":"miq-test-rhel1"},"publicIpAddressType":{"type":"String","value":"Dynamic"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-03-18T17:28:57.6212521Z","duration":"PT6M6.1062402S","correlationId":"3222315f-f31e-4ee7-b405-4d40dfd500a3","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]},{"resourceType":"virtualMachines/extensions","locations":["eastus"]}]},{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]},{"resourceType":"publicIpAddresses","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-rhel1390"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-rhel1"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-rhel1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686","actionName":"listKeys","apiVersion":"2015-05-01-preview"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-rhel1/Microsoft.Insights.VMDiagnosticsSettings"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"miq-azure-test1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-rhel1","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-rhel1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-rhel1"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-rhel1390"}],"outputs":{"adminUsername":{"type":"String","value":"dberger"}},"outputResources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/extensions/Microsoft.Insights.VMDiagnosticsSettings"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-rhel1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686"}]}}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:42 GMT
-- request:
-    method: post
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802122903/exportTemplate?api-version=2017-08-01
-    body:
-      encoding: ASCII-8BIT
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3ODksIm5iZiI6MTUyMDQ1Mzc4OSwiZXhwIjoxNTIwNDU3Njg5LCJhaW8iOiJZMk5nWUdBTzluZzJLY25wRWNmV20xS1NCOXJmQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibENhdzhSUlFzRUc1b3QzbmNIUUFBQSIsInZlciI6IjEuMCJ9.NjJPw1ksaOk2iyA699o9MPbQPQzcldpuJcvgMO2D851_sHs8aIbEejVf7P9Ea_F33pyoJTwYfa22s4vK3mI3-6WWOfdOmzwoMPVJAZ_uwYU9SM-idZOUKEQjQiMzI9Rhp9dk0xhs4tcwU_u6m4k2UUzfXtEnHQlC6sCQ_H1P4jZvfnygqQy5z-hxaJm33e71ogox7lnCxtQJ2S6kpVnflD-C-RW2X-g7A9yxmDe7yOG1MR3kZpilCs2HqqXzTzl0TOc91Xfdo9avET2GqN0t4WutUsVKEEbqAuSWUzsWzLQOz3EJ8OZG_PCiDpF4QAE5DtiZQyIgGIYwRWtBhE-tqQ
-      Content-Length:
-      - '0'
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
   response:
     status:
       code: 200
@@ -3786,526 +3672,42 @@ http_interactions:
       - application/json; charset=utf-8
       Expires:
       - "-1"
+      Etag:
+      - W/"3ba30997-7d2f-470c-96f6-301158e93b7c"
       Vary:
       - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1196'
       X-Ms-Request-Id:
-      - abef7674-98db-4091-b662-da0f2aef2ad5
-      X-Ms-Correlation-Request-Id:
-      - abef7674-98db-4091-b662-da0f2aef2ad5
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202143Z:abef7674-98db-4091-b662-da0f2aef2ad5
+      - f63e193f-8c88-4ace-8186-8327a924c576
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:21:42 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"template":{"$schema":"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#","contentVersion":"1.0.0.0","parameters":{"location":{"type":"String"},"virtualMachineName":{"type":"String"},"virtualMachineSize":{"type":"String"},"adminUsername":{"type":"String"},"storageAccountName":{"type":"String"},"virtualNetworkName":{"type":"String"},"networkInterfaceName":{"type":"String"},"networkSecurityGroupName":{"type":"String"},"adminPassword":{"type":"SecureString"},"availabilitySetName":{"type":"String"},"availabilitySetPlatformFaultDomainCount":{"type":"String"},"availabilitySetPlatformUpdateDomainCount":{"type":"String"},"storageAccountType":{"type":"String"},"diagnosticsStorageAccountName":{"type":"String"},"diagnosticsStorageAccountId":{"type":"String"},"subnetName":{"type":"String"},"publicIpAddressName":{"type":"String"},"publicIpAddressType":{"type":"String"}},"variables":{"vnetId":"[resourceId(''miq-azure-test1'',''Microsoft.Network/virtualNetworks'',
-        parameters(''virtualNetworkName''))]","subnetRef":"[concat(variables(''vnetId''),
-        ''/subnets/'', parameters(''subnetName''))]","metricsresourceid":"[concat(''/subscriptions/'',
-        subscription().subscriptionId, ''/resourceGroups/'', resourceGroup().name,
-        ''/providers/'', ''Microsoft.Compute/virtualMachines/'', parameters(''virtualMachineName''))]","metricsclosing":"[concat(''<Metrics
-        resourceId=\"'', variables(''metricsresourceid''), ''\"><MetricAggregation
-        scheduledTransferPeriod=\"PT1H\"/><MetricAggregation scheduledTransferPeriod=\"PT1M\"/></Metrics></DiagnosticMonitorConfiguration></WadCfg>'')]","metricscounters":"<PerformanceCounters
-        scheduledTransferPeriod=\"PT1M\"><PerformanceCounterConfiguration counterSpecifier=\"\\Memory\\AvailableMemory\"
-        sampleRate=\"PT15S\" unit=\"Bytes\"><annotation displayName=\"Memory available\"
-        locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PercentAvailableMemory\" sampleRate=\"PT15S\"
-        unit=\"Percent\"><annotation displayName=\"Mem. percent available\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\UsedMemory\" sampleRate=\"PT15S\" unit=\"Bytes\"><annotation
-        displayName=\"Memory used\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PercentUsedMemory\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"Memory percentage\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PercentUsedByCache\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"Mem. used by cache\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PagesPerSec\" sampleRate=\"PT15S\" unit=\"CountPerSecond\"><annotation
-        displayName=\"Pages\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PagesReadPerSec\" sampleRate=\"PT15S\" unit=\"CountPerSecond\"><annotation
-        displayName=\"Page reads\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PagesWrittenPerSec\" sampleRate=\"PT15S\" unit=\"CountPerSecond\"><annotation
-        displayName=\"Page writes\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\AvailableSwap\" sampleRate=\"PT15S\" unit=\"Bytes\"><annotation
-        displayName=\"Swap available\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PercentAvailableSwap\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"Swap percent available\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\UsedSwap\" sampleRate=\"PT15S\" unit=\"Bytes\"><annotation
-        displayName=\"Swap used\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PercentUsedSwap\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"Swap percent used\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentIdleTime\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"CPU idle time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentUserTime\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"CPU user time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentNiceTime\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"CPU nice time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentPrivilegedTime\" sampleRate=\"PT15S\"
-        unit=\"Percent\"><annotation displayName=\"CPU privileged time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentInterruptTime\" sampleRate=\"PT15S\"
-        unit=\"Percent\"><annotation displayName=\"CPU interrupt time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentDPCTime\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"CPU DPC time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentProcessorTime\" sampleRate=\"PT15S\"
-        unit=\"Percent\"><annotation displayName=\"CPU percentage guest OS\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentIOWaitTime\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"CPU IO wait time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\BytesPerSecond\" sampleRate=\"PT15S\" unit=\"BytesPerSecond\"><annotation
-        displayName=\"Disk total bytes\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\ReadBytesPerSecond\" sampleRate=\"PT15S\"
-        unit=\"BytesPerSecond\"><annotation displayName=\"Disk read guest OS\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\WriteBytesPerSecond\" sampleRate=\"PT15S\"
-        unit=\"BytesPerSecond\"><annotation displayName=\"Disk write guest OS\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\TransfersPerSecond\" sampleRate=\"PT15S\"
-        unit=\"CountPerSecond\"><annotation displayName=\"Disk transfers\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\ReadsPerSecond\" sampleRate=\"PT15S\" unit=\"CountPerSecond\"><annotation
-        displayName=\"Disk reads\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\WritesPerSecond\" sampleRate=\"PT15S\"
-        unit=\"CountPerSecond\"><annotation displayName=\"Disk writes\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\AverageReadTime\" sampleRate=\"PT15S\"
-        unit=\"Seconds\"><annotation displayName=\"Disk read time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\AverageWriteTime\" sampleRate=\"PT15S\"
-        unit=\"Seconds\"><annotation displayName=\"Disk write time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\AverageTransferTime\" sampleRate=\"PT15S\"
-        unit=\"Seconds\"><annotation displayName=\"Disk transfer time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\AverageDiskQueueLength\" sampleRate=\"PT15S\"
-        unit=\"Count\"><annotation displayName=\"Disk queue length\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\BytesTransmitted\" sampleRate=\"PT15S\"
-        unit=\"Bytes\"><annotation displayName=\"Network out guest OS\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\BytesReceived\" sampleRate=\"PT15S\"
-        unit=\"Bytes\"><annotation displayName=\"Network in guest OS\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\PacketsTransmitted\" sampleRate=\"PT15S\"
-        unit=\"Count\"><annotation displayName=\"Packets sent\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\PacketsReceived\" sampleRate=\"PT15S\"
-        unit=\"Count\"><annotation displayName=\"Packets received\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\BytesTotal\" sampleRate=\"PT15S\" unit=\"Bytes\"><annotation
-        displayName=\"Network total bytes\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\TotalRxErrors\" sampleRate=\"PT15S\"
-        unit=\"Count\"><annotation displayName=\"Packets received errors\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\TotalTxErrors\" sampleRate=\"PT15S\"
-        unit=\"Count\"><annotation displayName=\"Packets sent errors\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\TotalCollisions\" sampleRate=\"PT15S\"
-        unit=\"Count\"><annotation displayName=\"Network collisions\" locale=\"en-us\"/></PerformanceCounterConfiguration></PerformanceCounters>","metricsstart":"<WadCfg><DiagnosticMonitorConfiguration
-        overallQuotaInMB=\"4096\"><DiagnosticInfrastructureLogs scheduledTransferPeriod=\"PT1M\"
-        scheduledTransferLogLevelFilter=\"Warning\"/>","wadcfgx":"[concat(variables(''metricsstart''),
-        variables(''metricscounters''), variables(''metricsclosing''))]"},"resources":[{"type":"Microsoft.Compute/virtualMachines","name":"[parameters(''virtualMachineName'')]","apiVersion":"2015-06-15","location":"[parameters(''location'')]","properties":{"osProfile":{"computerName":"[parameters(''virtualMachineName'')]","adminUsername":"[parameters(''adminUsername'')]","adminPassword":"[parameters(''adminPassword'')]"},"hardwareProfile":{"vmSize":"[parameters(''virtualMachineSize'')]"},"storageProfile":{"imageReference":{"publisher":"RedHat","offer":"RHEL","sku":"6.7","version":"latest"},"osDisk":{"name":"[parameters(''virtualMachineName'')]","vhd":{"uri":"[concat(concat(reference(resourceId(''miq-azure-test1'',
-        ''Microsoft.Storage/storageAccounts'', parameters(''storageAccountName'')),
-        ''2015-06-15'').primaryEndpoints[''blob''], ''vhds/''), parameters(''virtualMachineName''),
-        ''201682122839.vhd'')]"},"createOption":"fromImage"},"dataDisks":[]},"networkProfile":{"networkInterfaces":[{"id":"[resourceId(''Microsoft.Network/networkInterfaces'',
-        parameters(''networkInterfaceName''))]"}]},"diagnosticsProfile":{"bootDiagnostics":{"enabled":true,"storageUri":"[reference(resourceId(''miq-azure-test1'',
-        ''Microsoft.Storage/storageAccounts'', parameters(''diagnosticsStorageAccountName'')),
-        ''2015-06-15'').primaryEndpoints[''blob'']]"}},"availabilitySet":{"id":"[resourceId(''Microsoft.Compute/availabilitySets'',
-        parameters(''availabilitySetName''))]"}},"dependsOn":["[concat(''Microsoft.Network/networkInterfaces/'',
-        parameters(''networkInterfaceName''))]","[concat(''Microsoft.Compute/availabilitySets/'',
-        parameters(''availabilitySetName''))]","[concat(''Microsoft.Storage/storageAccounts/'',
-        parameters(''storageAccountName''))]"]},{"type":"Microsoft.Compute/virtualMachines/extensions","name":"[concat(parameters(''virtualMachineName''),''/Microsoft.Insights.VMDiagnosticsSettings'')]","apiVersion":"2015-06-15","location":"[parameters(''location'')]","properties":{"publisher":"Microsoft.OSTCExtensions","type":"LinuxDiagnostic","typeHandlerVersion":"2.3","autoUpgradeMinorVersion":true,"settings":{"xmlCfg":"[base64(variables(''wadcfgx''))]","StorageAccount":"[parameters(''diagnosticsStorageAccountName'')]"},"protectedSettings":{"storageAccountName":"[parameters(''diagnosticsStorageAccountName'')]","storageAccountKey":"[listKeys(parameters(''diagnosticsStorageAccountId''),''2015-06-15'').key1]","storageAccountEndPoint":"https://core.windows.net/"}},"dependsOn":["[concat(''Microsoft.Compute/virtualMachines/'',
-        parameters(''virtualMachineName''))]"]},{"type":"Microsoft.Compute/availabilitySets","name":"[parameters(''availabilitySetName'')]","apiVersion":"2015-06-15","location":"[parameters(''location'')]","properties":{"platformFaultDomainCount":"[parameters(''availabilitySetPlatformFaultDomainCount'')]","platformUpdateDomainCount":"[parameters(''availabilitySetPlatformUpdateDomainCount'')]"}},{"type":"Microsoft.Storage/storageAccounts","name":"[parameters(''storageAccountName'')]","apiVersion":"2015-06-15","location":"[parameters(''location'')]","properties":{"accountType":"[parameters(''storageAccountType'')]"}},{"type":"Microsoft.Network/networkInterfaces","name":"[parameters(''networkInterfaceName'')]","apiVersion":"2015-06-15","location":"[parameters(''location'')]","properties":{"primary":true,"ipConfigurations":[{"name":"ipconfig1","properties":{"subnet":{"id":"[variables(''subnetRef'')]"},"privateIPAllocationMethod":"Dynamic","publicIpAddress":{"id":"[resourceId(''miq-azure-test1'',''Microsoft.Network/publicIpAddresses'',
-        parameters(''publicIpAddressName''))]"}}}],"networkSecurityGroup":{"id":"[resourceId(''miq-azure-test1'',
-        ''Microsoft.Network/networkSecurityGroups'', parameters(''networkSecurityGroupName''))]"}},"dependsOn":["[concat(''Microsoft.Network/publicIpAddresses/'',
-        parameters(''publicIpAddressName''))]","[concat(''Microsoft.Network/networkSecurityGroups/'',
-        parameters(''networkSecurityGroupName''))]"]},{"type":"Microsoft.Network/publicIpAddresses","name":"[parameters(''publicIpAddressName'')]","apiVersion":"2015-06-15","location":"[parameters(''location'')]","properties":{"publicIpAllocationMethod":"[parameters(''publicIpAddressType'')]"}},{"type":"Microsoft.Network/networkSecurityGroups","name":"[parameters(''networkSecurityGroupName'')]","apiVersion":"2015-06-15","location":"[parameters(''location'')]","properties":{"securityRules":[{"name":"default-allow-ssh","properties":{"priority":1000,"sourceAddressPrefix":"*","protocol":"TCP","destinationPortRange":"22","access":"Allow","direction":"Inbound","sourcePortRange":"*","destinationAddressPrefix":"*"}}]}}],"outputs":{"adminUsername":{"type":"String","value":"[parameters(''adminUsername'')]"}}}}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:43 GMT
-- request:
-    method: post
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802123704/exportTemplate?api-version=2017-08-01
-    body:
-      encoding: ASCII-8BIT
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3ODksIm5iZiI6MTUyMDQ1Mzc4OSwiZXhwIjoxNTIwNDU3Njg5LCJhaW8iOiJZMk5nWUdBTzluZzJLY25wRWNmV20xS1NCOXJmQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibENhdzhSUlFzRUc1b3QzbmNIUUFBQSIsInZlciI6IjEuMCJ9.NjJPw1ksaOk2iyA699o9MPbQPQzcldpuJcvgMO2D851_sHs8aIbEejVf7P9Ea_F33pyoJTwYfa22s4vK3mI3-6WWOfdOmzwoMPVJAZ_uwYU9SM-idZOUKEQjQiMzI9Rhp9dk0xhs4tcwU_u6m4k2UUzfXtEnHQlC6sCQ_H1P4jZvfnygqQy5z-hxaJm33e71ogox7lnCxtQJ2S6kpVnflD-C-RW2X-g7A9yxmDe7yOG1MR3kZpilCs2HqqXzTzl0TOc91Xfdo9avET2GqN0t4WutUsVKEEbqAuSWUzsWzLQOz3EJ8OZG_PCiDpF4QAE5DtiZQyIgGIYwRWtBhE-tqQ
-      Content-Length:
-      - '0'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1198'
-      X-Ms-Request-Id:
-      - 22231393-8575-407c-b21b-21211f17e3e2
-      X-Ms-Correlation-Request-Id:
-      - 22231393-8575-407c-b21b-21211f17e3e2
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202143Z:22231393-8575-407c-b21b-21211f17e3e2
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:21:43 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"template":{"$schema":"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#","contentVersion":"1.0.0.0","parameters":{"location":{"type":"String"},"virtualMachineName":{"type":"String"},"virtualMachineSize":{"type":"String"},"adminUsername":{"type":"String"},"storageAccountName":{"type":"String"},"virtualNetworkName":{"type":"String"},"networkInterfaceName":{"type":"String"},"networkSecurityGroupName":{"type":"String"},"adminPassword":{"type":"SecureString"},"availabilitySetName":{"type":"String"},"diagnosticsStorageAccountName":{"type":"String"},"diagnosticsStorageAccountId":{"type":"String"},"subnetName":{"type":"String"},"publicIpAddressName":{"type":"String"},"publicIpAddressType":{"type":"String"}},"variables":{"vnetId":"[resourceId(''miq-azure-test1'',''Microsoft.Network/virtualNetworks'',
-        parameters(''virtualNetworkName''))]","subnetRef":"[concat(variables(''vnetId''),
-        ''/subnets/'', parameters(''subnetName''))]","metricsresourceid":"[concat(''/subscriptions/'',
-        subscription().subscriptionId, ''/resourceGroups/'', resourceGroup().name,
-        ''/providers/'', ''Microsoft.Compute/virtualMachines/'', parameters(''virtualMachineName''))]","metricsclosing":"[concat(''<Metrics
-        resourceId=\"'', variables(''metricsresourceid''), ''\"><MetricAggregation
-        scheduledTransferPeriod=\"PT1H\"/><MetricAggregation scheduledTransferPeriod=\"PT1M\"/></Metrics></DiagnosticMonitorConfiguration></WadCfg>'')]","metricscounters":"<PerformanceCounters
-        scheduledTransferPeriod=\"PT1M\"><PerformanceCounterConfiguration counterSpecifier=\"\\Memory\\AvailableMemory\"
-        sampleRate=\"PT15S\" unit=\"Bytes\"><annotation displayName=\"Memory available\"
-        locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PercentAvailableMemory\" sampleRate=\"PT15S\"
-        unit=\"Percent\"><annotation displayName=\"Mem. percent available\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\UsedMemory\" sampleRate=\"PT15S\" unit=\"Bytes\"><annotation
-        displayName=\"Memory used\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PercentUsedMemory\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"Memory percentage\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PercentUsedByCache\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"Mem. used by cache\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PagesPerSec\" sampleRate=\"PT15S\" unit=\"CountPerSecond\"><annotation
-        displayName=\"Pages\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PagesReadPerSec\" sampleRate=\"PT15S\" unit=\"CountPerSecond\"><annotation
-        displayName=\"Page reads\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PagesWrittenPerSec\" sampleRate=\"PT15S\" unit=\"CountPerSecond\"><annotation
-        displayName=\"Page writes\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\AvailableSwap\" sampleRate=\"PT15S\" unit=\"Bytes\"><annotation
-        displayName=\"Swap available\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PercentAvailableSwap\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"Swap percent available\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\UsedSwap\" sampleRate=\"PT15S\" unit=\"Bytes\"><annotation
-        displayName=\"Swap used\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PercentUsedSwap\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"Swap percent used\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentIdleTime\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"CPU idle time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentUserTime\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"CPU user time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentNiceTime\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"CPU nice time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentPrivilegedTime\" sampleRate=\"PT15S\"
-        unit=\"Percent\"><annotation displayName=\"CPU privileged time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentInterruptTime\" sampleRate=\"PT15S\"
-        unit=\"Percent\"><annotation displayName=\"CPU interrupt time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentDPCTime\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"CPU DPC time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentProcessorTime\" sampleRate=\"PT15S\"
-        unit=\"Percent\"><annotation displayName=\"CPU percentage guest OS\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentIOWaitTime\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"CPU IO wait time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\BytesPerSecond\" sampleRate=\"PT15S\" unit=\"BytesPerSecond\"><annotation
-        displayName=\"Disk total bytes\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\ReadBytesPerSecond\" sampleRate=\"PT15S\"
-        unit=\"BytesPerSecond\"><annotation displayName=\"Disk read guest OS\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\WriteBytesPerSecond\" sampleRate=\"PT15S\"
-        unit=\"BytesPerSecond\"><annotation displayName=\"Disk write guest OS\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\TransfersPerSecond\" sampleRate=\"PT15S\"
-        unit=\"CountPerSecond\"><annotation displayName=\"Disk transfers\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\ReadsPerSecond\" sampleRate=\"PT15S\" unit=\"CountPerSecond\"><annotation
-        displayName=\"Disk reads\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\WritesPerSecond\" sampleRate=\"PT15S\"
-        unit=\"CountPerSecond\"><annotation displayName=\"Disk writes\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\AverageReadTime\" sampleRate=\"PT15S\"
-        unit=\"Seconds\"><annotation displayName=\"Disk read time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\AverageWriteTime\" sampleRate=\"PT15S\"
-        unit=\"Seconds\"><annotation displayName=\"Disk write time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\AverageTransferTime\" sampleRate=\"PT15S\"
-        unit=\"Seconds\"><annotation displayName=\"Disk transfer time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\AverageDiskQueueLength\" sampleRate=\"PT15S\"
-        unit=\"Count\"><annotation displayName=\"Disk queue length\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\BytesTransmitted\" sampleRate=\"PT15S\"
-        unit=\"Bytes\"><annotation displayName=\"Network out guest OS\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\BytesReceived\" sampleRate=\"PT15S\"
-        unit=\"Bytes\"><annotation displayName=\"Network in guest OS\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\PacketsTransmitted\" sampleRate=\"PT15S\"
-        unit=\"Count\"><annotation displayName=\"Packets sent\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\PacketsReceived\" sampleRate=\"PT15S\"
-        unit=\"Count\"><annotation displayName=\"Packets received\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\BytesTotal\" sampleRate=\"PT15S\" unit=\"Bytes\"><annotation
-        displayName=\"Network total bytes\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\TotalRxErrors\" sampleRate=\"PT15S\"
-        unit=\"Count\"><annotation displayName=\"Packets received errors\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\TotalTxErrors\" sampleRate=\"PT15S\"
-        unit=\"Count\"><annotation displayName=\"Packets sent errors\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\TotalCollisions\" sampleRate=\"PT15S\"
-        unit=\"Count\"><annotation displayName=\"Network collisions\" locale=\"en-us\"/></PerformanceCounterConfiguration></PerformanceCounters>","metricsstart":"<WadCfg><DiagnosticMonitorConfiguration
-        overallQuotaInMB=\"4096\"><DiagnosticInfrastructureLogs scheduledTransferPeriod=\"PT1M\"
-        scheduledTransferLogLevelFilter=\"Warning\"/>","wadcfgx":"[concat(variables(''metricsstart''),
-        variables(''metricscounters''), variables(''metricsclosing''))]"},"resources":[{"type":"Microsoft.Compute/virtualMachines","name":"[parameters(''virtualMachineName'')]","apiVersion":"2015-06-15","location":"[parameters(''location'')]","properties":{"osProfile":{"computerName":"[parameters(''virtualMachineName'')]","adminUsername":"[parameters(''adminUsername'')]","adminPassword":"[parameters(''adminPassword'')]"},"hardwareProfile":{"vmSize":"[parameters(''virtualMachineSize'')]"},"storageProfile":{"imageReference":{"publisher":"RedHat","offer":"RHEL","sku":"6.7","version":"latest"},"osDisk":{"name":"[parameters(''virtualMachineName'')]","vhd":{"uri":"[concat(concat(reference(resourceId(''miq-azure-test1'',
-        ''Microsoft.Storage/storageAccounts'', parameters(''storageAccountName'')),
-        ''2015-06-15'').primaryEndpoints[''blob''], ''vhds/''), parameters(''virtualMachineName''),
-        ''201682123650.vhd'')]"},"createOption":"fromImage"},"dataDisks":[]},"networkProfile":{"networkInterfaces":[{"id":"[resourceId(''Microsoft.Network/networkInterfaces'',
-        parameters(''networkInterfaceName''))]"}]},"diagnosticsProfile":{"bootDiagnostics":{"enabled":true,"storageUri":"[reference(resourceId(''amisstea-rg'',
-        ''Microsoft.Storage/storageAccounts'', parameters(''diagnosticsStorageAccountName'')),
-        ''2015-06-15'').primaryEndpoints[''blob'']]"}},"availabilitySet":{"id":"[resourceId(''Microsoft.Compute/availabilitySets'',
-        parameters(''availabilitySetName''))]"}},"dependsOn":["[concat(''Microsoft.Network/networkInterfaces/'',
-        parameters(''networkInterfaceName''))]"]},{"type":"Microsoft.Compute/virtualMachines/extensions","name":"[concat(parameters(''virtualMachineName''),''/Microsoft.Insights.VMDiagnosticsSettings'')]","apiVersion":"2015-06-15","location":"[parameters(''location'')]","properties":{"publisher":"Microsoft.OSTCExtensions","type":"LinuxDiagnostic","typeHandlerVersion":"2.3","autoUpgradeMinorVersion":true,"settings":{"xmlCfg":"[base64(variables(''wadcfgx''))]","StorageAccount":"[parameters(''diagnosticsStorageAccountName'')]"},"protectedSettings":{"storageAccountName":"[parameters(''diagnosticsStorageAccountName'')]","storageAccountKey":"[listKeys(parameters(''diagnosticsStorageAccountId''),''2015-06-15'').key1]","storageAccountEndPoint":"https://core.windows.net/"}},"dependsOn":["[concat(''Microsoft.Compute/virtualMachines/'',
-        parameters(''virtualMachineName''))]"]},{"type":"Microsoft.Network/networkInterfaces","name":"[parameters(''networkInterfaceName'')]","apiVersion":"2015-06-15","location":"[parameters(''location'')]","properties":{"primary":true,"ipConfigurations":[{"name":"ipconfig1","properties":{"subnet":{"id":"[variables(''subnetRef'')]"},"privateIPAllocationMethod":"Dynamic","publicIpAddress":{"id":"[resourceId(''miq-azure-test1'',''Microsoft.Network/publicIpAddresses'',
-        parameters(''publicIpAddressName''))]"}}}],"networkSecurityGroup":{"id":"[resourceId(''miq-azure-test1'',
-        ''Microsoft.Network/networkSecurityGroups'', parameters(''networkSecurityGroupName''))]"}},"dependsOn":["[concat(''Microsoft.Network/publicIpAddresses/'',
-        parameters(''publicIpAddressName''))]","[concat(''Microsoft.Network/networkSecurityGroups/'',
-        parameters(''networkSecurityGroupName''))]"]},{"type":"Microsoft.Network/publicIpAddresses","name":"[parameters(''publicIpAddressName'')]","apiVersion":"2015-06-15","location":"[parameters(''location'')]","properties":{"publicIpAllocationMethod":"[parameters(''publicIpAddressType'')]"}},{"type":"Microsoft.Network/networkSecurityGroups","name":"[parameters(''networkSecurityGroupName'')]","apiVersion":"2015-06-15","location":"[parameters(''location'')]","properties":{"securityRules":[{"name":"default-allow-ssh","properties":{"priority":1000,"sourceAddressPrefix":"*","protocol":"TCP","destinationPortRange":"22","access":"Allow","direction":"Inbound","sourcePortRange":"*","destinationAddressPrefix":"*"}}]}}],"outputs":{"adminUsername":{"type":"String","value":"[parameters(''adminUsername'')]"}}}}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:43 GMT
-- request:
-    method: post
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/exportTemplate?api-version=2017-08-01
-    body:
-      encoding: ASCII-8BIT
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3ODksIm5iZiI6MTUyMDQ1Mzc4OSwiZXhwIjoxNTIwNDU3Njg5LCJhaW8iOiJZMk5nWUdBTzluZzJLY25wRWNmV20xS1NCOXJmQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibENhdzhSUlFzRUc1b3QzbmNIUUFBQSIsInZlciI6IjEuMCJ9.NjJPw1ksaOk2iyA699o9MPbQPQzcldpuJcvgMO2D851_sHs8aIbEejVf7P9Ea_F33pyoJTwYfa22s4vK3mI3-6WWOfdOmzwoMPVJAZ_uwYU9SM-idZOUKEQjQiMzI9Rhp9dk0xhs4tcwU_u6m4k2UUzfXtEnHQlC6sCQ_H1P4jZvfnygqQy5z-hxaJm33e71ogox7lnCxtQJ2S6kpVnflD-C-RW2X-g7A9yxmDe7yOG1MR3kZpilCs2HqqXzTzl0TOc91Xfdo9avET2GqN0t4WutUsVKEEbqAuSWUzsWzLQOz3EJ8OZG_PCiDpF4QAE5DtiZQyIgGIYwRWtBhE-tqQ
-      Content-Length:
-      - '0'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1195'
-      X-Ms-Request-Id:
-      - b946feaa-54c0-4c41-be0a-5f699e345b7e
-      X-Ms-Correlation-Request-Id:
-      - b946feaa-54c0-4c41-be0a-5f699e345b7e
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202144Z:b946feaa-54c0-4c41-be0a-5f699e345b7e
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:21:44 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"template":{"$schema":"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#","contentVersion":"1.0.0.0","parameters":{"location":{"type":"String"},"virtualMachineName":{"type":"String"},"virtualMachineSize":{"type":"String"},"adminUsername":{"type":"String"},"storageAccountName":{"type":"String"},"virtualNetworkName":{"type":"String"},"networkInterfaceName":{"type":"String"},"networkSecurityGroupName":{"type":"String"},"adminPassword":{"type":"SecureString"},"storageAccountType":{"type":"String"},"diagnosticsStorageAccountName":{"type":"String"},"diagnosticsStorageAccountId":{"type":"String"},"diagnosticsStorageAccountType":{"type":"String"},"addressPrefix":{"type":"String"},"subnetName":{"type":"String"},"subnetPrefix":{"type":"String"},"publicIpAddressName":{"type":"String"},"publicIpAddressType":{"type":"String"}},"variables":{"vnetId":"[resourceId(''miq-azure-test1'',''Microsoft.Network/virtualNetworks'',
-        parameters(''virtualNetworkName''))]","subnetRef":"[concat(variables(''vnetId''),
-        ''/subnets/'', parameters(''subnetName''))]","metricsresourceid":"[concat(''/subscriptions/'',
-        subscription().subscriptionId, ''/resourceGroups/'', resourceGroup().name,
-        ''/providers/'', ''Microsoft.Compute/virtualMachines/'', parameters(''virtualMachineName''))]","metricsclosing":"[concat(''<Metrics
-        resourceId=\"'', variables(''metricsresourceid''), ''\"><MetricAggregation
-        scheduledTransferPeriod=\"PT1H\"/><MetricAggregation scheduledTransferPeriod=\"PT1M\"/></Metrics></DiagnosticMonitorConfiguration></WadCfg>'')]","metricscounters":"<PerformanceCounters
-        scheduledTransferPeriod=\"PT1M\"><PerformanceCounterConfiguration counterSpecifier=\"\\Memory\\AvailableMemory\"
-        sampleRate=\"PT15S\" unit=\"Bytes\"><annotation displayName=\"Memory available\"
-        locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PercentAvailableMemory\" sampleRate=\"PT15S\"
-        unit=\"Percent\"><annotation displayName=\"Mem. percent available\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\UsedMemory\" sampleRate=\"PT15S\" unit=\"Bytes\"><annotation
-        displayName=\"Memory used\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PercentUsedMemory\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"Memory percentage\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PercentUsedByCache\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"Mem. used by cache\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PagesPerSec\" sampleRate=\"PT15S\" unit=\"CountPerSecond\"><annotation
-        displayName=\"Pages\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PagesReadPerSec\" sampleRate=\"PT15S\" unit=\"CountPerSecond\"><annotation
-        displayName=\"Page reads\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PagesWrittenPerSec\" sampleRate=\"PT15S\" unit=\"CountPerSecond\"><annotation
-        displayName=\"Page writes\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\AvailableSwap\" sampleRate=\"PT15S\" unit=\"Bytes\"><annotation
-        displayName=\"Swap available\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PercentAvailableSwap\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"Swap percent available\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\UsedSwap\" sampleRate=\"PT15S\" unit=\"Bytes\"><annotation
-        displayName=\"Swap used\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PercentUsedSwap\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"Swap percent used\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentIdleTime\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"CPU idle time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentUserTime\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"CPU user time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentNiceTime\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"CPU nice time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentPrivilegedTime\" sampleRate=\"PT15S\"
-        unit=\"Percent\"><annotation displayName=\"CPU privileged time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentInterruptTime\" sampleRate=\"PT15S\"
-        unit=\"Percent\"><annotation displayName=\"CPU interrupt time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentDPCTime\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"CPU DPC time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentProcessorTime\" sampleRate=\"PT15S\"
-        unit=\"Percent\"><annotation displayName=\"CPU percentage guest OS\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentIOWaitTime\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"CPU IO wait time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\BytesPerSecond\" sampleRate=\"PT15S\" unit=\"BytesPerSecond\"><annotation
-        displayName=\"Disk total bytes\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\ReadBytesPerSecond\" sampleRate=\"PT15S\"
-        unit=\"BytesPerSecond\"><annotation displayName=\"Disk read guest OS\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\WriteBytesPerSecond\" sampleRate=\"PT15S\"
-        unit=\"BytesPerSecond\"><annotation displayName=\"Disk write guest OS\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\TransfersPerSecond\" sampleRate=\"PT15S\"
-        unit=\"CountPerSecond\"><annotation displayName=\"Disk transfers\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\ReadsPerSecond\" sampleRate=\"PT15S\" unit=\"CountPerSecond\"><annotation
-        displayName=\"Disk reads\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\WritesPerSecond\" sampleRate=\"PT15S\"
-        unit=\"CountPerSecond\"><annotation displayName=\"Disk writes\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\AverageReadTime\" sampleRate=\"PT15S\"
-        unit=\"Seconds\"><annotation displayName=\"Disk read time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\AverageWriteTime\" sampleRate=\"PT15S\"
-        unit=\"Seconds\"><annotation displayName=\"Disk write time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\AverageTransferTime\" sampleRate=\"PT15S\"
-        unit=\"Seconds\"><annotation displayName=\"Disk transfer time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\AverageDiskQueueLength\" sampleRate=\"PT15S\"
-        unit=\"Count\"><annotation displayName=\"Disk queue length\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\BytesTransmitted\" sampleRate=\"PT15S\"
-        unit=\"Bytes\"><annotation displayName=\"Network out guest OS\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\BytesReceived\" sampleRate=\"PT15S\"
-        unit=\"Bytes\"><annotation displayName=\"Network in guest OS\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\PacketsTransmitted\" sampleRate=\"PT15S\"
-        unit=\"Count\"><annotation displayName=\"Packets sent\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\PacketsReceived\" sampleRate=\"PT15S\"
-        unit=\"Count\"><annotation displayName=\"Packets received\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\BytesTotal\" sampleRate=\"PT15S\" unit=\"Bytes\"><annotation
-        displayName=\"Network total bytes\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\TotalRxErrors\" sampleRate=\"PT15S\"
-        unit=\"Count\"><annotation displayName=\"Packets received errors\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\TotalTxErrors\" sampleRate=\"PT15S\"
-        unit=\"Count\"><annotation displayName=\"Packets sent errors\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\TotalCollisions\" sampleRate=\"PT15S\"
-        unit=\"Count\"><annotation displayName=\"Network collisions\" locale=\"en-us\"/></PerformanceCounterConfiguration></PerformanceCounters>","metricsstart":"<WadCfg><DiagnosticMonitorConfiguration
-        overallQuotaInMB=\"4096\"><DiagnosticInfrastructureLogs scheduledTransferPeriod=\"PT1M\"
-        scheduledTransferLogLevelFilter=\"Warning\"/>","wadcfgx":"[concat(variables(''metricsstart''),
-        variables(''metricscounters''), variables(''metricsclosing''))]"},"resources":[{"type":"Microsoft.Compute/virtualMachines","name":"[parameters(''virtualMachineName'')]","apiVersion":"2015-06-15","location":"[parameters(''location'')]","properties":{"osProfile":{"computerName":"[parameters(''virtualMachineName'')]","adminUsername":"[parameters(''adminUsername'')]","adminPassword":"[parameters(''adminPassword'')]"},"hardwareProfile":{"vmSize":"[parameters(''virtualMachineSize'')]"},"storageProfile":{"imageReference":{"publisher":"RedHat","offer":"RHEL","sku":"7.2","version":"latest"},"osDisk":{"name":"[parameters(''virtualMachineName'')]","vhd":{"uri":"[concat(concat(reference(resourceId(''miq-azure-test1'',
-        ''Microsoft.Storage/storageAccounts'', parameters(''storageAccountName'')),
-        ''2015-06-15'').primaryEndpoints[''blob''], ''vhds/''), parameters(''virtualMachineName''),
-        ''2016218112243.vhd'')]"},"createOption":"fromImage"},"dataDisks":[]},"networkProfile":{"networkInterfaces":[{"id":"[resourceId(''Microsoft.Network/networkInterfaces'',
-        parameters(''networkInterfaceName''))]"}]},"diagnosticsProfile":{"bootDiagnostics":{"enabled":true,"storageUri":"[reference(resourceId(''miq-azure-test1'',
-        ''Microsoft.Storage/storageAccounts'', parameters(''diagnosticsStorageAccountName'')),
-        ''2015-06-15'').primaryEndpoints[''blob'']]"}}},"resources":[{"type":"extensions","name":"Microsoft.Insights.VMDiagnosticsSettings","apiVersion":"2015-05-01-preview","location":"[parameters(''location'')]","properties":{"publisher":"Microsoft.OSTCExtensions","type":"LinuxDiagnostic","typeHandlerVersion":"2.0","autoUpgradeMinorVersion":true,"settings":{"xmlCfg":"[base64(variables(''wadcfgx''))]","StorageAccount":"[parameters(''diagnosticsStorageAccountName'')]"},"protectedSettings":{"storageAccountName":"[parameters(''diagnosticsStorageAccountName'')]","storageAccountKey":"[listKeys(parameters(''diagnosticsStorageAccountId''),''2015-05-01-preview'').key1]","storageAccountEndPoint":"https://core.windows.net/"}},"dependsOn":["[concat(''Microsoft.Compute/virtualMachines/'',
-        parameters(''virtualMachineName''))]"]}],"dependsOn":["[concat(''Microsoft.Network/networkInterfaces/'',
-        parameters(''networkInterfaceName''))]","[concat(''Microsoft.Storage/storageAccounts/'',
-        parameters(''storageAccountName''))]"]},{"type":"Microsoft.Storage/storageAccounts","name":"[parameters(''storageAccountName'')]","apiVersion":"2015-05-01-preview","location":"[parameters(''location'')]","properties":{"accountType":"[parameters(''storageAccountType'')]"}},{"type":"Microsoft.Network/virtualNetworks","name":"[parameters(''virtualNetworkName'')]","apiVersion":"2015-05-01-preview","location":"[parameters(''location'')]","properties":{"addressSpace":{"addressPrefixes":["[parameters(''addressPrefix'')]"]},"subnets":[{"name":"[parameters(''subnetName'')]","properties":{"addressPrefix":"[parameters(''subnetPrefix'')]"}}]}},{"type":"Microsoft.Network/networkInterfaces","name":"[parameters(''networkInterfaceName'')]","apiVersion":"2015-05-01-preview","location":"[parameters(''location'')]","properties":{"ipConfigurations":[{"name":"ipconfig1","properties":{"subnet":{"id":"[variables(''subnetRef'')]"},"privateIPAllocationMethod":"Dynamic","publicIpAddress":{"id":"[resourceId(''miq-azure-test1'',''Microsoft.Network/publicIpAddresses'',
-        parameters(''publicIpAddressName''))]"}}}],"networkSecurityGroup":{"id":"[resourceId(''miq-azure-test1'',
-        ''Microsoft.Network/networkSecurityGroups'', parameters(''networkSecurityGroupName''))]"}},"dependsOn":["[concat(''Microsoft.Network/virtualNetworks/'',
-        parameters(''virtualNetworkName''))]","[concat(''Microsoft.Network/publicIpAddresses/'',
-        parameters(''publicIpAddressName''))]","[concat(''Microsoft.Network/networkSecurityGroups/'',
-        parameters(''networkSecurityGroupName''))]"]},{"type":"Microsoft.Network/publicIpAddresses","name":"[parameters(''publicIpAddressName'')]","apiVersion":"2015-05-01-preview","location":"[parameters(''location'')]","properties":{"publicIpAllocationMethod":"[parameters(''publicIpAddressType'')]"}},{"type":"Microsoft.Network/networkSecurityGroups","name":"[parameters(''networkSecurityGroupName'')]","apiVersion":"2015-05-01-preview","location":"[parameters(''location'')]","properties":{"securityRules":[{"name":"default-allow-ssh","properties":{"priority":1000,"sourceAddressPrefix":"*","protocol":"Tcp","destinationPortRange":"22","access":"Allow","direction":"inbound","sourcePortRange":"*","destinationAddressPrefix":"*"}}]}}],"outputs":{"adminUsername":{"type":"String","value":"[parameters(''adminUsername'')]"}}}}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:44 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a?api-version=2017-12-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3ODksIm5iZiI6MTUyMDQ1Mzc4OSwiZXhwIjoxNTIwNDU3Njg5LCJhaW8iOiJZMk5nWUdBTzluZzJLY25wRWNmV20xS1NCOXJmQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibENhdzhSUlFzRUc1b3QzbmNIUUFBQSIsInZlciI6IjEuMCJ9.NjJPw1ksaOk2iyA699o9MPbQPQzcldpuJcvgMO2D851_sHs8aIbEejVf7P9Ea_F33pyoJTwYfa22s4vK3mI3-6WWOfdOmzwoMPVJAZ_uwYU9SM-idZOUKEQjQiMzI9Rhp9dk0xhs4tcwU_u6m4k2UUzfXtEnHQlC6sCQ_H1P4jZvfnygqQy5z-hxaJm33e71ogox7lnCxtQJ2S6kpVnflD-C-RW2X-g7A9yxmDe7yOG1MR3kZpilCs2HqqXzTzl0TOc91Xfdo9avET2GqN0t4WutUsVKEEbqAuSWUzsWzLQOz3EJ8OZG_PCiDpF4QAE5DtiZQyIgGIYwRWtBhE-tqQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/LowCostGet3Min;4697,Microsoft.Compute/LowCostGet30Min;37838
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
-      X-Ms-Request-Id:
-      - 4cea3b3e-50b2-42b8-885f-99ddffb862f0
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14869'
+      - '14987'
       X-Ms-Correlation-Request-Id:
-      - 24c357a7-2ef5-4427-890a-c36c27e76e03
+      - 6c3356d4-097e-485f-8cec-53def85b2b72
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202144Z:24c357a7-2ef5-4427-890a-c36c27e76e03
+      - WESTEUROPE:20180312T102410Z:6c3356d4-097e-485f-8cec-53def85b2b72
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:21:44 GMT
+      - Mon, 12 Mar 2018 10:24:09 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"23b0beab-16d2-4135-a01f-2fe713217fd0\",\r\n
-        \   \"availabilitySet\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/RSPEC-LB\"\r\n
-        \   },\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_F1s\"\r\n
-        \   },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
-        \"RedHat\",\r\n        \"offer\": \"RHEL\",\r\n        \"sku\": \"6.7\",\r\n
-        \       \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
-        \"Linux\",\r\n        \"name\": \"rspec-lb-a\",\r\n        \"createOption\":
-        \"FromImage\",\r\n        \"vhd\": {\r\n          \"uri\": \"https://rspeclb.blob.core.windows.net/vhds/rspec-lb-a201682122839.vhd\"\r\n
-        \       },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n      \"dataDisks\":
-        []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"rspec-lb-a\",\r\n
-        \     \"adminUsername\": \"bronaghs\",\r\n      \"linuxConfiguration\": {\r\n
-        \       \"disablePasswordAuthentication\": false\r\n      },\r\n      \"secrets\":
-        []\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670\"}]},\r\n
-        \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
-        true,\r\n        \"storageUri\": \"https://miqazuretest16487.blob.core.windows.net/\"\r\n
-        \     }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n
-        \ \"resources\": [\r\n    {\r\n      \"properties\": {\r\n        \"publisher\":
-        \"Microsoft.OSTCExtensions\",\r\n        \"type\": \"LinuxDiagnostic\",\r\n
-        \       \"typeHandlerVersion\": \"2.3\",\r\n        \"autoUpgradeMinorVersion\":
-        true,\r\n        \"settings\": {\"xmlCfg\":\"PFdhZENmZz48RGlhZ25vc3RpY01vbml0b3JDb25maWd1cmF0aW9uIG92ZXJhbGxRdW90YUluTUI9IjQwOTYiPjxEaWFnbm9zdGljSW5mcmFzdHJ1Y3R1cmVMb2dzIHNjaGVkdWxlZFRyYW5zZmVyUGVyaW9kPSJQVDFNIiBzY2hlZHVsZWRUcmFuc2ZlckxvZ0xldmVsRmlsdGVyPSJXYXJuaW5nIi8+PFBlcmZvcm1hbmNlQ291bnRlcnMgc2NoZWR1bGVkVHJhbnNmZXJQZXJpb2Q9IlBUMU0iPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlTWVtb3J5IiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQnl0ZXMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcUGVyY2VudEF2YWlsYWJsZU1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iTWVtb3J5IHVzZWQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50VXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgcGVyY2VudGFnZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkQnlDYWNoZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHVzZWQgYnkgY2FjaGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1BlclNlYyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50UGVyU2Vjb25kIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFnZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1JlYWRQZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2UgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1dyaXR0ZW5QZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2Ugd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iU3dhcCBhdmFpbGFibGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50QXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZFN3YXAiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlN3YXAgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRJZGxlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgaWRsZSB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFVzZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iUGVyY2VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkNQVSB1c2VyIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50TmljZVRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIG5pY2UgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRQcml2aWxlZ2VkVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgcHJpdmlsZWdlZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudEludGVycnVwdFRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIGludGVycnVwdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudERQQ1RpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIERQQyB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFByb2Nlc3NvclRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIHBlcmNlbnRhZ2UgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50SU9XYWl0VGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgSU8gd2FpdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xSZWFkQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCBndWVzdCBPUyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXFdyaXRlQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGUgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xUcmFuc2ZlcnNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXJzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcUmVhZHNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xXcml0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVJlYWRUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVdyaXRlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlNlY29uZHMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJEaXNrIHdyaXRlIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xBdmVyYWdlVHJhbnNmZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXIgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXEF2ZXJhZ2VEaXNrUXVldWVMZW5ndGgiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcXVldWUgbGVuZ3RoIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVHJhbnNtaXR0ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgb3V0IGd1ZXN0IE9TIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzUmVjZWl2ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgaW4gZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1RyYW5zbWl0dGVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHNlbnQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1JlY2VpdmVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHJlY2VpdmVkIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVG90YWwiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxSeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyByZWNlaXZlZCBlcnJvcnMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxUeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyBzZW50IGVycm9ycyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTmV0d29ya0ludGVyZmFjZVxUb3RhbENvbGxpc2lvbnMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgY29sbGlzaW9ucyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48L1BlcmZvcm1hbmNlQ291bnRlcnM+PE1ldHJpY3MgcmVzb3VyY2VJZD0iL3N1YnNjcmlwdGlvbnMvMjU4NmM2NGItMzhiNC00NTI3LWExNDAtMDEyZDQ5ZGZjMDJjL3Jlc291cmNlR3JvdXBzL21pcS1henVyZS10ZXN0MS9wcm92aWRlcnMvTWljcm9zb2Z0LkNvbXB1dGUvdmlydHVhbE1hY2hpbmVzL3JzcGVjLWxiLWEiPjxNZXRyaWNBZ2dyZWdhdGlvbiBzY2hlZHVsZWRUcmFuc2ZlclBlcmlvZD0iUFQxSCIvPjxNZXRyaWNBZ2dyZWdhdGlvbiBzY2hlZHVsZWRUcmFuc2ZlclBlcmlvZD0iUFQxTSIvPjwvTWV0cmljcz48L0RpYWdub3N0aWNNb25pdG9yQ29uZmlndXJhdGlvbj48L1dhZENmZz4=\",\"StorageAccount\":\"miqazuretest16487\"},\r\n
-        \       \"provisioningState\": \"Succeeded\"\r\n      },\r\n      \"type\":
-        \"Microsoft.Compute/virtualMachines/extensions\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a/extensions/Microsoft.Insights.VMDiagnosticsSettings\",\r\n
-        \     \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n    }\r\n
-        \ ],\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\":
-        \"eastus\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a\",\r\n
-        \ \"name\": \"rspec-lb-a\"\r\n}"
+      string: "{\r\n  \"name\": \"rspec-lb-a-ip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-a-ip\",\r\n
+        \ \"etag\": \"W/\\\"3ba30997-7d2f-470c-96f6-301158e93b7c\\\"\",\r\n  \"location\":
+        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"3c605f75-23c0-46ab-ba2b-6fd4430140fd\",\r\n    \"publicIPAddressVersion\":
+        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
+        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
+        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
+        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:44 GMT
+  recorded_at: Mon, 12 Mar 2018 10:24:15 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-b-ip?api-version=2018-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -4319,7 +3721,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3ODksIm5iZiI6MTUyMDQ1Mzc4OSwiZXhwIjoxNTIwNDU3Njg5LCJhaW8iOiJZMk5nWUdBTzluZzJLY25wRWNmV20xS1NCOXJmQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibENhdzhSUlFzRUc1b3QzbmNIUUFBQSIsInZlciI6IjEuMCJ9.NjJPw1ksaOk2iyA699o9MPbQPQzcldpuJcvgMO2D851_sHs8aIbEejVf7P9Ea_F33pyoJTwYfa22s4vK3mI3-6WWOfdOmzwoMPVJAZ_uwYU9SM-idZOUKEQjQiMzI9Rhp9dk0xhs4tcwU_u6m4k2UUzfXtEnHQlC6sCQ_H1P4jZvfnygqQy5z-hxaJm33e71ogox7lnCxtQJ2S6kpVnflD-C-RW2X-g7A9yxmDe7yOG1MR3kZpilCs2HqqXzTzl0TOc91Xfdo9avET2GqN0t4WutUsVKEEbqAuSWUzsWzLQOz3EJ8OZG_PCiDpF4QAE5DtiZQyIgGIYwRWtBhE-tqQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
   response:
     status:
       code: 200
@@ -4335,63 +3737,42 @@ http_interactions:
       - application/json; charset=utf-8
       Expires:
       - "-1"
+      Etag:
+      - W/"cf6012c7-3d47-438f-84d7-332ad1ef4500"
       Vary:
       - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/LowCostGet3Min;4696,Microsoft.Compute/LowCostGet30Min;37837
+      X-Ms-Request-Id:
+      - 45f79d11-bcdd-4b08-8285-322e2f76b214
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
-      X-Ms-Request-Id:
-      - 05f2bf3f-b452-40b1-8e71-22398c1fa934
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14968'
+      - '14987'
       X-Ms-Correlation-Request-Id:
-      - 12497e88-62fe-4cdb-9a43-c8cf6877654e
+      - 37df786b-02d9-4ece-889b-1cc205390bc2
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202145Z:12497e88-62fe-4cdb-9a43-c8cf6877654e
+      - WESTEUROPE:20180312T102412Z:37df786b-02d9-4ece-889b-1cc205390bc2
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:21:44 GMT
+      - Mon, 12 Mar 2018 10:24:12 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"834a70b5-868d-4466-9dda-14e0f6b2caaf\",\r\n
-        \   \"availabilitySet\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/RSPEC-LB\"\r\n
-        \   },\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n
-        \   },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
-        \"RedHat\",\r\n        \"offer\": \"RHEL\",\r\n        \"sku\": \"6.7\",\r\n
-        \       \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
-        \"Linux\",\r\n        \"name\": \"rspec-lb-b\",\r\n        \"createOption\":
-        \"FromImage\",\r\n        \"vhd\": {\r\n          \"uri\": \"https://rspeclb.blob.core.windows.net/vhds/rspec-lb-b201682123650.vhd\"\r\n
-        \       },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n      \"dataDisks\":
-        []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"rspec-lb-b\",\r\n
-        \     \"adminUsername\": \"bronaghs\",\r\n      \"linuxConfiguration\": {\r\n
-        \       \"disablePasswordAuthentication\": false\r\n      },\r\n      \"secrets\":
-        []\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843\"}]},\r\n
-        \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
-        true,\r\n        \"storageUri\": \"https://amissteastorage.blob.core.windows.net/\"\r\n
-        \     }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n
-        \ \"resources\": [\r\n    {\r\n      \"properties\": {\r\n        \"publisher\":
-        \"Microsoft.OSTCExtensions\",\r\n        \"type\": \"LinuxDiagnostic\",\r\n
-        \       \"typeHandlerVersion\": \"2.3\",\r\n        \"autoUpgradeMinorVersion\":
-        true,\r\n        \"settings\": {\"xmlCfg\":\"PFdhZENmZz48RGlhZ25vc3RpY01vbml0b3JDb25maWd1cmF0aW9uIG92ZXJhbGxRdW90YUluTUI9IjQwOTYiPjxEaWFnbm9zdGljSW5mcmFzdHJ1Y3R1cmVMb2dzIHNjaGVkdWxlZFRyYW5zZmVyUGVyaW9kPSJQVDFNIiBzY2hlZHVsZWRUcmFuc2ZlckxvZ0xldmVsRmlsdGVyPSJXYXJuaW5nIi8+PFBlcmZvcm1hbmNlQ291bnRlcnMgc2NoZWR1bGVkVHJhbnNmZXJQZXJpb2Q9IlBUMU0iPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlTWVtb3J5IiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQnl0ZXMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcUGVyY2VudEF2YWlsYWJsZU1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iTWVtb3J5IHVzZWQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50VXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgcGVyY2VudGFnZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkQnlDYWNoZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHVzZWQgYnkgY2FjaGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1BlclNlYyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50UGVyU2Vjb25kIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFnZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1JlYWRQZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2UgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1dyaXR0ZW5QZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2Ugd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iU3dhcCBhdmFpbGFibGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50QXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZFN3YXAiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlN3YXAgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRJZGxlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgaWRsZSB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFVzZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iUGVyY2VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkNQVSB1c2VyIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50TmljZVRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIG5pY2UgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRQcml2aWxlZ2VkVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgcHJpdmlsZWdlZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudEludGVycnVwdFRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIGludGVycnVwdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudERQQ1RpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIERQQyB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFByb2Nlc3NvclRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIHBlcmNlbnRhZ2UgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50SU9XYWl0VGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgSU8gd2FpdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xSZWFkQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCBndWVzdCBPUyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXFdyaXRlQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGUgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xUcmFuc2ZlcnNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXJzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcUmVhZHNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xXcml0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVJlYWRUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVdyaXRlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlNlY29uZHMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJEaXNrIHdyaXRlIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xBdmVyYWdlVHJhbnNmZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXIgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXEF2ZXJhZ2VEaXNrUXVldWVMZW5ndGgiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcXVldWUgbGVuZ3RoIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVHJhbnNtaXR0ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgb3V0IGd1ZXN0IE9TIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzUmVjZWl2ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgaW4gZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1RyYW5zbWl0dGVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHNlbnQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1JlY2VpdmVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHJlY2VpdmVkIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVG90YWwiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxSeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyByZWNlaXZlZCBlcnJvcnMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxUeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyBzZW50IGVycm9ycyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTmV0d29ya0ludGVyZmFjZVxUb3RhbENvbGxpc2lvbnMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgY29sbGlzaW9ucyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48L1BlcmZvcm1hbmNlQ291bnRlcnM+PE1ldHJpY3MgcmVzb3VyY2VJZD0iL3N1YnNjcmlwdGlvbnMvMjU4NmM2NGItMzhiNC00NTI3LWExNDAtMDEyZDQ5ZGZjMDJjL3Jlc291cmNlR3JvdXBzL21pcS1henVyZS10ZXN0MS9wcm92aWRlcnMvTWljcm9zb2Z0LkNvbXB1dGUvdmlydHVhbE1hY2hpbmVzL3JzcGVjLWxiLWIiPjxNZXRyaWNBZ2dyZWdhdGlvbiBzY2hlZHVsZWRUcmFuc2ZlclBlcmlvZD0iUFQxSCIvPjxNZXRyaWNBZ2dyZWdhdGlvbiBzY2hlZHVsZWRUcmFuc2ZlclBlcmlvZD0iUFQxTSIvPjwvTWV0cmljcz48L0RpYWdub3N0aWNNb25pdG9yQ29uZmlndXJhdGlvbj48L1dhZENmZz4=\",\"StorageAccount\":\"amissteastorage\"},\r\n
-        \       \"provisioningState\": \"Succeeded\"\r\n      },\r\n      \"type\":
-        \"Microsoft.Compute/virtualMachines/extensions\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b/extensions/Microsoft.Insights.VMDiagnosticsSettings\",\r\n
-        \     \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n    }\r\n
-        \ ],\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\":
-        \"eastus\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b\",\r\n
-        \ \"name\": \"rspec-lb-b\"\r\n}"
+      string: "{\r\n  \"name\": \"rspec-lb-b-ip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-b-ip\",\r\n
+        \ \"etag\": \"W/\\\"cf6012c7-3d47-438f-84d7-332ad1ef4500\\\"\",\r\n  \"location\":
+        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"5d1a2425-a351-4c0f-bc87-37e6500bff22\",\r\n    \"publicIPAddressVersion\":
+        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
+        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\"\r\n
+        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
+        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:45 GMT
+  recorded_at: Mon, 12 Mar 2018 10:24:17 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a/instanceView?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb?api-version=2017-10-01
     body:
       encoding: US-ASCII
       string: ''
@@ -4405,7 +3786,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3ODksIm5iZiI6MTUyMDQ1Mzc4OSwiZXhwIjoxNTIwNDU3Njg5LCJhaW8iOiJZMk5nWUdBTzluZzJLY25wRWNmV20xS1NCOXJmQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibENhdzhSUlFzRUc1b3QzbmNIUUFBQSIsInZlciI6IjEuMCJ9.NjJPw1ksaOk2iyA699o9MPbQPQzcldpuJcvgMO2D851_sHs8aIbEejVf7P9Ea_F33pyoJTwYfa22s4vK3mI3-6WWOfdOmzwoMPVJAZ_uwYU9SM-idZOUKEQjQiMzI9Rhp9dk0xhs4tcwU_u6m4k2UUzfXtEnHQlC6sCQ_H1P4jZvfnygqQy5z-hxaJm33e71ogox7lnCxtQJ2S6kpVnflD-C-RW2X-g7A9yxmDe7yOG1MR3kZpilCs2HqqXzTzl0TOc91Xfdo9avET2GqN0t4WutUsVKEEbqAuSWUzsWzLQOz3EJ8OZG_PCiDpF4QAE5DtiZQyIgGIYwRWtBhE-tqQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
   response:
     status:
       code: 200
@@ -4418,207 +3799,32 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Content-Type:
-      - application/json; charset=utf-8
+      - application/json
       Expires:
       - "-1"
       Vary:
       - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/GetInstanceView3Min;4792,Microsoft.Compute/GetInstanceView30Min;23911
+      X-Ms-Request-Id:
+      - 6e11fc94-c51d-4bc0-949e-ed6a1d98be86
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
-      X-Ms-Request-Id:
-      - a6dce075-7559-476b-a005-83f53e3294c7
       Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14975'
+      - '14987'
       X-Ms-Correlation-Request-Id:
-      - b126163a-dd4f-4d41-bbe3-76baf843ddcf
+      - 92a4e4db-9419-4988-a0fb-ebcdd5518267
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202156Z:b126163a-dd4f-4d41-bbe3-76baf843ddcf
+      - WESTEUROPE:20180312T102413Z:92a4e4db-9419-4988-a0fb-ebcdd5518267
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:21:56 GMT
+      - Mon, 12 Mar 2018 10:24:12 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"platformUpdateDomain\": 0,\r\n  \"platformFaultDomain\": 0,\r\n
-        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
-        [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
-        \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
-        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2018-03-07T20:21:45+00:00\"\r\n
-        \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"rspec-lb-a\",\r\n
-        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
-        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"time\": \"2016-09-03T14:04:26.7359609+00:00\"\r\n
-        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
-        \"https://miqazuretest16487.blob.core.windows.net/bootdiagnostics-rspeclba-23b0beab-16d2-4135-a01f-2fe713217fd0/rspec-lb-a.23b0beab-16d2-4135-a01f-2fe713217fd0.screenshot.bmp\",\r\n
-        \   \"serialConsoleLogBlobUri\": \"https://miqazuretest16487.blob.core.windows.net/bootdiagnostics-rspeclba-23b0beab-16d2-4135-a01f-2fe713217fd0/rspec-lb-a.23b0beab-16d2-4135-a01f-2fe713217fd0.serialconsole.log\"\r\n
-        \ },\r\n  \"extensions\": [\r\n    {\r\n      \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n
-        \   }\r\n  ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n
-        \     \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n
-        \     \"time\": \"2016-09-03T14:04:26.7828345+00:00\"\r\n    },\r\n    {\r\n
-        \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
-        \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
+      string: '{"sku":{"name":"Premium_LRS","tier":"Premium"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb","name":"rspeclb","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-09-02T16:29:11.6823797Z","primaryEndpoints":{"blob":"https://rspeclb.blob.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:56 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Network/networkInterfaces?api-version=2017-11-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3ODksIm5iZiI6MTUyMDQ1Mzc4OSwiZXhwIjoxNTIwNDU3Njg5LCJhaW8iOiJZMk5nWUdBTzluZzJLY25wRWNmV20xS1NCOXJmQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibENhdzhSUlFzRUc1b3QzbmNIUUFBQSIsInZlciI6IjEuMCJ9.NjJPw1ksaOk2iyA699o9MPbQPQzcldpuJcvgMO2D851_sHs8aIbEejVf7P9Ea_F33pyoJTwYfa22s4vK3mI3-6WWOfdOmzwoMPVJAZ_uwYU9SM-idZOUKEQjQiMzI9Rhp9dk0xhs4tcwU_u6m4k2UUzfXtEnHQlC6sCQ_H1P4jZvfnygqQy5z-hxaJm33e71ogox7lnCxtQJ2S6kpVnflD-C-RW2X-g7A9yxmDe7yOG1MR3kZpilCs2HqqXzTzl0TOc91Xfdo9avET2GqN0t4WutUsVKEEbqAuSWUzsWzLQOz3EJ8OZG_PCiDpF4QAE5DtiZQyIgGIYwRWtBhE-tqQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - e37c7fba-6a25-4c70-ba75-67934bd82e0a
-      X-Ms-Correlation-Request-Id:
-      - e37c7fba-6a25-4c70-ba75-67934bd82e0a
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202158Z:e37c7fba-6a25-4c70-ba75-67934bd82e0a
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:21:58 GMT
-      Content-Length:
-      - '31614'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[{"name":"miqazure-coreos1235","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235","etag":"W/\"4a6546ab-a4c0-4d27-bccd-f6ebf3c405a2\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"fb0a5e60-a6c2-4bb8-a2f5-0c16216a49b0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235/ipConfigurations/ipconfig1","etag":"W/\"4a6546ab-a4c0-4d27-bccd-f6ebf3c405a2\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.20.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/publicIPAddresses/miqazure-coreos1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/virtualNetworks/miq-azure-test3/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"rliadcyr3l1elbnsw4rabxqg1f.dx.internal.cloudapp.net"},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkSecurityGroups/miqazure-coreos1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Compute/virtualMachines/miqazure-coreos1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"dbergerprov1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/dbergerprov1","etag":"W/\"074dd836-918c-4e40-a118-94f0d366e175\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"ecdcd2f0-91bb-4c40-91cd-a3d76fc5e455","ipConfigurations":[{"name":"dbergerprov1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/dbergerprov1/ipConfigurations/dbergerprov1","etag":"W/\"074dd836-918c-4e40-a118-94f0d366e175\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.9","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/dbergerprov1-publicIp"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/virtualMachines/dbergerprov1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-rhel1390","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390","etag":"W/\"f006e6f9-0292-42cd-99fc-f72f194553c1\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"98853f48-2806-4065-be57-cf9159550440","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1","etag":"W/\"f006e6f9-0292-42cd-99fc-f72f194553c1\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"macAddress":"00-0D-3A-10-EB-AB","enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-ubuntu1989","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989","etag":"W/\"64e07488-15a2-4cec-b84a-6fd5ef04323c\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"134a6669-ac4a-4d08-a0db-387bc4c49537","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989/ipConfigurations/ipconfig1","etag":"W/\"64e07488-15a2-4cec-b84a-6fd5ef04323c\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.17.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-ubuntu1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest18687/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-win12610","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610","etag":"W/\"dd925ef5-33d1-402c-a0f4-18c78c2641f4\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"5c2eef2c-0b36-4277-a940-957ed4d13be0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610/ipConfigurations/ipconfig1","etag":"W/\"dd925ef5-33d1-402c-a0f4-18c78c2641f4\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.18.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-win12"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest19881/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-winimg241","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241","etag":"W/\"4a17a745-16a9-42d9-88c9-17a518959525\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"8ed2f3b0-4a4b-49ae-9f1d-ff7890dbd396","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241/ipConfigurations/ipconfig1","etag":"W/\"4a17a745-16a9-42d9-88c9-17a518959525\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.7","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqtestwinimg6202"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-centos1611","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611","etag":"W/\"26031ef6-bb55-4019-8185-2dd1edcb207c\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"f1760e49-9853-4fdc-acfc-4ea232b9ed76","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1","etag":"W/\"26031ef6-bb55-4019-8185-2dd1edcb207c\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.5","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqmismatch1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1","etag":"W/\"3a72d0c3-bfda-4da5-a61b-e8c33e43de79\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"23d804a8-b623-49e7-9c8d-1d64245bef1e","ipConfigurations":[{"name":"miqmismatch1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1/ipConfigurations/miqmismatch1","etag":"W/\"3a72d0c3-bfda-4da5-a61b-e8c33e43de79\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.8","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqmismatch1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqmismatch1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"rspec-lb-a670","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670","etag":"W/\"cf3a0b0d-d596-4f33-bc31-749f92ba4f00\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"46cb8216-786e-408e-9d86-c0855b357349","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1","etag":"W/\"cf3a0b0d-d596-4f33-bc31-749f92ba4f00\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.6","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-a-ip"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"rspec-lb-b843","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843","etag":"W/\"76aabe0c-8678-43f0-81a5-2f15784a4b99\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"3ef6fa01-ac34-43a1-8fd7-67c706b4d8ef","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1","etag":"W/\"76aabe0c-8678-43f0-81a5-2f15784a4b99\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.11","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-b-ip"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"spec0deply1nic0","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","etag":"W/\"b817491c-aab8-4aab-b41d-b07bfffa5639\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"80ad9866-071d-4e3f-91d0-d47954eccee0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1","etag":"W/\"b817491c-aab8-4aab-b41d-b07bfffa5639\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.4","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"spec0deply1nic1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","etag":"W/\"2ec58a0b-4c03-4d0a-b788-9daffd54e7b2\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"57bbf7aa-d6c4-4f56-8f6a-089d15334221","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1","etag":"W/\"2ec58a0b-4c03-4d0a-b788-9daffd54e7b2\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.5","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqmismatch2656","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqmismatch2656","etag":"W/\"fef6a836-2802-4897-90c3-b3d71f133384\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"969dde6c-73c0-4340-877d-2b5fe2060026","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqmismatch2656/ipConfigurations/ipconfig1","etag":"W/\"fef6a836-2802-4897-90c3-b3d71f133384\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"172.23.0.4","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/virtualNetworks/miqazuretest33606/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkSecurityGroups/miqmismatch2-nsg"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Compute/virtualMachines/miqmismatch2"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-linux-manag944","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944","etag":"W/\"b6339880-8ead-4c9e-b5c0-f38c4f8612d5\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"c5e8b90e-5a78-49b0-b224-b70ed3fb45e5","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944/ipConfigurations/ipconfig1","etag":"W/\"b6339880-8ead-4c9e-b5c0-f38c4f8612d5\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"172.25.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqazure-linux-managed-ip"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"jf-metrics-2751","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751","etag":"W/\"c5f6f02a-b17c-4f34-882b-11c7adef0b44\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"207a58d3-f18d-4dab-8168-919877297a52","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751/ipConfigurations/ipconfig1","etag":"W/\"c5f6f02a-b17c-4f34-882b-11c7adef0b44\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.7","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-2"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-2"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/jf-metrics-2"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"jf-metrics-3421","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421","etag":"W/\"0b6f160b-ad10-48f8-9d0c-657193bb823f\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"b8b345e8-a353-4700-992e-be48a717b4e2","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421/ipConfigurations/ipconfig1","etag":"W/\"0b6f160b-ad10-48f8-9d0c-657193bb823f\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.8","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-3"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-3"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/jf-metrics-3"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-oraclelinux310","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310","etag":"W/\"54cd4fe1-3ed5-4a8c-bc8d-527679c7a631\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"6a3fc1d7-4532-4ca0-b5c2-546cc8f7f313","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310/ipConfigurations/ipconfig1","etag":"W/\"54cd4fe1-3ed5-4a8c-bc8d-527679c7a631\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.5","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-oraclelinux993","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993","etag":"W/\"a9432274-7b40-4eb3-a64f-a04267a423ff\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"75d8ed14-e0ae-4d84-99f6-e3f43d073e76","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993/ipConfigurations/ipconfig1","etag":"W/\"a9432274-7b40-4eb3-a64f-a04267a423ff\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.6","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux2"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux2"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"}]}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:59 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Network/publicIPAddresses?api-version=2017-11-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3ODksIm5iZiI6MTUyMDQ1Mzc4OSwiZXhwIjoxNTIwNDU3Njg5LCJhaW8iOiJZMk5nWUdBTzluZzJLY25wRWNmV20xS1NCOXJmQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibENhdzhSUlFzRUc1b3QzbmNIUUFBQSIsInZlciI6IjEuMCJ9.NjJPw1ksaOk2iyA699o9MPbQPQzcldpuJcvgMO2D851_sHs8aIbEejVf7P9Ea_F33pyoJTwYfa22s4vK3mI3-6WWOfdOmzwoMPVJAZ_uwYU9SM-idZOUKEQjQiMzI9Rhp9dk0xhs4tcwU_u6m4k2UUzfXtEnHQlC6sCQ_H1P4jZvfnygqQy5z-hxaJm33e71ogox7lnCxtQJ2S6kpVnflD-C-RW2X-g7A9yxmDe7yOG1MR3kZpilCs2HqqXzTzl0TOc91Xfdo9avET2GqN0t4WutUsVKEEbqAuSWUzsWzLQOz3EJ8OZG_PCiDpF4QAE5DtiZQyIgGIYwRWtBhE-tqQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 4fb2df68-7ae4-4f10-abc4-bdbb373ec493
-      X-Ms-Correlation-Request-Id:
-      - 4fb2df68-7ae4-4f10-abc4-bdbb373ec493
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202200Z:4fb2df68-7ae4-4f10-abc4-bdbb373ec493
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:22:00 GMT
-      Content-Length:
-      - '13978'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[{"name":"miqazure-coreos1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/publicIPAddresses/miqazure-coreos1","etag":"W/\"da64b64b-a755-4389-a2f3-5cba32f18c06\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"28617ed1-0270-4b39-873a-c3b48b3deef1","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"dbergerprov1-publicIp","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/dbergerprov1-publicIp","etag":"W/\"3d984c69-3f35-41ce-bdfc-8d207053a6a9\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"eb0e8804-e169-44ac-bb47-0929370977d2","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/dbergerprov1/ipConfigurations/dbergerprov1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"ladas_test","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/ladas_test","etag":"W/\"32e21623-9a1b-4c40-80f4-6a350aa237a7\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"3daa5f66-5a01-4242-b95b-c4e0ee8f0c36","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[]},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miq-test-rhel1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1","etag":"W/\"054052bb-11ff-4f6e-ac1a-3427c2fd17aa\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"f6cfc635-411e-48ce-a627-39a2fc0d3168","ipAddress":"52.224.165.15","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miq-test-ubuntu1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-ubuntu1","etag":"W/\"bcae50c5-146f-4fcb-a461-7c1030ba7b74\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"e272bd74-f661-484f-b223-88dd128a4049","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miq-test-win12","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-win12","etag":"W/\"56ce00f4-50d7-4682-9ee8-6836bf5c0ea6\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"b9200977-8147-40a5-83c2-d5892d5ddedc","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miqazure-centos1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1","etag":"W/\"734a3944-a880-444c-8c92-cace6e28e303\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"475a66f0-9e89-4226-a9f0-9baaaf31d619","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miqtestwinimg6202","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqtestwinimg6202","etag":"W/\"b656279a-26ff-4021-94bb-263420cf494e\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"fb942169-855b-44f8-b12f-fd63e961b140","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"rspec-lb-a-ip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-a-ip","etag":"W/\"3ba30997-7d2f-470c-96f6-301158e93b7c\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"3c605f75-23c0-46ab-ba2b-6fd4430140fd","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"rspec-lb-b-ip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-b-ip","etag":"W/\"cf6012c7-3d47-438f-84d7-332ad1ef4500\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"5d1a2425-a351-4c0f-bc87-37e6500bff22","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"rspec-lb1-LoadBalancerFrontEnd","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd","etag":"W/\"a38434c8-7b23-4092-b7c6-402238eac0dc\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"f28e0f25-b372-4edf-97d9-13a9e3b4ba2d","ipAddress":"40.71.82.83","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"rspec-lb2-publicip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip","etag":"W/\"cddd97d1-6111-4477-8a00-3dc885237a1d\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"83e7257d-ab94-4229-8eb5-4798f37ef28d","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"spec0deply1ip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip","etag":"W/\"2080997a-38a6-420d-ba86-e9582e1331c7\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"a08b891e-e45a-4970-aefc-f6c996989490","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"spec0deply1dns","fqdn":"spec0deply1dns.eastus.cloudapp.azure.com"},"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miqazure-linux-managed-ip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqazure-linux-managed-ip","etag":"W/\"0efc9684-fb7d-4fb7-b9b9-f33dbac04a28\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"6a2a9142-26e8-45cd-93bf-7318192f3528","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miqmismatch1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqmismatch1","etag":"W/\"9b8b1729-21c4-4c53-94f2-15715315ad73\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"a97c71d0-6b78-4ffe-8e5c-0be1ee653f8c","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"miqmismatch1","fqdn":"miqmismatch1.eastus.cloudapp.azure.com"},"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1/ipConfigurations/miqmismatch1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"jf-metrics-2","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-2","etag":"W/\"b43ebe01-574c-4454-87eb-3401fbcf36f2\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"e446f3e4-9410-4d7f-bb04-2652096359de","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"jf-metrics-3","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-3","etag":"W/\"a6ee7100-6202-4ae2-a2db-f828abec8af9\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"de5995a4-15c1-40ba-ad78-67e70a92654b","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miqazure-oraclelinux1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux1","etag":"W/\"98bee7b4-2fcc-471d-b5ce-92850e6c3d6b\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"f2ac7c18-520b-4b42-94e7-da264a842f41","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miqazure-oraclelinux2","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux2","etag":"W/\"0865cebc-95b9-49d2-9f10-21dbafb23cac\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"2f4e1091-46f0-474c-a697-8dbcea6ba2a6","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}}]}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:22:01 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Storage/storageAccounts?api-version=2017-10-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3ODksIm5iZiI6MTUyMDQ1Mzc4OSwiZXhwIjoxNTIwNDU3Njg5LCJhaW8iOiJZMk5nWUdBTzluZzJLY25wRWNmV20xS1NCOXJmQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibENhdzhSUlFzRUc1b3QzbmNIUUFBQSIsInZlciI6IjEuMCJ9.NjJPw1ksaOk2iyA699o9MPbQPQzcldpuJcvgMO2D851_sHs8aIbEejVf7P9Ea_F33pyoJTwYfa22s4vK3mI3-6WWOfdOmzwoMPVJAZ_uwYU9SM-idZOUKEQjQiMzI9Rhp9dk0xhs4tcwU_u6m4k2UUzfXtEnHQlC6sCQ_H1P4jZvfnygqQy5z-hxaJm33e71ogox7lnCxtQJ2S6kpVnflD-C-RW2X-g7A9yxmDe7yOG1MR3kZpilCs2HqqXzTzl0TOc91Xfdo9avET2GqN0t4WutUsVKEEbqAuSWUzsWzLQOz3EJ8OZG_PCiDpF4QAE5DtiZQyIgGIYwRWtBhE-tqQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 454c7974-bef7-4dd3-a692-bef323711995
-      X-Ms-Correlation-Request-Id:
-      - 454c7974-bef7-4dd3-a692-bef323711995
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202204Z:454c7974-bef7-4dd3-a692-bef323711995
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:22:04 GMT
-      Content-Length:
-      - '8649'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","name":"miqazuretest18686","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T17:22:54.7808677Z","primaryEndpoints":{"blob":"https://miqazuretest18686.blob.core.windows.net/","queue":"https://miqazuretest18686.queue.core.windows.net/","table":"https://miqazuretest18686.table.core.windows.net/","file":"https://miqazuretest18686.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","name":"miqazuretest14047","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T17:30:25.7028008Z","primaryEndpoints":{"blob":"https://miqazuretest14047.blob.core.windows.net/","queue":"https://miqazuretest14047.queue.core.windows.net/","table":"https://miqazuretest14047.table.core.windows.net/","file":"https://miqazuretest14047.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Premium_LRS","tier":"Premium"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb","name":"rspeclb","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-09-02T16:29:11.6823797Z","primaryEndpoints":{"blob":"https://rspeclb.blob.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","name":"spec0deply1stor","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-04-04T23:05:07.8274794Z","primaryEndpoints":{"blob":"https://spec0deply1stor.blob.core.windows.net/","queue":"https://spec0deply1stor.queue.core.windows.net/","table":"https://spec0deply1stor.table.core.windows.net/","file":"https://spec0deply1stor.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Storage/storageAccounts/miqazuretest26611","name":"miqazuretest26611","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2211656Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2211656Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-05-02T18:01:29.2743021Z","primaryEndpoints":{"blob":"https://miqazuretest26611.blob.core.windows.net/","queue":"https://miqazuretest26611.queue.core.windows.net/","table":"https://miqazuretest26611.table.core.windows.net/","file":"https://miqazuretest26611.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","name":"miqazuretest16487","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T17:26:55.3231669Z","primaryEndpoints":{"blob":"https://miqazuretest16487.blob.core.windows.net/","queue":"https://miqazuretest16487.queue.core.windows.net/","table":"https://miqazuretest16487.table.core.windows.net/","file":"https://miqazuretest16487.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Storage/storageAccounts/miqazuretest32946","name":"miqazuretest32946","type":"Microsoft.Storage/storageAccounts","location":"westus","tags":{"delete":"false"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.0404359Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.0404359Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T21:18:37.0793411Z","primaryEndpoints":{"blob":"https://miqazuretest32946.blob.core.windows.net/","queue":"https://miqazuretest32946.queue.core.windows.net/","table":"https://miqazuretest32946.table.core.windows.net/","file":"https://miqazuretest32946.file.core.windows.net/"},"primaryLocation":"westus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Storage/storageAccounts/miqazureshared1","name":"miqazureshared1","type":"Microsoft.Storage/storageAccounts","location":"centralus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.1935084Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.1935084Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T20:42:52.498085Z","primaryEndpoints":{"blob":"https://miqazureshared1.blob.core.windows.net/","queue":"https://miqazureshared1.queue.core.windows.net/","table":"https://miqazureshared1.table.core.windows.net/","file":"https://miqazureshared1.file.core.windows.net/"},"primaryLocation":"centralus","statusOfPrimary":"available","secondaryLocation":"eastus2","statusOfSecondary":"available","secondaryEndpoints":{"blob":"https://miqazureshared1-secondary.blob.core.windows.net/","queue":"https://miqazureshared1-secondary.queue.core.windows.net/","table":"https://miqazureshared1-secondary.table.core.windows.net/"}}}]}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:22:04 GMT
+  recorded_at: Mon, 12 Mar 2018 10:24:18 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb/listKeys?api-version=2017-10-01
@@ -4635,7 +3841,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3ODksIm5iZiI6MTUyMDQ1Mzc4OSwiZXhwIjoxNTIwNDU3Njg5LCJhaW8iOiJZMk5nWUdBTzluZzJLY25wRWNmV20xS1NCOXJmQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibENhdzhSUlFzRUc1b3QzbmNIUUFBQSIsInZlciI6IjEuMCJ9.NjJPw1ksaOk2iyA699o9MPbQPQzcldpuJcvgMO2D851_sHs8aIbEejVf7P9Ea_F33pyoJTwYfa22s4vK3mI3-6WWOfdOmzwoMPVJAZ_uwYU9SM-idZOUKEQjQiMzI9Rhp9dk0xhs4tcwU_u6m4k2UUzfXtEnHQlC6sCQ_H1P4jZvfnygqQy5z-hxaJm33e71ogox7lnCxtQJ2S6kpVnflD-C-RW2X-g7A9yxmDe7yOG1MR3kZpilCs2HqqXzTzl0TOc91Xfdo9avET2GqN0t4WutUsVKEEbqAuSWUzsWzLQOz3EJ8OZG_PCiDpF4QAE5DtiZQyIgGIYwRWtBhE-tqQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
       Content-Length:
       - '0'
   response:
@@ -4656,26 +3862,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 8445b084-36d1-4bc4-b422-1dcd3d1480c6
+      - 76e76af2-479b-4193-b8ea-ab4fa14f0b0d
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1196'
+      - '1197'
       X-Ms-Correlation-Request-Id:
-      - cfbd3529-730d-4eaa-8658-d44a78ef84d0
+      - 964a0be8-af61-4f91-96e6-d155fdb3def0
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202205Z:cfbd3529-730d-4eaa-8658-d44a78ef84d0
+      - WESTEUROPE:20180312T102414Z:964a0be8-af61-4f91-96e6-d155fdb3def0
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:22:04 GMT
+      - Mon, 12 Mar 2018 10:24:13 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keys":[{"keyName":"key1","value":"xMvZwiumnKCZnYVJjdtGLqaO1c2v6ERPx4XPDZO7TM1l7/jM1TxAAgtfCMkRn72aRPhqLqwWAn8n5a1iSGRHtA==","permissions":"Full"},{"keyName":"key2","value":"3nDvKhjGAIAvgnH2reuv7tzyeb/0dddgVeUT13VODYD5xO/jeAvQ7tkF3JqP2BAuFrmQqMB4GLkB4/cW4veYeA==","permissions":"Full"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:22:05 GMT
+  recorded_at: Mon, 12 Mar 2018 10:24:18 GMT
 - request:
     method: head
     uri: https://rspeclb.blob.core.windows.net/vhds/rspec-lb-a201682122839.vhd
@@ -4692,7 +3898,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:22:05 GMT
+      - Mon, 12 Mar 2018 10:24:18 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -4700,7 +3906,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey rspeclb:u7CQMniOvPT59Wj0OTuo4LQDl4D+Q1iTjyVh55mslZA=
+      - SharedKey rspeclb:rj96AWsKTq9rHhWML4HfPIuvmIGtKI8PdZ2kIC7Mly4=
   response:
     status:
       code: 200
@@ -4755,150 +3961,16 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       X-Ms-Request-Id:
-      - 38e596f3-e01c-0018-1f51-b64852000000
+      - f198077d-901c-0035-6dec-b9cb92000000
       X-Ms-Version:
       - '2016-05-31'
       Date:
-      - Wed, 07 Mar 2018 20:22:05 GMT
+      - Mon, 12 Mar 2018 10:24:14 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:22:05 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b/instanceView?api-version=2017-12-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3ODksIm5iZiI6MTUyMDQ1Mzc4OSwiZXhwIjoxNTIwNDU3Njg5LCJhaW8iOiJZMk5nWUdBTzluZzJLY25wRWNmV20xS1NCOXJmQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibENhdzhSUlFzRUc1b3QzbmNIUUFBQSIsInZlciI6IjEuMCJ9.NjJPw1ksaOk2iyA699o9MPbQPQzcldpuJcvgMO2D851_sHs8aIbEejVf7P9Ea_F33pyoJTwYfa22s4vK3mI3-6WWOfdOmzwoMPVJAZ_uwYU9SM-idZOUKEQjQiMzI9Rhp9dk0xhs4tcwU_u6m4k2UUzfXtEnHQlC6sCQ_H1P4jZvfnygqQy5z-hxaJm33e71ogox7lnCxtQJ2S6kpVnflD-C-RW2X-g7A9yxmDe7yOG1MR3kZpilCs2HqqXzTzl0TOc91Xfdo9avET2GqN0t4WutUsVKEEbqAuSWUzsWzLQOz3EJ8OZG_PCiDpF4QAE5DtiZQyIgGIYwRWtBhE-tqQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/GetInstanceView3Min;4792,Microsoft.Compute/GetInstanceView30Min;23910
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
-      X-Ms-Request-Id:
-      - b88be250-0a72-4bfd-b794-9fdccf2b7f83
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14965'
-      X-Ms-Correlation-Request-Id:
-      - b50240f6-42c7-4160-afd2-ff7c70dfbd6d
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202206Z:b50240f6-42c7-4160-afd2-ff7c70dfbd6d
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:22:05 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"platformUpdateDomain\": 1,\r\n  \"platformFaultDomain\": 1,\r\n
-        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
-        [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
-        \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
-        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2018-03-07T20:22:05+00:00\"\r\n
-        \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"rspec-lb-b\",\r\n
-        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
-        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"time\": \"2016-09-03T14:07:52.9377685+00:00\"\r\n
-        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
-        \"https://amissteastorage.blob.core.windows.net/bootdiagnostics-rspeclbb-834a70b5-868d-4466-9dda-14e0f6b2caaf/rspec-lb-b.834a70b5-868d-4466-9dda-14e0f6b2caaf.screenshot.bmp\",\r\n
-        \   \"serialConsoleLogBlobUri\": \"https://amissteastorage.blob.core.windows.net/bootdiagnostics-rspeclbb-834a70b5-868d-4466-9dda-14e0f6b2caaf/rspec-lb-b.834a70b5-868d-4466-9dda-14e0f6b2caaf.serialconsole.log\"\r\n
-        \ },\r\n  \"extensions\": [\r\n    {\r\n      \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n
-        \   }\r\n  ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n
-        \     \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n
-        \     \"time\": \"2016-09-03T14:07:52.9846158+00:00\"\r\n    },\r\n    {\r\n
-        \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
-        \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:22:06 GMT
-- request:
-    method: post
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb/listKeys?api-version=2017-10-01
-    body:
-      encoding: ASCII-8BIT
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3ODksIm5iZiI6MTUyMDQ1Mzc4OSwiZXhwIjoxNTIwNDU3Njg5LCJhaW8iOiJZMk5nWUdBTzluZzJLY25wRWNmV20xS1NCOXJmQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibENhdzhSUlFzRUc1b3QzbmNIUUFBQSIsInZlciI6IjEuMCJ9.NjJPw1ksaOk2iyA699o9MPbQPQzcldpuJcvgMO2D851_sHs8aIbEejVf7P9Ea_F33pyoJTwYfa22s4vK3mI3-6WWOfdOmzwoMPVJAZ_uwYU9SM-idZOUKEQjQiMzI9Rhp9dk0xhs4tcwU_u6m4k2UUzfXtEnHQlC6sCQ_H1P4jZvfnygqQy5z-hxaJm33e71ogox7lnCxtQJ2S6kpVnflD-C-RW2X-g7A9yxmDe7yOG1MR3kZpilCs2HqqXzTzl0TOc91Xfdo9avET2GqN0t4WutUsVKEEbqAuSWUzsWzLQOz3EJ8OZG_PCiDpF4QAE5DtiZQyIgGIYwRWtBhE-tqQ
-      Content-Length:
-      - '0'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 49a90981-35e0-4285-91ec-347ac30127da
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1195'
-      X-Ms-Correlation-Request-Id:
-      - 49cf589b-d52e-42ef-a6d1-1b94ec09fbe9
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202206Z:49cf589b-d52e-42ef-a6d1-1b94ec09fbe9
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:22:06 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"keys":[{"keyName":"key1","value":"xMvZwiumnKCZnYVJjdtGLqaO1c2v6ERPx4XPDZO7TM1l7/jM1TxAAgtfCMkRn72aRPhqLqwWAn8n5a1iSGRHtA==","permissions":"Full"},{"keyName":"key2","value":"3nDvKhjGAIAvgnH2reuv7tzyeb/0dddgVeUT13VODYD5xO/jeAvQ7tkF3JqP2BAuFrmQqMB4GLkB4/cW4veYeA==","permissions":"Full"}]}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:22:06 GMT
+  recorded_at: Mon, 12 Mar 2018 10:24:19 GMT
 - request:
     method: head
     uri: https://rspeclb.blob.core.windows.net/vhds/rspec-lb-b201682123650.vhd
@@ -4915,7 +3987,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:22:06 GMT
+      - Mon, 12 Mar 2018 10:24:19 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -4923,7 +3995,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey rspeclb:L4BvsfaGUz6dgCrLyT7mL5JdI0xJK7VUUqFrcA5NNNc=
+      - SharedKey rspeclb:W20tOzXUIfqG3NV+TNVU79cfjhFis6YNNW8SxEoZkZ4=
   response:
     status:
       code: 200
@@ -4978,16 +4050,16 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       X-Ms-Request-Id:
-      - 393fbfa7-201c-0027-4651-b6ff8e000000
+      - a91801be-601c-0009-0aec-b97f49000000
       X-Ms-Version:
       - '2016-05-31'
       Date:
-      - Wed, 07 Mar 2018 20:22:06 GMT
+      - Mon, 12 Mar 2018 10:24:15 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:22:07 GMT
+  recorded_at: Mon, 12 Mar 2018 10:24:20 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg?api-version=2018-01-01
@@ -5004,7 +4076,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3ODksIm5iZiI6MTUyMDQ1Mzc4OSwiZXhwIjoxNTIwNDU3Njg5LCJhaW8iOiJZMk5nWUdBTzluZzJLY25wRWNmV20xS1NCOXJmQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibENhdzhSUlFzRUc1b3QzbmNIUUFBQSIsInZlciI6IjEuMCJ9.NjJPw1ksaOk2iyA699o9MPbQPQzcldpuJcvgMO2D851_sHs8aIbEejVf7P9Ea_F33pyoJTwYfa22s4vK3mI3-6WWOfdOmzwoMPVJAZ_uwYU9SM-idZOUKEQjQiMzI9Rhp9dk0xhs4tcwU_u6m4k2UUzfXtEnHQlC6sCQ_H1P4jZvfnygqQy5z-hxaJm33e71ogox7lnCxtQJ2S6kpVnflD-C-RW2X-g7A9yxmDe7yOG1MR3kZpilCs2HqqXzTzl0TOc91Xfdo9avET2GqN0t4WutUsVKEEbqAuSWUzsWzLQOz3EJ8OZG_PCiDpF4QAE5DtiZQyIgGIYwRWtBhE-tqQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
   response:
     status:
       code: 200
@@ -5025,22 +4097,22 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 6ef8d9fe-2efe-43a9-a95e-8fd1e2267dae
+      - 9450760e-8199-4142-a5d1-a56ecb76bf4d
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14964'
+      - '14986'
       X-Ms-Correlation-Request-Id:
-      - e3b1b346-dc09-4803-9f19-b2dad10062da
+      - 5f62a3c7-3f7a-41f9-bf13-caa25e93ddc8
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202207Z:e3b1b346-dc09-4803-9f19-b2dad10062da
+      - WESTEUROPE:20180312T102415Z:5f62a3c7-3f7a-41f9-bf13-caa25e93ddc8
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:22:07 GMT
+      - Mon, 12 Mar 2018 10:24:15 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"rspec-lb-a-nsg\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg\",\r\n
@@ -5125,7 +4197,7 @@ http_interactions:
         \   ],\r\n    \"networkInterfaces\": [\r\n      {\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670\"\r\n
         \     }\r\n    ]\r\n  }\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:22:07 GMT
+  recorded_at: Mon, 12 Mar 2018 10:24:20 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg?api-version=2018-01-01
@@ -5142,7 +4214,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3ODksIm5iZiI6MTUyMDQ1Mzc4OSwiZXhwIjoxNTIwNDU3Njg5LCJhaW8iOiJZMk5nWUdBTzluZzJLY25wRWNmV20xS1NCOXJmQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibENhdzhSUlFzRUc1b3QzbmNIUUFBQSIsInZlciI6IjEuMCJ9.NjJPw1ksaOk2iyA699o9MPbQPQzcldpuJcvgMO2D851_sHs8aIbEejVf7P9Ea_F33pyoJTwYfa22s4vK3mI3-6WWOfdOmzwoMPVJAZ_uwYU9SM-idZOUKEQjQiMzI9Rhp9dk0xhs4tcwU_u6m4k2UUzfXtEnHQlC6sCQ_H1P4jZvfnygqQy5z-hxaJm33e71ogox7lnCxtQJ2S6kpVnflD-C-RW2X-g7A9yxmDe7yOG1MR3kZpilCs2HqqXzTzl0TOc91Xfdo9avET2GqN0t4WutUsVKEEbqAuSWUzsWzLQOz3EJ8OZG_PCiDpF4QAE5DtiZQyIgGIYwRWtBhE-tqQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
   response:
     status:
       code: 200
@@ -5163,22 +4235,22 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - c0ef2617-1609-44ab-976b-a7b1f4976462
+      - 51482f3d-03ca-4310-8dea-2d98fdac801c
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14769'
+      - '14988'
       X-Ms-Correlation-Request-Id:
-      - 634c3e6a-9b98-45fa-99e4-fc853776ada3
+      - 9ab051ec-23c0-4d78-aed5-904c5c8c78ae
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202207Z:634c3e6a-9b98-45fa-99e4-fc853776ada3
+      - WESTEUROPE:20180312T102416Z:9ab051ec-23c0-4d78-aed5-904c5c8c78ae
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:22:06 GMT
+      - Mon, 12 Mar 2018 10:24:16 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"rspec-lb-b-nsg\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg\",\r\n
@@ -5263,7 +4335,7 @@ http_interactions:
         \   ],\r\n    \"networkInterfaces\": [\r\n      {\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843\"\r\n
         \     }\r\n    ]\r\n  }\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:22:08 GMT
+  recorded_at: Mon, 12 Mar 2018 10:24:21 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1?api-version=2018-01-01
@@ -5280,7 +4352,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3ODksIm5iZiI6MTUyMDQ1Mzc4OSwiZXhwIjoxNTIwNDU3Njg5LCJhaW8iOiJZMk5nWUdBTzluZzJLY25wRWNmV20xS1NCOXJmQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibENhdzhSUlFzRUc1b3QzbmNIUUFBQSIsInZlciI6IjEuMCJ9.NjJPw1ksaOk2iyA699o9MPbQPQzcldpuJcvgMO2D851_sHs8aIbEejVf7P9Ea_F33pyoJTwYfa22s4vK3mI3-6WWOfdOmzwoMPVJAZ_uwYU9SM-idZOUKEQjQiMzI9Rhp9dk0xhs4tcwU_u6m4k2UUzfXtEnHQlC6sCQ_H1P4jZvfnygqQy5z-hxaJm33e71ogox7lnCxtQJ2S6kpVnflD-C-RW2X-g7A9yxmDe7yOG1MR3kZpilCs2HqqXzTzl0TOc91Xfdo9avET2GqN0t4WutUsVKEEbqAuSWUzsWzLQOz3EJ8OZG_PCiDpF4QAE5DtiZQyIgGIYwRWtBhE-tqQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
   response:
     status:
       code: 200
@@ -5297,36 +4369,36 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"fceae1ac-4620-482a-bc6d-79c867179ae5"
+      - W/"a8b09238-30fc-4b36-a58d-e3cc69e267c5"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 2a697257-4c2c-424f-97ae-8d70cef88638
+      - c80ef0fb-f67b-4dfd-a4fa-28cd509ef945
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14966'
+      - '14986'
       X-Ms-Correlation-Request-Id:
-      - a398f9f9-6089-4cfc-af1c-7e81250133d3
+      - 034ba07a-2bd1-4375-868b-ec285198154c
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202211Z:a398f9f9-6089-4cfc-af1c-7e81250133d3
+      - WESTEUROPE:20180312T102417Z:034ba07a-2bd1-4375-868b-ec285198154c
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:22:11 GMT
+      - Mon, 12 Mar 2018 10:24:16 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"miq-azure-test1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1\",\r\n
-        \ \"etag\": \"W/\\\"fceae1ac-4620-482a-bc6d-79c867179ae5\\\"\",\r\n  \"type\":
+        \ \"etag\": \"W/\\\"a8b09238-30fc-4b36-a58d-e3cc69e267c5\\\"\",\r\n  \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
         \"d74c1e5f-50e4-4c8a-a7fe-78eaddc6b915\",\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\":
         [\r\n        \"10.16.0.0/16\"\r\n      ]\r\n    },\r\n    \"subnets\": [\r\n
         \     {\r\n        \"name\": \"default\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\",\r\n
-        \       \"etag\": \"W/\\\"fceae1ac-4620-482a-bc6d-79c867179ae5\\\"\",\r\n
+        \       \"etag\": \"W/\\\"a8b09238-30fc-4b36-a58d-e3cc69e267c5\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"addressPrefix\": \"10.16.0.0/24\",\r\n          \"ipConfigurations\":
         [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1\"\r\n
@@ -5336,298 +4408,10 @@ http_interactions:
         \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/dbergerprov1/ipConfigurations/dbergerprov1\"\r\n
         \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
         \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/ladas_test_1/ipConfigurations/ladas_test_1\"\r\n
         \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"virtualNetworkPeerings\":
         [],\r\n    \"enableDdosProtection\": false,\r\n    \"enableVmProtection\":
         false\r\n  }\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:22:11 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3ODksIm5iZiI6MTUyMDQ1Mzc4OSwiZXhwIjoxNTIwNDU3Njg5LCJhaW8iOiJZMk5nWUdBTzluZzJLY25wRWNmV20xS1NCOXJmQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibENhdzhSUlFzRUc1b3QzbmNIUUFBQSIsInZlciI6IjEuMCJ9.NjJPw1ksaOk2iyA699o9MPbQPQzcldpuJcvgMO2D851_sHs8aIbEejVf7P9Ea_F33pyoJTwYfa22s4vK3mI3-6WWOfdOmzwoMPVJAZ_uwYU9SM-idZOUKEQjQiMzI9Rhp9dk0xhs4tcwU_u6m4k2UUzfXtEnHQlC6sCQ_H1P4jZvfnygqQy5z-hxaJm33e71ogox7lnCxtQJ2S6kpVnflD-C-RW2X-g7A9yxmDe7yOG1MR3kZpilCs2HqqXzTzl0TOc91Xfdo9avET2GqN0t4WutUsVKEEbqAuSWUzsWzLQOz3EJ8OZG_PCiDpF4QAE5DtiZQyIgGIYwRWtBhE-tqQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"cf3a0b0d-d596-4f33-bc31-749f92ba4f00"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - '0749d614-1ddb-42ca-8b55-54587f50a702'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14977'
-      X-Ms-Correlation-Request-Id:
-      - f6be6acd-1ccd-4eaf-aed2-cc6596e9a570
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202212Z:f6be6acd-1ccd-4eaf-aed2-cc6596e9a570
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:22:11 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb-a670\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670\",\r\n
-        \ \"etag\": \"W/\\\"cf3a0b0d-d596-4f33-bc31-749f92ba4f00\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"46cb8216-786e-408e-9d86-c0855b357349\",\r\n    \"ipConfigurations\":
-        [\r\n      {\r\n        \"name\": \"ipconfig1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\",\r\n
-        \       \"etag\": \"W/\\\"cf3a0b0d-d596-4f33-bc31-749f92ba4f00\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAddress\": \"10.16.0.6\",\r\n          \"privateIPAllocationMethod\":
-        \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-a-ip\"\r\n
-        \         },\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\"\r\n
-        \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
-        \"IPv4\",\r\n          \"loadBalancerBackendAddressPools\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\"\r\n
-        \           }\r\n          ],\r\n          \"loadBalancerInboundNatRules\":
-        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\":
-        {\r\n      \"dnsServers\": [],\r\n      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\":
-        \"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net\"\r\n    },\r\n    \"enableAcceleratedNetworking\":
-        false,\r\n    \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\":
-        {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg\"\r\n
-        \   },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a\"\r\n
-        \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
-        \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:22:12 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3ODksIm5iZiI6MTUyMDQ1Mzc4OSwiZXhwIjoxNTIwNDU3Njg5LCJhaW8iOiJZMk5nWUdBTzluZzJLY25wRWNmV20xS1NCOXJmQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibENhdzhSUlFzRUc1b3QzbmNIUUFBQSIsInZlciI6IjEuMCJ9.NjJPw1ksaOk2iyA699o9MPbQPQzcldpuJcvgMO2D851_sHs8aIbEejVf7P9Ea_F33pyoJTwYfa22s4vK3mI3-6WWOfdOmzwoMPVJAZ_uwYU9SM-idZOUKEQjQiMzI9Rhp9dk0xhs4tcwU_u6m4k2UUzfXtEnHQlC6sCQ_H1P4jZvfnygqQy5z-hxaJm33e71ogox7lnCxtQJ2S6kpVnflD-C-RW2X-g7A9yxmDe7yOG1MR3kZpilCs2HqqXzTzl0TOc91Xfdo9avET2GqN0t4WutUsVKEEbqAuSWUzsWzLQOz3EJ8OZG_PCiDpF4QAE5DtiZQyIgGIYwRWtBhE-tqQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"76aabe0c-8678-43f0-81a5-2f15784a4b99"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - f9ca3394-02ab-4cb6-afa8-4c7d4d4e01f5
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14964'
-      X-Ms-Correlation-Request-Id:
-      - 934292a0-1ba3-4095-a2cb-c6576b066558
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202212Z:934292a0-1ba3-4095-a2cb-c6576b066558
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:22:12 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb-b843\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843\",\r\n
-        \ \"etag\": \"W/\\\"76aabe0c-8678-43f0-81a5-2f15784a4b99\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"3ef6fa01-ac34-43a1-8fd7-67c706b4d8ef\",\r\n    \"ipConfigurations\":
-        [\r\n      {\r\n        \"name\": \"ipconfig1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\",\r\n
-        \       \"etag\": \"W/\\\"76aabe0c-8678-43f0-81a5-2f15784a4b99\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAddress\": \"10.16.0.11\",\r\n          \"privateIPAllocationMethod\":
-        \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-b-ip\"\r\n
-        \         },\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\"\r\n
-        \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
-        \"IPv4\",\r\n          \"loadBalancerBackendAddressPools\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\":
-        {\r\n      \"dnsServers\": [],\r\n      \"appliedDnsServers\": []\r\n    },\r\n
-        \   \"enableAcceleratedNetworking\": false,\r\n    \"enableIPForwarding\":
-        false,\r\n    \"networkSecurityGroup\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg\"\r\n
-        \   },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b\"\r\n
-        \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
-        \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:22:12 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-a-ip?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3ODksIm5iZiI6MTUyMDQ1Mzc4OSwiZXhwIjoxNTIwNDU3Njg5LCJhaW8iOiJZMk5nWUdBTzluZzJLY25wRWNmV20xS1NCOXJmQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibENhdzhSUlFzRUc1b3QzbmNIUUFBQSIsInZlciI6IjEuMCJ9.NjJPw1ksaOk2iyA699o9MPbQPQzcldpuJcvgMO2D851_sHs8aIbEejVf7P9Ea_F33pyoJTwYfa22s4vK3mI3-6WWOfdOmzwoMPVJAZ_uwYU9SM-idZOUKEQjQiMzI9Rhp9dk0xhs4tcwU_u6m4k2UUzfXtEnHQlC6sCQ_H1P4jZvfnygqQy5z-hxaJm33e71ogox7lnCxtQJ2S6kpVnflD-C-RW2X-g7A9yxmDe7yOG1MR3kZpilCs2HqqXzTzl0TOc91Xfdo9avET2GqN0t4WutUsVKEEbqAuSWUzsWzLQOz3EJ8OZG_PCiDpF4QAE5DtiZQyIgGIYwRWtBhE-tqQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"3ba30997-7d2f-470c-96f6-301158e93b7c"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 681cc608-da3a-4f05-9d59-b5288db32f50
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14968'
-      X-Ms-Correlation-Request-Id:
-      - 10de50ba-b68a-4e63-9697-8303ec5b1b9a
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202213Z:10de50ba-b68a-4e63-9697-8303ec5b1b9a
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:22:12 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb-a-ip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-a-ip\",\r\n
-        \ \"etag\": \"W/\\\"3ba30997-7d2f-470c-96f6-301158e93b7c\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"3c605f75-23c0-46ab-ba2b-6fd4430140fd\",\r\n    \"publicIPAddressVersion\":
-        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
-        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
-        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:22:13 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-b-ip?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3ODksIm5iZiI6MTUyMDQ1Mzc4OSwiZXhwIjoxNTIwNDU3Njg5LCJhaW8iOiJZMk5nWUdBTzluZzJLY25wRWNmV20xS1NCOXJmQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibENhdzhSUlFzRUc1b3QzbmNIUUFBQSIsInZlciI6IjEuMCJ9.NjJPw1ksaOk2iyA699o9MPbQPQzcldpuJcvgMO2D851_sHs8aIbEejVf7P9Ea_F33pyoJTwYfa22s4vK3mI3-6WWOfdOmzwoMPVJAZ_uwYU9SM-idZOUKEQjQiMzI9Rhp9dk0xhs4tcwU_u6m4k2UUzfXtEnHQlC6sCQ_H1P4jZvfnygqQy5z-hxaJm33e71ogox7lnCxtQJ2S6kpVnflD-C-RW2X-g7A9yxmDe7yOG1MR3kZpilCs2HqqXzTzl0TOc91Xfdo9avET2GqN0t4WutUsVKEEbqAuSWUzsWzLQOz3EJ8OZG_PCiDpF4QAE5DtiZQyIgGIYwRWtBhE-tqQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"cf6012c7-3d47-438f-84d7-332ad1ef4500"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - e93a53c5-2b02-4d5b-ba27-f72a7346c221
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14977'
-      X-Ms-Correlation-Request-Id:
-      - 8c11892c-ae7f-47af-b55e-1d37262f62ce
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202213Z:8c11892c-ae7f-47af-b55e-1d37262f62ce
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:22:13 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb-b-ip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-b-ip\",\r\n
-        \ \"etag\": \"W/\\\"cf6012c7-3d47-438f-84d7-332ad1ef4500\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"5d1a2425-a351-4c0f-bc87-37e6500bff22\",\r\n    \"publicIPAddressVersion\":
-        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
-        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\"\r\n
-        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
-        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:22:13 GMT
+  recorded_at: Mon, 12 Mar 2018 10:24:21 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted_scope/lb_with_vms_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted_scope/lb_with_vms_refresh.yml
@@ -37,25 +37,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - b62658e7-b535-4f87-b458-6711bb570000
+      - 81a25c73-ea8f-4183-9a26-5d23cf121600
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHz-8iAFPO8sULryAKkrPkdqjPapuaGUbK9VggHgB_SfKpM5h-ox5WwEr66kGRlQN-dh3TGlLDyQGO1Ayxv0BvPkj3hup3RPusJLrH0D14qVAy8BTCqh1O2JQpSxCu1L52Q49kI2Bt51IctQeKmE4dZv0gAW3Zp5laMeh-XnKu1GrcgAA;
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzNY1NlHNRxYgoIOVZARJG6Tw8Dm25ZUKrulxKhw3AeACuAqkzNeWPU8I_xKL17N1gpGUMJC24T5eP7cyJwjShd7Tm6qhZfHSJkKa_umUj5JBUFSVV7Ydkm4e2AeN0lJps8dtr30rASdfoZtZKm-p2IsfK6I6DW-rWJSdOlV1kSW8gAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
       - x-ms-gateway-slice=007; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Wed, 07 Mar 2018 20:20:06 GMT
+      - Mon, 12 Mar 2018 10:27:30 GMT
       Content-Length:
       - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1520457606","not_before":"1520453706","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3MDYsIm5iZiI6MTUyMDQ1MzcwNiwiZXhwIjoxNTIwNDU3NjA2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTFnbXRqVzFoMC0wV0djUnUxY0FBQSIsInZlciI6IjEuMCJ9.Erl0psNafp3XtL4oqBb3M0lFjZ_MJ_SHo7l_36xqNg7ftRHb3N_Z-UV9MvDb4JuraazeDmSbyds8cs5HtDmrkjbp1N4kpcNw2R3qVMQqkEafMmzKiXPNaLk_GI3qaiD1pwr7RLP5ooUohDLpy-YBFD9JqzpenQ8oOHjd6-FKZVm7Bra-o3FdOoU7U4BY0SDUmRqf9HOcquo-2AhSLYpXAXzpKY3Fs6o63k2qKcm2Z0jPmmmFnnz0QSnbWqFz6KhsH5AuNwmSgLsQ6EpUYGMlYAthQG2lWG5j4z-LkrZRhSNNHwRLcHSwtGNZhfoiFNHJsuGrP7fUY5xfucJl_cWfVA"}'
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1520854051","not_before":"1520850151","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAxNTEsIm5iZiI6MTUyMDg1MDE1MSwiZXhwIjoxNTIwODU0MDUxLCJhaW8iOiJZMk5nWU5oMlRiYXo0MmZ6c1NCSjZ3K1BUbmhKQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYzF5aWdZX3FnMEdhSmwwanp4SVdBQSIsInZlciI6IjEuMCJ9.C_t36CdMu-7-Tut5olza_36ERC--pFhJlg7cSqEsjI-FGSw4l4kQpgGNNKJWn8fueTIslcIlvTH0FrjGIhhelAf9KNYqITzZTkj33Ewj023i8bS7H3vWuA_w-kG6dXqzBRRQfDrVwTpDDV1qMCCdz0Jd_G0vZb7AIJKMaFtik5fEC24UzolIFeaLxAuGNm26YdPA4-9oWfqLt7vYMdfioMpnTsnx6PBiIzZ235slf1f0u3FYNOzNnIdmX9WecqD1BxHqp5aizLX2aZXIPWQtn01mYSu6dMhpKnfiIs-FLj4UC0JXmR8Lb9jRuIvrTSLnF1WE9ScCqV_N4brfiqVKKQ"}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:20:06 GMT
+  recorded_at: Mon, 12 Mar 2018 10:27:36 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -72,7 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3MDYsIm5iZiI6MTUyMDQ1MzcwNiwiZXhwIjoxNTIwNDU3NjA2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTFnbXRqVzFoMC0wV0djUnUxY0FBQSIsInZlciI6IjEuMCJ9.Erl0psNafp3XtL4oqBb3M0lFjZ_MJ_SHo7l_36xqNg7ftRHb3N_Z-UV9MvDb4JuraazeDmSbyds8cs5HtDmrkjbp1N4kpcNw2R3qVMQqkEafMmzKiXPNaLk_GI3qaiD1pwr7RLP5ooUohDLpy-YBFD9JqzpenQ8oOHjd6-FKZVm7Bra-o3FdOoU7U4BY0SDUmRqf9HOcquo-2AhSLYpXAXzpKY3Fs6o63k2qKcm2Z0jPmmmFnnz0QSnbWqFz6KhsH5AuNwmSgLsQ6EpUYGMlYAthQG2lWG5j4z-LkrZRhSNNHwRLcHSwtGNZhfoiFNHJsuGrP7fUY5xfucJl_cWfVA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAxNTEsIm5iZiI6MTUyMDg1MDE1MSwiZXhwIjoxNTIwODU0MDUxLCJhaW8iOiJZMk5nWU5oMlRiYXo0MmZ6c1NCSjZ3K1BUbmhKQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYzF5aWdZX3FnMEdhSmwwanp4SVdBQSIsInZlciI6IjEuMCJ9.C_t36CdMu-7-Tut5olza_36ERC--pFhJlg7cSqEsjI-FGSw4l4kQpgGNNKJWn8fueTIslcIlvTH0FrjGIhhelAf9KNYqITzZTkj33Ewj023i8bS7H3vWuA_w-kG6dXqzBRRQfDrVwTpDDV1qMCCdz0Jd_G0vZb7AIJKMaFtik5fEC24UzolIFeaLxAuGNm26YdPA4-9oWfqLt7vYMdfioMpnTsnx6PBiIzZ235slf1f0u3FYNOzNnIdmX9WecqD1BxHqp5aizLX2aZXIPWQtn01mYSu6dMhpKnfiIs-FLj4UC0JXmR8Lb9jRuIvrTSLnF1WE9ScCqV_N4brfiqVKKQ
   response:
     status:
       code: 200
@@ -91,26 +91,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14999'
+      - '14997'
       X-Ms-Request-Id:
-      - 30e5790c-7e22-4afd-b3b6-b637df104138
+      - 566f5453-80ce-4d4d-a29b-1b37b4320b27
       X-Ms-Correlation-Request-Id:
-      - 30e5790c-7e22-4afd-b3b6-b637df104138
+      - 566f5453-80ce-4d4d-a29b-1b37b4320b27
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202006Z:30e5790c-7e22-4afd-b3b6-b637df104138
+      - WESTEUROPE:20180312T102732Z:566f5453-80ce-4d4d-a29b-1b37b4320b27
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:20:06 GMT
+      - Mon, 12 Mar 2018 10:27:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID","subscriptionId":"AZURE_SUBSCRIPTION_ID","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:20:07 GMT
+  recorded_at: Mon, 12 Mar 2018 10:27:37 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers?api-version=2015-01-01
@@ -127,7 +127,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3MDYsIm5iZiI6MTUyMDQ1MzcwNiwiZXhwIjoxNTIwNDU3NjA2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTFnbXRqVzFoMC0wV0djUnUxY0FBQSIsInZlciI6IjEuMCJ9.Erl0psNafp3XtL4oqBb3M0lFjZ_MJ_SHo7l_36xqNg7ftRHb3N_Z-UV9MvDb4JuraazeDmSbyds8cs5HtDmrkjbp1N4kpcNw2R3qVMQqkEafMmzKiXPNaLk_GI3qaiD1pwr7RLP5ooUohDLpy-YBFD9JqzpenQ8oOHjd6-FKZVm7Bra-o3FdOoU7U4BY0SDUmRqf9HOcquo-2AhSLYpXAXzpKY3Fs6o63k2qKcm2Z0jPmmmFnnz0QSnbWqFz6KhsH5AuNwmSgLsQ6EpUYGMlYAthQG2lWG5j4z-LkrZRhSNNHwRLcHSwtGNZhfoiFNHJsuGrP7fUY5xfucJl_cWfVA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAxNTEsIm5iZiI6MTUyMDg1MDE1MSwiZXhwIjoxNTIwODU0MDUxLCJhaW8iOiJZMk5nWU5oMlRiYXo0MmZ6c1NCSjZ3K1BUbmhKQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYzF5aWdZX3FnMEdhSmwwanp4SVdBQSIsInZlciI6IjEuMCJ9.C_t36CdMu-7-Tut5olza_36ERC--pFhJlg7cSqEsjI-FGSw4l4kQpgGNNKJWn8fueTIslcIlvTH0FrjGIhhelAf9KNYqITzZTkj33Ewj023i8bS7H3vWuA_w-kG6dXqzBRRQfDrVwTpDDV1qMCCdz0Jd_G0vZb7AIJKMaFtik5fEC24UzolIFeaLxAuGNm26YdPA4-9oWfqLt7vYMdfioMpnTsnx6PBiIzZ235slf1f0u3FYNOzNnIdmX9WecqD1BxHqp5aizLX2aZXIPWQtn01mYSu6dMhpKnfiIs-FLj4UC0JXmR8Lb9jRuIvrTSLnF1WE9ScCqV_N4brfiqVKKQ
   response:
     status:
       code: 200
@@ -144,39 +144,37 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14976'
+      - '14981'
       X-Ms-Request-Id:
-      - 8a5832ea-c706-4db8-a525-d6716075d441
+      - 8345ddbc-37ff-45de-a86d-9ddeba719d31
       X-Ms-Correlation-Request-Id:
-      - 8a5832ea-c706-4db8-a525-d6716075d441
+      - 8345ddbc-37ff-45de-a86d-9ddeba719d31
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202008Z:8a5832ea-c706-4db8-a525-d6716075d441
+      - WESTEUROPE:20180312T102734Z:8345ddbc-37ff-45de-a86d-9ddeba719d31
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:20:07 GMT
+      - Mon, 12 Mar 2018 10:27:33 GMT
       Content-Length:
-      - '310901'
+      - '320853'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"},{"applicationId":"d87dcbc6-a371-462e-88e3-28ad15ec4e64","roleDefinitionId":"861776c5-e0df-4f95-be4f-ac1eec193323"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
+      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"},{"applicationId":"d87dcbc6-a371-462e-88e3-28ad15ec4e64","roleDefinitionId":"861776c5-e0df-4f95-be4f-ac1eec193323"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["East
+        Asia","Southeast Asia","Australia East","Australia Southeast","Japan East","Japan
+        West","Central India","South India","West India","West Europe","North Europe","Canada
+        Central","Canada East","Brazil South","West US","Central US","East US","South
+        Central US","East US 2","West Central US","North Central US","West US 2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
         US","Central US","East US","South Central US","West Europe","North Europe","East
         Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
         Central US","North Central US","Japan East","Japan West","Brazil South","Central
         India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"operations","locations":["West
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["East
+        Asia","Southeast Asia","Australia East","Australia Southeast","Japan East","Japan
+        West","Central India","South India","West India","West Europe","North Europe","Canada
+        Central","Canada East","Brazil South","West US","Central US","East US","South
+        Central US","East US 2","West Central US","North Central US","West US 2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"operations","locations":["West
         US","Central US","East US","South Central US","West Europe","North Europe","East
         Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
         Central US","North Central US","Japan East","Japan West","Brazil South","Central
@@ -232,177 +230,177 @@ http_interactions:
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/internalLoadBalancers","locations":[],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"domainNames/slots/roles/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"domainNames/slots/roles/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"domainNames/capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"domainNames/serviceCertificates","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
         US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
         Central","Canada East","UK South","UK West","West US","Central US","South
         Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
-        East","Australia Southeast","West US 2","West Central US","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        East","Australia Southeast","West US 2","West Central US","France Central","South
+        India","Central India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
         US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
         Central","Canada East","UK South","UK West","West US","Central US","South
         Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
-        East","Australia Southeast","West US 2","West Central US","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metrics","locations":["North
+        East","Australia Southeast","West US 2","West Central US","France Central","South
+        India","Central India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metrics","locations":["North
         Central US","South Central US","East US","East US 2","Canada Central","Canada
         East","West US","West US 2","West Central US","Central US","East Asia","Southeast
         Asia","North Europe","West Europe","UK South","UK West","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"resourceTypes","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"moveSubscriptionResources","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"validateSubscriptionMoveAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operationStatuses","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operatingSystems","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"operatingSystemFamilies","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicNetwork","namespace":"Microsoft.ClassicNetwork","resourceTypes":[{"resourceType":"virtualNetworks","locations":["East
+        India","West India","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"resourceTypes","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"moveSubscriptionResources","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"validateSubscriptionMoveAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operationStatuses","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operatingSystems","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"operatingSystemFamilies","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicNetwork","namespace":"Microsoft.ClassicNetwork","resourceTypes":[{"resourceType":"virtualNetworks","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"virtualNetworks/remoteVirtualNetworkPeeringProxies","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01"]},{"resourceType":"virtualNetworks/remoteVirtualNetworkPeeringProxies","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"reservedIps","locations":["East
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01"]},{"resourceType":"reservedIps","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"gatewaySupportedDevices","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"networkSecurityGroups","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"gatewaySupportedDevices","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"networkSecurityGroups","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicStorage","namespace":"Microsoft.ClassicStorage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"expressRouteCrossConnections","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"expressRouteCrossConnections/peerings","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicStorage","namespace":"Microsoft.ClassicStorage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkStorageAccountAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"storageAccounts/services","locations":["West
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkStorageAccountAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"storageAccounts/services","locations":["West
         US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
         Asia","Australia East","Australia Southeast","South India","Central India","West
         India","West US 2","West Central US","East US","East US 2","North Central
         US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
-        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/diagnosticSettings","locations":["West
+        South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/diagnosticSettings","locations":["West
         US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
         Asia","Australia East","Australia Southeast","South India","Central India","West
         India","West US 2","West Central US","East US","East US 2","North Central
         US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
-        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"disks","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"images","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"vmImages","locations":[],"apiVersions":["2016-11-01"]},{"resourceType":"publicImages","locations":[],"apiVersions":["2016-11-01","2016-04-01"]},{"resourceType":"osImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"osPlatformImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute","namespace":"Microsoft.Compute","authorizations":[{"applicationId":"60e6cd67-9c8c-4951-9b3c-23c25a2169af","roleDefinitionId":"e4770acb-272e-4dc8-87f3-12f44a612224"},{"applicationId":"a303894e-f1d8-4a37-bf10-67aa654a0596","roleDefinitionId":"903ac751-8ad5-4e5a-bfc2-5e49f450a241"},{"applicationId":"a8b6bf88-1d1a-4626-b040-9a729ea93c65","roleDefinitionId":"45c8267c-80ba-4b96-9a43-115b8f49fccd"}],"resourceTypes":[{"resourceType":"availabilitySets","locations":["East
+        South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"disks","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"images","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"vmImages","locations":[],"apiVersions":["2016-11-01"]},{"resourceType":"storageAccounts/vmImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"publicImages","locations":[],"apiVersions":["2016-11-01","2016-04-01"]},{"resourceType":"osImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"osPlatformImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute","namespace":"Microsoft.Compute","authorizations":[{"applicationId":"60e6cd67-9c8c-4951-9b3c-23c25a2169af","roleDefinitionId":"e4770acb-272e-4dc8-87f3-12f44a612224"},{"applicationId":"a303894e-f1d8-4a37-bf10-67aa654a0596","roleDefinitionId":"903ac751-8ad5-4e5a-bfc2-5e49f450a241"},{"applicationId":"a8b6bf88-1d1a-4626-b040-9a729ea93c65","roleDefinitionId":"45c8267c-80ba-4b96-9a43-115b8f49fccd"}],"resourceTypes":[{"resourceType":"availabilitySets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations/usages","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations/usages","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"sharedVMImages","locations":["West
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"sharedVMImages","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"sharedVMImages/versions","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"locations/capsoperations","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"disks","locations":["Southeast
@@ -410,27 +408,27 @@ http_interactions:
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"snapshots","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"snapshots","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"locations/diskoperations","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"locations/diskoperations","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"images","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"images","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"]},{"resourceType":"locations/logAnalytics","locations":["East
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"]},{"resourceType":"locations/logAnalytics","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
         US","East US","South Central US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
@@ -547,7 +545,12 @@ http_interactions:
         US","East Asia","East US","East US 2","Japan East","Japan West","North Central
         US","North Europe","South Central US","South India","Southeast Asia","West
         Central US","West Europe","West India","West US","West US 2","UK West","UK
-        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"},{"applicationId":"f5c26e74-f226-4ae8-85f0-b4af0080ac9e","roleDefinitionId":"529d7ae6-e892-4d43-809d-8547aeb90643"}],"resourceTypes":[{"resourceType":"components","locations":["East
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/consumergroups","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/disasterrecoveryconfigs","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"},{"applicationId":"f5c26e74-f226-4ae8-85f0-b4af0080ac9e","roleDefinitionId":"529d7ae6-e892-4d43-809d-8547aeb90643"}],"resourceTypes":[{"resourceType":"components","locations":["East
         US","South Central US","North Europe","West Europe","Southeast Asia","West
         US 2"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
         US","South Central US","North Europe","West Europe","Southeast Asia","West
@@ -614,32 +617,32 @@ http_interactions:
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/accessPolicies","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"vaults/accessPolicies","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-10-01","2015-06-01","2014-12-19-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"deletedVaults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01","2014-12-19-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"deletedVaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-10-01"]},{"resourceType":"locations/deletedVaults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations/deletedVaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
         Central US","West Europe","Southeast Asia","Japan East","West Central US"],"apiVersions":["2016-04-01"]},{"resourceType":"webServices","locations":["South
         Central US","West Europe","Southeast Asia","Japan East","East US 2","West
         Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"operations","locations":["South
@@ -665,97 +668,97 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"networkWatchers/lenses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"networkWatchers/lenses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","West
         US 2","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
@@ -846,7 +849,7 @@ http_interactions:
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
         West","Korea Central","Korea South"],"apiVersions":["2017-07-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ResourceHealth","namespace":"Microsoft.ResourceHealth","authorizations":[{"applicationId":"8bdebf23-c0fe-4187-a378-717ad86f6a53","roleDefinitionId":"cc026344-c8b1-4561-83ba-59eba84b27cc"}],"resourceTypes":[{"resourceType":"availabilityStatuses","locations":[],"apiVersions":["2017-07-01","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"notifications","locations":["Australia
-        Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Security","namespace":"Microsoft.Security","authorization":{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
+        Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Security","namespace":"Microsoft.Security","authorizations":[{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},{"applicationId":"fc780465-2017-40d4-a0c5-307022471b92"}],"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatuses","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/virtualMachines","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/endpoints","locations":["Central
@@ -898,565 +901,595 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Central India","South
         India"],"apiVersions":["2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Sql","namespace":"Microsoft.Sql","authorizations":[{"applicationId":"e4ab13ed-33cb-41b4-9140-6e264582cf85","roleDefinitionId":"ec3ddc95-44dc-47a2-9926-5e9f5ffd44ec"},{"applicationId":"0130cc9f-7ac5-4026-bd5f-80a08a54e6d9","roleDefinitionId":"45e8abf8-0ec4-44f3-9c37-cff4f7779302"},{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},{"applicationId":"76c7f279-7959-468f-8943-3954880e0d8c","roleDefinitionId":"7f7513a8-73f9-4c5f-97a2-c41f0ea783ef"}],"resourceTypes":[{"resourceType":"operations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/capabilities","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/databaseAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/databaseOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverKeyOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/keys","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/encryptionProtector","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/usages","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01","2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/communicationLinks","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administrators","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administratorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/restorableDroppedDatabases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recoverableDatabases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/geoBackupPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/importExportOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/operationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/backupLongTermRetentionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/automaticTuning","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/automaticTuning","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/databases/transparentDataEncryption","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recommendedElasticPools","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/auditingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/connectionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/connectionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies/rules","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/securityAlertPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/securityAlertPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/auditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/extendedAuditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/elasticpools","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-09-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/jobAgentOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/jobAgentAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/disasterRecoveryConfiguration","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/dnsAliases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/failoverGroups","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/virtualNetworkRules","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/virtualNetworkRulesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/virtualNetworkRulesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/databaseRestoreAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metricDefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/aggregatedDatabaseMetrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metricdefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries/queryText","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPools/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/extensions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPoolEstimates","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditRecords","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentScans","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/vulnerabilityAssessments","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessment","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/syncGroups","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups/syncMembers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/syncAgents","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"managedInstances/administrators","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/databases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metricDefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/administratorAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/administratorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncMemberOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncAgentOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncDatabaseIds","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorizations":[{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},{"applicationId":"e406a681-f3d4-42a8-90b6-c2b029497af1"}],"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/capabilities","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/databaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"locations/databaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverKeyOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/keys","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/encryptionProtector","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01","2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/communicationLinks","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/restorableDroppedDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recoverableDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/geoBackupPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/importExportOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/operationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/backupLongTermRetentionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/databases/transparentDataEncryption","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recommendedElasticPools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies/rules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/extendedAuditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/elasticPoolAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/elasticPoolOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/elasticpools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-09-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/jobAgentOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/jobAgentAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/disasterRecoveryConfiguration","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/dnsAliases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/failoverGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/virtualNetworkRules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/virtualNetworkRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/virtualNetworkRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/databaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/aggregatedDatabaseMetrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metricdefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries/queryText","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPools/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/extensions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPoolEstimates","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditRecords","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentScans","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/vulnerabilityAssessments","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessment","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/syncGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups/syncMembers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/syncAgents","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"managedInstances/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/administratorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncMemberOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncAgentOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncDatabaseIds","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/longTermRetentionPolicyOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionPolicyAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionBackupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionBackupAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorizations":[{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},{"applicationId":"e406a681-f3d4-42a8-90b6-c2b029497af1"}],"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
@@ -1795,12 +1828,12 @@ http_interactions:
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","Canada Central","Canada East","UK South","UK West","West US 2","West
-        Central US","South India","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","South India","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","South India","Canada Central","Canada East","UK South","UK West","West
-        US 2","West Central US","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Capacity","namespace":"Microsoft.Capacity","authorization":{"applicationId":"4d0ad6c7-f6c3-46d8-ab0d-1406d5e6c86b","roleDefinitionId":"FD9C0A9A-4DB9-4F41-8A61-98385DEB6E2D"},"resourceTypes":[{"resourceType":"resources","locations":["South
+        US 2","West Central US","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Capacity","namespace":"Microsoft.Capacity","authorization":{"applicationId":"4d0ad6c7-f6c3-46d8-ab0d-1406d5e6c86b","roleDefinitionId":"FD9C0A9A-4DB9-4F41-8A61-98385DEB6E2D"},"resourceTypes":[{"resourceType":"resources","locations":["South
         Central US"],"apiVersions":["2017-11-01"]},{"resourceType":"reservationOrders","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/reservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/reservations/revisions","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"catalogs","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"appliedReservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"checkOffers","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"checkScopes","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"calculatePrice","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/calculateRefund","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/return","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/split","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/merge","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"validateReservationOrder","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/availableScopes","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Cdn","namespace":"Microsoft.Cdn","resourceTypes":[{"resourceType":"profiles","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
@@ -1876,9 +1909,9 @@ http_interactions:
         2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/updateAccountsCreationSettings","locations":["West
         US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/accountsCreationSettings","locations":["West
         US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2016-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Commerce","namespace":"Microsoft.Commerce","resourceTypes":[{"resourceType":"UsageAggregates","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]},{"resourceType":"RateCard","locations":[],"apiVersions":["2016-08-31-preview","2015-06-01-preview","2015-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Consumption","namespace":"Microsoft.Consumption","resourceTypes":[{"resourceType":"ReservationSummaries","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationTransactions","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Balances","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Marketplaces","locations":[],"apiVersions":["2018-01-31"]},{"resourceType":"Pricesheets","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationDetails","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Budgets","locations":[],"apiVersions":["2018-01-31","2017-12-30-preview"]},{"resourceType":"Terms","locations":[],"apiVersions":["2018-01-31","2017-12-30-preview"]},{"resourceType":"UsageDetails","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview","2017-04-24-preview"]},{"resourceType":"Operations","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview","2017-04-24-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerInstance","namespace":"Microsoft.ContainerInstance","resourceTypes":[{"resourceType":"containerGroups","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/usages","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/operations","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/operations","locations":["West
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
         US"],"apiVersions":["2016-04-08"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.CustomerInsights","namespace":"Microsoft.CustomerInsights","authorization":{"applicationId":"38c77d00-5fcb-4cce-9d93-af4738258e3c","roleDefinitionId":"E006F9C7-F333-477C-8AD6-1F3A9FE87F55"},"resourceTypes":[{"resourceType":"hubs","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/profiles","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/interactions","locations":["East
@@ -1895,7 +1928,9 @@ http_interactions:
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"operations","locations":["East
         US 2"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Databricks","namespace":"Microsoft.Databricks","authorizations":[{"applicationId":"d9327919-6775-4843-9037-3fb0fb0473cb","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},{"applicationId":"2ff814a6-3304-4ab8-85cb-cd0e6f879c1d","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"}],"resourceTypes":[{"resourceType":"workspaces","locations":["West
         US","East US 2","West Europe","East US","North Europe","Southeast Asia","East
-        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]},{"resourceType":"locations","locations":["West
+        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2017-09-01-preview"]},{"resourceType":"workspaces/virtualNetworkPeerings","locations":["West
+        US","East US 2","West Europe","North Europe","East US","Southeast Asia","East
+        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01"]},{"resourceType":"locations","locations":["West
         US","East US 2","West Europe","North Europe","East US","Southeast Asia"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
         US","East US 2","West Europe","East US","North Europe","Southeast Asia","East
         Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataCatalog","namespace":"Microsoft.DataCatalog","resourceTypes":[{"resourceType":"catalogs","locations":["East
@@ -1919,23 +1954,26 @@ http_interactions:
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers/listSasTokens","locations":["East
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataLakeStore","namespace":"Microsoft.DataLakeStore","authorization":{"applicationId":"e9f49c6b-5ce5-44c8-925d-015017e9f7ad","roleDefinitionId":"17eb9cca-f08a-4499-b2d3-852d175f614f"},"resourceTypes":[{"resourceType":"accounts","locations":["East
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/firewallRules","locations":["East
-        US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataMigration","namespace":"Microsoft.DataMigration","authorization":{"applicationId":"a4bad4aa-bf02-4631-9f78-a64ffdba8150","roleDefinitionId":"b831a21d-db98-4760-89cb-bef871952df1","managedByRoleDefinitionId":"6256fb55-9e59-4018-a9e1-76b11c0a4c89"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services/projects","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationStatuses","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
+        US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataMigration","namespace":"Microsoft.DataMigration","authorization":{"applicationId":"a4bad4aa-bf02-4631-9f78-a64ffdba8150","roleDefinitionId":"b831a21d-db98-4760-89cb-bef871952df1","managedByRoleDefinitionId":"6256fb55-9e59-4018-a9e1-76b11c0a4c89"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services/projects","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationStatuses","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
-        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/recoverableServers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
@@ -1959,7 +1997,10 @@ http_interactions:
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
-        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/recoverableServers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
@@ -2015,12 +2056,7 @@ http_interactions:
         US 2","East US","West US","Central US","East US 2","West Central US","West
         Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
         US 2","East US","West US","Central US","East US 2","West Central US","West
-        Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","West
-        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
-        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
-        India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/consumergroups","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/disasterrecoveryconfigs","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
         US 2","South Central US","Central US","Australia Southeast","Central India","West
         Central US","West US 2","Canada East","Canada Central","Brazil South","UK
         South","UK West","East Asia","Australia East","Japan East","Japan West","North
@@ -2131,7 +2167,7 @@ http_interactions:
         West","Japan East","East Asia","Southeast Asia","West Europe","North Europe","East
         US","West US","Australia East","Australia Southeast","Central US","Brazil
         South","Central India","West India","South India","South Central US","Canada
-        Central","Canada East","West Central US","West US 2"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
+        Central","Canada East","West Central US","West US 2"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-05","2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
         Central US","East US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"operations","locations":["West
         Central US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
         Central US","East US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.PolicyInsights","namespace":"Microsoft.PolicyInsights","authorization":{"applicationId":"1d78a85d-813d-46f0-b496-dd72f50a3ec0","roleDefinitionId":"63d2b225-4c34-4641-8768-21a1f7c68ce8"},"resourceTypes":[{"resourceType":"policyEvents","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"policyStates","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
@@ -2163,12 +2199,12 @@ http_interactions:
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
         Central US","South Central US","North Europe","West Europe","East Asia","Southeast
         Asia","West US","East US","Japan West","Japan East","Brazil South","Central
         US","East US 2","Australia East","Australia Southeast","South India","Central
@@ -2208,40 +2244,50 @@ http_interactions:
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/clusterVersions","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"clusters/applications","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operations","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/clusterVersions","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/environments","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operations","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
         Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applianceDefinitions","locations":["West
         Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applications","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
-        Central US"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
+        Central US"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
         US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
         US","Canada Central","Canada East","Central US","East US 2","UK South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups","locations":["West
         US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
@@ -2332,7 +2378,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:20:08 GMT
+  recorded_at: Mon, 12 Mar 2018 10:27:39 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1?api-version=2018-01-01
@@ -2349,7 +2395,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3MDYsIm5iZiI6MTUyMDQ1MzcwNiwiZXhwIjoxNTIwNDU3NjA2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTFnbXRqVzFoMC0wV0djUnUxY0FBQSIsInZlciI6IjEuMCJ9.Erl0psNafp3XtL4oqBb3M0lFjZ_MJ_SHo7l_36xqNg7ftRHb3N_Z-UV9MvDb4JuraazeDmSbyds8cs5HtDmrkjbp1N4kpcNw2R3qVMQqkEafMmzKiXPNaLk_GI3qaiD1pwr7RLP5ooUohDLpy-YBFD9JqzpenQ8oOHjd6-FKZVm7Bra-o3FdOoU7U4BY0SDUmRqf9HOcquo-2AhSLYpXAXzpKY3Fs6o63k2qKcm2Z0jPmmmFnnz0QSnbWqFz6KhsH5AuNwmSgLsQ6EpUYGMlYAthQG2lWG5j4z-LkrZRhSNNHwRLcHSwtGNZhfoiFNHJsuGrP7fUY5xfucJl_cWfVA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAxNTEsIm5iZiI6MTUyMDg1MDE1MSwiZXhwIjoxNTIwODU0MDUxLCJhaW8iOiJZMk5nWU5oMlRiYXo0MmZ6c1NCSjZ3K1BUbmhKQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYzF5aWdZX3FnMEdhSmwwanp4SVdBQSIsInZlciI6IjEuMCJ9.C_t36CdMu-7-Tut5olza_36ERC--pFhJlg7cSqEsjI-FGSw4l4kQpgGNNKJWn8fueTIslcIlvTH0FrjGIhhelAf9KNYqITzZTkj33Ewj023i8bS7H3vWuA_w-kG6dXqzBRRQfDrVwTpDDV1qMCCdz0Jd_G0vZb7AIJKMaFtik5fEC24UzolIFeaLxAuGNm26YdPA4-9oWfqLt7vYMdfioMpnTsnx6PBiIzZ235slf1f0u3FYNOzNnIdmX9WecqD1BxHqp5aizLX2aZXIPWQtn01mYSu6dMhpKnfiIs-FLj4UC0JXmR8Lb9jRuIvrTSLnF1WE9ScCqV_N4brfiqVKKQ
   response:
     status:
       code: 200
@@ -2370,22 +2416,22 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 8bb97a92-bfa8-4f6c-a07d-ebb14774258b
+      - df24d715-81d8-454f-a31e-93bc04ea768e
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14974'
+      - '14983'
       X-Ms-Correlation-Request-Id:
-      - 41288a3b-55fa-45e6-80be-532910aabe2e
+      - 5e576c7c-35d4-468d-8951-ebd02b688d11
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202009Z:41288a3b-55fa-45e6-80be-532910aabe2e
+      - WESTEUROPE:20180312T102735Z:5e576c7c-35d4-468d-8951-ebd02b688d11
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:20:08 GMT
+      - Mon, 12 Mar 2018 10:27:35 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"rspec-lb1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1\",\r\n
@@ -2443,7 +2489,7 @@ http_interactions:
         [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
         \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:20:09 GMT
+  recorded_at: Mon, 12 Mar 2018 10:27:40 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2?api-version=2018-01-01
@@ -2460,7 +2506,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3MDYsIm5iZiI6MTUyMDQ1MzcwNiwiZXhwIjoxNTIwNDU3NjA2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTFnbXRqVzFoMC0wV0djUnUxY0FBQSIsInZlciI6IjEuMCJ9.Erl0psNafp3XtL4oqBb3M0lFjZ_MJ_SHo7l_36xqNg7ftRHb3N_Z-UV9MvDb4JuraazeDmSbyds8cs5HtDmrkjbp1N4kpcNw2R3qVMQqkEafMmzKiXPNaLk_GI3qaiD1pwr7RLP5ooUohDLpy-YBFD9JqzpenQ8oOHjd6-FKZVm7Bra-o3FdOoU7U4BY0SDUmRqf9HOcquo-2AhSLYpXAXzpKY3Fs6o63k2qKcm2Z0jPmmmFnnz0QSnbWqFz6KhsH5AuNwmSgLsQ6EpUYGMlYAthQG2lWG5j4z-LkrZRhSNNHwRLcHSwtGNZhfoiFNHJsuGrP7fUY5xfucJl_cWfVA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAxNTEsIm5iZiI6MTUyMDg1MDE1MSwiZXhwIjoxNTIwODU0MDUxLCJhaW8iOiJZMk5nWU5oMlRiYXo0MmZ6c1NCSjZ3K1BUbmhKQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYzF5aWdZX3FnMEdhSmwwanp4SVdBQSIsInZlciI6IjEuMCJ9.C_t36CdMu-7-Tut5olza_36ERC--pFhJlg7cSqEsjI-FGSw4l4kQpgGNNKJWn8fueTIslcIlvTH0FrjGIhhelAf9KNYqITzZTkj33Ewj023i8bS7H3vWuA_w-kG6dXqzBRRQfDrVwTpDDV1qMCCdz0Jd_G0vZb7AIJKMaFtik5fEC24UzolIFeaLxAuGNm26YdPA4-9oWfqLt7vYMdfioMpnTsnx6PBiIzZ235slf1f0u3FYNOzNnIdmX9WecqD1BxHqp5aizLX2aZXIPWQtn01mYSu6dMhpKnfiIs-FLj4UC0JXmR8Lb9jRuIvrTSLnF1WE9ScCqV_N4brfiqVKKQ
   response:
     status:
       code: 200
@@ -2481,22 +2527,22 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 516bd027-ca8e-4a56-9bff-9947dc4ec4c9
+      - c64e8fe2-1146-44cb-9538-3ad63d4199f9
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14975'
+      - '14988'
       X-Ms-Correlation-Request-Id:
-      - 23d1b0be-01cf-47b8-b01f-0768887be952
+      - 3ba17533-1fa5-4619-8034-160b65b8daff
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202009Z:23d1b0be-01cf-47b8-b01f-0768887be952
+      - WESTEUROPE:20180312T102736Z:3ba17533-1fa5-4619-8034-160b65b8daff
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:20:09 GMT
+      - Mon, 12 Mar 2018 10:27:36 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"rspec-lb2\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2\",\r\n
@@ -2524,7 +2570,7 @@ http_interactions:
         [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
         \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:20:09 GMT
+  recorded_at: Mon, 12 Mar 2018 10:27:41 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a?api-version=2017-12-01
@@ -2541,7 +2587,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3MDYsIm5iZiI6MTUyMDQ1MzcwNiwiZXhwIjoxNTIwNDU3NjA2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTFnbXRqVzFoMC0wV0djUnUxY0FBQSIsInZlciI6IjEuMCJ9.Erl0psNafp3XtL4oqBb3M0lFjZ_MJ_SHo7l_36xqNg7ftRHb3N_Z-UV9MvDb4JuraazeDmSbyds8cs5HtDmrkjbp1N4kpcNw2R3qVMQqkEafMmzKiXPNaLk_GI3qaiD1pwr7RLP5ooUohDLpy-YBFD9JqzpenQ8oOHjd6-FKZVm7Bra-o3FdOoU7U4BY0SDUmRqf9HOcquo-2AhSLYpXAXzpKY3Fs6o63k2qKcm2Z0jPmmmFnnz0QSnbWqFz6KhsH5AuNwmSgLsQ6EpUYGMlYAthQG2lWG5j4z-LkrZRhSNNHwRLcHSwtGNZhfoiFNHJsuGrP7fUY5xfucJl_cWfVA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAxNTEsIm5iZiI6MTUyMDg1MDE1MSwiZXhwIjoxNTIwODU0MDUxLCJhaW8iOiJZMk5nWU5oMlRiYXo0MmZ6c1NCSjZ3K1BUbmhKQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYzF5aWdZX3FnMEdhSmwwanp4SVdBQSIsInZlciI6IjEuMCJ9.C_t36CdMu-7-Tut5olza_36ERC--pFhJlg7cSqEsjI-FGSw4l4kQpgGNNKJWn8fueTIslcIlvTH0FrjGIhhelAf9KNYqITzZTkj33Ewj023i8bS7H3vWuA_w-kG6dXqzBRRQfDrVwTpDDV1qMCCdz0Jd_G0vZb7AIJKMaFtik5fEC24UzolIFeaLxAuGNm26YdPA4-9oWfqLt7vYMdfioMpnTsnx6PBiIzZ235slf1f0u3FYNOzNnIdmX9WecqD1BxHqp5aizLX2aZXIPWQtn01mYSu6dMhpKnfiIs-FLj4UC0JXmR8Lb9jRuIvrTSLnF1WE9ScCqV_N4brfiqVKKQ
   response:
     status:
       code: 200
@@ -2560,26 +2606,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/LowCostGet3Min;4727,Microsoft.Compute/LowCostGet30Min;37902
+      - Microsoft.Compute/LowCostGet3Min;4752,Microsoft.Compute/LowCostGet30Min;37768
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344652126238
       X-Ms-Request-Id:
-      - 8c25646f-d2b1-4ca0-8389-6f0e047494f5
+      - '01038a33-b4ce-4c48-91c9-b77a7a03981d'
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14976'
+      - '14986'
       X-Ms-Correlation-Request-Id:
-      - e2f8af5a-4ee8-4e3b-bea5-443e33c0707d
+      - fbeda843-6126-4edd-a423-ad6e007f33d7
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202013Z:e2f8af5a-4ee8-4e3b-bea5-443e33c0707d
+      - WESTEUROPE:20180312T102737Z:fbeda843-6126-4edd-a423-ad6e007f33d7
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:20:12 GMT
+      - Mon, 12 Mar 2018 10:27:37 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"23b0beab-16d2-4135-a01f-2fe713217fd0\",\r\n
@@ -2610,7 +2656,7 @@ http_interactions:
         \"eastus\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a\",\r\n
         \ \"name\": \"rspec-lb-a\"\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:20:13 GMT
+  recorded_at: Mon, 12 Mar 2018 10:27:42 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b?api-version=2017-12-01
@@ -2627,7 +2673,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3MDYsIm5iZiI6MTUyMDQ1MzcwNiwiZXhwIjoxNTIwNDU3NjA2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTFnbXRqVzFoMC0wV0djUnUxY0FBQSIsInZlciI6IjEuMCJ9.Erl0psNafp3XtL4oqBb3M0lFjZ_MJ_SHo7l_36xqNg7ftRHb3N_Z-UV9MvDb4JuraazeDmSbyds8cs5HtDmrkjbp1N4kpcNw2R3qVMQqkEafMmzKiXPNaLk_GI3qaiD1pwr7RLP5ooUohDLpy-YBFD9JqzpenQ8oOHjd6-FKZVm7Bra-o3FdOoU7U4BY0SDUmRqf9HOcquo-2AhSLYpXAXzpKY3Fs6o63k2qKcm2Z0jPmmmFnnz0QSnbWqFz6KhsH5AuNwmSgLsQ6EpUYGMlYAthQG2lWG5j4z-LkrZRhSNNHwRLcHSwtGNZhfoiFNHJsuGrP7fUY5xfucJl_cWfVA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAxNTEsIm5iZiI6MTUyMDg1MDE1MSwiZXhwIjoxNTIwODU0MDUxLCJhaW8iOiJZMk5nWU5oMlRiYXo0MmZ6c1NCSjZ3K1BUbmhKQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYzF5aWdZX3FnMEdhSmwwanp4SVdBQSIsInZlciI6IjEuMCJ9.C_t36CdMu-7-Tut5olza_36ERC--pFhJlg7cSqEsjI-FGSw4l4kQpgGNNKJWn8fueTIslcIlvTH0FrjGIhhelAf9KNYqITzZTkj33Ewj023i8bS7H3vWuA_w-kG6dXqzBRRQfDrVwTpDDV1qMCCdz0Jd_G0vZb7AIJKMaFtik5fEC24UzolIFeaLxAuGNm26YdPA4-9oWfqLt7vYMdfioMpnTsnx6PBiIzZ235slf1f0u3FYNOzNnIdmX9WecqD1BxHqp5aizLX2aZXIPWQtn01mYSu6dMhpKnfiIs-FLj4UC0JXmR8Lb9jRuIvrTSLnF1WE9ScCqV_N4brfiqVKKQ
   response:
     status:
       code: 200
@@ -2646,26 +2692,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/LowCostGet3Min;4720,Microsoft.Compute/LowCostGet30Min;37895
+      - Microsoft.Compute/LowCostGet3Min;4750,Microsoft.Compute/LowCostGet30Min;37766
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344652126238
       X-Ms-Request-Id:
-      - 84d2f5d0-67df-4312-8466-d25670c6791c
+      - 8f8afd6f-6d36-416a-bdf3-2f42c0d164bb
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14978'
+      - '14981'
       X-Ms-Correlation-Request-Id:
-      - 157f67ca-bde1-4ecb-b74a-07f4a88cf40e
+      - bd2646f1-7524-4383-8e62-4e31c0bfbd18
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202014Z:157f67ca-bde1-4ecb-b74a-07f4a88cf40e
+      - WESTEUROPE:20180312T102738Z:bd2646f1-7524-4383-8e62-4e31c0bfbd18
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:20:13 GMT
+      - Mon, 12 Mar 2018 10:27:37 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"834a70b5-868d-4466-9dda-14e0f6b2caaf\",\r\n
@@ -2696,7 +2742,7 @@ http_interactions:
         \"eastus\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b\",\r\n
         \ \"name\": \"rspec-lb-b\"\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:20:14 GMT
+  recorded_at: Mon, 12 Mar 2018 10:27:43 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670?api-version=2018-01-01
@@ -2713,7 +2759,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3MDYsIm5iZiI6MTUyMDQ1MzcwNiwiZXhwIjoxNTIwNDU3NjA2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTFnbXRqVzFoMC0wV0djUnUxY0FBQSIsInZlciI6IjEuMCJ9.Erl0psNafp3XtL4oqBb3M0lFjZ_MJ_SHo7l_36xqNg7ftRHb3N_Z-UV9MvDb4JuraazeDmSbyds8cs5HtDmrkjbp1N4kpcNw2R3qVMQqkEafMmzKiXPNaLk_GI3qaiD1pwr7RLP5ooUohDLpy-YBFD9JqzpenQ8oOHjd6-FKZVm7Bra-o3FdOoU7U4BY0SDUmRqf9HOcquo-2AhSLYpXAXzpKY3Fs6o63k2qKcm2Z0jPmmmFnnz0QSnbWqFz6KhsH5AuNwmSgLsQ6EpUYGMlYAthQG2lWG5j4z-LkrZRhSNNHwRLcHSwtGNZhfoiFNHJsuGrP7fUY5xfucJl_cWfVA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAxNTEsIm5iZiI6MTUyMDg1MDE1MSwiZXhwIjoxNTIwODU0MDUxLCJhaW8iOiJZMk5nWU5oMlRiYXo0MmZ6c1NCSjZ3K1BUbmhKQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYzF5aWdZX3FnMEdhSmwwanp4SVdBQSIsInZlciI6IjEuMCJ9.C_t36CdMu-7-Tut5olza_36ERC--pFhJlg7cSqEsjI-FGSw4l4kQpgGNNKJWn8fueTIslcIlvTH0FrjGIhhelAf9KNYqITzZTkj33Ewj023i8bS7H3vWuA_w-kG6dXqzBRRQfDrVwTpDDV1qMCCdz0Jd_G0vZb7AIJKMaFtik5fEC24UzolIFeaLxAuGNm26YdPA4-9oWfqLt7vYMdfioMpnTsnx6PBiIzZ235slf1f0u3FYNOzNnIdmX9WecqD1BxHqp5aizLX2aZXIPWQtn01mYSu6dMhpKnfiIs-FLj4UC0JXmR8Lb9jRuIvrTSLnF1WE9ScCqV_N4brfiqVKKQ
   response:
     status:
       code: 200
@@ -2734,22 +2780,22 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - e39658b2-acad-4d31-9299-d036fbc20efb
+      - '07027490-4451-41cf-8aef-5665f8bef341'
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14979'
+      - '14984'
       X-Ms-Correlation-Request-Id:
-      - c4493456-c50a-4cb7-bd7b-c2b1a71c675f
+      - 866923c4-8811-407e-b16b-371c36594cde
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202014Z:c4493456-c50a-4cb7-bd7b-c2b1a71c675f
+      - WESTEUROPE:20180312T102739Z:866923c4-8811-407e-b16b-371c36594cde
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:20:14 GMT
+      - Mon, 12 Mar 2018 10:27:39 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"rspec-lb-a670\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670\",\r\n
@@ -2777,7 +2823,7 @@ http_interactions:
         \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
         \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:20:14 GMT
+  recorded_at: Mon, 12 Mar 2018 10:27:43 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843?api-version=2018-01-01
@@ -2794,7 +2840,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3MDYsIm5iZiI6MTUyMDQ1MzcwNiwiZXhwIjoxNTIwNDU3NjA2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTFnbXRqVzFoMC0wV0djUnUxY0FBQSIsInZlciI6IjEuMCJ9.Erl0psNafp3XtL4oqBb3M0lFjZ_MJ_SHo7l_36xqNg7ftRHb3N_Z-UV9MvDb4JuraazeDmSbyds8cs5HtDmrkjbp1N4kpcNw2R3qVMQqkEafMmzKiXPNaLk_GI3qaiD1pwr7RLP5ooUohDLpy-YBFD9JqzpenQ8oOHjd6-FKZVm7Bra-o3FdOoU7U4BY0SDUmRqf9HOcquo-2AhSLYpXAXzpKY3Fs6o63k2qKcm2Z0jPmmmFnnz0QSnbWqFz6KhsH5AuNwmSgLsQ6EpUYGMlYAthQG2lWG5j4z-LkrZRhSNNHwRLcHSwtGNZhfoiFNHJsuGrP7fUY5xfucJl_cWfVA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAxNTEsIm5iZiI6MTUyMDg1MDE1MSwiZXhwIjoxNTIwODU0MDUxLCJhaW8iOiJZMk5nWU5oMlRiYXo0MmZ6c1NCSjZ3K1BUbmhKQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYzF5aWdZX3FnMEdhSmwwanp4SVdBQSIsInZlciI6IjEuMCJ9.C_t36CdMu-7-Tut5olza_36ERC--pFhJlg7cSqEsjI-FGSw4l4kQpgGNNKJWn8fueTIslcIlvTH0FrjGIhhelAf9KNYqITzZTkj33Ewj023i8bS7H3vWuA_w-kG6dXqzBRRQfDrVwTpDDV1qMCCdz0Jd_G0vZb7AIJKMaFtik5fEC24UzolIFeaLxAuGNm26YdPA4-9oWfqLt7vYMdfioMpnTsnx6PBiIzZ235slf1f0u3FYNOzNnIdmX9WecqD1BxHqp5aizLX2aZXIPWQtn01mYSu6dMhpKnfiIs-FLj4UC0JXmR8Lb9jRuIvrTSLnF1WE9ScCqV_N4brfiqVKKQ
   response:
     status:
       code: 200
@@ -2815,22 +2861,22 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 13f2ebf3-6536-4cb7-be59-932129d45838
+      - 6e989216-f55b-4871-81bb-42dbe0790ca8
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14975'
+      - '14983'
       X-Ms-Correlation-Request-Id:
-      - b813d13a-9e09-4a84-bd73-3854d47d0a2b
+      - 016a5a7d-6224-421a-b3c3-5a5aa4ecd9bb
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202015Z:b813d13a-9e09-4a84-bd73-3854d47d0a2b
+      - WESTEUROPE:20180312T102740Z:016a5a7d-6224-421a-b3c3-5a5aa4ecd9bb
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:20:14 GMT
+      - Mon, 12 Mar 2018 10:27:40 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"rspec-lb-b843\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843\",\r\n
@@ -2855,10 +2901,10 @@ http_interactions:
         \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
         \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:20:15 GMT
+  recorded_at: Mon, 12 Mar 2018 10:27:45 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups/miq-azure-test1?api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a/instanceView?api-version=2017-12-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2872,60 +2918,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3MDYsIm5iZiI6MTUyMDQ1MzcwNiwiZXhwIjoxNTIwNDU3NjA2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTFnbXRqVzFoMC0wV0djUnUxY0FBQSIsInZlciI6IjEuMCJ9.Erl0psNafp3XtL4oqBb3M0lFjZ_MJ_SHo7l_36xqNg7ftRHb3N_Z-UV9MvDb4JuraazeDmSbyds8cs5HtDmrkjbp1N4kpcNw2R3qVMQqkEafMmzKiXPNaLk_GI3qaiD1pwr7RLP5ooUohDLpy-YBFD9JqzpenQ8oOHjd6-FKZVm7Bra-o3FdOoU7U4BY0SDUmRqf9HOcquo-2AhSLYpXAXzpKY3Fs6o63k2qKcm2Z0jPmmmFnnz0QSnbWqFz6KhsH5AuNwmSgLsQ6EpUYGMlYAthQG2lWG5j4z-LkrZRhSNNHwRLcHSwtGNZhfoiFNHJsuGrP7fUY5xfucJl_cWfVA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14979'
-      X-Ms-Request-Id:
-      - 5aeca77a-6904-4d6a-90cc-2f5e093dac4a
-      X-Ms-Correlation-Request-Id:
-      - 5aeca77a-6904-4d6a-90cc-2f5e093dac4a
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202015Z:5aeca77a-6904-4d6a-90cc-2f5e093dac4a
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:20:15 GMT
-      Content-Length:
-      - '183'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1","name":"miq-azure-test1","location":"eastus","properties":{"provisioningState":"Succeeded"}}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:20:15 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute/locations/eastus/vmSizes?api-version=2017-12-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3MDYsIm5iZiI6MTUyMDQ1MzcwNiwiZXhwIjoxNTIwNDU3NjA2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTFnbXRqVzFoMC0wV0djUnUxY0FBQSIsInZlciI6IjEuMCJ9.Erl0psNafp3XtL4oqBb3M0lFjZ_MJ_SHo7l_36xqNg7ftRHb3N_Z-UV9MvDb4JuraazeDmSbyds8cs5HtDmrkjbp1N4kpcNw2R3qVMQqkEafMmzKiXPNaLk_GI3qaiD1pwr7RLP5ooUohDLpy-YBFD9JqzpenQ8oOHjd6-FKZVm7Bra-o3FdOoU7U4BY0SDUmRqf9HOcquo-2AhSLYpXAXzpKY3Fs6o63k2qKcm2Z0jPmmmFnnz0QSnbWqFz6KhsH5AuNwmSgLsQ6EpUYGMlYAthQG2lWG5j4z-LkrZRhSNNHwRLcHSwtGNZhfoiFNHJsuGrP7fUY5xfucJl_cWfVA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAxNTEsIm5iZiI6MTUyMDg1MDE1MSwiZXhwIjoxNTIwODU0MDUxLCJhaW8iOiJZMk5nWU5oMlRiYXo0MmZ6c1NCSjZ3K1BUbmhKQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYzF5aWdZX3FnMEdhSmwwanp4SVdBQSIsInZlciI6IjEuMCJ9.C_t36CdMu-7-Tut5olza_36ERC--pFhJlg7cSqEsjI-FGSw4l4kQpgGNNKJWn8fueTIslcIlvTH0FrjGIhhelAf9KNYqITzZTkj33Ewj023i8bS7H3vWuA_w-kG6dXqzBRRQfDrVwTpDDV1qMCCdz0Jd_G0vZb7AIJKMaFtik5fEC24UzolIFeaLxAuGNm26YdPA4-9oWfqLt7vYMdfioMpnTsnx6PBiIzZ235slf1f0u3FYNOzNnIdmX9WecqD1BxHqp5aizLX2aZXIPWQtn01mYSu6dMhpKnfiIs-FLj4UC0JXmR8Lb9jRuIvrTSLnF1WE9ScCqV_N4brfiqVKKQ
   response:
     status:
       code: 200
@@ -2944,26 +2937,233 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/LowCostGet3Min;4719,Microsoft.Compute/LowCostGet30Min;37894
+      - Microsoft.Compute/GetInstanceView3Min;4796,Microsoft.Compute/GetInstanceView30Min;23762
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344652126238
       X-Ms-Request-Id:
-      - 9157e803-95ee-4e1e-b56f-62da29c5e0d3
+      - cfa13c05-fcde-4fb6-8368-6f8180ed3e92
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14972'
+      - '14984'
       X-Ms-Correlation-Request-Id:
-      - 1fae04f1-6333-413d-9b6a-2e8bbc73a20c
+      - a456e04b-d7ef-4d16-9661-edd4697918f5
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202016Z:1fae04f1-6333-413d-9b6a-2e8bbc73a20c
+      - WESTEUROPE:20180312T102749Z:a456e04b-d7ef-4d16-9661-edd4697918f5
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:20:15 GMT
+      - Mon, 12 Mar 2018 10:27:49 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"platformUpdateDomain\": 0,\r\n  \"platformFaultDomain\": 0,\r\n
+        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
+        [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
+        \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
+        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2018-03-12T10:27:41+00:00\"\r\n
+        \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"rspec-lb-a\",\r\n
+        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
+        succeeded\",\r\n          \"time\": \"2016-09-03T14:04:26.7359609+00:00\"\r\n
+        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
+        \"https://miqazuretest16487.blob.core.windows.net/bootdiagnostics-rspeclba-23b0beab-16d2-4135-a01f-2fe713217fd0/rspec-lb-a.23b0beab-16d2-4135-a01f-2fe713217fd0.screenshot.bmp\",\r\n
+        \   \"serialConsoleLogBlobUri\": \"https://miqazuretest16487.blob.core.windows.net/bootdiagnostics-rspeclba-23b0beab-16d2-4135-a01f-2fe713217fd0/rspec-lb-a.23b0beab-16d2-4135-a01f-2fe713217fd0.serialconsole.log\"\r\n
+        \ },\r\n  \"extensions\": [\r\n    {\r\n      \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n
+        \   }\r\n  ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n
+        \     \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n
+        \     \"time\": \"2016-09-03T14:04:26.7828345+00:00\"\r\n    },\r\n    {\r\n
+        \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
+        \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 10:27:54 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b/instanceView?api-version=2017-12-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAxNTEsIm5iZiI6MTUyMDg1MDE1MSwiZXhwIjoxNTIwODU0MDUxLCJhaW8iOiJZMk5nWU5oMlRiYXo0MmZ6c1NCSjZ3K1BUbmhKQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYzF5aWdZX3FnMEdhSmwwanp4SVdBQSIsInZlciI6IjEuMCJ9.C_t36CdMu-7-Tut5olza_36ERC--pFhJlg7cSqEsjI-FGSw4l4kQpgGNNKJWn8fueTIslcIlvTH0FrjGIhhelAf9KNYqITzZTkj33Ewj023i8bS7H3vWuA_w-kG6dXqzBRRQfDrVwTpDDV1qMCCdz0Jd_G0vZb7AIJKMaFtik5fEC24UzolIFeaLxAuGNm26YdPA4-9oWfqLt7vYMdfioMpnTsnx6PBiIzZ235slf1f0u3FYNOzNnIdmX9WecqD1BxHqp5aizLX2aZXIPWQtn01mYSu6dMhpKnfiIs-FLj4UC0JXmR8Lb9jRuIvrTSLnF1WE9ScCqV_N4brfiqVKKQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/GetInstanceView3Min;4795,Microsoft.Compute/GetInstanceView30Min;23761
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344652126238
+      X-Ms-Request-Id:
+      - be1bd565-5fbf-4d15-9f95-8b901c5c7efc
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14980'
+      X-Ms-Correlation-Request-Id:
+      - 7423d70a-6cb9-417b-b4d8-729c0aa1f52e
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T102750Z:7423d70a-6cb9-417b-b4d8-729c0aa1f52e
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 10:27:50 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"platformUpdateDomain\": 1,\r\n  \"platformFaultDomain\": 1,\r\n
+        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
+        [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
+        \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
+        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2018-03-12T10:27:50+00:00\"\r\n
+        \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"rspec-lb-b\",\r\n
+        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
+        succeeded\",\r\n          \"time\": \"2016-09-03T14:07:52.9377685+00:00\"\r\n
+        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
+        \"https://amissteastorage.blob.core.windows.net/bootdiagnostics-rspeclbb-834a70b5-868d-4466-9dda-14e0f6b2caaf/rspec-lb-b.834a70b5-868d-4466-9dda-14e0f6b2caaf.screenshot.bmp\",\r\n
+        \   \"serialConsoleLogBlobUri\": \"https://amissteastorage.blob.core.windows.net/bootdiagnostics-rspeclbb-834a70b5-868d-4466-9dda-14e0f6b2caaf/rspec-lb-b.834a70b5-868d-4466-9dda-14e0f6b2caaf.serialconsole.log\"\r\n
+        \ },\r\n  \"extensions\": [\r\n    {\r\n      \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n
+        \   }\r\n  ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n
+        \     \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n
+        \     \"time\": \"2016-09-03T14:07:52.9846158+00:00\"\r\n    },\r\n    {\r\n
+        \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
+        \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 10:27:55 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups/miq-azure-test1?api-version=2017-08-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAxNTEsIm5iZiI6MTUyMDg1MDE1MSwiZXhwIjoxNTIwODU0MDUxLCJhaW8iOiJZMk5nWU5oMlRiYXo0MmZ6c1NCSjZ3K1BUbmhKQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYzF5aWdZX3FnMEdhSmwwanp4SVdBQSIsInZlciI6IjEuMCJ9.C_t36CdMu-7-Tut5olza_36ERC--pFhJlg7cSqEsjI-FGSw4l4kQpgGNNKJWn8fueTIslcIlvTH0FrjGIhhelAf9KNYqITzZTkj33Ewj023i8bS7H3vWuA_w-kG6dXqzBRRQfDrVwTpDDV1qMCCdz0Jd_G0vZb7AIJKMaFtik5fEC24UzolIFeaLxAuGNm26YdPA4-9oWfqLt7vYMdfioMpnTsnx6PBiIzZ235slf1f0u3FYNOzNnIdmX9WecqD1BxHqp5aizLX2aZXIPWQtn01mYSu6dMhpKnfiIs-FLj4UC0JXmR8Lb9jRuIvrTSLnF1WE9ScCqV_N4brfiqVKKQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14984'
+      X-Ms-Request-Id:
+      - 045f384f-756b-4b69-a8de-9bf18c7f65e3
+      X-Ms-Correlation-Request-Id:
+      - 045f384f-756b-4b69-a8de-9bf18c7f65e3
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T102751Z:045f384f-756b-4b69-a8de-9bf18c7f65e3
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 10:27:50 GMT
+      Content-Length:
+      - '183'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1","name":"miq-azure-test1","location":"eastus","properties":{"provisioningState":"Succeeded"}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 10:27:55 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute/locations/eastus/vmSizes?api-version=2017-12-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAxNTEsIm5iZiI6MTUyMDg1MDE1MSwiZXhwIjoxNTIwODU0MDUxLCJhaW8iOiJZMk5nWU5oMlRiYXo0MmZ6c1NCSjZ3K1BUbmhKQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYzF5aWdZX3FnMEdhSmwwanp4SVdBQSIsInZlciI6IjEuMCJ9.C_t36CdMu-7-Tut5olza_36ERC--pFhJlg7cSqEsjI-FGSw4l4kQpgGNNKJWn8fueTIslcIlvTH0FrjGIhhelAf9KNYqITzZTkj33Ewj023i8bS7H3vWuA_w-kG6dXqzBRRQfDrVwTpDDV1qMCCdz0Jd_G0vZb7AIJKMaFtik5fEC24UzolIFeaLxAuGNm26YdPA4-9oWfqLt7vYMdfioMpnTsnx6PBiIzZ235slf1f0u3FYNOzNnIdmX9WecqD1BxHqp5aizLX2aZXIPWQtn01mYSu6dMhpKnfiIs-FLj4UC0JXmR8Lb9jRuIvrTSLnF1WE9ScCqV_N4brfiqVKKQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/LowCostGet3Min;4744,Microsoft.Compute/LowCostGet30Min;37760
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344652126238
+      X-Ms-Request-Id:
+      - a2883b86-0355-4cc0-a1da-b0dacd48d482
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14986'
+      X-Ms-Correlation-Request-Id:
+      - 1b3f9149-fb67-4ea9-b098-3b842879f04c
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T102751Z:1b3f9149-fb67-4ea9-b098-3b842879f04c
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 10:27:51 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"Standard_B1ms\",\r\n
@@ -3440,6 +3640,12 @@ http_interactions:
         \   },\r\n    {\r\n      \"name\": \"Standard_F72s_v2\",\r\n      \"numberOfCores\":
         72,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
         589824,\r\n      \"memoryInMB\": 147456,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_L8s_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1811981,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_L16s_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        3623962,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
         \   },\r\n    {\r\n      \"name\": \"Standard_ND6s\",\r\n      \"numberOfCores\":
         6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
         344064,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 12\r\n
@@ -3466,7 +3672,7 @@ http_interactions:
         391168,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
         \   }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:20:16 GMT
+  recorded_at: Mon, 12 Mar 2018 10:27:56 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802122903?api-version=2017-08-01
@@ -3483,7 +3689,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3MDYsIm5iZiI6MTUyMDQ1MzcwNiwiZXhwIjoxNTIwNDU3NjA2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTFnbXRqVzFoMC0wV0djUnUxY0FBQSIsInZlciI6IjEuMCJ9.Erl0psNafp3XtL4oqBb3M0lFjZ_MJ_SHo7l_36xqNg7ftRHb3N_Z-UV9MvDb4JuraazeDmSbyds8cs5HtDmrkjbp1N4kpcNw2R3qVMQqkEafMmzKiXPNaLk_GI3qaiD1pwr7RLP5ooUohDLpy-YBFD9JqzpenQ8oOHjd6-FKZVm7Bra-o3FdOoU7U4BY0SDUmRqf9HOcquo-2AhSLYpXAXzpKY3Fs6o63k2qKcm2Z0jPmmmFnnz0QSnbWqFz6KhsH5AuNwmSgLsQ6EpUYGMlYAthQG2lWG5j4z-LkrZRhSNNHwRLcHSwtGNZhfoiFNHJsuGrP7fUY5xfucJl_cWfVA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAxNTEsIm5iZiI6MTUyMDg1MDE1MSwiZXhwIjoxNTIwODU0MDUxLCJhaW8iOiJZMk5nWU5oMlRiYXo0MmZ6c1NCSjZ3K1BUbmhKQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYzF5aWdZX3FnMEdhSmwwanp4SVdBQSIsInZlciI6IjEuMCJ9.C_t36CdMu-7-Tut5olza_36ERC--pFhJlg7cSqEsjI-FGSw4l4kQpgGNNKJWn8fueTIslcIlvTH0FrjGIhhelAf9KNYqITzZTkj33Ewj023i8bS7H3vWuA_w-kG6dXqzBRRQfDrVwTpDDV1qMCCdz0Jd_G0vZb7AIJKMaFtik5fEC24UzolIFeaLxAuGNm26YdPA4-9oWfqLt7vYMdfioMpnTsnx6PBiIzZ235slf1f0u3FYNOzNnIdmX9WecqD1BxHqp5aizLX2aZXIPWQtn01mYSu6dMhpKnfiIs-FLj4UC0JXmR8Lb9jRuIvrTSLnF1WE9ScCqV_N4brfiqVKKQ
   response:
     status:
       code: 200
@@ -3500,26 +3706,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14975'
+      - '14987'
       X-Ms-Request-Id:
-      - 0ea4d0cb-3d02-4096-b7ff-0f17db35a1f7
+      - 2ce6a2bb-fc5c-4886-b2d6-f3392acdedb8
       X-Ms-Correlation-Request-Id:
-      - 0ea4d0cb-3d02-4096-b7ff-0f17db35a1f7
+      - 2ce6a2bb-fc5c-4886-b2d6-f3392acdedb8
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202017Z:0ea4d0cb-3d02-4096-b7ff-0f17db35a1f7
+      - WESTEUROPE:20180312T102756Z:2ce6a2bb-fc5c-4886-b2d6-f3392acdedb8
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:20:16 GMT
+      - Mon, 12 Mar 2018 10:27:56 GMT
       Content-Length:
       - '6500'
     body:
       encoding: ASCII-8BIT
       string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802122903","name":"RedHat.RedHatEnterpriseLinux67-20160802122903","properties":{"parameters":{"location":{"type":"String","value":"eastus"},"virtualMachineName":{"type":"String","value":"rspec-lb-a"},"virtualMachineSize":{"type":"String","value":"Standard_F1s"},"adminUsername":{"type":"String","value":"bronaghs"},"storageAccountName":{"type":"String","value":"rspeclb"},"virtualNetworkName":{"type":"String","value":"miq-azure-test1"},"networkInterfaceName":{"type":"String","value":"rspec-lb-a670"},"networkSecurityGroupName":{"type":"String","value":"rspec-lb-a-nsg"},"adminPassword":{"type":"SecureString"},"availabilitySetName":{"type":"String","value":"rspec-lb"},"availabilitySetPlatformFaultDomainCount":{"type":"String","value":"3"},"availabilitySetPlatformUpdateDomainCount":{"type":"String","value":"5"},"storageAccountType":{"type":"String","value":"Premium_LRS"},"diagnosticsStorageAccountName":{"type":"String","value":"miqazuretest16487"},"diagnosticsStorageAccountId":{"type":"String","value":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487"},"subnetName":{"type":"String","value":"default"},"publicIpAddressName":{"type":"String","value":"rspec-lb-a-ip"},"publicIpAddressType":{"type":"String","value":"Dynamic"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-09-02T16:34:50.7306487Z","duration":"PT5M42.9911979S","correlationId":"8ed1d69b-1d36-4441-9d80-b07a5982a384","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]},{"resourceType":"virtualMachines/extensions","locations":["eastus"]},{"resourceType":"availabilitySets","locations":["eastus"]}]},{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkInterfaces","locations":["eastus"]},{"resourceType":"publicIpAddresses","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"rspec-lb-a670"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/rspec-lb","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"rspec-lb"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"rspeclb"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"rspeclb","apiVersion":"2015-06-15"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest16487","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"rspec-lb-a"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"rspec-lb-a"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest16487","actionName":"listKeys","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"rspec-lb-a/Microsoft.Insights.VMDiagnosticsSettings"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/rspec-lb-a-ip","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"rspec-lb-a-ip"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"rspec-lb-a-nsg"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"rspec-lb-a670"}],"outputs":{"adminUsername":{"type":"String","value":"bronaghs"}},"outputResources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/rspec-lb"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a/extensions/Microsoft.Insights.VMDiagnosticsSettings"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/rspec-lb-a-ip"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb"}]}}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:20:17 GMT
+  recorded_at: Mon, 12 Mar 2018 10:28:01 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802123704?api-version=2017-08-01
@@ -3536,7 +3742,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3MDYsIm5iZiI6MTUyMDQ1MzcwNiwiZXhwIjoxNTIwNDU3NjA2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTFnbXRqVzFoMC0wV0djUnUxY0FBQSIsInZlciI6IjEuMCJ9.Erl0psNafp3XtL4oqBb3M0lFjZ_MJ_SHo7l_36xqNg7ftRHb3N_Z-UV9MvDb4JuraazeDmSbyds8cs5HtDmrkjbp1N4kpcNw2R3qVMQqkEafMmzKiXPNaLk_GI3qaiD1pwr7RLP5ooUohDLpy-YBFD9JqzpenQ8oOHjd6-FKZVm7Bra-o3FdOoU7U4BY0SDUmRqf9HOcquo-2AhSLYpXAXzpKY3Fs6o63k2qKcm2Z0jPmmmFnnz0QSnbWqFz6KhsH5AuNwmSgLsQ6EpUYGMlYAthQG2lWG5j4z-LkrZRhSNNHwRLcHSwtGNZhfoiFNHJsuGrP7fUY5xfucJl_cWfVA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAxNTEsIm5iZiI6MTUyMDg1MDE1MSwiZXhwIjoxNTIwODU0MDUxLCJhaW8iOiJZMk5nWU5oMlRiYXo0MmZ6c1NCSjZ3K1BUbmhKQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYzF5aWdZX3FnMEdhSmwwanp4SVdBQSIsInZlciI6IjEuMCJ9.C_t36CdMu-7-Tut5olza_36ERC--pFhJlg7cSqEsjI-FGSw4l4kQpgGNNKJWn8fueTIslcIlvTH0FrjGIhhelAf9KNYqITzZTkj33Ewj023i8bS7H3vWuA_w-kG6dXqzBRRQfDrVwTpDDV1qMCCdz0Jd_G0vZb7AIJKMaFtik5fEC24UzolIFeaLxAuGNm26YdPA4-9oWfqLt7vYMdfioMpnTsnx6PBiIzZ235slf1f0u3FYNOzNnIdmX9WecqD1BxHqp5aizLX2aZXIPWQtn01mYSu6dMhpKnfiIs-FLj4UC0JXmR8Lb9jRuIvrTSLnF1WE9ScCqV_N4brfiqVKKQ
   response:
     status:
       code: 200
@@ -3553,26 +3759,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14974'
+      - '14980'
       X-Ms-Request-Id:
-      - 6b2c3618-fce7-4c3c-955c-8c531ba67b2d
+      - 3349fde0-0589-434d-bde8-9fc9b636e511
       X-Ms-Correlation-Request-Id:
-      - 6b2c3618-fce7-4c3c-955c-8c531ba67b2d
+      - 3349fde0-0589-434d-bde8-9fc9b636e511
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202018Z:6b2c3618-fce7-4c3c-955c-8c531ba67b2d
+      - WESTEUROPE:20180312T102757Z:3349fde0-0589-434d-bde8-9fc9b636e511
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:20:17 GMT
+      - Mon, 12 Mar 2018 10:27:56 GMT
       Content-Length:
       - '5370'
     body:
       encoding: ASCII-8BIT
       string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802123704","name":"RedHat.RedHatEnterpriseLinux67-20160802123704","properties":{"parameters":{"location":{"type":"String","value":"eastus"},"virtualMachineName":{"type":"String","value":"rspec-lb-b"},"virtualMachineSize":{"type":"String","value":"Standard_DS1_v2"},"adminUsername":{"type":"String","value":"bronaghs"},"storageAccountName":{"type":"String","value":"rspeclb"},"virtualNetworkName":{"type":"String","value":"miq-azure-test1"},"networkInterfaceName":{"type":"String","value":"rspec-lb-b843"},"networkSecurityGroupName":{"type":"String","value":"rspec-lb-b-nsg"},"adminPassword":{"type":"SecureString"},"availabilitySetName":{"type":"String","value":"rspec-lb"},"diagnosticsStorageAccountName":{"type":"String","value":"amissteastorage"},"diagnosticsStorageAccountId":{"type":"String","value":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/amisstea-rg/providers/Microsoft.Storage/storageAccounts/amissteastorage"},"subnetName":{"type":"String","value":"default"},"publicIpAddressName":{"type":"String","value":"rspec-lb-b-ip"},"publicIpAddressType":{"type":"String","value":"Dynamic"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-09-02T16:42:20.1492177Z","duration":"PT5M12.4641651S","correlationId":"55d1443a-bd21-4f39-9411-c1e4db80945f","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]},{"resourceType":"virtualMachines/extensions","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkInterfaces","locations":["eastus"]},{"resourceType":"publicIpAddresses","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"rspec-lb-b843"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"rspeclb","apiVersion":"2015-06-15"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/amisstea-rg/providers/Microsoft.Storage/storageAccounts/amissteastorage","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"amissteastorage","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"rspec-lb-b"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"rspec-lb-b"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/amisstea-rg/providers/Microsoft.Storage/storageAccounts/amissteastorage","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"amissteastorage","actionName":"listKeys","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"rspec-lb-b/Microsoft.Insights.VMDiagnosticsSettings"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/rspec-lb-b-ip","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"rspec-lb-b-ip"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"rspec-lb-b-nsg"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"rspec-lb-b843"}],"outputs":{"adminUsername":{"type":"String","value":"bronaghs"}},"outputResources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b/extensions/Microsoft.Insights.VMDiagnosticsSettings"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/rspec-lb-b-ip"}]}}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:20:18 GMT
+  recorded_at: Mon, 12 Mar 2018 10:28:02 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250?api-version=2017-08-01
@@ -3589,7 +3795,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3MDYsIm5iZiI6MTUyMDQ1MzcwNiwiZXhwIjoxNTIwNDU3NjA2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTFnbXRqVzFoMC0wV0djUnUxY0FBQSIsInZlciI6IjEuMCJ9.Erl0psNafp3XtL4oqBb3M0lFjZ_MJ_SHo7l_36xqNg7ftRHb3N_Z-UV9MvDb4JuraazeDmSbyds8cs5HtDmrkjbp1N4kpcNw2R3qVMQqkEafMmzKiXPNaLk_GI3qaiD1pwr7RLP5ooUohDLpy-YBFD9JqzpenQ8oOHjd6-FKZVm7Bra-o3FdOoU7U4BY0SDUmRqf9HOcquo-2AhSLYpXAXzpKY3Fs6o63k2qKcm2Z0jPmmmFnnz0QSnbWqFz6KhsH5AuNwmSgLsQ6EpUYGMlYAthQG2lWG5j4z-LkrZRhSNNHwRLcHSwtGNZhfoiFNHJsuGrP7fUY5xfucJl_cWfVA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAxNTEsIm5iZiI6MTUyMDg1MDE1MSwiZXhwIjoxNTIwODU0MDUxLCJhaW8iOiJZMk5nWU5oMlRiYXo0MmZ6c1NCSjZ3K1BUbmhKQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYzF5aWdZX3FnMEdhSmwwanp4SVdBQSIsInZlciI6IjEuMCJ9.C_t36CdMu-7-Tut5olza_36ERC--pFhJlg7cSqEsjI-FGSw4l4kQpgGNNKJWn8fueTIslcIlvTH0FrjGIhhelAf9KNYqITzZTkj33Ewj023i8bS7H3vWuA_w-kG6dXqzBRRQfDrVwTpDDV1qMCCdz0Jd_G0vZb7AIJKMaFtik5fEC24UzolIFeaLxAuGNm26YdPA4-9oWfqLt7vYMdfioMpnTsnx6PBiIzZ235slf1f0u3FYNOzNnIdmX9WecqD1BxHqp5aizLX2aZXIPWQtn01mYSu6dMhpKnfiIs-FLj4UC0JXmR8Lb9jRuIvrTSLnF1WE9ScCqV_N4brfiqVKKQ
   response:
     status:
       code: 200
@@ -3606,29 +3812,29 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14973'
+      - '14982'
       X-Ms-Request-Id:
-      - 75cc026e-ae5d-4fdb-b2a6-bccd79fe5741
+      - 519b78ea-d180-4644-977b-c697db6c4643
       X-Ms-Correlation-Request-Id:
-      - 75cc026e-ae5d-4fdb-b2a6-bccd79fe5741
+      - 519b78ea-d180-4644-977b-c697db6c4643
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202018Z:75cc026e-ae5d-4fdb-b2a6-bccd79fe5741
+      - WESTEUROPE:20180312T102758Z:519b78ea-d180-4644-977b-c697db6c4643
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:20:17 GMT
+      - Mon, 12 Mar 2018 10:27:57 GMT
       Content-Length:
       - '6266'
     body:
       encoding: ASCII-8BIT
       string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250","name":"RedHat.RedHatEnterpriseLinux72-20160218112250","properties":{"parameters":{"location":{"type":"String","value":"eastus"},"virtualMachineName":{"type":"String","value":"miq-test-rhel1"},"virtualMachineSize":{"type":"String","value":"Basic_A0"},"adminUsername":{"type":"String","value":"dberger"},"storageAccountName":{"type":"String","value":"miqazuretest18686"},"virtualNetworkName":{"type":"String","value":"miq-azure-test1"},"networkInterfaceName":{"type":"String","value":"miq-test-rhel1390"},"networkSecurityGroupName":{"type":"String","value":"miq-test-rhel1"},"adminPassword":{"type":"SecureString"},"storageAccountType":{"type":"String","value":"Standard_LRS"},"diagnosticsStorageAccountName":{"type":"String","value":"miqazuretest18686"},"diagnosticsStorageAccountId":{"type":"String","value":"Microsoft.Storage/storageAccounts/miqazuretest18686"},"diagnosticsStorageAccountType":{"type":"String","value":"Standard_LRS"},"addressPrefix":{"type":"String","value":"10.16.0.0/16"},"subnetName":{"type":"String","value":"default"},"subnetPrefix":{"type":"String","value":"10.16.0.0/24"},"publicIpAddressName":{"type":"String","value":"miq-test-rhel1"},"publicIpAddressType":{"type":"String","value":"Dynamic"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-03-18T17:28:57.6212521Z","duration":"PT6M6.1062402S","correlationId":"3222315f-f31e-4ee7-b405-4d40dfd500a3","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]},{"resourceType":"virtualMachines/extensions","locations":["eastus"]}]},{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]},{"resourceType":"publicIpAddresses","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-rhel1390"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-rhel1"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-rhel1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686","actionName":"listKeys","apiVersion":"2015-05-01-preview"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-rhel1/Microsoft.Insights.VMDiagnosticsSettings"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"miq-azure-test1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-rhel1","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-rhel1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-rhel1"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-rhel1390"}],"outputs":{"adminUsername":{"type":"String","value":"dberger"}},"outputResources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/extensions/Microsoft.Insights.VMDiagnosticsSettings"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-rhel1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686"}]}}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:20:19 GMT
+  recorded_at: Mon, 12 Mar 2018 10:28:02 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802122903/operations?api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd?api-version=2018-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3642,7 +3848,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3MDYsIm5iZiI6MTUyMDQ1MzcwNiwiZXhwIjoxNTIwNDU3NjA2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTFnbXRqVzFoMC0wV0djUnUxY0FBQSIsInZlciI6IjEuMCJ9.Erl0psNafp3XtL4oqBb3M0lFjZ_MJ_SHo7l_36xqNg7ftRHb3N_Z-UV9MvDb4JuraazeDmSbyds8cs5HtDmrkjbp1N4kpcNw2R3qVMQqkEafMmzKiXPNaLk_GI3qaiD1pwr7RLP5ooUohDLpy-YBFD9JqzpenQ8oOHjd6-FKZVm7Bra-o3FdOoU7U4BY0SDUmRqf9HOcquo-2AhSLYpXAXzpKY3Fs6o63k2qKcm2Z0jPmmmFnnz0QSnbWqFz6KhsH5AuNwmSgLsQ6EpUYGMlYAthQG2lWG5j4z-LkrZRhSNNHwRLcHSwtGNZhfoiFNHJsuGrP7fUY5xfucJl_cWfVA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAxNTEsIm5iZiI6MTUyMDg1MDE1MSwiZXhwIjoxNTIwODU0MDUxLCJhaW8iOiJZMk5nWU5oMlRiYXo0MmZ6c1NCSjZ3K1BUbmhKQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYzF5aWdZX3FnMEdhSmwwanp4SVdBQSIsInZlciI6IjEuMCJ9.C_t36CdMu-7-Tut5olza_36ERC--pFhJlg7cSqEsjI-FGSw4l4kQpgGNNKJWn8fueTIslcIlvTH0FrjGIhhelAf9KNYqITzZTkj33Ewj023i8bS7H3vWuA_w-kG6dXqzBRRQfDrVwTpDDV1qMCCdz0Jd_G0vZb7AIJKMaFtik5fEC24UzolIFeaLxAuGNm26YdPA4-9oWfqLt7vYMdfioMpnTsnx6PBiIzZ235slf1f0u3FYNOzNnIdmX9WecqD1BxHqp5aizLX2aZXIPWQtn01mYSu6dMhpKnfiIs-FLj4UC0JXmR8Lb9jRuIvrTSLnF1WE9ScCqV_N4brfiqVKKQ
   response:
     status:
       code: 200
@@ -3652,248 +3858,49 @@ http_interactions:
       - no-cache
       Pragma:
       - no-cache
+      Transfer-Encoding:
+      - chunked
       Content-Type:
       - application/json; charset=utf-8
       Expires:
       - "-1"
+      Etag:
+      - W/"a38434c8-7b23-4092-b7c6-402238eac0dc"
       Vary:
       - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14974'
       X-Ms-Request-Id:
-      - 44272394-f7b5-4837-8d30-612456d2b2c8
-      X-Ms-Correlation-Request-Id:
-      - 44272394-f7b5-4837-8d30-612456d2b2c8
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202022Z:44272394-f7b5-4837-8d30-612456d2b2c8
+      - ba173282-305e-476f-a3fa-1b8b3bebf4df
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:20:22 GMT
-      Content-Length:
-      - '8275'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802122903/operations/48A8B19CEC64C173","operationId":"48A8B19CEC64C173","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-09-02T16:34:50.179304Z","duration":"PT3M15.9148608S","trackingId":"6621f53a-bb4c-4914-8928-a21f0fad462b","serviceRequestId":"10450de5-018f-4832-b9b2-8dbeef4329e4","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"rspec-lb-a/Microsoft.Insights.VMDiagnosticsSettings"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802122903/operations/210AB817B36AD006","operationId":"210AB817B36AD006","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-09-02T16:31:34.1720715Z","duration":"PT1M55.3321384S","trackingId":"c1abc3b5-41b7-4e66-8b78-82756e43a4f5","serviceRequestId":"3bbe3405-472e-46cd-9d0f-6eef141ad715","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"rspec-lb-a"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802122903/operations/F77424ED32CB70F0","operationId":"F77424ED32CB70F0","properties":{"provisioningOperation":"Read","provisioningState":"Succeeded","timestamp":"2016-09-02T16:29:38.772059Z","duration":"PT0.4582883S","trackingId":"d9e7d64d-f57c-4675-aa66-2f0bee040167","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"rspeclb","apiVersion":"2015-06-15"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802122903/operations/986DE70BC89CDFE7","operationId":"986DE70BC89CDFE7","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-09-02T16:29:26.4636058Z","duration":"PT2.189989S","trackingId":"7b69bca1-4e85-4722-88c0-8ee10f245beb","serviceRequestId":"0321218c-4bdd-4485-96ac-09cf4208ff7f","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"rspec-lb-a670"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802122903/operations/5064B02C668F3E98","operationId":"5064B02C668F3E98","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-09-02T16:29:38.2436278Z","duration":"PT27.64535S","trackingId":"32f4ac11-eb11-4a16-bf6c-74813d560af3","serviceRequestId":"8ed1d69b-1d36-4441-9d80-b07a5982a384","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"rspeclb"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802122903/operations/0F06C77DFE66C888","operationId":"0F06C77DFE66C888","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-09-02T16:29:24.201372Z","duration":"PT13.6021499S","trackingId":"17881050-3c7a-451a-abe2-643dba3e0dd5","serviceRequestId":"5c72198e-795a-4f1b-9d3a-1facb1e55004","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"rspec-lb-a-nsg"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802122903/operations/580FB462E46F8B3E","operationId":"580FB462E46F8B3E","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-09-02T16:29:12.2815826Z","duration":"PT1.6624975S","trackingId":"305761d4-7e14-437a-be92-42648530b875","serviceRequestId":"298bb1ba-c61a-4c3a-af00-ada3fd033cf8","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/rspec-lb","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"rspec-lb"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802122903/operations/F0FB3DED90543099","operationId":"F0FB3DED90543099","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-09-02T16:29:23.1864805Z","duration":"PT12.5622692S","trackingId":"4761ff79-3ced-4623-9187-f5c54cfb081c","serviceRequestId":"2dbe5cef-91aa-4ffb-b1d7-77baf7a9fd91","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/rspec-lb-a-ip","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"rspec-lb-a-ip"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802122903/operations/FD71B215BA4C3896","operationId":"FD71B215BA4C3896","properties":{"provisioningOperation":"Action","provisioningState":"Succeeded","timestamp":"2016-09-02T16:29:11.1330107Z","duration":"PT0.4963293S","trackingId":"b81ff5ed-ed16-4ec7-9757-aa6555ff9b44","serviceRequestId":"8ed1d69b-1d36-4441-9d80-b07a5982a384","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest16487","actionName":"listKeys","apiVersion":"2015-06-15"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802122903/operations/8FAE05273E5E7FD9","operationId":"8FAE05273E5E7FD9","properties":{"provisioningOperation":"Read","provisioningState":"Succeeded","timestamp":"2016-09-02T16:29:11.0799469Z","duration":"PT0.450359S","trackingId":"8c5a2516-fcee-4fa8-b335-41d9f3e0181a","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest16487","apiVersion":"2015-06-15"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802122903/operations/08587287731377382400","operationId":"08587287731377382400","properties":{"provisioningOperation":"EvaluateDeploymentOutput","provisioningState":"Succeeded","timestamp":"2016-09-02T16:34:50.6327712Z","duration":"PT0.3207448S","trackingId":"f365a963-c99a-4c95-8df0-384b7769036b","statusCode":"OK","statusMessage":null}}]}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:20:23 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802123704/operations?api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3MDYsIm5iZiI6MTUyMDQ1MzcwNiwiZXhwIjoxNTIwNDU3NjA2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTFnbXRqVzFoMC0wV0djUnUxY0FBQSIsInZlciI6IjEuMCJ9.Erl0psNafp3XtL4oqBb3M0lFjZ_MJ_SHo7l_36xqNg7ftRHb3N_Z-UV9MvDb4JuraazeDmSbyds8cs5HtDmrkjbp1N4kpcNw2R3qVMQqkEafMmzKiXPNaLk_GI3qaiD1pwr7RLP5ooUohDLpy-YBFD9JqzpenQ8oOHjd6-FKZVm7Bra-o3FdOoU7U4BY0SDUmRqf9HOcquo-2AhSLYpXAXzpKY3Fs6o63k2qKcm2Z0jPmmmFnnz0QSnbWqFz6KhsH5AuNwmSgLsQ6EpUYGMlYAthQG2lWG5j4z-LkrZRhSNNHwRLcHSwtGNZhfoiFNHJsuGrP7fUY5xfucJl_cWfVA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14978'
-      X-Ms-Request-Id:
-      - b11500cc-5885-4f01-bb15-77f53042261d
-      X-Ms-Correlation-Request-Id:
-      - b11500cc-5885-4f01-bb15-77f53042261d
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202023Z:b11500cc-5885-4f01-bb15-77f53042261d
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:20:23 GMT
-      Content-Length:
-      - '6749'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802123704/operations/5980E17A3BB3BA88","operationId":"5980E17A3BB3BA88","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-09-02T16:42:19.6441784Z","duration":"PT3M12.6404681S","trackingId":"96993dcd-e9d1-4488-a583-59d2334c03fa","serviceRequestId":"7f754871-8266-4557-a0fc-d60818f78dfb","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"rspec-lb-b/Microsoft.Insights.VMDiagnosticsSettings"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802123704/operations/9B8161B7EC4A5300","operationId":"9B8161B7EC4A5300","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-09-02T16:39:06.894563Z","duration":"PT1M39.9156702S","trackingId":"17e6b4dd-7dee-4f5a-b9b5-ac21c8e6d6e3","serviceRequestId":"10e38ed0-57ce-4265-8a23-5974bc05ee4a","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"rspec-lb-b"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802123704/operations/255C04C9CEE1C896","operationId":"255C04C9CEE1C896","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-09-02T16:37:26.8548295Z","duration":"PT2.3465059S","trackingId":"0d766573-a411-44d7-8fe1-bf748a546593","serviceRequestId":"df2239b5-e982-4ecc-9a76-3d6a9e8030e1","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"rspec-lb-b843"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802123704/operations/B0AC30BF03BF196C","operationId":"B0AC30BF03BF196C","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-09-02T16:37:23.8097625Z","duration":"PT14.5526774S","trackingId":"0413ed6a-bd76-44d4-a2e0-2d7b61cbe02e","serviceRequestId":"1cd0dbe9-b117-4bd2-aa09-dc1388bae3dd","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/rspec-lb-b-ip","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"rspec-lb-b-ip"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802123704/operations/8FA4CFC0E28A6EEA","operationId":"8FA4CFC0E28A6EEA","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-09-02T16:37:24.4007807Z","duration":"PT15.1804313S","trackingId":"16bd7484-0747-49fd-a680-d50cec97d25a","serviceRequestId":"7d4ef02c-bb92-49bd-9b7f-f71d84eeac21","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"rspec-lb-b-nsg"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802123704/operations/125929E0A29D3A03","operationId":"125929E0A29D3A03","properties":{"provisioningOperation":"Action","provisioningState":"Succeeded","timestamp":"2016-09-02T16:37:10.3958766Z","duration":"PT1.2143901S","trackingId":"c97eb614-9b2b-441a-b29b-810a0267d622","serviceRequestId":"55d1443a-bd21-4f39-9411-c1e4db80945f","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/amisstea-rg/providers/Microsoft.Storage/storageAccounts/amissteastorage","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"amissteastorage","actionName":"listKeys","apiVersion":"2015-06-15"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802123704/operations/9227F7F6B387D66B","operationId":"9227F7F6B387D66B","properties":{"provisioningOperation":"Read","provisioningState":"Succeeded","timestamp":"2016-09-02T16:37:10.274491Z","duration":"PT1.0632594S","trackingId":"80cf31f4-af3e-4a5d-9ca2-836c0f0309b1","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/amisstea-rg/providers/Microsoft.Storage/storageAccounts/amissteastorage","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"amissteastorage","apiVersion":"2015-06-15"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802123704/operations/F77424ED32CB70F0","operationId":"F77424ED32CB70F0","properties":{"provisioningOperation":"Read","provisioningState":"Succeeded","timestamp":"2016-09-02T16:37:10.2732507Z","duration":"PT1.0178922S","trackingId":"5111053f-19ff-488a-b43d-ed10b7b8e2e7","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"rspeclb","apiVersion":"2015-06-15"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802123704/operations/08587287726577926452","operationId":"08587287726577926452","properties":{"provisioningOperation":"EvaluateDeploymentOutput","provisioningState":"Succeeded","timestamp":"2016-09-02T16:42:20.0050132Z","duration":"PT0.2565693S","trackingId":"8aa39138-1910-493d-84c4-cf15df5b5802","statusCode":"OK","statusMessage":null}}]}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:20:23 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations?api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3MDYsIm5iZiI6MTUyMDQ1MzcwNiwiZXhwIjoxNTIwNDU3NjA2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTFnbXRqVzFoMC0wV0djUnUxY0FBQSIsInZlciI6IjEuMCJ9.Erl0psNafp3XtL4oqBb3M0lFjZ_MJ_SHo7l_36xqNg7ftRHb3N_Z-UV9MvDb4JuraazeDmSbyds8cs5HtDmrkjbp1N4kpcNw2R3qVMQqkEafMmzKiXPNaLk_GI3qaiD1pwr7RLP5ooUohDLpy-YBFD9JqzpenQ8oOHjd6-FKZVm7Bra-o3FdOoU7U4BY0SDUmRqf9HOcquo-2AhSLYpXAXzpKY3Fs6o63k2qKcm2Z0jPmmmFnnz0QSnbWqFz6KhsH5AuNwmSgLsQ6EpUYGMlYAthQG2lWG5j4z-LkrZRhSNNHwRLcHSwtGNZhfoiFNHJsuGrP7fUY5xfucJl_cWfVA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14974'
-      X-Ms-Request-Id:
-      - 64df08ad-09cc-4c4d-9ed4-1f700386439c
-      X-Ms-Correlation-Request-Id:
-      - 64df08ad-09cc-4c4d-9ed4-1f700386439c
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202024Z:64df08ad-09cc-4c4d-9ed4-1f700386439c
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:20:23 GMT
-      Content-Length:
-      - '7624'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/B42FCDF4A2A39FE2","operationId":"B42FCDF4A2A39FE2","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:28:56.9829484Z","duration":"PT3M1.9672591S","trackingId":"14feeb1c-b462-4bdc-98e0-07e3c051bc4a","serviceRequestId":"929da49c-b732-4413-8fe7-6a94ebf1b7df","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-rhel1/Microsoft.Insights.VMDiagnosticsSettings"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/90897F1FE623927D","operationId":"90897F1FE623927D","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:25:54.9100087Z","duration":"PT2M28.9316677S","trackingId":"677bf860-1814-46bf-81b8-2f40e478702f","serviceRequestId":"0d568f4d-db1a-414b-82af-8a476f4ee398","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-rhel1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/465DEB7D7737AAEB","operationId":"465DEB7D7737AAEB","properties":{"provisioningOperation":"Read","provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:25.8536981Z","duration":"PT2.5042804S","trackingId":"39bb6568-d7b8-42e4-97ed-3b32cb629561","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686","apiVersion":"2015-06-15"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/2972B36A0CF48AB3","operationId":"2972B36A0CF48AB3","properties":{"provisioningOperation":"Action","provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:23.6072605Z","duration":"PT0.2582045S","trackingId":"c5a9e298-ec4e-439b-ba11-f531388139de","serviceRequestId":"3222315f-f31e-4ee7-b405-4d40dfd500a3","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686","actionName":"listKeys","apiVersion":"2015-05-01-preview"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/E74E878C29CB66B6","operationId":"E74E878C29CB66B6","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:10.196193Z","duration":"PT1.6122458S","trackingId":"2341df4a-20e3-4fb4-b417-2f2263e009d3","serviceRequestId":"ad2b548c-e848-42f3-8834-a07996ead051","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-rhel1390"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/159B68AE177CBFD9","operationId":"159B68AE177CBFD9","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:23.2936909Z","duration":"PT30.2333245S","trackingId":"3d2daef3-03af-4017-9b52-2202b98e54c0","serviceRequestId":"3222315f-f31e-4ee7-b405-4d40dfd500a3","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/601C5CBE140F5FC4","operationId":"601C5CBE140F5FC4","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:08.4807196Z","duration":"PT15.4177267S","trackingId":"5280cb26-eed9-43e1-aff7-2c60ba0a4e32","serviceRequestId":"18d0a142-7dcb-4e5d-86ea-b8cd95ab1ff4","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-rhel1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/DDFCB6138638C2AE","operationId":"DDFCB6138638C2AE","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:06.4145604Z","duration":"PT13.2922738S","trackingId":"18bf2d19-1ef3-4026-b6c2-650bcd5a6da9","serviceRequestId":"8f6af50d-004e-4653-b263-3e2a8e85ebeb","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-rhel1","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-rhel1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/6E56D08B1E39DCCA","operationId":"6E56D08B1E39DCCA","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:05.836911Z","duration":"PT12.771463S","trackingId":"33412052-f3be-4e84-bd79-0a00abef61f4","serviceRequestId":"2252541d-7285-41d8-87d1-3a0a1d1b330a","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"miq-azure-test1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/08587432851139626716","operationId":"08587432851139626716","properties":{"provisioningOperation":"EvaluateDeploymentOutput","provisioningState":"Succeeded","timestamp":"2016-03-18T17:28:57.5892101Z","duration":"PT0.2087634S","trackingId":"85e2cf8a-3929-4515-8a51-97dbc778352e","statusCode":"OK","statusMessage":null}}]}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:20:24 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802122903?api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3MDYsIm5iZiI6MTUyMDQ1MzcwNiwiZXhwIjoxNTIwNDU3NjA2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTFnbXRqVzFoMC0wV0djUnUxY0FBQSIsInZlciI6IjEuMCJ9.Erl0psNafp3XtL4oqBb3M0lFjZ_MJ_SHo7l_36xqNg7ftRHb3N_Z-UV9MvDb4JuraazeDmSbyds8cs5HtDmrkjbp1N4kpcNw2R3qVMQqkEafMmzKiXPNaLk_GI3qaiD1pwr7RLP5ooUohDLpy-YBFD9JqzpenQ8oOHjd6-FKZVm7Bra-o3FdOoU7U4BY0SDUmRqf9HOcquo-2AhSLYpXAXzpKY3Fs6o63k2qKcm2Z0jPmmmFnnz0QSnbWqFz6KhsH5AuNwmSgLsQ6EpUYGMlYAthQG2lWG5j4z-LkrZRhSNNHwRLcHSwtGNZhfoiFNHJsuGrP7fUY5xfucJl_cWfVA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14978'
-      X-Ms-Request-Id:
-      - 308cd5b1-b79c-4478-a090-272ece3d0f3d
-      X-Ms-Correlation-Request-Id:
-      - 308cd5b1-b79c-4478-a090-272ece3d0f3d
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202025Z:308cd5b1-b79c-4478-a090-272ece3d0f3d
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:20:24 GMT
-      Content-Length:
-      - '6500'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802122903","name":"RedHat.RedHatEnterpriseLinux67-20160802122903","properties":{"parameters":{"location":{"type":"String","value":"eastus"},"virtualMachineName":{"type":"String","value":"rspec-lb-a"},"virtualMachineSize":{"type":"String","value":"Standard_F1s"},"adminUsername":{"type":"String","value":"bronaghs"},"storageAccountName":{"type":"String","value":"rspeclb"},"virtualNetworkName":{"type":"String","value":"miq-azure-test1"},"networkInterfaceName":{"type":"String","value":"rspec-lb-a670"},"networkSecurityGroupName":{"type":"String","value":"rspec-lb-a-nsg"},"adminPassword":{"type":"SecureString"},"availabilitySetName":{"type":"String","value":"rspec-lb"},"availabilitySetPlatformFaultDomainCount":{"type":"String","value":"3"},"availabilitySetPlatformUpdateDomainCount":{"type":"String","value":"5"},"storageAccountType":{"type":"String","value":"Premium_LRS"},"diagnosticsStorageAccountName":{"type":"String","value":"miqazuretest16487"},"diagnosticsStorageAccountId":{"type":"String","value":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487"},"subnetName":{"type":"String","value":"default"},"publicIpAddressName":{"type":"String","value":"rspec-lb-a-ip"},"publicIpAddressType":{"type":"String","value":"Dynamic"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-09-02T16:34:50.7306487Z","duration":"PT5M42.9911979S","correlationId":"8ed1d69b-1d36-4441-9d80-b07a5982a384","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]},{"resourceType":"virtualMachines/extensions","locations":["eastus"]},{"resourceType":"availabilitySets","locations":["eastus"]}]},{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkInterfaces","locations":["eastus"]},{"resourceType":"publicIpAddresses","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"rspec-lb-a670"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/rspec-lb","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"rspec-lb"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"rspeclb"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"rspeclb","apiVersion":"2015-06-15"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest16487","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"rspec-lb-a"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"rspec-lb-a"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest16487","actionName":"listKeys","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"rspec-lb-a/Microsoft.Insights.VMDiagnosticsSettings"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/rspec-lb-a-ip","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"rspec-lb-a-ip"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"rspec-lb-a-nsg"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"rspec-lb-a670"}],"outputs":{"adminUsername":{"type":"String","value":"bronaghs"}},"outputResources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/rspec-lb"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a/extensions/Microsoft.Insights.VMDiagnosticsSettings"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/rspec-lb-a-ip"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb"}]}}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:20:25 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802123704?api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3MDYsIm5iZiI6MTUyMDQ1MzcwNiwiZXhwIjoxNTIwNDU3NjA2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTFnbXRqVzFoMC0wV0djUnUxY0FBQSIsInZlciI6IjEuMCJ9.Erl0psNafp3XtL4oqBb3M0lFjZ_MJ_SHo7l_36xqNg7ftRHb3N_Z-UV9MvDb4JuraazeDmSbyds8cs5HtDmrkjbp1N4kpcNw2R3qVMQqkEafMmzKiXPNaLk_GI3qaiD1pwr7RLP5ooUohDLpy-YBFD9JqzpenQ8oOHjd6-FKZVm7Bra-o3FdOoU7U4BY0SDUmRqf9HOcquo-2AhSLYpXAXzpKY3Fs6o63k2qKcm2Z0jPmmmFnnz0QSnbWqFz6KhsH5AuNwmSgLsQ6EpUYGMlYAthQG2lWG5j4z-LkrZRhSNNHwRLcHSwtGNZhfoiFNHJsuGrP7fUY5xfucJl_cWfVA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
       - '14985'
-      X-Ms-Request-Id:
-      - 16b62b93-002a-4f6c-a836-30b7d274f331
       X-Ms-Correlation-Request-Id:
-      - 16b62b93-002a-4f6c-a836-30b7d274f331
+      - 030aff2b-341f-4f92-b457-1c4535c8f5c0
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202026Z:16b62b93-002a-4f6c-a836-30b7d274f331
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
+      - WESTEUROPE:20180312T102758Z:030aff2b-341f-4f92-b457-1c4535c8f5c0
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:20:25 GMT
-      Content-Length:
-      - '5370'
+      - Mon, 12 Mar 2018 10:27:58 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802123704","name":"RedHat.RedHatEnterpriseLinux67-20160802123704","properties":{"parameters":{"location":{"type":"String","value":"eastus"},"virtualMachineName":{"type":"String","value":"rspec-lb-b"},"virtualMachineSize":{"type":"String","value":"Standard_DS1_v2"},"adminUsername":{"type":"String","value":"bronaghs"},"storageAccountName":{"type":"String","value":"rspeclb"},"virtualNetworkName":{"type":"String","value":"miq-azure-test1"},"networkInterfaceName":{"type":"String","value":"rspec-lb-b843"},"networkSecurityGroupName":{"type":"String","value":"rspec-lb-b-nsg"},"adminPassword":{"type":"SecureString"},"availabilitySetName":{"type":"String","value":"rspec-lb"},"diagnosticsStorageAccountName":{"type":"String","value":"amissteastorage"},"diagnosticsStorageAccountId":{"type":"String","value":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/amisstea-rg/providers/Microsoft.Storage/storageAccounts/amissteastorage"},"subnetName":{"type":"String","value":"default"},"publicIpAddressName":{"type":"String","value":"rspec-lb-b-ip"},"publicIpAddressType":{"type":"String","value":"Dynamic"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-09-02T16:42:20.1492177Z","duration":"PT5M12.4641651S","correlationId":"55d1443a-bd21-4f39-9411-c1e4db80945f","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]},{"resourceType":"virtualMachines/extensions","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkInterfaces","locations":["eastus"]},{"resourceType":"publicIpAddresses","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"rspec-lb-b843"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"rspeclb","apiVersion":"2015-06-15"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/amisstea-rg/providers/Microsoft.Storage/storageAccounts/amissteastorage","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"amissteastorage","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"rspec-lb-b"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"rspec-lb-b"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/amisstea-rg/providers/Microsoft.Storage/storageAccounts/amissteastorage","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"amissteastorage","actionName":"listKeys","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"rspec-lb-b/Microsoft.Insights.VMDiagnosticsSettings"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/rspec-lb-b-ip","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"rspec-lb-b-ip"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"rspec-lb-b-nsg"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"rspec-lb-b843"}],"outputs":{"adminUsername":{"type":"String","value":"bronaghs"}},"outputResources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b/extensions/Microsoft.Insights.VMDiagnosticsSettings"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/rspec-lb-b-ip"}]}}'
+      string: "{\r\n  \"name\": \"rspec-lb1-LoadBalancerFrontEnd\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\",\r\n
+        \ \"etag\": \"W/\\\"a38434c8-7b23-4092-b7c6-402238eac0dc\\\"\",\r\n  \"location\":
+        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"f28e0f25-b372-4edf-97d9-13a9e3b4ba2d\",\r\n    \"ipAddress\":
+        \"40.71.82.83\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\":
+        \"Static\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipTags\": [],\r\n
+        \   \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
+        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
+        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:20:26 GMT
+  recorded_at: Mon, 12 Mar 2018 10:28:03 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250?api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip?api-version=2018-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3907,62 +3914,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3MDYsIm5iZiI6MTUyMDQ1MzcwNiwiZXhwIjoxNTIwNDU3NjA2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTFnbXRqVzFoMC0wV0djUnUxY0FBQSIsInZlciI6IjEuMCJ9.Erl0psNafp3XtL4oqBb3M0lFjZ_MJ_SHo7l_36xqNg7ftRHb3N_Z-UV9MvDb4JuraazeDmSbyds8cs5HtDmrkjbp1N4kpcNw2R3qVMQqkEafMmzKiXPNaLk_GI3qaiD1pwr7RLP5ooUohDLpy-YBFD9JqzpenQ8oOHjd6-FKZVm7Bra-o3FdOoU7U4BY0SDUmRqf9HOcquo-2AhSLYpXAXzpKY3Fs6o63k2qKcm2Z0jPmmmFnnz0QSnbWqFz6KhsH5AuNwmSgLsQ6EpUYGMlYAthQG2lWG5j4z-LkrZRhSNNHwRLcHSwtGNZhfoiFNHJsuGrP7fUY5xfucJl_cWfVA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14971'
-      X-Ms-Request-Id:
-      - 43975082-276c-453f-8f4b-1178f6a6fc60
-      X-Ms-Correlation-Request-Id:
-      - 43975082-276c-453f-8f4b-1178f6a6fc60
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202026Z:43975082-276c-453f-8f4b-1178f6a6fc60
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:20:26 GMT
-      Content-Length:
-      - '6266'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250","name":"RedHat.RedHatEnterpriseLinux72-20160218112250","properties":{"parameters":{"location":{"type":"String","value":"eastus"},"virtualMachineName":{"type":"String","value":"miq-test-rhel1"},"virtualMachineSize":{"type":"String","value":"Basic_A0"},"adminUsername":{"type":"String","value":"dberger"},"storageAccountName":{"type":"String","value":"miqazuretest18686"},"virtualNetworkName":{"type":"String","value":"miq-azure-test1"},"networkInterfaceName":{"type":"String","value":"miq-test-rhel1390"},"networkSecurityGroupName":{"type":"String","value":"miq-test-rhel1"},"adminPassword":{"type":"SecureString"},"storageAccountType":{"type":"String","value":"Standard_LRS"},"diagnosticsStorageAccountName":{"type":"String","value":"miqazuretest18686"},"diagnosticsStorageAccountId":{"type":"String","value":"Microsoft.Storage/storageAccounts/miqazuretest18686"},"diagnosticsStorageAccountType":{"type":"String","value":"Standard_LRS"},"addressPrefix":{"type":"String","value":"10.16.0.0/16"},"subnetName":{"type":"String","value":"default"},"subnetPrefix":{"type":"String","value":"10.16.0.0/24"},"publicIpAddressName":{"type":"String","value":"miq-test-rhel1"},"publicIpAddressType":{"type":"String","value":"Dynamic"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-03-18T17:28:57.6212521Z","duration":"PT6M6.1062402S","correlationId":"3222315f-f31e-4ee7-b405-4d40dfd500a3","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]},{"resourceType":"virtualMachines/extensions","locations":["eastus"]}]},{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]},{"resourceType":"publicIpAddresses","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-rhel1390"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-rhel1"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-rhel1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686","actionName":"listKeys","apiVersion":"2015-05-01-preview"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-rhel1/Microsoft.Insights.VMDiagnosticsSettings"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"miq-azure-test1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-rhel1","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-rhel1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-rhel1"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-rhel1390"}],"outputs":{"adminUsername":{"type":"String","value":"dberger"}},"outputResources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/extensions/Microsoft.Insights.VMDiagnosticsSettings"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-rhel1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686"}]}}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:20:27 GMT
-- request:
-    method: post
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802122903/exportTemplate?api-version=2017-08-01
-    body:
-      encoding: ASCII-8BIT
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3MDYsIm5iZiI6MTUyMDQ1MzcwNiwiZXhwIjoxNTIwNDU3NjA2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTFnbXRqVzFoMC0wV0djUnUxY0FBQSIsInZlciI6IjEuMCJ9.Erl0psNafp3XtL4oqBb3M0lFjZ_MJ_SHo7l_36xqNg7ftRHb3N_Z-UV9MvDb4JuraazeDmSbyds8cs5HtDmrkjbp1N4kpcNw2R3qVMQqkEafMmzKiXPNaLk_GI3qaiD1pwr7RLP5ooUohDLpy-YBFD9JqzpenQ8oOHjd6-FKZVm7Bra-o3FdOoU7U4BY0SDUmRqf9HOcquo-2AhSLYpXAXzpKY3Fs6o63k2qKcm2Z0jPmmmFnnz0QSnbWqFz6KhsH5AuNwmSgLsQ6EpUYGMlYAthQG2lWG5j4z-LkrZRhSNNHwRLcHSwtGNZhfoiFNHJsuGrP7fUY5xfucJl_cWfVA
-      Content-Length:
-      - '0'
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAxNTEsIm5iZiI6MTUyMDg1MDE1MSwiZXhwIjoxNTIwODU0MDUxLCJhaW8iOiJZMk5nWU5oMlRiYXo0MmZ6c1NCSjZ3K1BUbmhKQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYzF5aWdZX3FnMEdhSmwwanp4SVdBQSIsInZlciI6IjEuMCJ9.C_t36CdMu-7-Tut5olza_36ERC--pFhJlg7cSqEsjI-FGSw4l4kQpgGNNKJWn8fueTIslcIlvTH0FrjGIhhelAf9KNYqITzZTkj33Ewj023i8bS7H3vWuA_w-kG6dXqzBRRQfDrVwTpDDV1qMCCdz0Jd_G0vZb7AIJKMaFtik5fEC24UzolIFeaLxAuGNm26YdPA4-9oWfqLt7vYMdfioMpnTsnx6PBiIzZ235slf1f0u3FYNOzNnIdmX9WecqD1BxHqp5aizLX2aZXIPWQtn01mYSu6dMhpKnfiIs-FLj4UC0JXmR8Lb9jRuIvrTSLnF1WE9ScCqV_N4brfiqVKKQ
   response:
     status:
       code: 200
@@ -3978,526 +3930,42 @@ http_interactions:
       - application/json; charset=utf-8
       Expires:
       - "-1"
+      Etag:
+      - W/"cddd97d1-6111-4477-8a00-3dc885237a1d"
       Vary:
       - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1198'
       X-Ms-Request-Id:
-      - acd0b07d-307f-4fbb-89e5-94476e5b1840
-      X-Ms-Correlation-Request-Id:
-      - acd0b07d-307f-4fbb-89e5-94476e5b1840
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202027Z:acd0b07d-307f-4fbb-89e5-94476e5b1840
+      - 63e39a1e-6c7b-49a0-aff8-885a29170058
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:20:27 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"template":{"$schema":"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#","contentVersion":"1.0.0.0","parameters":{"location":{"type":"String"},"virtualMachineName":{"type":"String"},"virtualMachineSize":{"type":"String"},"adminUsername":{"type":"String"},"storageAccountName":{"type":"String"},"virtualNetworkName":{"type":"String"},"networkInterfaceName":{"type":"String"},"networkSecurityGroupName":{"type":"String"},"adminPassword":{"type":"SecureString"},"availabilitySetName":{"type":"String"},"availabilitySetPlatformFaultDomainCount":{"type":"String"},"availabilitySetPlatformUpdateDomainCount":{"type":"String"},"storageAccountType":{"type":"String"},"diagnosticsStorageAccountName":{"type":"String"},"diagnosticsStorageAccountId":{"type":"String"},"subnetName":{"type":"String"},"publicIpAddressName":{"type":"String"},"publicIpAddressType":{"type":"String"}},"variables":{"vnetId":"[resourceId(''miq-azure-test1'',''Microsoft.Network/virtualNetworks'',
-        parameters(''virtualNetworkName''))]","subnetRef":"[concat(variables(''vnetId''),
-        ''/subnets/'', parameters(''subnetName''))]","metricsresourceid":"[concat(''/subscriptions/'',
-        subscription().subscriptionId, ''/resourceGroups/'', resourceGroup().name,
-        ''/providers/'', ''Microsoft.Compute/virtualMachines/'', parameters(''virtualMachineName''))]","metricsclosing":"[concat(''<Metrics
-        resourceId=\"'', variables(''metricsresourceid''), ''\"><MetricAggregation
-        scheduledTransferPeriod=\"PT1H\"/><MetricAggregation scheduledTransferPeriod=\"PT1M\"/></Metrics></DiagnosticMonitorConfiguration></WadCfg>'')]","metricscounters":"<PerformanceCounters
-        scheduledTransferPeriod=\"PT1M\"><PerformanceCounterConfiguration counterSpecifier=\"\\Memory\\AvailableMemory\"
-        sampleRate=\"PT15S\" unit=\"Bytes\"><annotation displayName=\"Memory available\"
-        locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PercentAvailableMemory\" sampleRate=\"PT15S\"
-        unit=\"Percent\"><annotation displayName=\"Mem. percent available\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\UsedMemory\" sampleRate=\"PT15S\" unit=\"Bytes\"><annotation
-        displayName=\"Memory used\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PercentUsedMemory\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"Memory percentage\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PercentUsedByCache\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"Mem. used by cache\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PagesPerSec\" sampleRate=\"PT15S\" unit=\"CountPerSecond\"><annotation
-        displayName=\"Pages\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PagesReadPerSec\" sampleRate=\"PT15S\" unit=\"CountPerSecond\"><annotation
-        displayName=\"Page reads\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PagesWrittenPerSec\" sampleRate=\"PT15S\" unit=\"CountPerSecond\"><annotation
-        displayName=\"Page writes\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\AvailableSwap\" sampleRate=\"PT15S\" unit=\"Bytes\"><annotation
-        displayName=\"Swap available\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PercentAvailableSwap\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"Swap percent available\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\UsedSwap\" sampleRate=\"PT15S\" unit=\"Bytes\"><annotation
-        displayName=\"Swap used\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PercentUsedSwap\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"Swap percent used\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentIdleTime\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"CPU idle time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentUserTime\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"CPU user time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentNiceTime\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"CPU nice time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentPrivilegedTime\" sampleRate=\"PT15S\"
-        unit=\"Percent\"><annotation displayName=\"CPU privileged time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentInterruptTime\" sampleRate=\"PT15S\"
-        unit=\"Percent\"><annotation displayName=\"CPU interrupt time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentDPCTime\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"CPU DPC time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentProcessorTime\" sampleRate=\"PT15S\"
-        unit=\"Percent\"><annotation displayName=\"CPU percentage guest OS\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentIOWaitTime\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"CPU IO wait time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\BytesPerSecond\" sampleRate=\"PT15S\" unit=\"BytesPerSecond\"><annotation
-        displayName=\"Disk total bytes\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\ReadBytesPerSecond\" sampleRate=\"PT15S\"
-        unit=\"BytesPerSecond\"><annotation displayName=\"Disk read guest OS\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\WriteBytesPerSecond\" sampleRate=\"PT15S\"
-        unit=\"BytesPerSecond\"><annotation displayName=\"Disk write guest OS\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\TransfersPerSecond\" sampleRate=\"PT15S\"
-        unit=\"CountPerSecond\"><annotation displayName=\"Disk transfers\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\ReadsPerSecond\" sampleRate=\"PT15S\" unit=\"CountPerSecond\"><annotation
-        displayName=\"Disk reads\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\WritesPerSecond\" sampleRate=\"PT15S\"
-        unit=\"CountPerSecond\"><annotation displayName=\"Disk writes\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\AverageReadTime\" sampleRate=\"PT15S\"
-        unit=\"Seconds\"><annotation displayName=\"Disk read time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\AverageWriteTime\" sampleRate=\"PT15S\"
-        unit=\"Seconds\"><annotation displayName=\"Disk write time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\AverageTransferTime\" sampleRate=\"PT15S\"
-        unit=\"Seconds\"><annotation displayName=\"Disk transfer time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\AverageDiskQueueLength\" sampleRate=\"PT15S\"
-        unit=\"Count\"><annotation displayName=\"Disk queue length\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\BytesTransmitted\" sampleRate=\"PT15S\"
-        unit=\"Bytes\"><annotation displayName=\"Network out guest OS\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\BytesReceived\" sampleRate=\"PT15S\"
-        unit=\"Bytes\"><annotation displayName=\"Network in guest OS\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\PacketsTransmitted\" sampleRate=\"PT15S\"
-        unit=\"Count\"><annotation displayName=\"Packets sent\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\PacketsReceived\" sampleRate=\"PT15S\"
-        unit=\"Count\"><annotation displayName=\"Packets received\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\BytesTotal\" sampleRate=\"PT15S\" unit=\"Bytes\"><annotation
-        displayName=\"Network total bytes\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\TotalRxErrors\" sampleRate=\"PT15S\"
-        unit=\"Count\"><annotation displayName=\"Packets received errors\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\TotalTxErrors\" sampleRate=\"PT15S\"
-        unit=\"Count\"><annotation displayName=\"Packets sent errors\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\TotalCollisions\" sampleRate=\"PT15S\"
-        unit=\"Count\"><annotation displayName=\"Network collisions\" locale=\"en-us\"/></PerformanceCounterConfiguration></PerformanceCounters>","metricsstart":"<WadCfg><DiagnosticMonitorConfiguration
-        overallQuotaInMB=\"4096\"><DiagnosticInfrastructureLogs scheduledTransferPeriod=\"PT1M\"
-        scheduledTransferLogLevelFilter=\"Warning\"/>","wadcfgx":"[concat(variables(''metricsstart''),
-        variables(''metricscounters''), variables(''metricsclosing''))]"},"resources":[{"type":"Microsoft.Compute/virtualMachines","name":"[parameters(''virtualMachineName'')]","apiVersion":"2015-06-15","location":"[parameters(''location'')]","properties":{"osProfile":{"computerName":"[parameters(''virtualMachineName'')]","adminUsername":"[parameters(''adminUsername'')]","adminPassword":"[parameters(''adminPassword'')]"},"hardwareProfile":{"vmSize":"[parameters(''virtualMachineSize'')]"},"storageProfile":{"imageReference":{"publisher":"RedHat","offer":"RHEL","sku":"6.7","version":"latest"},"osDisk":{"name":"[parameters(''virtualMachineName'')]","vhd":{"uri":"[concat(concat(reference(resourceId(''miq-azure-test1'',
-        ''Microsoft.Storage/storageAccounts'', parameters(''storageAccountName'')),
-        ''2015-06-15'').primaryEndpoints[''blob''], ''vhds/''), parameters(''virtualMachineName''),
-        ''201682122839.vhd'')]"},"createOption":"fromImage"},"dataDisks":[]},"networkProfile":{"networkInterfaces":[{"id":"[resourceId(''Microsoft.Network/networkInterfaces'',
-        parameters(''networkInterfaceName''))]"}]},"diagnosticsProfile":{"bootDiagnostics":{"enabled":true,"storageUri":"[reference(resourceId(''miq-azure-test1'',
-        ''Microsoft.Storage/storageAccounts'', parameters(''diagnosticsStorageAccountName'')),
-        ''2015-06-15'').primaryEndpoints[''blob'']]"}},"availabilitySet":{"id":"[resourceId(''Microsoft.Compute/availabilitySets'',
-        parameters(''availabilitySetName''))]"}},"dependsOn":["[concat(''Microsoft.Network/networkInterfaces/'',
-        parameters(''networkInterfaceName''))]","[concat(''Microsoft.Compute/availabilitySets/'',
-        parameters(''availabilitySetName''))]","[concat(''Microsoft.Storage/storageAccounts/'',
-        parameters(''storageAccountName''))]"]},{"type":"Microsoft.Compute/virtualMachines/extensions","name":"[concat(parameters(''virtualMachineName''),''/Microsoft.Insights.VMDiagnosticsSettings'')]","apiVersion":"2015-06-15","location":"[parameters(''location'')]","properties":{"publisher":"Microsoft.OSTCExtensions","type":"LinuxDiagnostic","typeHandlerVersion":"2.3","autoUpgradeMinorVersion":true,"settings":{"xmlCfg":"[base64(variables(''wadcfgx''))]","StorageAccount":"[parameters(''diagnosticsStorageAccountName'')]"},"protectedSettings":{"storageAccountName":"[parameters(''diagnosticsStorageAccountName'')]","storageAccountKey":"[listKeys(parameters(''diagnosticsStorageAccountId''),''2015-06-15'').key1]","storageAccountEndPoint":"https://core.windows.net/"}},"dependsOn":["[concat(''Microsoft.Compute/virtualMachines/'',
-        parameters(''virtualMachineName''))]"]},{"type":"Microsoft.Compute/availabilitySets","name":"[parameters(''availabilitySetName'')]","apiVersion":"2015-06-15","location":"[parameters(''location'')]","properties":{"platformFaultDomainCount":"[parameters(''availabilitySetPlatformFaultDomainCount'')]","platformUpdateDomainCount":"[parameters(''availabilitySetPlatformUpdateDomainCount'')]"}},{"type":"Microsoft.Storage/storageAccounts","name":"[parameters(''storageAccountName'')]","apiVersion":"2015-06-15","location":"[parameters(''location'')]","properties":{"accountType":"[parameters(''storageAccountType'')]"}},{"type":"Microsoft.Network/networkInterfaces","name":"[parameters(''networkInterfaceName'')]","apiVersion":"2015-06-15","location":"[parameters(''location'')]","properties":{"primary":true,"ipConfigurations":[{"name":"ipconfig1","properties":{"subnet":{"id":"[variables(''subnetRef'')]"},"privateIPAllocationMethod":"Dynamic","publicIpAddress":{"id":"[resourceId(''miq-azure-test1'',''Microsoft.Network/publicIpAddresses'',
-        parameters(''publicIpAddressName''))]"}}}],"networkSecurityGroup":{"id":"[resourceId(''miq-azure-test1'',
-        ''Microsoft.Network/networkSecurityGroups'', parameters(''networkSecurityGroupName''))]"}},"dependsOn":["[concat(''Microsoft.Network/publicIpAddresses/'',
-        parameters(''publicIpAddressName''))]","[concat(''Microsoft.Network/networkSecurityGroups/'',
-        parameters(''networkSecurityGroupName''))]"]},{"type":"Microsoft.Network/publicIpAddresses","name":"[parameters(''publicIpAddressName'')]","apiVersion":"2015-06-15","location":"[parameters(''location'')]","properties":{"publicIpAllocationMethod":"[parameters(''publicIpAddressType'')]"}},{"type":"Microsoft.Network/networkSecurityGroups","name":"[parameters(''networkSecurityGroupName'')]","apiVersion":"2015-06-15","location":"[parameters(''location'')]","properties":{"securityRules":[{"name":"default-allow-ssh","properties":{"priority":1000,"sourceAddressPrefix":"*","protocol":"TCP","destinationPortRange":"22","access":"Allow","direction":"Inbound","sourcePortRange":"*","destinationAddressPrefix":"*"}}]}}],"outputs":{"adminUsername":{"type":"String","value":"[parameters(''adminUsername'')]"}}}}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:20:28 GMT
-- request:
-    method: post
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux67-20160802123704/exportTemplate?api-version=2017-08-01
-    body:
-      encoding: ASCII-8BIT
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3MDYsIm5iZiI6MTUyMDQ1MzcwNiwiZXhwIjoxNTIwNDU3NjA2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTFnbXRqVzFoMC0wV0djUnUxY0FBQSIsInZlciI6IjEuMCJ9.Erl0psNafp3XtL4oqBb3M0lFjZ_MJ_SHo7l_36xqNg7ftRHb3N_Z-UV9MvDb4JuraazeDmSbyds8cs5HtDmrkjbp1N4kpcNw2R3qVMQqkEafMmzKiXPNaLk_GI3qaiD1pwr7RLP5ooUohDLpy-YBFD9JqzpenQ8oOHjd6-FKZVm7Bra-o3FdOoU7U4BY0SDUmRqf9HOcquo-2AhSLYpXAXzpKY3Fs6o63k2qKcm2Z0jPmmmFnnz0QSnbWqFz6KhsH5AuNwmSgLsQ6EpUYGMlYAthQG2lWG5j4z-LkrZRhSNNHwRLcHSwtGNZhfoiFNHJsuGrP7fUY5xfucJl_cWfVA
-      Content-Length:
-      - '0'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1198'
-      X-Ms-Request-Id:
-      - f9327829-c9ed-4fa8-b873-eec77d7f2bfa
-      X-Ms-Correlation-Request-Id:
-      - f9327829-c9ed-4fa8-b873-eec77d7f2bfa
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202028Z:f9327829-c9ed-4fa8-b873-eec77d7f2bfa
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:20:27 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"template":{"$schema":"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#","contentVersion":"1.0.0.0","parameters":{"location":{"type":"String"},"virtualMachineName":{"type":"String"},"virtualMachineSize":{"type":"String"},"adminUsername":{"type":"String"},"storageAccountName":{"type":"String"},"virtualNetworkName":{"type":"String"},"networkInterfaceName":{"type":"String"},"networkSecurityGroupName":{"type":"String"},"adminPassword":{"type":"SecureString"},"availabilitySetName":{"type":"String"},"diagnosticsStorageAccountName":{"type":"String"},"diagnosticsStorageAccountId":{"type":"String"},"subnetName":{"type":"String"},"publicIpAddressName":{"type":"String"},"publicIpAddressType":{"type":"String"}},"variables":{"vnetId":"[resourceId(''miq-azure-test1'',''Microsoft.Network/virtualNetworks'',
-        parameters(''virtualNetworkName''))]","subnetRef":"[concat(variables(''vnetId''),
-        ''/subnets/'', parameters(''subnetName''))]","metricsresourceid":"[concat(''/subscriptions/'',
-        subscription().subscriptionId, ''/resourceGroups/'', resourceGroup().name,
-        ''/providers/'', ''Microsoft.Compute/virtualMachines/'', parameters(''virtualMachineName''))]","metricsclosing":"[concat(''<Metrics
-        resourceId=\"'', variables(''metricsresourceid''), ''\"><MetricAggregation
-        scheduledTransferPeriod=\"PT1H\"/><MetricAggregation scheduledTransferPeriod=\"PT1M\"/></Metrics></DiagnosticMonitorConfiguration></WadCfg>'')]","metricscounters":"<PerformanceCounters
-        scheduledTransferPeriod=\"PT1M\"><PerformanceCounterConfiguration counterSpecifier=\"\\Memory\\AvailableMemory\"
-        sampleRate=\"PT15S\" unit=\"Bytes\"><annotation displayName=\"Memory available\"
-        locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PercentAvailableMemory\" sampleRate=\"PT15S\"
-        unit=\"Percent\"><annotation displayName=\"Mem. percent available\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\UsedMemory\" sampleRate=\"PT15S\" unit=\"Bytes\"><annotation
-        displayName=\"Memory used\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PercentUsedMemory\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"Memory percentage\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PercentUsedByCache\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"Mem. used by cache\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PagesPerSec\" sampleRate=\"PT15S\" unit=\"CountPerSecond\"><annotation
-        displayName=\"Pages\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PagesReadPerSec\" sampleRate=\"PT15S\" unit=\"CountPerSecond\"><annotation
-        displayName=\"Page reads\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PagesWrittenPerSec\" sampleRate=\"PT15S\" unit=\"CountPerSecond\"><annotation
-        displayName=\"Page writes\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\AvailableSwap\" sampleRate=\"PT15S\" unit=\"Bytes\"><annotation
-        displayName=\"Swap available\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PercentAvailableSwap\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"Swap percent available\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\UsedSwap\" sampleRate=\"PT15S\" unit=\"Bytes\"><annotation
-        displayName=\"Swap used\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PercentUsedSwap\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"Swap percent used\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentIdleTime\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"CPU idle time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentUserTime\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"CPU user time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentNiceTime\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"CPU nice time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentPrivilegedTime\" sampleRate=\"PT15S\"
-        unit=\"Percent\"><annotation displayName=\"CPU privileged time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentInterruptTime\" sampleRate=\"PT15S\"
-        unit=\"Percent\"><annotation displayName=\"CPU interrupt time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentDPCTime\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"CPU DPC time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentProcessorTime\" sampleRate=\"PT15S\"
-        unit=\"Percent\"><annotation displayName=\"CPU percentage guest OS\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentIOWaitTime\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"CPU IO wait time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\BytesPerSecond\" sampleRate=\"PT15S\" unit=\"BytesPerSecond\"><annotation
-        displayName=\"Disk total bytes\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\ReadBytesPerSecond\" sampleRate=\"PT15S\"
-        unit=\"BytesPerSecond\"><annotation displayName=\"Disk read guest OS\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\WriteBytesPerSecond\" sampleRate=\"PT15S\"
-        unit=\"BytesPerSecond\"><annotation displayName=\"Disk write guest OS\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\TransfersPerSecond\" sampleRate=\"PT15S\"
-        unit=\"CountPerSecond\"><annotation displayName=\"Disk transfers\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\ReadsPerSecond\" sampleRate=\"PT15S\" unit=\"CountPerSecond\"><annotation
-        displayName=\"Disk reads\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\WritesPerSecond\" sampleRate=\"PT15S\"
-        unit=\"CountPerSecond\"><annotation displayName=\"Disk writes\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\AverageReadTime\" sampleRate=\"PT15S\"
-        unit=\"Seconds\"><annotation displayName=\"Disk read time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\AverageWriteTime\" sampleRate=\"PT15S\"
-        unit=\"Seconds\"><annotation displayName=\"Disk write time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\AverageTransferTime\" sampleRate=\"PT15S\"
-        unit=\"Seconds\"><annotation displayName=\"Disk transfer time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\AverageDiskQueueLength\" sampleRate=\"PT15S\"
-        unit=\"Count\"><annotation displayName=\"Disk queue length\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\BytesTransmitted\" sampleRate=\"PT15S\"
-        unit=\"Bytes\"><annotation displayName=\"Network out guest OS\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\BytesReceived\" sampleRate=\"PT15S\"
-        unit=\"Bytes\"><annotation displayName=\"Network in guest OS\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\PacketsTransmitted\" sampleRate=\"PT15S\"
-        unit=\"Count\"><annotation displayName=\"Packets sent\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\PacketsReceived\" sampleRate=\"PT15S\"
-        unit=\"Count\"><annotation displayName=\"Packets received\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\BytesTotal\" sampleRate=\"PT15S\" unit=\"Bytes\"><annotation
-        displayName=\"Network total bytes\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\TotalRxErrors\" sampleRate=\"PT15S\"
-        unit=\"Count\"><annotation displayName=\"Packets received errors\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\TotalTxErrors\" sampleRate=\"PT15S\"
-        unit=\"Count\"><annotation displayName=\"Packets sent errors\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\TotalCollisions\" sampleRate=\"PT15S\"
-        unit=\"Count\"><annotation displayName=\"Network collisions\" locale=\"en-us\"/></PerformanceCounterConfiguration></PerformanceCounters>","metricsstart":"<WadCfg><DiagnosticMonitorConfiguration
-        overallQuotaInMB=\"4096\"><DiagnosticInfrastructureLogs scheduledTransferPeriod=\"PT1M\"
-        scheduledTransferLogLevelFilter=\"Warning\"/>","wadcfgx":"[concat(variables(''metricsstart''),
-        variables(''metricscounters''), variables(''metricsclosing''))]"},"resources":[{"type":"Microsoft.Compute/virtualMachines","name":"[parameters(''virtualMachineName'')]","apiVersion":"2015-06-15","location":"[parameters(''location'')]","properties":{"osProfile":{"computerName":"[parameters(''virtualMachineName'')]","adminUsername":"[parameters(''adminUsername'')]","adminPassword":"[parameters(''adminPassword'')]"},"hardwareProfile":{"vmSize":"[parameters(''virtualMachineSize'')]"},"storageProfile":{"imageReference":{"publisher":"RedHat","offer":"RHEL","sku":"6.7","version":"latest"},"osDisk":{"name":"[parameters(''virtualMachineName'')]","vhd":{"uri":"[concat(concat(reference(resourceId(''miq-azure-test1'',
-        ''Microsoft.Storage/storageAccounts'', parameters(''storageAccountName'')),
-        ''2015-06-15'').primaryEndpoints[''blob''], ''vhds/''), parameters(''virtualMachineName''),
-        ''201682123650.vhd'')]"},"createOption":"fromImage"},"dataDisks":[]},"networkProfile":{"networkInterfaces":[{"id":"[resourceId(''Microsoft.Network/networkInterfaces'',
-        parameters(''networkInterfaceName''))]"}]},"diagnosticsProfile":{"bootDiagnostics":{"enabled":true,"storageUri":"[reference(resourceId(''amisstea-rg'',
-        ''Microsoft.Storage/storageAccounts'', parameters(''diagnosticsStorageAccountName'')),
-        ''2015-06-15'').primaryEndpoints[''blob'']]"}},"availabilitySet":{"id":"[resourceId(''Microsoft.Compute/availabilitySets'',
-        parameters(''availabilitySetName''))]"}},"dependsOn":["[concat(''Microsoft.Network/networkInterfaces/'',
-        parameters(''networkInterfaceName''))]"]},{"type":"Microsoft.Compute/virtualMachines/extensions","name":"[concat(parameters(''virtualMachineName''),''/Microsoft.Insights.VMDiagnosticsSettings'')]","apiVersion":"2015-06-15","location":"[parameters(''location'')]","properties":{"publisher":"Microsoft.OSTCExtensions","type":"LinuxDiagnostic","typeHandlerVersion":"2.3","autoUpgradeMinorVersion":true,"settings":{"xmlCfg":"[base64(variables(''wadcfgx''))]","StorageAccount":"[parameters(''diagnosticsStorageAccountName'')]"},"protectedSettings":{"storageAccountName":"[parameters(''diagnosticsStorageAccountName'')]","storageAccountKey":"[listKeys(parameters(''diagnosticsStorageAccountId''),''2015-06-15'').key1]","storageAccountEndPoint":"https://core.windows.net/"}},"dependsOn":["[concat(''Microsoft.Compute/virtualMachines/'',
-        parameters(''virtualMachineName''))]"]},{"type":"Microsoft.Network/networkInterfaces","name":"[parameters(''networkInterfaceName'')]","apiVersion":"2015-06-15","location":"[parameters(''location'')]","properties":{"primary":true,"ipConfigurations":[{"name":"ipconfig1","properties":{"subnet":{"id":"[variables(''subnetRef'')]"},"privateIPAllocationMethod":"Dynamic","publicIpAddress":{"id":"[resourceId(''miq-azure-test1'',''Microsoft.Network/publicIpAddresses'',
-        parameters(''publicIpAddressName''))]"}}}],"networkSecurityGroup":{"id":"[resourceId(''miq-azure-test1'',
-        ''Microsoft.Network/networkSecurityGroups'', parameters(''networkSecurityGroupName''))]"}},"dependsOn":["[concat(''Microsoft.Network/publicIpAddresses/'',
-        parameters(''publicIpAddressName''))]","[concat(''Microsoft.Network/networkSecurityGroups/'',
-        parameters(''networkSecurityGroupName''))]"]},{"type":"Microsoft.Network/publicIpAddresses","name":"[parameters(''publicIpAddressName'')]","apiVersion":"2015-06-15","location":"[parameters(''location'')]","properties":{"publicIpAllocationMethod":"[parameters(''publicIpAddressType'')]"}},{"type":"Microsoft.Network/networkSecurityGroups","name":"[parameters(''networkSecurityGroupName'')]","apiVersion":"2015-06-15","location":"[parameters(''location'')]","properties":{"securityRules":[{"name":"default-allow-ssh","properties":{"priority":1000,"sourceAddressPrefix":"*","protocol":"TCP","destinationPortRange":"22","access":"Allow","direction":"Inbound","sourcePortRange":"*","destinationAddressPrefix":"*"}}]}}],"outputs":{"adminUsername":{"type":"String","value":"[parameters(''adminUsername'')]"}}}}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:20:28 GMT
-- request:
-    method: post
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/exportTemplate?api-version=2017-08-01
-    body:
-      encoding: ASCII-8BIT
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3MDYsIm5iZiI6MTUyMDQ1MzcwNiwiZXhwIjoxNTIwNDU3NjA2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTFnbXRqVzFoMC0wV0djUnUxY0FBQSIsInZlciI6IjEuMCJ9.Erl0psNafp3XtL4oqBb3M0lFjZ_MJ_SHo7l_36xqNg7ftRHb3N_Z-UV9MvDb4JuraazeDmSbyds8cs5HtDmrkjbp1N4kpcNw2R3qVMQqkEafMmzKiXPNaLk_GI3qaiD1pwr7RLP5ooUohDLpy-YBFD9JqzpenQ8oOHjd6-FKZVm7Bra-o3FdOoU7U4BY0SDUmRqf9HOcquo-2AhSLYpXAXzpKY3Fs6o63k2qKcm2Z0jPmmmFnnz0QSnbWqFz6KhsH5AuNwmSgLsQ6EpUYGMlYAthQG2lWG5j4z-LkrZRhSNNHwRLcHSwtGNZhfoiFNHJsuGrP7fUY5xfucJl_cWfVA
-      Content-Length:
-      - '0'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1196'
-      X-Ms-Request-Id:
-      - e1ee1bd1-9098-487a-9c71-a47423e00006
-      X-Ms-Correlation-Request-Id:
-      - e1ee1bd1-9098-487a-9c71-a47423e00006
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202029Z:e1ee1bd1-9098-487a-9c71-a47423e00006
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:20:28 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"template":{"$schema":"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#","contentVersion":"1.0.0.0","parameters":{"location":{"type":"String"},"virtualMachineName":{"type":"String"},"virtualMachineSize":{"type":"String"},"adminUsername":{"type":"String"},"storageAccountName":{"type":"String"},"virtualNetworkName":{"type":"String"},"networkInterfaceName":{"type":"String"},"networkSecurityGroupName":{"type":"String"},"adminPassword":{"type":"SecureString"},"storageAccountType":{"type":"String"},"diagnosticsStorageAccountName":{"type":"String"},"diagnosticsStorageAccountId":{"type":"String"},"diagnosticsStorageAccountType":{"type":"String"},"addressPrefix":{"type":"String"},"subnetName":{"type":"String"},"subnetPrefix":{"type":"String"},"publicIpAddressName":{"type":"String"},"publicIpAddressType":{"type":"String"}},"variables":{"vnetId":"[resourceId(''miq-azure-test1'',''Microsoft.Network/virtualNetworks'',
-        parameters(''virtualNetworkName''))]","subnetRef":"[concat(variables(''vnetId''),
-        ''/subnets/'', parameters(''subnetName''))]","metricsresourceid":"[concat(''/subscriptions/'',
-        subscription().subscriptionId, ''/resourceGroups/'', resourceGroup().name,
-        ''/providers/'', ''Microsoft.Compute/virtualMachines/'', parameters(''virtualMachineName''))]","metricsclosing":"[concat(''<Metrics
-        resourceId=\"'', variables(''metricsresourceid''), ''\"><MetricAggregation
-        scheduledTransferPeriod=\"PT1H\"/><MetricAggregation scheduledTransferPeriod=\"PT1M\"/></Metrics></DiagnosticMonitorConfiguration></WadCfg>'')]","metricscounters":"<PerformanceCounters
-        scheduledTransferPeriod=\"PT1M\"><PerformanceCounterConfiguration counterSpecifier=\"\\Memory\\AvailableMemory\"
-        sampleRate=\"PT15S\" unit=\"Bytes\"><annotation displayName=\"Memory available\"
-        locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PercentAvailableMemory\" sampleRate=\"PT15S\"
-        unit=\"Percent\"><annotation displayName=\"Mem. percent available\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\UsedMemory\" sampleRate=\"PT15S\" unit=\"Bytes\"><annotation
-        displayName=\"Memory used\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PercentUsedMemory\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"Memory percentage\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PercentUsedByCache\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"Mem. used by cache\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PagesPerSec\" sampleRate=\"PT15S\" unit=\"CountPerSecond\"><annotation
-        displayName=\"Pages\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PagesReadPerSec\" sampleRate=\"PT15S\" unit=\"CountPerSecond\"><annotation
-        displayName=\"Page reads\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PagesWrittenPerSec\" sampleRate=\"PT15S\" unit=\"CountPerSecond\"><annotation
-        displayName=\"Page writes\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\AvailableSwap\" sampleRate=\"PT15S\" unit=\"Bytes\"><annotation
-        displayName=\"Swap available\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PercentAvailableSwap\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"Swap percent available\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\UsedSwap\" sampleRate=\"PT15S\" unit=\"Bytes\"><annotation
-        displayName=\"Swap used\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PercentUsedSwap\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"Swap percent used\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentIdleTime\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"CPU idle time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentUserTime\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"CPU user time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentNiceTime\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"CPU nice time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentPrivilegedTime\" sampleRate=\"PT15S\"
-        unit=\"Percent\"><annotation displayName=\"CPU privileged time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentInterruptTime\" sampleRate=\"PT15S\"
-        unit=\"Percent\"><annotation displayName=\"CPU interrupt time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentDPCTime\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"CPU DPC time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentProcessorTime\" sampleRate=\"PT15S\"
-        unit=\"Percent\"><annotation displayName=\"CPU percentage guest OS\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentIOWaitTime\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"CPU IO wait time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\BytesPerSecond\" sampleRate=\"PT15S\" unit=\"BytesPerSecond\"><annotation
-        displayName=\"Disk total bytes\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\ReadBytesPerSecond\" sampleRate=\"PT15S\"
-        unit=\"BytesPerSecond\"><annotation displayName=\"Disk read guest OS\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\WriteBytesPerSecond\" sampleRate=\"PT15S\"
-        unit=\"BytesPerSecond\"><annotation displayName=\"Disk write guest OS\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\TransfersPerSecond\" sampleRate=\"PT15S\"
-        unit=\"CountPerSecond\"><annotation displayName=\"Disk transfers\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\ReadsPerSecond\" sampleRate=\"PT15S\" unit=\"CountPerSecond\"><annotation
-        displayName=\"Disk reads\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\WritesPerSecond\" sampleRate=\"PT15S\"
-        unit=\"CountPerSecond\"><annotation displayName=\"Disk writes\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\AverageReadTime\" sampleRate=\"PT15S\"
-        unit=\"Seconds\"><annotation displayName=\"Disk read time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\AverageWriteTime\" sampleRate=\"PT15S\"
-        unit=\"Seconds\"><annotation displayName=\"Disk write time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\AverageTransferTime\" sampleRate=\"PT15S\"
-        unit=\"Seconds\"><annotation displayName=\"Disk transfer time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\AverageDiskQueueLength\" sampleRate=\"PT15S\"
-        unit=\"Count\"><annotation displayName=\"Disk queue length\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\BytesTransmitted\" sampleRate=\"PT15S\"
-        unit=\"Bytes\"><annotation displayName=\"Network out guest OS\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\BytesReceived\" sampleRate=\"PT15S\"
-        unit=\"Bytes\"><annotation displayName=\"Network in guest OS\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\PacketsTransmitted\" sampleRate=\"PT15S\"
-        unit=\"Count\"><annotation displayName=\"Packets sent\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\PacketsReceived\" sampleRate=\"PT15S\"
-        unit=\"Count\"><annotation displayName=\"Packets received\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\BytesTotal\" sampleRate=\"PT15S\" unit=\"Bytes\"><annotation
-        displayName=\"Network total bytes\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\TotalRxErrors\" sampleRate=\"PT15S\"
-        unit=\"Count\"><annotation displayName=\"Packets received errors\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\TotalTxErrors\" sampleRate=\"PT15S\"
-        unit=\"Count\"><annotation displayName=\"Packets sent errors\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\TotalCollisions\" sampleRate=\"PT15S\"
-        unit=\"Count\"><annotation displayName=\"Network collisions\" locale=\"en-us\"/></PerformanceCounterConfiguration></PerformanceCounters>","metricsstart":"<WadCfg><DiagnosticMonitorConfiguration
-        overallQuotaInMB=\"4096\"><DiagnosticInfrastructureLogs scheduledTransferPeriod=\"PT1M\"
-        scheduledTransferLogLevelFilter=\"Warning\"/>","wadcfgx":"[concat(variables(''metricsstart''),
-        variables(''metricscounters''), variables(''metricsclosing''))]"},"resources":[{"type":"Microsoft.Compute/virtualMachines","name":"[parameters(''virtualMachineName'')]","apiVersion":"2015-06-15","location":"[parameters(''location'')]","properties":{"osProfile":{"computerName":"[parameters(''virtualMachineName'')]","adminUsername":"[parameters(''adminUsername'')]","adminPassword":"[parameters(''adminPassword'')]"},"hardwareProfile":{"vmSize":"[parameters(''virtualMachineSize'')]"},"storageProfile":{"imageReference":{"publisher":"RedHat","offer":"RHEL","sku":"7.2","version":"latest"},"osDisk":{"name":"[parameters(''virtualMachineName'')]","vhd":{"uri":"[concat(concat(reference(resourceId(''miq-azure-test1'',
-        ''Microsoft.Storage/storageAccounts'', parameters(''storageAccountName'')),
-        ''2015-06-15'').primaryEndpoints[''blob''], ''vhds/''), parameters(''virtualMachineName''),
-        ''2016218112243.vhd'')]"},"createOption":"fromImage"},"dataDisks":[]},"networkProfile":{"networkInterfaces":[{"id":"[resourceId(''Microsoft.Network/networkInterfaces'',
-        parameters(''networkInterfaceName''))]"}]},"diagnosticsProfile":{"bootDiagnostics":{"enabled":true,"storageUri":"[reference(resourceId(''miq-azure-test1'',
-        ''Microsoft.Storage/storageAccounts'', parameters(''diagnosticsStorageAccountName'')),
-        ''2015-06-15'').primaryEndpoints[''blob'']]"}}},"resources":[{"type":"extensions","name":"Microsoft.Insights.VMDiagnosticsSettings","apiVersion":"2015-05-01-preview","location":"[parameters(''location'')]","properties":{"publisher":"Microsoft.OSTCExtensions","type":"LinuxDiagnostic","typeHandlerVersion":"2.0","autoUpgradeMinorVersion":true,"settings":{"xmlCfg":"[base64(variables(''wadcfgx''))]","StorageAccount":"[parameters(''diagnosticsStorageAccountName'')]"},"protectedSettings":{"storageAccountName":"[parameters(''diagnosticsStorageAccountName'')]","storageAccountKey":"[listKeys(parameters(''diagnosticsStorageAccountId''),''2015-05-01-preview'').key1]","storageAccountEndPoint":"https://core.windows.net/"}},"dependsOn":["[concat(''Microsoft.Compute/virtualMachines/'',
-        parameters(''virtualMachineName''))]"]}],"dependsOn":["[concat(''Microsoft.Network/networkInterfaces/'',
-        parameters(''networkInterfaceName''))]","[concat(''Microsoft.Storage/storageAccounts/'',
-        parameters(''storageAccountName''))]"]},{"type":"Microsoft.Storage/storageAccounts","name":"[parameters(''storageAccountName'')]","apiVersion":"2015-05-01-preview","location":"[parameters(''location'')]","properties":{"accountType":"[parameters(''storageAccountType'')]"}},{"type":"Microsoft.Network/virtualNetworks","name":"[parameters(''virtualNetworkName'')]","apiVersion":"2015-05-01-preview","location":"[parameters(''location'')]","properties":{"addressSpace":{"addressPrefixes":["[parameters(''addressPrefix'')]"]},"subnets":[{"name":"[parameters(''subnetName'')]","properties":{"addressPrefix":"[parameters(''subnetPrefix'')]"}}]}},{"type":"Microsoft.Network/networkInterfaces","name":"[parameters(''networkInterfaceName'')]","apiVersion":"2015-05-01-preview","location":"[parameters(''location'')]","properties":{"ipConfigurations":[{"name":"ipconfig1","properties":{"subnet":{"id":"[variables(''subnetRef'')]"},"privateIPAllocationMethod":"Dynamic","publicIpAddress":{"id":"[resourceId(''miq-azure-test1'',''Microsoft.Network/publicIpAddresses'',
-        parameters(''publicIpAddressName''))]"}}}],"networkSecurityGroup":{"id":"[resourceId(''miq-azure-test1'',
-        ''Microsoft.Network/networkSecurityGroups'', parameters(''networkSecurityGroupName''))]"}},"dependsOn":["[concat(''Microsoft.Network/virtualNetworks/'',
-        parameters(''virtualNetworkName''))]","[concat(''Microsoft.Network/publicIpAddresses/'',
-        parameters(''publicIpAddressName''))]","[concat(''Microsoft.Network/networkSecurityGroups/'',
-        parameters(''networkSecurityGroupName''))]"]},{"type":"Microsoft.Network/publicIpAddresses","name":"[parameters(''publicIpAddressName'')]","apiVersion":"2015-05-01-preview","location":"[parameters(''location'')]","properties":{"publicIpAllocationMethod":"[parameters(''publicIpAddressType'')]"}},{"type":"Microsoft.Network/networkSecurityGroups","name":"[parameters(''networkSecurityGroupName'')]","apiVersion":"2015-05-01-preview","location":"[parameters(''location'')]","properties":{"securityRules":[{"name":"default-allow-ssh","properties":{"priority":1000,"sourceAddressPrefix":"*","protocol":"Tcp","destinationPortRange":"22","access":"Allow","direction":"inbound","sourcePortRange":"*","destinationAddressPrefix":"*"}}]}}],"outputs":{"adminUsername":{"type":"String","value":"[parameters(''adminUsername'')]"}}}}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:20:29 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a?api-version=2017-12-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3MDYsIm5iZiI6MTUyMDQ1MzcwNiwiZXhwIjoxNTIwNDU3NjA2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTFnbXRqVzFoMC0wV0djUnUxY0FBQSIsInZlciI6IjEuMCJ9.Erl0psNafp3XtL4oqBb3M0lFjZ_MJ_SHo7l_36xqNg7ftRHb3N_Z-UV9MvDb4JuraazeDmSbyds8cs5HtDmrkjbp1N4kpcNw2R3qVMQqkEafMmzKiXPNaLk_GI3qaiD1pwr7RLP5ooUohDLpy-YBFD9JqzpenQ8oOHjd6-FKZVm7Bra-o3FdOoU7U4BY0SDUmRqf9HOcquo-2AhSLYpXAXzpKY3Fs6o63k2qKcm2Z0jPmmmFnnz0QSnbWqFz6KhsH5AuNwmSgLsQ6EpUYGMlYAthQG2lWG5j4z-LkrZRhSNNHwRLcHSwtGNZhfoiFNHJsuGrP7fUY5xfucJl_cWfVA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/LowCostGet3Min;4708,Microsoft.Compute/LowCostGet30Min;37883
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
-      X-Ms-Request-Id:
-      - a3e1364c-5f73-4e3e-82ab-81b778db55a8
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14977'
+      - '14980'
       X-Ms-Correlation-Request-Id:
-      - f9ee2908-9189-489f-9792-29006c6aa876
+      - 4829ba43-f80b-4e2b-b6d8-86e29ec7d438
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202029Z:f9ee2908-9189-489f-9792-29006c6aa876
+      - WESTEUROPE:20180312T102759Z:4829ba43-f80b-4e2b-b6d8-86e29ec7d438
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:20:29 GMT
+      - Mon, 12 Mar 2018 10:27:59 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"23b0beab-16d2-4135-a01f-2fe713217fd0\",\r\n
-        \   \"availabilitySet\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/RSPEC-LB\"\r\n
-        \   },\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_F1s\"\r\n
-        \   },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
-        \"RedHat\",\r\n        \"offer\": \"RHEL\",\r\n        \"sku\": \"6.7\",\r\n
-        \       \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
-        \"Linux\",\r\n        \"name\": \"rspec-lb-a\",\r\n        \"createOption\":
-        \"FromImage\",\r\n        \"vhd\": {\r\n          \"uri\": \"https://rspeclb.blob.core.windows.net/vhds/rspec-lb-a201682122839.vhd\"\r\n
-        \       },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n      \"dataDisks\":
-        []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"rspec-lb-a\",\r\n
-        \     \"adminUsername\": \"bronaghs\",\r\n      \"linuxConfiguration\": {\r\n
-        \       \"disablePasswordAuthentication\": false\r\n      },\r\n      \"secrets\":
-        []\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670\"}]},\r\n
-        \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
-        true,\r\n        \"storageUri\": \"https://miqazuretest16487.blob.core.windows.net/\"\r\n
-        \     }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n
-        \ \"resources\": [\r\n    {\r\n      \"properties\": {\r\n        \"publisher\":
-        \"Microsoft.OSTCExtensions\",\r\n        \"type\": \"LinuxDiagnostic\",\r\n
-        \       \"typeHandlerVersion\": \"2.3\",\r\n        \"autoUpgradeMinorVersion\":
-        true,\r\n        \"settings\": {\"xmlCfg\":\"PFdhZENmZz48RGlhZ25vc3RpY01vbml0b3JDb25maWd1cmF0aW9uIG92ZXJhbGxRdW90YUluTUI9IjQwOTYiPjxEaWFnbm9zdGljSW5mcmFzdHJ1Y3R1cmVMb2dzIHNjaGVkdWxlZFRyYW5zZmVyUGVyaW9kPSJQVDFNIiBzY2hlZHVsZWRUcmFuc2ZlckxvZ0xldmVsRmlsdGVyPSJXYXJuaW5nIi8+PFBlcmZvcm1hbmNlQ291bnRlcnMgc2NoZWR1bGVkVHJhbnNmZXJQZXJpb2Q9IlBUMU0iPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlTWVtb3J5IiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQnl0ZXMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcUGVyY2VudEF2YWlsYWJsZU1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iTWVtb3J5IHVzZWQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50VXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgcGVyY2VudGFnZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkQnlDYWNoZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHVzZWQgYnkgY2FjaGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1BlclNlYyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50UGVyU2Vjb25kIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFnZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1JlYWRQZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2UgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1dyaXR0ZW5QZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2Ugd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iU3dhcCBhdmFpbGFibGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50QXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZFN3YXAiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlN3YXAgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRJZGxlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgaWRsZSB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFVzZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iUGVyY2VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkNQVSB1c2VyIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50TmljZVRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIG5pY2UgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRQcml2aWxlZ2VkVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgcHJpdmlsZWdlZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudEludGVycnVwdFRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIGludGVycnVwdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudERQQ1RpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIERQQyB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFByb2Nlc3NvclRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIHBlcmNlbnRhZ2UgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50SU9XYWl0VGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgSU8gd2FpdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xSZWFkQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCBndWVzdCBPUyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXFdyaXRlQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGUgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xUcmFuc2ZlcnNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXJzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcUmVhZHNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xXcml0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVJlYWRUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVdyaXRlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlNlY29uZHMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJEaXNrIHdyaXRlIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xBdmVyYWdlVHJhbnNmZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXIgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXEF2ZXJhZ2VEaXNrUXVldWVMZW5ndGgiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcXVldWUgbGVuZ3RoIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVHJhbnNtaXR0ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgb3V0IGd1ZXN0IE9TIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzUmVjZWl2ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgaW4gZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1RyYW5zbWl0dGVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHNlbnQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1JlY2VpdmVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHJlY2VpdmVkIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVG90YWwiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxSeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyByZWNlaXZlZCBlcnJvcnMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxUeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyBzZW50IGVycm9ycyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTmV0d29ya0ludGVyZmFjZVxUb3RhbENvbGxpc2lvbnMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgY29sbGlzaW9ucyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48L1BlcmZvcm1hbmNlQ291bnRlcnM+PE1ldHJpY3MgcmVzb3VyY2VJZD0iL3N1YnNjcmlwdGlvbnMvMjU4NmM2NGItMzhiNC00NTI3LWExNDAtMDEyZDQ5ZGZjMDJjL3Jlc291cmNlR3JvdXBzL21pcS1henVyZS10ZXN0MS9wcm92aWRlcnMvTWljcm9zb2Z0LkNvbXB1dGUvdmlydHVhbE1hY2hpbmVzL3JzcGVjLWxiLWEiPjxNZXRyaWNBZ2dyZWdhdGlvbiBzY2hlZHVsZWRUcmFuc2ZlclBlcmlvZD0iUFQxSCIvPjxNZXRyaWNBZ2dyZWdhdGlvbiBzY2hlZHVsZWRUcmFuc2ZlclBlcmlvZD0iUFQxTSIvPjwvTWV0cmljcz48L0RpYWdub3N0aWNNb25pdG9yQ29uZmlndXJhdGlvbj48L1dhZENmZz4=\",\"StorageAccount\":\"miqazuretest16487\"},\r\n
-        \       \"provisioningState\": \"Succeeded\"\r\n      },\r\n      \"type\":
-        \"Microsoft.Compute/virtualMachines/extensions\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a/extensions/Microsoft.Insights.VMDiagnosticsSettings\",\r\n
-        \     \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n    }\r\n
-        \ ],\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\":
-        \"eastus\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a\",\r\n
-        \ \"name\": \"rspec-lb-a\"\r\n}"
+      string: "{\r\n  \"name\": \"rspec-lb2-publicip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\",\r\n
+        \ \"etag\": \"W/\\\"cddd97d1-6111-4477-8a00-3dc885237a1d\\\"\",\r\n  \"location\":
+        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"83e7257d-ab94-4229-8eb5-4798f37ef28d\",\r\n    \"publicIPAddressVersion\":
+        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
+        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
+        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
+        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:20:30 GMT
+  recorded_at: Mon, 12 Mar 2018 10:28:03 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-a-ip?api-version=2018-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -4511,7 +3979,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3MDYsIm5iZiI6MTUyMDQ1MzcwNiwiZXhwIjoxNTIwNDU3NjA2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTFnbXRqVzFoMC0wV0djUnUxY0FBQSIsInZlciI6IjEuMCJ9.Erl0psNafp3XtL4oqBb3M0lFjZ_MJ_SHo7l_36xqNg7ftRHb3N_Z-UV9MvDb4JuraazeDmSbyds8cs5HtDmrkjbp1N4kpcNw2R3qVMQqkEafMmzKiXPNaLk_GI3qaiD1pwr7RLP5ooUohDLpy-YBFD9JqzpenQ8oOHjd6-FKZVm7Bra-o3FdOoU7U4BY0SDUmRqf9HOcquo-2AhSLYpXAXzpKY3Fs6o63k2qKcm2Z0jPmmmFnnz0QSnbWqFz6KhsH5AuNwmSgLsQ6EpUYGMlYAthQG2lWG5j4z-LkrZRhSNNHwRLcHSwtGNZhfoiFNHJsuGrP7fUY5xfucJl_cWfVA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAxNTEsIm5iZiI6MTUyMDg1MDE1MSwiZXhwIjoxNTIwODU0MDUxLCJhaW8iOiJZMk5nWU5oMlRiYXo0MmZ6c1NCSjZ3K1BUbmhKQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYzF5aWdZX3FnMEdhSmwwanp4SVdBQSIsInZlciI6IjEuMCJ9.C_t36CdMu-7-Tut5olza_36ERC--pFhJlg7cSqEsjI-FGSw4l4kQpgGNNKJWn8fueTIslcIlvTH0FrjGIhhelAf9KNYqITzZTkj33Ewj023i8bS7H3vWuA_w-kG6dXqzBRRQfDrVwTpDDV1qMCCdz0Jd_G0vZb7AIJKMaFtik5fEC24UzolIFeaLxAuGNm26YdPA4-9oWfqLt7vYMdfioMpnTsnx6PBiIzZ235slf1f0u3FYNOzNnIdmX9WecqD1BxHqp5aizLX2aZXIPWQtn01mYSu6dMhpKnfiIs-FLj4UC0JXmR8Lb9jRuIvrTSLnF1WE9ScCqV_N4brfiqVKKQ
   response:
     status:
       code: 200
@@ -4527,63 +3995,42 @@ http_interactions:
       - application/json; charset=utf-8
       Expires:
       - "-1"
+      Etag:
+      - W/"3ba30997-7d2f-470c-96f6-301158e93b7c"
       Vary:
       - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/LowCostGet3Min;4718,Microsoft.Compute/LowCostGet30Min;37882
+      X-Ms-Request-Id:
+      - 87555b3b-5d22-437f-8e86-12083a472672
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
-      X-Ms-Request-Id:
-      - 7ff8fd33-35cd-4ac1-bede-ba78cf18161a
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14984'
+      - '14983'
       X-Ms-Correlation-Request-Id:
-      - fa343672-a5fe-4a17-a321-e2a66371ee6b
+      - ecc032b6-6df9-4eea-8eb2-ba01e4d47611
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202038Z:fa343672-a5fe-4a17-a321-e2a66371ee6b
+      - WESTEUROPE:20180312T102759Z:ecc032b6-6df9-4eea-8eb2-ba01e4d47611
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:20:37 GMT
+      - Mon, 12 Mar 2018 10:27:59 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"834a70b5-868d-4466-9dda-14e0f6b2caaf\",\r\n
-        \   \"availabilitySet\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/RSPEC-LB\"\r\n
-        \   },\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_DS1_v2\"\r\n
-        \   },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
-        \"RedHat\",\r\n        \"offer\": \"RHEL\",\r\n        \"sku\": \"6.7\",\r\n
-        \       \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
-        \"Linux\",\r\n        \"name\": \"rspec-lb-b\",\r\n        \"createOption\":
-        \"FromImage\",\r\n        \"vhd\": {\r\n          \"uri\": \"https://rspeclb.blob.core.windows.net/vhds/rspec-lb-b201682123650.vhd\"\r\n
-        \       },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n      \"dataDisks\":
-        []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"rspec-lb-b\",\r\n
-        \     \"adminUsername\": \"bronaghs\",\r\n      \"linuxConfiguration\": {\r\n
-        \       \"disablePasswordAuthentication\": false\r\n      },\r\n      \"secrets\":
-        []\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843\"}]},\r\n
-        \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
-        true,\r\n        \"storageUri\": \"https://amissteastorage.blob.core.windows.net/\"\r\n
-        \     }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n
-        \ \"resources\": [\r\n    {\r\n      \"properties\": {\r\n        \"publisher\":
-        \"Microsoft.OSTCExtensions\",\r\n        \"type\": \"LinuxDiagnostic\",\r\n
-        \       \"typeHandlerVersion\": \"2.3\",\r\n        \"autoUpgradeMinorVersion\":
-        true,\r\n        \"settings\": {\"xmlCfg\":\"PFdhZENmZz48RGlhZ25vc3RpY01vbml0b3JDb25maWd1cmF0aW9uIG92ZXJhbGxRdW90YUluTUI9IjQwOTYiPjxEaWFnbm9zdGljSW5mcmFzdHJ1Y3R1cmVMb2dzIHNjaGVkdWxlZFRyYW5zZmVyUGVyaW9kPSJQVDFNIiBzY2hlZHVsZWRUcmFuc2ZlckxvZ0xldmVsRmlsdGVyPSJXYXJuaW5nIi8+PFBlcmZvcm1hbmNlQ291bnRlcnMgc2NoZWR1bGVkVHJhbnNmZXJQZXJpb2Q9IlBUMU0iPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlTWVtb3J5IiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQnl0ZXMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcUGVyY2VudEF2YWlsYWJsZU1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iTWVtb3J5IHVzZWQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50VXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgcGVyY2VudGFnZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkQnlDYWNoZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHVzZWQgYnkgY2FjaGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1BlclNlYyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50UGVyU2Vjb25kIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFnZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1JlYWRQZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2UgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1dyaXR0ZW5QZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2Ugd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iU3dhcCBhdmFpbGFibGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50QXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZFN3YXAiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlN3YXAgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRJZGxlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgaWRsZSB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFVzZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iUGVyY2VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkNQVSB1c2VyIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50TmljZVRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIG5pY2UgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRQcml2aWxlZ2VkVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgcHJpdmlsZWdlZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudEludGVycnVwdFRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIGludGVycnVwdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudERQQ1RpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIERQQyB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFByb2Nlc3NvclRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIHBlcmNlbnRhZ2UgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50SU9XYWl0VGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgSU8gd2FpdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xSZWFkQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCBndWVzdCBPUyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXFdyaXRlQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGUgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xUcmFuc2ZlcnNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXJzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcUmVhZHNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xXcml0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVJlYWRUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVdyaXRlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlNlY29uZHMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJEaXNrIHdyaXRlIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xBdmVyYWdlVHJhbnNmZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXIgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXEF2ZXJhZ2VEaXNrUXVldWVMZW5ndGgiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcXVldWUgbGVuZ3RoIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVHJhbnNtaXR0ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgb3V0IGd1ZXN0IE9TIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzUmVjZWl2ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgaW4gZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1RyYW5zbWl0dGVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHNlbnQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1JlY2VpdmVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHJlY2VpdmVkIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVG90YWwiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxSeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyByZWNlaXZlZCBlcnJvcnMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxUeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyBzZW50IGVycm9ycyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTmV0d29ya0ludGVyZmFjZVxUb3RhbENvbGxpc2lvbnMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgY29sbGlzaW9ucyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48L1BlcmZvcm1hbmNlQ291bnRlcnM+PE1ldHJpY3MgcmVzb3VyY2VJZD0iL3N1YnNjcmlwdGlvbnMvMjU4NmM2NGItMzhiNC00NTI3LWExNDAtMDEyZDQ5ZGZjMDJjL3Jlc291cmNlR3JvdXBzL21pcS1henVyZS10ZXN0MS9wcm92aWRlcnMvTWljcm9zb2Z0LkNvbXB1dGUvdmlydHVhbE1hY2hpbmVzL3JzcGVjLWxiLWIiPjxNZXRyaWNBZ2dyZWdhdGlvbiBzY2hlZHVsZWRUcmFuc2ZlclBlcmlvZD0iUFQxSCIvPjxNZXRyaWNBZ2dyZWdhdGlvbiBzY2hlZHVsZWRUcmFuc2ZlclBlcmlvZD0iUFQxTSIvPjwvTWV0cmljcz48L0RpYWdub3N0aWNNb25pdG9yQ29uZmlndXJhdGlvbj48L1dhZENmZz4=\",\"StorageAccount\":\"amissteastorage\"},\r\n
-        \       \"provisioningState\": \"Succeeded\"\r\n      },\r\n      \"type\":
-        \"Microsoft.Compute/virtualMachines/extensions\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b/extensions/Microsoft.Insights.VMDiagnosticsSettings\",\r\n
-        \     \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n    }\r\n
-        \ ],\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\":
-        \"eastus\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b\",\r\n
-        \ \"name\": \"rspec-lb-b\"\r\n}"
+      string: "{\r\n  \"name\": \"rspec-lb-a-ip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-a-ip\",\r\n
+        \ \"etag\": \"W/\\\"3ba30997-7d2f-470c-96f6-301158e93b7c\\\"\",\r\n  \"location\":
+        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"3c605f75-23c0-46ab-ba2b-6fd4430140fd\",\r\n    \"publicIPAddressVersion\":
+        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
+        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
+        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
+        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:20:38 GMT
+  recorded_at: Mon, 12 Mar 2018 10:28:04 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a/instanceView?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-b-ip?api-version=2018-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -4597,7 +4044,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3MDYsIm5iZiI6MTUyMDQ1MzcwNiwiZXhwIjoxNTIwNDU3NjA2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTFnbXRqVzFoMC0wV0djUnUxY0FBQSIsInZlciI6IjEuMCJ9.Erl0psNafp3XtL4oqBb3M0lFjZ_MJ_SHo7l_36xqNg7ftRHb3N_Z-UV9MvDb4JuraazeDmSbyds8cs5HtDmrkjbp1N4kpcNw2R3qVMQqkEafMmzKiXPNaLk_GI3qaiD1pwr7RLP5ooUohDLpy-YBFD9JqzpenQ8oOHjd6-FKZVm7Bra-o3FdOoU7U4BY0SDUmRqf9HOcquo-2AhSLYpXAXzpKY3Fs6o63k2qKcm2Z0jPmmmFnnz0QSnbWqFz6KhsH5AuNwmSgLsQ6EpUYGMlYAthQG2lWG5j4z-LkrZRhSNNHwRLcHSwtGNZhfoiFNHJsuGrP7fUY5xfucJl_cWfVA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAxNTEsIm5iZiI6MTUyMDg1MDE1MSwiZXhwIjoxNTIwODU0MDUxLCJhaW8iOiJZMk5nWU5oMlRiYXo0MmZ6c1NCSjZ3K1BUbmhKQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYzF5aWdZX3FnMEdhSmwwanp4SVdBQSIsInZlciI6IjEuMCJ9.C_t36CdMu-7-Tut5olza_36ERC--pFhJlg7cSqEsjI-FGSw4l4kQpgGNNKJWn8fueTIslcIlvTH0FrjGIhhelAf9KNYqITzZTkj33Ewj023i8bS7H3vWuA_w-kG6dXqzBRRQfDrVwTpDDV1qMCCdz0Jd_G0vZb7AIJKMaFtik5fEC24UzolIFeaLxAuGNm26YdPA4-9oWfqLt7vYMdfioMpnTsnx6PBiIzZ235slf1f0u3FYNOzNnIdmX9WecqD1BxHqp5aizLX2aZXIPWQtn01mYSu6dMhpKnfiIs-FLj4UC0JXmR8Lb9jRuIvrTSLnF1WE9ScCqV_N4brfiqVKKQ
   response:
     status:
       code: 200
@@ -4613,54 +4060,42 @@ http_interactions:
       - application/json; charset=utf-8
       Expires:
       - "-1"
+      Etag:
+      - W/"cf6012c7-3d47-438f-84d7-332ad1ef4500"
       Vary:
       - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/GetInstanceView3Min;4793,Microsoft.Compute/GetInstanceView30Min;23914
+      X-Ms-Request-Id:
+      - 5fd35e8f-0600-497d-82b0-0227cb6f1193
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
-      X-Ms-Request-Id:
-      - c6beb08e-4874-4109-9f96-4121e4842bd0
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14974'
+      - '14982'
       X-Ms-Correlation-Request-Id:
-      - 384524fa-5f22-4f74-bc53-9e2df24825f3
+      - 66c46d2c-9048-4826-8be9-c7080b835c86
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202041Z:384524fa-5f22-4f74-bc53-9e2df24825f3
+      - WESTEUROPE:20180312T102804Z:66c46d2c-9048-4826-8be9-c7080b835c86
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:20:41 GMT
+      - Mon, 12 Mar 2018 10:28:04 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"platformUpdateDomain\": 0,\r\n  \"platformFaultDomain\": 0,\r\n
-        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
-        [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
-        \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
-        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2018-03-07T20:20:38+00:00\"\r\n
-        \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"rspec-lb-a\",\r\n
-        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
-        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"time\": \"2016-09-03T14:04:26.7359609+00:00\"\r\n
-        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
-        \"https://miqazuretest16487.blob.core.windows.net/bootdiagnostics-rspeclba-23b0beab-16d2-4135-a01f-2fe713217fd0/rspec-lb-a.23b0beab-16d2-4135-a01f-2fe713217fd0.screenshot.bmp\",\r\n
-        \   \"serialConsoleLogBlobUri\": \"https://miqazuretest16487.blob.core.windows.net/bootdiagnostics-rspeclba-23b0beab-16d2-4135-a01f-2fe713217fd0/rspec-lb-a.23b0beab-16d2-4135-a01f-2fe713217fd0.serialconsole.log\"\r\n
-        \ },\r\n  \"extensions\": [\r\n    {\r\n      \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n
-        \   }\r\n  ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n
-        \     \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n
-        \     \"time\": \"2016-09-03T14:04:26.7828345+00:00\"\r\n    },\r\n    {\r\n
-        \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
-        \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
+      string: "{\r\n  \"name\": \"rspec-lb-b-ip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-b-ip\",\r\n
+        \ \"etag\": \"W/\\\"cf6012c7-3d47-438f-84d7-332ad1ef4500\\\"\",\r\n  \"location\":
+        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"5d1a2425-a351-4c0f-bc87-37e6500bff22\",\r\n    \"publicIPAddressVersion\":
+        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
+        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\"\r\n
+        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
+        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:20:42 GMT
+  recorded_at: Mon, 12 Mar 2018 10:28:09 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Network/networkInterfaces?api-version=2017-11-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb?api-version=2017-10-01
     body:
       encoding: US-ASCII
       string: ''
@@ -4674,7 +4109,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3MDYsIm5iZiI6MTUyMDQ1MzcwNiwiZXhwIjoxNTIwNDU3NjA2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTFnbXRqVzFoMC0wV0djUnUxY0FBQSIsInZlciI6IjEuMCJ9.Erl0psNafp3XtL4oqBb3M0lFjZ_MJ_SHo7l_36xqNg7ftRHb3N_Z-UV9MvDb4JuraazeDmSbyds8cs5HtDmrkjbp1N4kpcNw2R3qVMQqkEafMmzKiXPNaLk_GI3qaiD1pwr7RLP5ooUohDLpy-YBFD9JqzpenQ8oOHjd6-FKZVm7Bra-o3FdOoU7U4BY0SDUmRqf9HOcquo-2AhSLYpXAXzpKY3Fs6o63k2qKcm2Z0jPmmmFnnz0QSnbWqFz6KhsH5AuNwmSgLsQ6EpUYGMlYAthQG2lWG5j4z-LkrZRhSNNHwRLcHSwtGNZhfoiFNHJsuGrP7fUY5xfucJl_cWfVA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAxNTEsIm5iZiI6MTUyMDg1MDE1MSwiZXhwIjoxNTIwODU0MDUxLCJhaW8iOiJZMk5nWU5oMlRiYXo0MmZ6c1NCSjZ3K1BUbmhKQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYzF5aWdZX3FnMEdhSmwwanp4SVdBQSIsInZlciI6IjEuMCJ9.C_t36CdMu-7-Tut5olza_36ERC--pFhJlg7cSqEsjI-FGSw4l4kQpgGNNKJWn8fueTIslcIlvTH0FrjGIhhelAf9KNYqITzZTkj33Ewj023i8bS7H3vWuA_w-kG6dXqzBRRQfDrVwTpDDV1qMCCdz0Jd_G0vZb7AIJKMaFtik5fEC24UzolIFeaLxAuGNm26YdPA4-9oWfqLt7vYMdfioMpnTsnx6PBiIzZ235slf1f0u3FYNOzNnIdmX9WecqD1BxHqp5aizLX2aZXIPWQtn01mYSu6dMhpKnfiIs-FLj4UC0JXmR8Lb9jRuIvrTSLnF1WE9ScCqV_N4brfiqVKKQ
   response:
     status:
       code: 200
@@ -4684,133 +4119,35 @@ http_interactions:
       - no-cache
       Pragma:
       - no-cache
+      Transfer-Encoding:
+      - chunked
       Content-Type:
-      - application/json; charset=utf-8
+      - application/json
       Expires:
       - "-1"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 28d5a1d6-82c8-47ca-beea-7daa37a34b53
-      X-Ms-Correlation-Request-Id:
-      - 28d5a1d6-82c8-47ca-beea-7daa37a34b53
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202044Z:28d5a1d6-82c8-47ca-beea-7daa37a34b53
+      - 9b1538c8-d813-4f37-b65d-7f3d3dcf7e51
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14983'
+      X-Ms-Correlation-Request-Id:
+      - 59f006be-e416-418a-ac1b-bdd861ec6eb1
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T102808Z:59f006be-e416-418a-ac1b-bdd861ec6eb1
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:20:44 GMT
-      Content-Length:
-      - '31614'
+      - Mon, 12 Mar 2018 10:28:08 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"name":"miqazure-coreos1235","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235","etag":"W/\"4a6546ab-a4c0-4d27-bccd-f6ebf3c405a2\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"fb0a5e60-a6c2-4bb8-a2f5-0c16216a49b0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235/ipConfigurations/ipconfig1","etag":"W/\"4a6546ab-a4c0-4d27-bccd-f6ebf3c405a2\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.20.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/publicIPAddresses/miqazure-coreos1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/virtualNetworks/miq-azure-test3/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"rliadcyr3l1elbnsw4rabxqg1f.dx.internal.cloudapp.net"},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkSecurityGroups/miqazure-coreos1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Compute/virtualMachines/miqazure-coreos1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"dbergerprov1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/dbergerprov1","etag":"W/\"074dd836-918c-4e40-a118-94f0d366e175\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"ecdcd2f0-91bb-4c40-91cd-a3d76fc5e455","ipConfigurations":[{"name":"dbergerprov1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/dbergerprov1/ipConfigurations/dbergerprov1","etag":"W/\"074dd836-918c-4e40-a118-94f0d366e175\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.9","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/dbergerprov1-publicIp"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/virtualMachines/dbergerprov1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-rhel1390","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390","etag":"W/\"f006e6f9-0292-42cd-99fc-f72f194553c1\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"98853f48-2806-4065-be57-cf9159550440","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1","etag":"W/\"f006e6f9-0292-42cd-99fc-f72f194553c1\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"macAddress":"00-0D-3A-10-EB-AB","enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-ubuntu1989","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989","etag":"W/\"64e07488-15a2-4cec-b84a-6fd5ef04323c\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"134a6669-ac4a-4d08-a0db-387bc4c49537","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989/ipConfigurations/ipconfig1","etag":"W/\"64e07488-15a2-4cec-b84a-6fd5ef04323c\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.17.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-ubuntu1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest18687/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-win12610","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610","etag":"W/\"dd925ef5-33d1-402c-a0f4-18c78c2641f4\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"5c2eef2c-0b36-4277-a940-957ed4d13be0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610/ipConfigurations/ipconfig1","etag":"W/\"dd925ef5-33d1-402c-a0f4-18c78c2641f4\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.18.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-win12"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest19881/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-winimg241","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241","etag":"W/\"4a17a745-16a9-42d9-88c9-17a518959525\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"8ed2f3b0-4a4b-49ae-9f1d-ff7890dbd396","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241/ipConfigurations/ipconfig1","etag":"W/\"4a17a745-16a9-42d9-88c9-17a518959525\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.7","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqtestwinimg6202"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-centos1611","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611","etag":"W/\"26031ef6-bb55-4019-8185-2dd1edcb207c\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"f1760e49-9853-4fdc-acfc-4ea232b9ed76","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1","etag":"W/\"26031ef6-bb55-4019-8185-2dd1edcb207c\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.5","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqmismatch1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1","etag":"W/\"3a72d0c3-bfda-4da5-a61b-e8c33e43de79\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"23d804a8-b623-49e7-9c8d-1d64245bef1e","ipConfigurations":[{"name":"miqmismatch1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1/ipConfigurations/miqmismatch1","etag":"W/\"3a72d0c3-bfda-4da5-a61b-e8c33e43de79\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.8","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqmismatch1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqmismatch1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"rspec-lb-a670","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670","etag":"W/\"cf3a0b0d-d596-4f33-bc31-749f92ba4f00\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"46cb8216-786e-408e-9d86-c0855b357349","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1","etag":"W/\"cf3a0b0d-d596-4f33-bc31-749f92ba4f00\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.6","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-a-ip"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"rspec-lb-b843","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843","etag":"W/\"76aabe0c-8678-43f0-81a5-2f15784a4b99\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"3ef6fa01-ac34-43a1-8fd7-67c706b4d8ef","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1","etag":"W/\"76aabe0c-8678-43f0-81a5-2f15784a4b99\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.11","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-b-ip"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"spec0deply1nic0","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","etag":"W/\"b817491c-aab8-4aab-b41d-b07bfffa5639\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"80ad9866-071d-4e3f-91d0-d47954eccee0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1","etag":"W/\"b817491c-aab8-4aab-b41d-b07bfffa5639\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.4","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"spec0deply1nic1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","etag":"W/\"2ec58a0b-4c03-4d0a-b788-9daffd54e7b2\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"57bbf7aa-d6c4-4f56-8f6a-089d15334221","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1","etag":"W/\"2ec58a0b-4c03-4d0a-b788-9daffd54e7b2\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.5","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqmismatch2656","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqmismatch2656","etag":"W/\"fef6a836-2802-4897-90c3-b3d71f133384\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"969dde6c-73c0-4340-877d-2b5fe2060026","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqmismatch2656/ipConfigurations/ipconfig1","etag":"W/\"fef6a836-2802-4897-90c3-b3d71f133384\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"172.23.0.4","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/virtualNetworks/miqazuretest33606/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkSecurityGroups/miqmismatch2-nsg"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Compute/virtualMachines/miqmismatch2"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-linux-manag944","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944","etag":"W/\"b6339880-8ead-4c9e-b5c0-f38c4f8612d5\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"c5e8b90e-5a78-49b0-b224-b70ed3fb45e5","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944/ipConfigurations/ipconfig1","etag":"W/\"b6339880-8ead-4c9e-b5c0-f38c4f8612d5\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"172.25.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqazure-linux-managed-ip"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"jf-metrics-2751","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751","etag":"W/\"c5f6f02a-b17c-4f34-882b-11c7adef0b44\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"207a58d3-f18d-4dab-8168-919877297a52","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751/ipConfigurations/ipconfig1","etag":"W/\"c5f6f02a-b17c-4f34-882b-11c7adef0b44\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.7","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-2"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-2"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/jf-metrics-2"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"jf-metrics-3421","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421","etag":"W/\"0b6f160b-ad10-48f8-9d0c-657193bb823f\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"b8b345e8-a353-4700-992e-be48a717b4e2","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421/ipConfigurations/ipconfig1","etag":"W/\"0b6f160b-ad10-48f8-9d0c-657193bb823f\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.8","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-3"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-3"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/jf-metrics-3"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-oraclelinux310","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310","etag":"W/\"54cd4fe1-3ed5-4a8c-bc8d-527679c7a631\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"6a3fc1d7-4532-4ca0-b5c2-546cc8f7f313","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310/ipConfigurations/ipconfig1","etag":"W/\"54cd4fe1-3ed5-4a8c-bc8d-527679c7a631\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.5","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-oraclelinux993","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993","etag":"W/\"a9432274-7b40-4eb3-a64f-a04267a423ff\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"75d8ed14-e0ae-4d84-99f6-e3f43d073e76","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993/ipConfigurations/ipconfig1","etag":"W/\"a9432274-7b40-4eb3-a64f-a04267a423ff\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.6","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux2"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux2"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"}]}'
+      string: '{"sku":{"name":"Premium_LRS","tier":"Premium"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb","name":"rspeclb","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-09-02T16:29:11.6823797Z","primaryEndpoints":{"blob":"https://rspeclb.blob.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:20:44 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Network/publicIPAddresses?api-version=2017-11-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3MDYsIm5iZiI6MTUyMDQ1MzcwNiwiZXhwIjoxNTIwNDU3NjA2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTFnbXRqVzFoMC0wV0djUnUxY0FBQSIsInZlciI6IjEuMCJ9.Erl0psNafp3XtL4oqBb3M0lFjZ_MJ_SHo7l_36xqNg7ftRHb3N_Z-UV9MvDb4JuraazeDmSbyds8cs5HtDmrkjbp1N4kpcNw2R3qVMQqkEafMmzKiXPNaLk_GI3qaiD1pwr7RLP5ooUohDLpy-YBFD9JqzpenQ8oOHjd6-FKZVm7Bra-o3FdOoU7U4BY0SDUmRqf9HOcquo-2AhSLYpXAXzpKY3Fs6o63k2qKcm2Z0jPmmmFnnz0QSnbWqFz6KhsH5AuNwmSgLsQ6EpUYGMlYAthQG2lWG5j4z-LkrZRhSNNHwRLcHSwtGNZhfoiFNHJsuGrP7fUY5xfucJl_cWfVA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 8023896b-ca79-4adf-af02-34943a3c600b
-      X-Ms-Correlation-Request-Id:
-      - 8023896b-ca79-4adf-af02-34943a3c600b
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202046Z:8023896b-ca79-4adf-af02-34943a3c600b
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:20:45 GMT
-      Content-Length:
-      - '13978'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[{"name":"miqazure-coreos1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/publicIPAddresses/miqazure-coreos1","etag":"W/\"da64b64b-a755-4389-a2f3-5cba32f18c06\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"28617ed1-0270-4b39-873a-c3b48b3deef1","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"dbergerprov1-publicIp","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/dbergerprov1-publicIp","etag":"W/\"3d984c69-3f35-41ce-bdfc-8d207053a6a9\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"eb0e8804-e169-44ac-bb47-0929370977d2","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/dbergerprov1/ipConfigurations/dbergerprov1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"ladas_test","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/ladas_test","etag":"W/\"32e21623-9a1b-4c40-80f4-6a350aa237a7\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"3daa5f66-5a01-4242-b95b-c4e0ee8f0c36","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[]},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miq-test-rhel1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1","etag":"W/\"054052bb-11ff-4f6e-ac1a-3427c2fd17aa\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"f6cfc635-411e-48ce-a627-39a2fc0d3168","ipAddress":"52.224.165.15","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miq-test-ubuntu1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-ubuntu1","etag":"W/\"bcae50c5-146f-4fcb-a461-7c1030ba7b74\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"e272bd74-f661-484f-b223-88dd128a4049","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miq-test-win12","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-win12","etag":"W/\"56ce00f4-50d7-4682-9ee8-6836bf5c0ea6\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"b9200977-8147-40a5-83c2-d5892d5ddedc","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miqazure-centos1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1","etag":"W/\"734a3944-a880-444c-8c92-cace6e28e303\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"475a66f0-9e89-4226-a9f0-9baaaf31d619","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miqtestwinimg6202","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqtestwinimg6202","etag":"W/\"b656279a-26ff-4021-94bb-263420cf494e\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"fb942169-855b-44f8-b12f-fd63e961b140","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"rspec-lb-a-ip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-a-ip","etag":"W/\"3ba30997-7d2f-470c-96f6-301158e93b7c\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"3c605f75-23c0-46ab-ba2b-6fd4430140fd","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"rspec-lb-b-ip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-b-ip","etag":"W/\"cf6012c7-3d47-438f-84d7-332ad1ef4500\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"5d1a2425-a351-4c0f-bc87-37e6500bff22","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"rspec-lb1-LoadBalancerFrontEnd","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd","etag":"W/\"a38434c8-7b23-4092-b7c6-402238eac0dc\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"f28e0f25-b372-4edf-97d9-13a9e3b4ba2d","ipAddress":"40.71.82.83","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"rspec-lb2-publicip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip","etag":"W/\"cddd97d1-6111-4477-8a00-3dc885237a1d\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"83e7257d-ab94-4229-8eb5-4798f37ef28d","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"spec0deply1ip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip","etag":"W/\"2080997a-38a6-420d-ba86-e9582e1331c7\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"a08b891e-e45a-4970-aefc-f6c996989490","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"spec0deply1dns","fqdn":"spec0deply1dns.eastus.cloudapp.azure.com"},"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miqazure-linux-managed-ip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqazure-linux-managed-ip","etag":"W/\"0efc9684-fb7d-4fb7-b9b9-f33dbac04a28\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"6a2a9142-26e8-45cd-93bf-7318192f3528","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miqmismatch1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqmismatch1","etag":"W/\"9b8b1729-21c4-4c53-94f2-15715315ad73\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"a97c71d0-6b78-4ffe-8e5c-0be1ee653f8c","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"miqmismatch1","fqdn":"miqmismatch1.eastus.cloudapp.azure.com"},"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1/ipConfigurations/miqmismatch1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"jf-metrics-2","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-2","etag":"W/\"b43ebe01-574c-4454-87eb-3401fbcf36f2\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"e446f3e4-9410-4d7f-bb04-2652096359de","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"jf-metrics-3","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-3","etag":"W/\"a6ee7100-6202-4ae2-a2db-f828abec8af9\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"de5995a4-15c1-40ba-ad78-67e70a92654b","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miqazure-oraclelinux1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux1","etag":"W/\"98bee7b4-2fcc-471d-b5ce-92850e6c3d6b\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"f2ac7c18-520b-4b42-94e7-da264a842f41","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miqazure-oraclelinux2","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux2","etag":"W/\"0865cebc-95b9-49d2-9f10-21dbafb23cac\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"2f4e1091-46f0-474c-a697-8dbcea6ba2a6","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}}]}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:20:46 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Storage/storageAccounts?api-version=2017-10-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3MDYsIm5iZiI6MTUyMDQ1MzcwNiwiZXhwIjoxNTIwNDU3NjA2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTFnbXRqVzFoMC0wV0djUnUxY0FBQSIsInZlciI6IjEuMCJ9.Erl0psNafp3XtL4oqBb3M0lFjZ_MJ_SHo7l_36xqNg7ftRHb3N_Z-UV9MvDb4JuraazeDmSbyds8cs5HtDmrkjbp1N4kpcNw2R3qVMQqkEafMmzKiXPNaLk_GI3qaiD1pwr7RLP5ooUohDLpy-YBFD9JqzpenQ8oOHjd6-FKZVm7Bra-o3FdOoU7U4BY0SDUmRqf9HOcquo-2AhSLYpXAXzpKY3Fs6o63k2qKcm2Z0jPmmmFnnz0QSnbWqFz6KhsH5AuNwmSgLsQ6EpUYGMlYAthQG2lWG5j4z-LkrZRhSNNHwRLcHSwtGNZhfoiFNHJsuGrP7fUY5xfucJl_cWfVA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - a28cadbb-b5fb-4205-a4d2-6587d852d953
-      X-Ms-Correlation-Request-Id:
-      - a28cadbb-b5fb-4205-a4d2-6587d852d953
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202110Z:a28cadbb-b5fb-4205-a4d2-6587d852d953
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:21:10 GMT
-      Content-Length:
-      - '8649'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","name":"miqazuretest18686","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T17:22:54.7808677Z","primaryEndpoints":{"blob":"https://miqazuretest18686.blob.core.windows.net/","queue":"https://miqazuretest18686.queue.core.windows.net/","table":"https://miqazuretest18686.table.core.windows.net/","file":"https://miqazuretest18686.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","name":"miqazuretest14047","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T17:30:25.7028008Z","primaryEndpoints":{"blob":"https://miqazuretest14047.blob.core.windows.net/","queue":"https://miqazuretest14047.queue.core.windows.net/","table":"https://miqazuretest14047.table.core.windows.net/","file":"https://miqazuretest14047.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Premium_LRS","tier":"Premium"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb","name":"rspeclb","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-09-02T16:29:11.6823797Z","primaryEndpoints":{"blob":"https://rspeclb.blob.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","name":"spec0deply1stor","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-04-04T23:05:07.8274794Z","primaryEndpoints":{"blob":"https://spec0deply1stor.blob.core.windows.net/","queue":"https://spec0deply1stor.queue.core.windows.net/","table":"https://spec0deply1stor.table.core.windows.net/","file":"https://spec0deply1stor.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Storage/storageAccounts/miqazuretest26611","name":"miqazuretest26611","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2211656Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2211656Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-05-02T18:01:29.2743021Z","primaryEndpoints":{"blob":"https://miqazuretest26611.blob.core.windows.net/","queue":"https://miqazuretest26611.queue.core.windows.net/","table":"https://miqazuretest26611.table.core.windows.net/","file":"https://miqazuretest26611.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","name":"miqazuretest16487","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T17:26:55.3231669Z","primaryEndpoints":{"blob":"https://miqazuretest16487.blob.core.windows.net/","queue":"https://miqazuretest16487.queue.core.windows.net/","table":"https://miqazuretest16487.table.core.windows.net/","file":"https://miqazuretest16487.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Storage/storageAccounts/miqazuretest32946","name":"miqazuretest32946","type":"Microsoft.Storage/storageAccounts","location":"westus","tags":{"delete":"false"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.0404359Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.0404359Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T21:18:37.0793411Z","primaryEndpoints":{"blob":"https://miqazuretest32946.blob.core.windows.net/","queue":"https://miqazuretest32946.queue.core.windows.net/","table":"https://miqazuretest32946.table.core.windows.net/","file":"https://miqazuretest32946.file.core.windows.net/"},"primaryLocation":"westus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Storage/storageAccounts/miqazureshared1","name":"miqazureshared1","type":"Microsoft.Storage/storageAccounts","location":"centralus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.1935084Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.1935084Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T20:42:52.498085Z","primaryEndpoints":{"blob":"https://miqazureshared1.blob.core.windows.net/","queue":"https://miqazureshared1.queue.core.windows.net/","table":"https://miqazureshared1.table.core.windows.net/","file":"https://miqazureshared1.file.core.windows.net/"},"primaryLocation":"centralus","statusOfPrimary":"available","secondaryLocation":"eastus2","statusOfSecondary":"available","secondaryEndpoints":{"blob":"https://miqazureshared1-secondary.blob.core.windows.net/","queue":"https://miqazureshared1-secondary.queue.core.windows.net/","table":"https://miqazureshared1-secondary.table.core.windows.net/"}}}]}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:11 GMT
+  recorded_at: Mon, 12 Mar 2018 10:28:13 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb/listKeys?api-version=2017-10-01
@@ -4827,7 +4164,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3MDYsIm5iZiI6MTUyMDQ1MzcwNiwiZXhwIjoxNTIwNDU3NjA2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTFnbXRqVzFoMC0wV0djUnUxY0FBQSIsInZlciI6IjEuMCJ9.Erl0psNafp3XtL4oqBb3M0lFjZ_MJ_SHo7l_36xqNg7ftRHb3N_Z-UV9MvDb4JuraazeDmSbyds8cs5HtDmrkjbp1N4kpcNw2R3qVMQqkEafMmzKiXPNaLk_GI3qaiD1pwr7RLP5ooUohDLpy-YBFD9JqzpenQ8oOHjd6-FKZVm7Bra-o3FdOoU7U4BY0SDUmRqf9HOcquo-2AhSLYpXAXzpKY3Fs6o63k2qKcm2Z0jPmmmFnnz0QSnbWqFz6KhsH5AuNwmSgLsQ6EpUYGMlYAthQG2lWG5j4z-LkrZRhSNNHwRLcHSwtGNZhfoiFNHJsuGrP7fUY5xfucJl_cWfVA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAxNTEsIm5iZiI6MTUyMDg1MDE1MSwiZXhwIjoxNTIwODU0MDUxLCJhaW8iOiJZMk5nWU5oMlRiYXo0MmZ6c1NCSjZ3K1BUbmhKQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYzF5aWdZX3FnMEdhSmwwanp4SVdBQSIsInZlciI6IjEuMCJ9.C_t36CdMu-7-Tut5olza_36ERC--pFhJlg7cSqEsjI-FGSw4l4kQpgGNNKJWn8fueTIslcIlvTH0FrjGIhhelAf9KNYqITzZTkj33Ewj023i8bS7H3vWuA_w-kG6dXqzBRRQfDrVwTpDDV1qMCCdz0Jd_G0vZb7AIJKMaFtik5fEC24UzolIFeaLxAuGNm26YdPA4-9oWfqLt7vYMdfioMpnTsnx6PBiIzZ235slf1f0u3FYNOzNnIdmX9WecqD1BxHqp5aizLX2aZXIPWQtn01mYSu6dMhpKnfiIs-FLj4UC0JXmR8Lb9jRuIvrTSLnF1WE9ScCqV_N4brfiqVKKQ
       Content-Length:
       - '0'
   response:
@@ -4848,26 +4185,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - aa93305d-5f45-4aa6-aaea-1911a45cc58b
+      - e73cd127-3029-4539-9f9f-8ec1f649d4ea
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1198'
+      - '1197'
       X-Ms-Correlation-Request-Id:
-      - 1fe3bc5d-cad6-4627-b7c6-035888fb6f71
+      - 4887feb6-270d-42b6-ab3c-119d0fccb6a0
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202111Z:1fe3bc5d-cad6-4627-b7c6-035888fb6f71
+      - WESTEUROPE:20180312T102809Z:4887feb6-270d-42b6-ab3c-119d0fccb6a0
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:21:10 GMT
+      - Mon, 12 Mar 2018 10:28:08 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keys":[{"keyName":"key1","value":"xMvZwiumnKCZnYVJjdtGLqaO1c2v6ERPx4XPDZO7TM1l7/jM1TxAAgtfCMkRn72aRPhqLqwWAn8n5a1iSGRHtA==","permissions":"Full"},{"keyName":"key2","value":"3nDvKhjGAIAvgnH2reuv7tzyeb/0dddgVeUT13VODYD5xO/jeAvQ7tkF3JqP2BAuFrmQqMB4GLkB4/cW4veYeA==","permissions":"Full"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:11 GMT
+  recorded_at: Mon, 12 Mar 2018 10:28:13 GMT
 - request:
     method: head
     uri: https://rspeclb.blob.core.windows.net/vhds/rspec-lb-a201682122839.vhd
@@ -4884,7 +4221,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:21:11 GMT
+      - Mon, 12 Mar 2018 10:28:13 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -4892,7 +4229,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey rspeclb:bGndKIwIotEAS+RuGdTX90Izjq2uwaXgS8nymVNSHu8=
+      - SharedKey rspeclb:ccK53CFyvXc5uI8e0vwqhEDXQl42igtUzFqhrSAyZDE=
   response:
     status:
       code: 200
@@ -4947,150 +4284,16 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       X-Ms-Request-Id:
-      - a7167fed-b01c-000b-5a51-b67db3000000
+      - a5214a34-701c-0070-50ec-b91603000000
       X-Ms-Version:
       - '2016-05-31'
       Date:
-      - Wed, 07 Mar 2018 20:21:11 GMT
+      - Mon, 12 Mar 2018 10:28:09 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:12 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b/instanceView?api-version=2017-12-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3MDYsIm5iZiI6MTUyMDQ1MzcwNiwiZXhwIjoxNTIwNDU3NjA2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTFnbXRqVzFoMC0wV0djUnUxY0FBQSIsInZlciI6IjEuMCJ9.Erl0psNafp3XtL4oqBb3M0lFjZ_MJ_SHo7l_36xqNg7ftRHb3N_Z-UV9MvDb4JuraazeDmSbyds8cs5HtDmrkjbp1N4kpcNw2R3qVMQqkEafMmzKiXPNaLk_GI3qaiD1pwr7RLP5ooUohDLpy-YBFD9JqzpenQ8oOHjd6-FKZVm7Bra-o3FdOoU7U4BY0SDUmRqf9HOcquo-2AhSLYpXAXzpKY3Fs6o63k2qKcm2Z0jPmmmFnnz0QSnbWqFz6KhsH5AuNwmSgLsQ6EpUYGMlYAthQG2lWG5j4z-LkrZRhSNNHwRLcHSwtGNZhfoiFNHJsuGrP7fUY5xfucJl_cWfVA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/GetInstanceView3Min;4792,Microsoft.Compute/GetInstanceView30Min;23912
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
-      X-Ms-Request-Id:
-      - 5cd13693-3e43-491d-a009-6f0e3ad9d583
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14982'
-      X-Ms-Correlation-Request-Id:
-      - d70a3631-cbbc-4a5c-b65a-462eda156aa4
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202112Z:d70a3631-cbbc-4a5c-b65a-462eda156aa4
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:21:12 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"platformUpdateDomain\": 1,\r\n  \"platformFaultDomain\": 1,\r\n
-        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
-        [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
-        \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
-        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2018-03-07T20:21:12+00:00\"\r\n
-        \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"rspec-lb-b\",\r\n
-        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
-        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"time\": \"2016-09-03T14:07:52.9377685+00:00\"\r\n
-        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
-        \"https://amissteastorage.blob.core.windows.net/bootdiagnostics-rspeclbb-834a70b5-868d-4466-9dda-14e0f6b2caaf/rspec-lb-b.834a70b5-868d-4466-9dda-14e0f6b2caaf.screenshot.bmp\",\r\n
-        \   \"serialConsoleLogBlobUri\": \"https://amissteastorage.blob.core.windows.net/bootdiagnostics-rspeclbb-834a70b5-868d-4466-9dda-14e0f6b2caaf/rspec-lb-b.834a70b5-868d-4466-9dda-14e0f6b2caaf.serialconsole.log\"\r\n
-        \ },\r\n  \"extensions\": [\r\n    {\r\n      \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n
-        \   }\r\n  ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n
-        \     \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n
-        \     \"time\": \"2016-09-03T14:07:52.9846158+00:00\"\r\n    },\r\n    {\r\n
-        \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
-        \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:12 GMT
-- request:
-    method: post
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb/listKeys?api-version=2017-10-01
-    body:
-      encoding: ASCII-8BIT
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3MDYsIm5iZiI6MTUyMDQ1MzcwNiwiZXhwIjoxNTIwNDU3NjA2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTFnbXRqVzFoMC0wV0djUnUxY0FBQSIsInZlciI6IjEuMCJ9.Erl0psNafp3XtL4oqBb3M0lFjZ_MJ_SHo7l_36xqNg7ftRHb3N_Z-UV9MvDb4JuraazeDmSbyds8cs5HtDmrkjbp1N4kpcNw2R3qVMQqkEafMmzKiXPNaLk_GI3qaiD1pwr7RLP5ooUohDLpy-YBFD9JqzpenQ8oOHjd6-FKZVm7Bra-o3FdOoU7U4BY0SDUmRqf9HOcquo-2AhSLYpXAXzpKY3Fs6o63k2qKcm2Z0jPmmmFnnz0QSnbWqFz6KhsH5AuNwmSgLsQ6EpUYGMlYAthQG2lWG5j4z-LkrZRhSNNHwRLcHSwtGNZhfoiFNHJsuGrP7fUY5xfucJl_cWfVA
-      Content-Length:
-      - '0'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 4ca242b4-9912-4af4-ae57-a0503b0f25cd
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1197'
-      X-Ms-Correlation-Request-Id:
-      - 4190d59c-f1c9-4cc0-897b-2948e422cc64
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202112Z:4190d59c-f1c9-4cc0-897b-2948e422cc64
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:21:12 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"keys":[{"keyName":"key1","value":"xMvZwiumnKCZnYVJjdtGLqaO1c2v6ERPx4XPDZO7TM1l7/jM1TxAAgtfCMkRn72aRPhqLqwWAn8n5a1iSGRHtA==","permissions":"Full"},{"keyName":"key2","value":"3nDvKhjGAIAvgnH2reuv7tzyeb/0dddgVeUT13VODYD5xO/jeAvQ7tkF3JqP2BAuFrmQqMB4GLkB4/cW4veYeA==","permissions":"Full"}]}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:12 GMT
+  recorded_at: Mon, 12 Mar 2018 10:28:14 GMT
 - request:
     method: head
     uri: https://rspeclb.blob.core.windows.net/vhds/rspec-lb-b201682123650.vhd
@@ -5107,7 +4310,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:21:12 GMT
+      - Mon, 12 Mar 2018 10:28:14 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -5115,7 +4318,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey rspeclb:jQEY6q3CCOLpTEE1ZxQCGV/R1FKGx7BxFqgmV9Jstzo=
+      - SharedKey rspeclb:K/8pfJXWFjqiQ83yRpGxcKD/gMr9y1pbZCD8c5jltro=
   response:
     status:
       code: 200
@@ -5170,16 +4373,16 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       X-Ms-Request-Id:
-      - 878389b2-701c-0070-2551-b61603000000
+      - 0cec8e26-301c-0033-5eec-b93cea000000
       X-Ms-Version:
       - '2016-05-31'
       Date:
-      - Wed, 07 Mar 2018 20:21:12 GMT
+      - Mon, 12 Mar 2018 10:28:10 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:13 GMT
+  recorded_at: Mon, 12 Mar 2018 10:28:15 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg?api-version=2018-01-01
@@ -5196,7 +4399,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3MDYsIm5iZiI6MTUyMDQ1MzcwNiwiZXhwIjoxNTIwNDU3NjA2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTFnbXRqVzFoMC0wV0djUnUxY0FBQSIsInZlciI6IjEuMCJ9.Erl0psNafp3XtL4oqBb3M0lFjZ_MJ_SHo7l_36xqNg7ftRHb3N_Z-UV9MvDb4JuraazeDmSbyds8cs5HtDmrkjbp1N4kpcNw2R3qVMQqkEafMmzKiXPNaLk_GI3qaiD1pwr7RLP5ooUohDLpy-YBFD9JqzpenQ8oOHjd6-FKZVm7Bra-o3FdOoU7U4BY0SDUmRqf9HOcquo-2AhSLYpXAXzpKY3Fs6o63k2qKcm2Z0jPmmmFnnz0QSnbWqFz6KhsH5AuNwmSgLsQ6EpUYGMlYAthQG2lWG5j4z-LkrZRhSNNHwRLcHSwtGNZhfoiFNHJsuGrP7fUY5xfucJl_cWfVA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAxNTEsIm5iZiI6MTUyMDg1MDE1MSwiZXhwIjoxNTIwODU0MDUxLCJhaW8iOiJZMk5nWU5oMlRiYXo0MmZ6c1NCSjZ3K1BUbmhKQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYzF5aWdZX3FnMEdhSmwwanp4SVdBQSIsInZlciI6IjEuMCJ9.C_t36CdMu-7-Tut5olza_36ERC--pFhJlg7cSqEsjI-FGSw4l4kQpgGNNKJWn8fueTIslcIlvTH0FrjGIhhelAf9KNYqITzZTkj33Ewj023i8bS7H3vWuA_w-kG6dXqzBRRQfDrVwTpDDV1qMCCdz0Jd_G0vZb7AIJKMaFtik5fEC24UzolIFeaLxAuGNm26YdPA4-9oWfqLt7vYMdfioMpnTsnx6PBiIzZ235slf1f0u3FYNOzNnIdmX9WecqD1BxHqp5aizLX2aZXIPWQtn01mYSu6dMhpKnfiIs-FLj4UC0JXmR8Lb9jRuIvrTSLnF1WE9ScCqV_N4brfiqVKKQ
   response:
     status:
       code: 200
@@ -5217,22 +4420,22 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 271c6393-b645-4126-a418-4c3bbbbc1119
+      - 8f190ed6-a7bb-44cd-b778-e9361778845c
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14972'
+      - '14979'
       X-Ms-Correlation-Request-Id:
-      - b290a6e6-6b94-4135-8f2f-0ef98e1a6617
+      - 9f793d56-b09d-4683-94cc-edb9789d048d
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202113Z:b290a6e6-6b94-4135-8f2f-0ef98e1a6617
+      - WESTEUROPE:20180312T102811Z:9f793d56-b09d-4683-94cc-edb9789d048d
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:21:13 GMT
+      - Mon, 12 Mar 2018 10:28:10 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"rspec-lb-a-nsg\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg\",\r\n
@@ -5317,7 +4520,7 @@ http_interactions:
         \   ],\r\n    \"networkInterfaces\": [\r\n      {\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670\"\r\n
         \     }\r\n    ]\r\n  }\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:13 GMT
+  recorded_at: Mon, 12 Mar 2018 10:28:15 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg?api-version=2018-01-01
@@ -5334,7 +4537,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3MDYsIm5iZiI6MTUyMDQ1MzcwNiwiZXhwIjoxNTIwNDU3NjA2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTFnbXRqVzFoMC0wV0djUnUxY0FBQSIsInZlciI6IjEuMCJ9.Erl0psNafp3XtL4oqBb3M0lFjZ_MJ_SHo7l_36xqNg7ftRHb3N_Z-UV9MvDb4JuraazeDmSbyds8cs5HtDmrkjbp1N4kpcNw2R3qVMQqkEafMmzKiXPNaLk_GI3qaiD1pwr7RLP5ooUohDLpy-YBFD9JqzpenQ8oOHjd6-FKZVm7Bra-o3FdOoU7U4BY0SDUmRqf9HOcquo-2AhSLYpXAXzpKY3Fs6o63k2qKcm2Z0jPmmmFnnz0QSnbWqFz6KhsH5AuNwmSgLsQ6EpUYGMlYAthQG2lWG5j4z-LkrZRhSNNHwRLcHSwtGNZhfoiFNHJsuGrP7fUY5xfucJl_cWfVA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAxNTEsIm5iZiI6MTUyMDg1MDE1MSwiZXhwIjoxNTIwODU0MDUxLCJhaW8iOiJZMk5nWU5oMlRiYXo0MmZ6c1NCSjZ3K1BUbmhKQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYzF5aWdZX3FnMEdhSmwwanp4SVdBQSIsInZlciI6IjEuMCJ9.C_t36CdMu-7-Tut5olza_36ERC--pFhJlg7cSqEsjI-FGSw4l4kQpgGNNKJWn8fueTIslcIlvTH0FrjGIhhelAf9KNYqITzZTkj33Ewj023i8bS7H3vWuA_w-kG6dXqzBRRQfDrVwTpDDV1qMCCdz0Jd_G0vZb7AIJKMaFtik5fEC24UzolIFeaLxAuGNm26YdPA4-9oWfqLt7vYMdfioMpnTsnx6PBiIzZ235slf1f0u3FYNOzNnIdmX9WecqD1BxHqp5aizLX2aZXIPWQtn01mYSu6dMhpKnfiIs-FLj4UC0JXmR8Lb9jRuIvrTSLnF1WE9ScCqV_N4brfiqVKKQ
   response:
     status:
       code: 200
@@ -5355,22 +4558,22 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 2c52da7b-651a-4a10-afa3-280f6188890b
+      - 697d216e-8aa3-44e4-92e7-ba5d814714c9
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14969'
+      - '14984'
       X-Ms-Correlation-Request-Id:
-      - 105f85c3-ebac-4cab-9395-e75842e3d921
+      - f19f37ff-756d-44dc-8dd3-38c1134ac8bc
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202113Z:105f85c3-ebac-4cab-9395-e75842e3d921
+      - WESTEUROPE:20180312T102811Z:f19f37ff-756d-44dc-8dd3-38c1134ac8bc
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:21:13 GMT
+      - Mon, 12 Mar 2018 10:28:10 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"rspec-lb-b-nsg\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg\",\r\n
@@ -5455,7 +4658,7 @@ http_interactions:
         \   ],\r\n    \"networkInterfaces\": [\r\n      {\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843\"\r\n
         \     }\r\n    ]\r\n  }\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:14 GMT
+  recorded_at: Mon, 12 Mar 2018 10:28:16 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1?api-version=2018-01-01
@@ -5472,7 +4675,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3MDYsIm5iZiI6MTUyMDQ1MzcwNiwiZXhwIjoxNTIwNDU3NjA2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTFnbXRqVzFoMC0wV0djUnUxY0FBQSIsInZlciI6IjEuMCJ9.Erl0psNafp3XtL4oqBb3M0lFjZ_MJ_SHo7l_36xqNg7ftRHb3N_Z-UV9MvDb4JuraazeDmSbyds8cs5HtDmrkjbp1N4kpcNw2R3qVMQqkEafMmzKiXPNaLk_GI3qaiD1pwr7RLP5ooUohDLpy-YBFD9JqzpenQ8oOHjd6-FKZVm7Bra-o3FdOoU7U4BY0SDUmRqf9HOcquo-2AhSLYpXAXzpKY3Fs6o63k2qKcm2Z0jPmmmFnnz0QSnbWqFz6KhsH5AuNwmSgLsQ6EpUYGMlYAthQG2lWG5j4z-LkrZRhSNNHwRLcHSwtGNZhfoiFNHJsuGrP7fUY5xfucJl_cWfVA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAxNTEsIm5iZiI6MTUyMDg1MDE1MSwiZXhwIjoxNTIwODU0MDUxLCJhaW8iOiJZMk5nWU5oMlRiYXo0MmZ6c1NCSjZ3K1BUbmhKQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiYzF5aWdZX3FnMEdhSmwwanp4SVdBQSIsInZlciI6IjEuMCJ9.C_t36CdMu-7-Tut5olza_36ERC--pFhJlg7cSqEsjI-FGSw4l4kQpgGNNKJWn8fueTIslcIlvTH0FrjGIhhelAf9KNYqITzZTkj33Ewj023i8bS7H3vWuA_w-kG6dXqzBRRQfDrVwTpDDV1qMCCdz0Jd_G0vZb7AIJKMaFtik5fEC24UzolIFeaLxAuGNm26YdPA4-9oWfqLt7vYMdfioMpnTsnx6PBiIzZ235slf1f0u3FYNOzNnIdmX9WecqD1BxHqp5aizLX2aZXIPWQtn01mYSu6dMhpKnfiIs-FLj4UC0JXmR8Lb9jRuIvrTSLnF1WE9ScCqV_N4brfiqVKKQ
   response:
     status:
       code: 200
@@ -5489,36 +4692,36 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"fceae1ac-4620-482a-bc6d-79c867179ae5"
+      - W/"a8b09238-30fc-4b36-a58d-e3cc69e267c5"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 402318dd-6695-4532-a763-ad320980e185
+      - 66c9b70b-1377-4342-913a-8497dc67235a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14970'
+      - '14983'
       X-Ms-Correlation-Request-Id:
-      - 89e29978-9431-4791-87e4-80271c0c81d1
+      - fda960cd-b709-4cc4-920b-37ef060761cb
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202114Z:89e29978-9431-4791-87e4-80271c0c81d1
+      - WESTEUROPE:20180312T102812Z:fda960cd-b709-4cc4-920b-37ef060761cb
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:21:13 GMT
+      - Mon, 12 Mar 2018 10:28:12 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"miq-azure-test1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1\",\r\n
-        \ \"etag\": \"W/\\\"fceae1ac-4620-482a-bc6d-79c867179ae5\\\"\",\r\n  \"type\":
+        \ \"etag\": \"W/\\\"a8b09238-30fc-4b36-a58d-e3cc69e267c5\\\"\",\r\n  \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
         \"d74c1e5f-50e4-4c8a-a7fe-78eaddc6b915\",\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\":
         [\r\n        \"10.16.0.0/16\"\r\n      ]\r\n    },\r\n    \"subnets\": [\r\n
         \     {\r\n        \"name\": \"default\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\",\r\n
-        \       \"etag\": \"W/\\\"fceae1ac-4620-482a-bc6d-79c867179ae5\\\"\",\r\n
+        \       \"etag\": \"W/\\\"a8b09238-30fc-4b36-a58d-e3cc69e267c5\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"addressPrefix\": \"10.16.0.0/24\",\r\n          \"ipConfigurations\":
         [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1\"\r\n
@@ -5528,813 +4731,10 @@ http_interactions:
         \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/dbergerprov1/ipConfigurations/dbergerprov1\"\r\n
         \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
         \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/ladas_test_1/ipConfigurations/ladas_test_1\"\r\n
         \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"virtualNetworkPeerings\":
         [],\r\n    \"enableDdosProtection\": false,\r\n    \"enableVmProtection\":
         false\r\n  }\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:14 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3MDYsIm5iZiI6MTUyMDQ1MzcwNiwiZXhwIjoxNTIwNDU3NjA2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTFnbXRqVzFoMC0wV0djUnUxY0FBQSIsInZlciI6IjEuMCJ9.Erl0psNafp3XtL4oqBb3M0lFjZ_MJ_SHo7l_36xqNg7ftRHb3N_Z-UV9MvDb4JuraazeDmSbyds8cs5HtDmrkjbp1N4kpcNw2R3qVMQqkEafMmzKiXPNaLk_GI3qaiD1pwr7RLP5ooUohDLpy-YBFD9JqzpenQ8oOHjd6-FKZVm7Bra-o3FdOoU7U4BY0SDUmRqf9HOcquo-2AhSLYpXAXzpKY3Fs6o63k2qKcm2Z0jPmmmFnnz0QSnbWqFz6KhsH5AuNwmSgLsQ6EpUYGMlYAthQG2lWG5j4z-LkrZRhSNNHwRLcHSwtGNZhfoiFNHJsuGrP7fUY5xfucJl_cWfVA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"cf3a0b0d-d596-4f33-bc31-749f92ba4f00"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - b9fe4977-02d9-4add-b5f0-167ddec2178c
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14972'
-      X-Ms-Correlation-Request-Id:
-      - 40dac618-56be-40b6-8bcf-c0fbb1b70bec
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202114Z:40dac618-56be-40b6-8bcf-c0fbb1b70bec
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:21:14 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb-a670\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670\",\r\n
-        \ \"etag\": \"W/\\\"cf3a0b0d-d596-4f33-bc31-749f92ba4f00\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"46cb8216-786e-408e-9d86-c0855b357349\",\r\n    \"ipConfigurations\":
-        [\r\n      {\r\n        \"name\": \"ipconfig1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\",\r\n
-        \       \"etag\": \"W/\\\"cf3a0b0d-d596-4f33-bc31-749f92ba4f00\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAddress\": \"10.16.0.6\",\r\n          \"privateIPAllocationMethod\":
-        \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-a-ip\"\r\n
-        \         },\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\"\r\n
-        \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
-        \"IPv4\",\r\n          \"loadBalancerBackendAddressPools\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\"\r\n
-        \           }\r\n          ],\r\n          \"loadBalancerInboundNatRules\":
-        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\":
-        {\r\n      \"dnsServers\": [],\r\n      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\":
-        \"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net\"\r\n    },\r\n    \"enableAcceleratedNetworking\":
-        false,\r\n    \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\":
-        {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg\"\r\n
-        \   },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a\"\r\n
-        \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
-        \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:15 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3MDYsIm5iZiI6MTUyMDQ1MzcwNiwiZXhwIjoxNTIwNDU3NjA2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTFnbXRqVzFoMC0wV0djUnUxY0FBQSIsInZlciI6IjEuMCJ9.Erl0psNafp3XtL4oqBb3M0lFjZ_MJ_SHo7l_36xqNg7ftRHb3N_Z-UV9MvDb4JuraazeDmSbyds8cs5HtDmrkjbp1N4kpcNw2R3qVMQqkEafMmzKiXPNaLk_GI3qaiD1pwr7RLP5ooUohDLpy-YBFD9JqzpenQ8oOHjd6-FKZVm7Bra-o3FdOoU7U4BY0SDUmRqf9HOcquo-2AhSLYpXAXzpKY3Fs6o63k2qKcm2Z0jPmmmFnnz0QSnbWqFz6KhsH5AuNwmSgLsQ6EpUYGMlYAthQG2lWG5j4z-LkrZRhSNNHwRLcHSwtGNZhfoiFNHJsuGrP7fUY5xfucJl_cWfVA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"76aabe0c-8678-43f0-81a5-2f15784a4b99"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - af2870dc-cf7e-42c2-85a9-4a354a9bde06
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14971'
-      X-Ms-Correlation-Request-Id:
-      - 59239add-4152-4390-b9f5-0468b5f0f271
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202115Z:59239add-4152-4390-b9f5-0468b5f0f271
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:21:14 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb-b843\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843\",\r\n
-        \ \"etag\": \"W/\\\"76aabe0c-8678-43f0-81a5-2f15784a4b99\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"3ef6fa01-ac34-43a1-8fd7-67c706b4d8ef\",\r\n    \"ipConfigurations\":
-        [\r\n      {\r\n        \"name\": \"ipconfig1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\",\r\n
-        \       \"etag\": \"W/\\\"76aabe0c-8678-43f0-81a5-2f15784a4b99\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAddress\": \"10.16.0.11\",\r\n          \"privateIPAllocationMethod\":
-        \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-b-ip\"\r\n
-        \         },\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\"\r\n
-        \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
-        \"IPv4\",\r\n          \"loadBalancerBackendAddressPools\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\":
-        {\r\n      \"dnsServers\": [],\r\n      \"appliedDnsServers\": []\r\n    },\r\n
-        \   \"enableAcceleratedNetworking\": false,\r\n    \"enableIPForwarding\":
-        false,\r\n    \"networkSecurityGroup\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg\"\r\n
-        \   },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b\"\r\n
-        \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
-        \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:15 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3MDYsIm5iZiI6MTUyMDQ1MzcwNiwiZXhwIjoxNTIwNDU3NjA2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTFnbXRqVzFoMC0wV0djUnUxY0FBQSIsInZlciI6IjEuMCJ9.Erl0psNafp3XtL4oqBb3M0lFjZ_MJ_SHo7l_36xqNg7ftRHb3N_Z-UV9MvDb4JuraazeDmSbyds8cs5HtDmrkjbp1N4kpcNw2R3qVMQqkEafMmzKiXPNaLk_GI3qaiD1pwr7RLP5ooUohDLpy-YBFD9JqzpenQ8oOHjd6-FKZVm7Bra-o3FdOoU7U4BY0SDUmRqf9HOcquo-2AhSLYpXAXzpKY3Fs6o63k2qKcm2Z0jPmmmFnnz0QSnbWqFz6KhsH5AuNwmSgLsQ6EpUYGMlYAthQG2lWG5j4z-LkrZRhSNNHwRLcHSwtGNZhfoiFNHJsuGrP7fUY5xfucJl_cWfVA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 22fb7ce7-6540-40f6-bf1a-57ad31e47fd5
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14974'
-      X-Ms-Correlation-Request-Id:
-      - 1320b49b-c4da-440b-9b07-9d269a9e565a
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202116Z:1320b49b-c4da-440b-9b07-9d269a9e565a
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:21:15 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1\",\r\n
-        \ \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"7ab88756-810f-4083-95db-8b05d50e38f2\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ],\r\n          \"inboundNatRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"backendIPConfigurations\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\"\r\n
-        \           }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-rule\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\":
-        80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\"\r\n
-        \         },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n
-        \       \"name\": \"rspec-lb-probe\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-NAT\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 3441,\r\n          \"backendPort\":
-        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:16 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3MDYsIm5iZiI6MTUyMDQ1MzcwNiwiZXhwIjoxNTIwNDU3NjA2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTFnbXRqVzFoMC0wV0djUnUxY0FBQSIsInZlciI6IjEuMCJ9.Erl0psNafp3XtL4oqBb3M0lFjZ_MJ_SHo7l_36xqNg7ftRHb3N_Z-UV9MvDb4JuraazeDmSbyds8cs5HtDmrkjbp1N4kpcNw2R3qVMQqkEafMmzKiXPNaLk_GI3qaiD1pwr7RLP5ooUohDLpy-YBFD9JqzpenQ8oOHjd6-FKZVm7Bra-o3FdOoU7U4BY0SDUmRqf9HOcquo-2AhSLYpXAXzpKY3Fs6o63k2qKcm2Z0jPmmmFnnz0QSnbWqFz6KhsH5AuNwmSgLsQ6EpUYGMlYAthQG2lWG5j4z-LkrZRhSNNHwRLcHSwtGNZhfoiFNHJsuGrP7fUY5xfucJl_cWfVA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"7a8e5fe7-f777-4435-992b-a54f28c2f28c"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 2b378a67-a722-4d11-8a2a-87fd4772e0f9
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14975'
-      X-Ms-Correlation-Request-Id:
-      - 47cd0e8a-1de4-4839-9b70-4bf7c9dcab51
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202117Z:47cd0e8a-1de4-4839-9b70-4bf7c9dcab51
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:21:16 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb2\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2\",\r\n
-        \ \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"e2e30a77-f81b-43fc-9693-08303e43deed\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/backendAddressPools/rspec-lb2-pool\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\r\n
-        \       }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\": [],\r\n    \"probes\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-probe\",\r\n        \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/probes/rspec-lb2-probe\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\": [],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:17 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3MDYsIm5iZiI6MTUyMDQ1MzcwNiwiZXhwIjoxNTIwNDU3NjA2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTFnbXRqVzFoMC0wV0djUnUxY0FBQSIsInZlciI6IjEuMCJ9.Erl0psNafp3XtL4oqBb3M0lFjZ_MJ_SHo7l_36xqNg7ftRHb3N_Z-UV9MvDb4JuraazeDmSbyds8cs5HtDmrkjbp1N4kpcNw2R3qVMQqkEafMmzKiXPNaLk_GI3qaiD1pwr7RLP5ooUohDLpy-YBFD9JqzpenQ8oOHjd6-FKZVm7Bra-o3FdOoU7U4BY0SDUmRqf9HOcquo-2AhSLYpXAXzpKY3Fs6o63k2qKcm2Z0jPmmmFnnz0QSnbWqFz6KhsH5AuNwmSgLsQ6EpUYGMlYAthQG2lWG5j4z-LkrZRhSNNHwRLcHSwtGNZhfoiFNHJsuGrP7fUY5xfucJl_cWfVA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 74d4fdf1-6c9f-4110-962b-969e6fac49be
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14970'
-      X-Ms-Correlation-Request-Id:
-      - 12ea0485-4841-4214-8671-37a9e22541fe
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202117Z:12ea0485-4841-4214-8671-37a9e22541fe
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:21:16 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1\",\r\n
-        \ \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"7ab88756-810f-4083-95db-8b05d50e38f2\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ],\r\n          \"inboundNatRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"backendIPConfigurations\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\"\r\n
-        \           }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-rule\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\":
-        80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\"\r\n
-        \         },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n
-        \       \"name\": \"rspec-lb-probe\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-NAT\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 3441,\r\n          \"backendPort\":
-        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:17 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3MDYsIm5iZiI6MTUyMDQ1MzcwNiwiZXhwIjoxNTIwNDU3NjA2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTFnbXRqVzFoMC0wV0djUnUxY0FBQSIsInZlciI6IjEuMCJ9.Erl0psNafp3XtL4oqBb3M0lFjZ_MJ_SHo7l_36xqNg7ftRHb3N_Z-UV9MvDb4JuraazeDmSbyds8cs5HtDmrkjbp1N4kpcNw2R3qVMQqkEafMmzKiXPNaLk_GI3qaiD1pwr7RLP5ooUohDLpy-YBFD9JqzpenQ8oOHjd6-FKZVm7Bra-o3FdOoU7U4BY0SDUmRqf9HOcquo-2AhSLYpXAXzpKY3Fs6o63k2qKcm2Z0jPmmmFnnz0QSnbWqFz6KhsH5AuNwmSgLsQ6EpUYGMlYAthQG2lWG5j4z-LkrZRhSNNHwRLcHSwtGNZhfoiFNHJsuGrP7fUY5xfucJl_cWfVA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"7a8e5fe7-f777-4435-992b-a54f28c2f28c"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 155c8c94-1864-463b-b80a-aa831db78c05
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14976'
-      X-Ms-Correlation-Request-Id:
-      - 605600f6-e551-4905-8a22-72d5eca6e7f8
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202118Z:605600f6-e551-4905-8a22-72d5eca6e7f8
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:21:17 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb2\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2\",\r\n
-        \ \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"e2e30a77-f81b-43fc-9693-08303e43deed\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/backendAddressPools/rspec-lb2-pool\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\r\n
-        \       }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\": [],\r\n    \"probes\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-probe\",\r\n        \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/probes/rspec-lb2-probe\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\": [],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:18 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3MDYsIm5iZiI6MTUyMDQ1MzcwNiwiZXhwIjoxNTIwNDU3NjA2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTFnbXRqVzFoMC0wV0djUnUxY0FBQSIsInZlciI6IjEuMCJ9.Erl0psNafp3XtL4oqBb3M0lFjZ_MJ_SHo7l_36xqNg7ftRHb3N_Z-UV9MvDb4JuraazeDmSbyds8cs5HtDmrkjbp1N4kpcNw2R3qVMQqkEafMmzKiXPNaLk_GI3qaiD1pwr7RLP5ooUohDLpy-YBFD9JqzpenQ8oOHjd6-FKZVm7Bra-o3FdOoU7U4BY0SDUmRqf9HOcquo-2AhSLYpXAXzpKY3Fs6o63k2qKcm2Z0jPmmmFnnz0QSnbWqFz6KhsH5AuNwmSgLsQ6EpUYGMlYAthQG2lWG5j4z-LkrZRhSNNHwRLcHSwtGNZhfoiFNHJsuGrP7fUY5xfucJl_cWfVA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"a38434c8-7b23-4092-b7c6-402238eac0dc"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 129acd87-3fc4-4260-a2dc-1cdb997cb01b
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14981'
-      X-Ms-Correlation-Request-Id:
-      - afd247c5-74b9-45a5-8ab0-3e3506dd6534
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202119Z:afd247c5-74b9-45a5-8ab0-3e3506dd6534
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:21:19 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb1-LoadBalancerFrontEnd\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\",\r\n
-        \ \"etag\": \"W/\\\"a38434c8-7b23-4092-b7c6-402238eac0dc\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"f28e0f25-b372-4edf-97d9-13a9e3b4ba2d\",\r\n    \"ipAddress\":
-        \"40.71.82.83\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\":
-        \"Static\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipTags\": [],\r\n
-        \   \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
-        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:19 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3MDYsIm5iZiI6MTUyMDQ1MzcwNiwiZXhwIjoxNTIwNDU3NjA2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTFnbXRqVzFoMC0wV0djUnUxY0FBQSIsInZlciI6IjEuMCJ9.Erl0psNafp3XtL4oqBb3M0lFjZ_MJ_SHo7l_36xqNg7ftRHb3N_Z-UV9MvDb4JuraazeDmSbyds8cs5HtDmrkjbp1N4kpcNw2R3qVMQqkEafMmzKiXPNaLk_GI3qaiD1pwr7RLP5ooUohDLpy-YBFD9JqzpenQ8oOHjd6-FKZVm7Bra-o3FdOoU7U4BY0SDUmRqf9HOcquo-2AhSLYpXAXzpKY3Fs6o63k2qKcm2Z0jPmmmFnnz0QSnbWqFz6KhsH5AuNwmSgLsQ6EpUYGMlYAthQG2lWG5j4z-LkrZRhSNNHwRLcHSwtGNZhfoiFNHJsuGrP7fUY5xfucJl_cWfVA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"cddd97d1-6111-4477-8a00-3dc885237a1d"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 3c89e9ee-cda1-4e5f-ac1e-75bcb22f8ced
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14972'
-      X-Ms-Correlation-Request-Id:
-      - 732014a9-ed4a-4e7e-a65d-43662f206144
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202120Z:732014a9-ed4a-4e7e-a65d-43662f206144
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:21:19 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb2-publicip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\",\r\n
-        \ \"etag\": \"W/\\\"cddd97d1-6111-4477-8a00-3dc885237a1d\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"83e7257d-ab94-4229-8eb5-4798f37ef28d\",\r\n    \"publicIPAddressVersion\":
-        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
-        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
-        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:20 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-a-ip?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3MDYsIm5iZiI6MTUyMDQ1MzcwNiwiZXhwIjoxNTIwNDU3NjA2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTFnbXRqVzFoMC0wV0djUnUxY0FBQSIsInZlciI6IjEuMCJ9.Erl0psNafp3XtL4oqBb3M0lFjZ_MJ_SHo7l_36xqNg7ftRHb3N_Z-UV9MvDb4JuraazeDmSbyds8cs5HtDmrkjbp1N4kpcNw2R3qVMQqkEafMmzKiXPNaLk_GI3qaiD1pwr7RLP5ooUohDLpy-YBFD9JqzpenQ8oOHjd6-FKZVm7Bra-o3FdOoU7U4BY0SDUmRqf9HOcquo-2AhSLYpXAXzpKY3Fs6o63k2qKcm2Z0jPmmmFnnz0QSnbWqFz6KhsH5AuNwmSgLsQ6EpUYGMlYAthQG2lWG5j4z-LkrZRhSNNHwRLcHSwtGNZhfoiFNHJsuGrP7fUY5xfucJl_cWfVA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"3ba30997-7d2f-470c-96f6-301158e93b7c"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 7983788a-5f41-48d3-b1bb-82d1a21221b9
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14970'
-      X-Ms-Correlation-Request-Id:
-      - 179bb6cb-8465-4c54-b4b7-916fbcce199a
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202120Z:179bb6cb-8465-4c54-b4b7-916fbcce199a
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:21:20 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb-a-ip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-a-ip\",\r\n
-        \ \"etag\": \"W/\\\"3ba30997-7d2f-470c-96f6-301158e93b7c\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"3c605f75-23c0-46ab-ba2b-6fd4430140fd\",\r\n    \"publicIPAddressVersion\":
-        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
-        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
-        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:20 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-b-ip?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM3MDYsIm5iZiI6MTUyMDQ1MzcwNiwiZXhwIjoxNTIwNDU3NjA2LCJhaW8iOiJZMk5nWU5nNnB5bkwvK2VaemJlYmJMbzNuYmxaQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNTFnbXRqVzFoMC0wV0djUnUxY0FBQSIsInZlciI6IjEuMCJ9.Erl0psNafp3XtL4oqBb3M0lFjZ_MJ_SHo7l_36xqNg7ftRHb3N_Z-UV9MvDb4JuraazeDmSbyds8cs5HtDmrkjbp1N4kpcNw2R3qVMQqkEafMmzKiXPNaLk_GI3qaiD1pwr7RLP5ooUohDLpy-YBFD9JqzpenQ8oOHjd6-FKZVm7Bra-o3FdOoU7U4BY0SDUmRqf9HOcquo-2AhSLYpXAXzpKY3Fs6o63k2qKcm2Z0jPmmmFnnz0QSnbWqFz6KhsH5AuNwmSgLsQ6EpUYGMlYAthQG2lWG5j4z-LkrZRhSNNHwRLcHSwtGNZhfoiFNHJsuGrP7fUY5xfucJl_cWfVA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"cf6012c7-3d47-438f-84d7-332ad1ef4500"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - e08e6dce-081f-42bd-8660-da96de1dafca
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14971'
-      X-Ms-Correlation-Request-Id:
-      - 5ad1e7e1-2d1c-4e8f-877a-98696606445d
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202121Z:5ad1e7e1-2d1c-4e8f-877a-98696606445d
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:21:20 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb-b-ip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-b-ip\",\r\n
-        \ \"etag\": \"W/\\\"cf6012c7-3d47-438f-84d7-332ad1ef4500\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"5d1a2425-a351-4c0f-bc87-37e6500bff22\",\r\n    \"publicIPAddressVersion\":
-        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
-        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\"\r\n
-        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
-        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:21:21 GMT
+  recorded_at: Mon, 12 Mar 2018 10:28:17 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted_scope/multiple_targets_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted_scope/multiple_targets_refresh.yml
@@ -1,6 +1,62 @@
 ---
 http_interactions:
 - request:
+    method: post
+    uri: https://login.microsoftonline.com/AZURE_TENANT_ID/oauth2/token
+    body:
+      encoding: UTF-8
+      string: grant_type=client_credentials&client_id=AZURE_CLIENT_ID&client_secret=AZURE_CLIENT_SECRET&resource=https%3A%2F%2Fmanagement.azure.com%2F
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Server:
+      - Microsoft-IIS/10.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Request-Id:
+      - ccad58b2-c040-4303-a440-7604dc471800
+      P3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Set-Cookie:
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzG5ReQa1FexFvJ2jOFXVDZJnYoDhsIXmg513s4jOaYpnOvpquWW_X0EVTFHyBPm678mAODqqolqPXajAQGQJDgOg7ewCSctjsw7XjZOD1GYFng9TGzsjfwcp_n6KmciAFjaZaaox07331ShfD-HBCNFz4WLjKoZqZZGQ7Yg11wesgAA;
+        domain=.login.microsoftonline.com; path=/; secure; HttpOnly
+      - stsservicecookie=ests; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=002; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 12 Mar 2018 13:57:33 GMT
+      Content-Length:
+      - '1505'
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1520866653","not_before":"1520862753","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjI3NTMsIm5iZiI6MTUyMDg2Mjc1MywiZXhwIjoxNTIwODY2NjUzLCJhaW8iOiJZMk5nWU5qQnVUVng5OU1Kai9QZUY0akhQV2xXQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoic2xpdHpFREFBME9rUUhZRTNFY1lBQSIsInZlciI6IjEuMCJ9.Qxnn-5NYOZmogiHt-I2F53zJrRBSHKuYBrutjin7QFLQo8dufzsLR3NrLvELmnt43-mpOR7pZv7OpKrkyfVtl9xaN2WlKDLVS7ZTnQQlB-C2KGavbhf_Od1Ab4k0S2xRMKymzQmdxDF2LBBe1G4B7FLm_OIBg-DLhULmdhjxSVFTylJP7tCGHxUPaBt1B94nvKs5ZzwANQwV4ix34f07MzVJ6FckHthHCdLGcWkrB2wdp5TPT6qkjjczxeDJ8r-9lGDCKLvcs-FdjeIogKCNwsu3kPcJC2vE22Eezi1C6fHRg5jpqO2NyZvHTBLGUV0tgpUorQ431-uGgVuv0hotHA"}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:57:34 GMT
+- request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
     body:
@@ -16,7 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjI3NTMsIm5iZiI6MTUyMDg2Mjc1MywiZXhwIjoxNTIwODY2NjUzLCJhaW8iOiJZMk5nWU5qQnVUVng5OU1Kai9QZUY0akhQV2xXQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoic2xpdHpFREFBME9rUUhZRTNFY1lBQSIsInZlciI6IjEuMCJ9.Qxnn-5NYOZmogiHt-I2F53zJrRBSHKuYBrutjin7QFLQo8dufzsLR3NrLvELmnt43-mpOR7pZv7OpKrkyfVtl9xaN2WlKDLVS7ZTnQQlB-C2KGavbhf_Od1Ab4k0S2xRMKymzQmdxDF2LBBe1G4B7FLm_OIBg-DLhULmdhjxSVFTylJP7tCGHxUPaBt1B94nvKs5ZzwANQwV4ix34f07MzVJ6FckHthHCdLGcWkrB2wdp5TPT6qkjjczxeDJ8r-9lGDCKLvcs-FdjeIogKCNwsu3kPcJC2vE22Eezi1C6fHRg5jpqO2NyZvHTBLGUV0tgpUorQ431-uGgVuv0hotHA
   response:
     status:
       code: 200
@@ -35,26 +91,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14997'
+      - '14999'
       X-Ms-Request-Id:
-      - cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - 55a4639c-3408-4843-8c1d-95eb49db7a7f
       X-Ms-Correlation-Request-Id:
-      - cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - 55a4639c-3408-4843-8c1d-95eb49db7a7f
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102417Z:cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - WESTEUROPE:20180312T135734Z:55a4639c-3408-4843-8c1d-95eb49db7a7f
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:17 GMT
+      - Mon, 12 Mar 2018 13:57:33 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID","subscriptionId":"AZURE_SUBSCRIPTION_ID","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:22 GMT
+  recorded_at: Mon, 12 Mar 2018 13:57:34 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers?api-version=2015-01-01
@@ -71,7 +127,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjI3NTMsIm5iZiI6MTUyMDg2Mjc1MywiZXhwIjoxNTIwODY2NjUzLCJhaW8iOiJZMk5nWU5qQnVUVng5OU1Kai9QZUY0akhQV2xXQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoic2xpdHpFREFBME9rUUhZRTNFY1lBQSIsInZlciI6IjEuMCJ9.Qxnn-5NYOZmogiHt-I2F53zJrRBSHKuYBrutjin7QFLQo8dufzsLR3NrLvELmnt43-mpOR7pZv7OpKrkyfVtl9xaN2WlKDLVS7ZTnQQlB-C2KGavbhf_Od1Ab4k0S2xRMKymzQmdxDF2LBBe1G4B7FLm_OIBg-DLhULmdhjxSVFTylJP7tCGHxUPaBt1B94nvKs5ZzwANQwV4ix34f07MzVJ6FckHthHCdLGcWkrB2wdp5TPT6qkjjczxeDJ8r-9lGDCKLvcs-FdjeIogKCNwsu3kPcJC2vE22Eezi1C6fHRg5jpqO2NyZvHTBLGUV0tgpUorQ431-uGgVuv0hotHA
   response:
     status:
       code: 200
@@ -88,19 +144,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - '14999'
       X-Ms-Request-Id:
-      - fe3532ca-59a2-474e-9094-8a3697b82bef
+      - 94fefd7d-b9a8-445b-a7e4-b33033787957
       X-Ms-Correlation-Request-Id:
-      - fe3532ca-59a2-474e-9094-8a3697b82bef
+      - 94fefd7d-b9a8-445b-a7e4-b33033787957
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102419Z:fe3532ca-59a2-474e-9094-8a3697b82bef
+      - WESTEUROPE:20180312T135736Z:94fefd7d-b9a8-445b-a7e4-b33033787957
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:18 GMT
+      - Mon, 12 Mar 2018 13:57:35 GMT
       Content-Length:
       - '320853'
     body:
@@ -2322,10 +2378,10 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:23 GMT
+  recorded_at: Mon, 12 Mar 2018 13:57:37 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/non_existent?api-version=2017-08-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2339,7 +2395,61 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjI3NTMsIm5iZiI6MTUyMDg2Mjc1MywiZXhwIjoxNTIwODY2NjUzLCJhaW8iOiJZMk5nWU5qQnVUVng5OU1Kai9QZUY0akhQV2xXQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoic2xpdHpFREFBME9rUUhZRTNFY1lBQSIsInZlciI6IjEuMCJ9.Qxnn-5NYOZmogiHt-I2F53zJrRBSHKuYBrutjin7QFLQo8dufzsLR3NrLvELmnt43-mpOR7pZv7OpKrkyfVtl9xaN2WlKDLVS7ZTnQQlB-C2KGavbhf_Od1Ab4k0S2xRMKymzQmdxDF2LBBe1G4B7FLm_OIBg-DLhULmdhjxSVFTylJP7tCGHxUPaBt1B94nvKs5ZzwANQwV4ix34f07MzVJ6FckHthHCdLGcWkrB2wdp5TPT6qkjjczxeDJ8r-9lGDCKLvcs-FdjeIogKCNwsu3kPcJC2vE22Eezi1C6fHRg5jpqO2NyZvHTBLGUV0tgpUorQ431-uGgVuv0hotHA
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      X-Ms-Failure-Cause:
+      - gateway
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14998'
+      X-Ms-Request-Id:
+      - f1a840de-69de-4697-ab5c-552a4677a763
+      X-Ms-Correlation-Request-Id:
+      - f1a840de-69de-4697-ab5c-552a4677a763
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T135738Z:f1a840de-69de-4697-ab5c-552a4677a763
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:57:37 GMT
+      Content-Length:
+      - '97'
+    body:
+      encoding: UTF-8
+      string: '{"error":{"code":"DeploymentNotFound","message":"Deployment ''non_existent''
+        could not be found."}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:57:38 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjI3NTMsIm5iZiI6MTUyMDg2Mjc1MywiZXhwIjoxNTIwODY2NjUzLCJhaW8iOiJZMk5nWU5qQnVUVng5OU1Kai9QZUY0akhQV2xXQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoic2xpdHpFREFBME9rUUhZRTNFY1lBQSIsInZlciI6IjEuMCJ9.Qxnn-5NYOZmogiHt-I2F53zJrRBSHKuYBrutjin7QFLQo8dufzsLR3NrLvELmnt43-mpOR7pZv7OpKrkyfVtl9xaN2WlKDLVS7ZTnQQlB-C2KGavbhf_Od1Ab4k0S2xRMKymzQmdxDF2LBBe1G4B7FLm_OIBg-DLhULmdhjxSVFTylJP7tCGHxUPaBt1B94nvKs5ZzwANQwV4ix34f07MzVJ6FckHthHCdLGcWkrB2wdp5TPT6qkjjczxeDJ8r-9lGDCKLvcs-FdjeIogKCNwsu3kPcJC2vE22Eezi1C6fHRg5jpqO2NyZvHTBLGUV0tgpUorQ431-uGgVuv0hotHA
   response:
     status:
       code: 200
@@ -2356,87 +2466,96 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67"
+      - W/"92982330-0f29-406e-bba9-ad19198579a5"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - '080de667-081e-4d58-9e94-9e7243d4200e'
+      - 9ad5d899-eab9-4146-8296-be471c4ee29b
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
+      - '14998'
       X-Ms-Correlation-Request-Id:
-      - '093d49ac-c85f-440e-956b-955b6698dd19'
+      - d04a2649-4d55-4e24-9b50-50c35f346a66
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102419Z:093d49ac-c85f-440e-956b-955b6698dd19
+      - WESTEUROPE:20180312T135739Z:d04a2649-4d55-4e24-9b50-50c35f346a66
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:19 GMT
+      - Mon, 12 Mar 2018 13:57:39 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1\",\r\n
-        \ \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n  \"type\":
+      string: "{\r\n  \"name\": \"spec0deply1lb\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb\",\r\n
+        \ \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n  \"type\":
         \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"7ab88756-810f-4083-95db-8b05d50e38f2\",\r\n
+        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"8cd72f7c-03bd-4584-abc6-d9ce77ae6202\",\r\n
         \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
+        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\"\r\n
+        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip\"\r\n
         \         },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
         \           }\r\n          ],\r\n          \"inboundNatRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\"\r\n
+        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1\"\r\n
         \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
+        [\r\n      {\r\n        \"name\": \"BackendPool1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\",\r\n
+        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"backendIPConfigurations\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\"\r\n
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1\"\r\n
         \           }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
+        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
         \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-rule\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
+        [\r\n      {\r\n        \"name\": \"LBRule\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\",\r\n
+        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
+        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
         \         },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\":
         80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
+        5,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
         false,\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\"\r\n
-        \         },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\"\r\n
+        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\"\r\n
+        \         },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/probes/tcpProbe\"\r\n
         \         }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n
-        \       \"name\": \"rspec-lb-probe\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
+        \       \"name\": \"tcpProbe\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/probes/tcpProbe\",\r\n
+        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
+        \         \"protocol\": \"Tcp\",\r\n          \"port\": 80,\r\n          \"intervalInSeconds\":
+        5,\r\n          \"numberOfProbes\": 2,\r\n          \"loadBalancingRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
         \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-NAT\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
+        [\r\n      {\r\n        \"name\": \"RDP-VM0\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0\",\r\n
+        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 3441,\r\n          \"backendPort\":
+        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
+        \         },\r\n          \"frontendPort\": 50001,\r\n          \"backendPort\":
         3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
         4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
+        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1\"\r\n
+        \         }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"RDP-VM1\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1\",\r\n
+        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
+        \         },\r\n          \"frontendPort\": 50002,\r\n          \"backendPort\":
+        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
+        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
+        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1\"\r\n
         \         }\r\n        }\r\n      }\r\n    ],\r\n    \"outboundNatRules\":
         [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
         \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:24 GMT
+  recorded_at: Mon, 12 Mar 2018 13:57:39 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/non_existent_lb?api-version=2018-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2450,74 +2569,45 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjI3NTMsIm5iZiI6MTUyMDg2Mjc1MywiZXhwIjoxNTIwODY2NjUzLCJhaW8iOiJZMk5nWU5qQnVUVng5OU1Kai9QZUY0akhQV2xXQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoic2xpdHpFREFBME9rUUhZRTNFY1lBQSIsInZlciI6IjEuMCJ9.Qxnn-5NYOZmogiHt-I2F53zJrRBSHKuYBrutjin7QFLQo8dufzsLR3NrLvELmnt43-mpOR7pZv7OpKrkyfVtl9xaN2WlKDLVS7ZTnQQlB-C2KGavbhf_Od1Ab4k0S2xRMKymzQmdxDF2LBBe1G4B7FLm_OIBg-DLhULmdhjxSVFTylJP7tCGHxUPaBt1B94nvKs5ZzwANQwV4ix34f07MzVJ6FckHthHCdLGcWkrB2wdp5TPT6qkjjczxeDJ8r-9lGDCKLvcs-FdjeIogKCNwsu3kPcJC2vE22Eezi1C6fHRg5jpqO2NyZvHTBLGUV0tgpUorQ431-uGgVuv0hotHA
   response:
     status:
-      code: 200
-      message: OK
+      code: 404
+      message: Not Found
     headers:
       Cache-Control:
       - no-cache
       Pragma:
       - no-cache
-      Transfer-Encoding:
-      - chunked
       Content-Type:
       - application/json; charset=utf-8
       Expires:
       - "-1"
-      Etag:
-      - W/"7a8e5fe7-f777-4435-992b-a54f28c2f28c"
-      Vary:
-      - Accept-Encoding
+      X-Ms-Failure-Cause:
+      - gateway
       X-Ms-Request-Id:
-      - bd22ca22-a01f-4ecf-9230-a4558fb66931
+      - e07896c9-eae8-4233-a457-f82e47406d90
+      X-Ms-Correlation-Request-Id:
+      - e07896c9-eae8-4233-a457-f82e47406d90
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T135741Z:e07896c9-eae8-4233-a457-f82e47406d90
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Correlation-Request-Id:
-      - 19c674a8-c8da-4b5e-8265-5ebc21926459
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102420Z:19c674a8-c8da-4b5e-8265-5ebc21926459
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:19 GMT
+      - Mon, 12 Mar 2018 13:57:40 GMT
+      Content-Length:
+      - '166'
     body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb2\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2\",\r\n
-        \ \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"e2e30a77-f81b-43fc-9693-08303e43deed\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/backendAddressPools/rspec-lb2-pool\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\r\n
-        \       }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\": [],\r\n    \"probes\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-probe\",\r\n        \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/probes/rspec-lb2-probe\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\": [],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
+      encoding: UTF-8
+      string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Network/loadBalancers/non_existent_lb''
+        under resource group ''miq-azure-test1'' was not found."}}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:25 GMT
+  recorded_at: Mon, 12 Mar 2018 13:57:41 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed?api-version=2017-12-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2531,7 +2621,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjI3NTMsIm5iZiI6MTUyMDg2Mjc1MywiZXhwIjoxNTIwODY2NjUzLCJhaW8iOiJZMk5nWU5qQnVUVng5OU1Kai9QZUY0akhQV2xXQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoic2xpdHpFREFBME9rUUhZRTNFY1lBQSIsInZlciI6IjEuMCJ9.Qxnn-5NYOZmogiHt-I2F53zJrRBSHKuYBrutjin7QFLQo8dufzsLR3NrLvELmnt43-mpOR7pZv7OpKrkyfVtl9xaN2WlKDLVS7ZTnQQlB-C2KGavbhf_Od1Ab4k0S2xRMKymzQmdxDF2LBBe1G4B7FLm_OIBg-DLhULmdhjxSVFTylJP7tCGHxUPaBt1B94nvKs5ZzwANQwV4ix34f07MzVJ6FckHthHCdLGcWkrB2wdp5TPT6qkjjczxeDJ8r-9lGDCKLvcs-FdjeIogKCNwsu3kPcJC2vE22Eezi1C6fHRg5jpqO2NyZvHTBLGUV0tgpUorQ431-uGgVuv0hotHA
   response:
     status:
       code: 200
@@ -2547,43 +2637,56 @@ http_interactions:
       - application/json; charset=utf-8
       Expires:
       - "-1"
-      Etag:
-      - W/"a38434c8-7b23-4092-b7c6-402238eac0dc"
       Vary:
       - Accept-Encoding
-      X-Ms-Request-Id:
-      - 0fd15240-6a1c-4b39-a4f6-aa53fd8591c2
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/LowCostGet3Min;4795,Microsoft.Compute/LowCostGet30Min;38349
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      X-Ms-Request-Id:
+      - 04e65b4c-68fb-4b64-b19e-6161a7dcd4c2
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
+      - '14997'
       X-Ms-Correlation-Request-Id:
-      - 5cc03163-922e-41a1-9601-dba2d7cf2a81
+      - d1870c8c-4699-4bd1-a25f-1912da991f9b
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102421Z:5cc03163-922e-41a1-9601-dba2d7cf2a81
+      - WESTEUROPE:20180312T135743Z:d1870c8c-4699-4bd1-a25f-1912da991f9b
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:20 GMT
+      - Mon, 12 Mar 2018 13:57:42 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb1-LoadBalancerFrontEnd\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\",\r\n
-        \ \"etag\": \"W/\\\"a38434c8-7b23-4092-b7c6-402238eac0dc\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"f28e0f25-b372-4edf-97d9-13a9e3b4ba2d\",\r\n    \"ipAddress\":
-        \"40.71.82.83\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\":
-        \"Static\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipTags\": [],\r\n
-        \   \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
-        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
+      string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"61b7c052-1d09-4898-b995-cce5676aaab0\",\r\n
+        \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Basic_A0\"\r\n    },\r\n
+        \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
+        \"RedHat\",\r\n        \"offer\": \"RHEL\",\r\n        \"sku\": \"7.3\",\r\n
+        \       \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
+        \"Linux\",\r\n        \"name\": \"miqazure-linux-managed_OsDisk_1_7b2bdf790a7d4379ace2846d307730cd\",\r\n
+        \       \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n
+        \       \"managedDisk\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/disks/miqazure-linux-managed_OsDisk_1_7b2bdf790a7d4379ace2846d307730cd\"\r\n
+        \       }\r\n      },\r\n      \"dataDisks\": [\r\n        {\r\n          \"lun\":
+        0,\r\n          \"name\": \"miqazure-linux-managed-data-disk\",\r\n          \"createOption\":
+        \"Attach\",\r\n          \"caching\": \"None\",\r\n          \"managedDisk\":
+        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/disks/miqazure-linux-managed-data-disk\"\r\n
+        \         }\r\n        }\r\n      ]\r\n    },\r\n    \"osProfile\": {\r\n
+        \     \"computerName\": \"miqazure-linux-managed\",\r\n      \"adminUsername\":
+        \"dberger\",\r\n      \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\":
+        false\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\":
+        {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944\"}]},\r\n
+        \   \"provisioningState\": \"Succeeded\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n
+        \ \"location\": \"eastus\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed\",\r\n
+        \ \"name\": \"miqazure-linux-managed\"\r\n}"
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:25 GMT
+  recorded_at: Mon, 12 Mar 2018 13:57:43 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1?api-version=2017-12-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2597,7 +2700,232 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjI3NTMsIm5iZiI6MTUyMDg2Mjc1MywiZXhwIjoxNTIwODY2NjUzLCJhaW8iOiJZMk5nWU5qQnVUVng5OU1Kai9QZUY0akhQV2xXQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoic2xpdHpFREFBME9rUUhZRTNFY1lBQSIsInZlciI6IjEuMCJ9.Qxnn-5NYOZmogiHt-I2F53zJrRBSHKuYBrutjin7QFLQo8dufzsLR3NrLvELmnt43-mpOR7pZv7OpKrkyfVtl9xaN2WlKDLVS7ZTnQQlB-C2KGavbhf_Od1Ab4k0S2xRMKymzQmdxDF2LBBe1G4B7FLm_OIBg-DLhULmdhjxSVFTylJP7tCGHxUPaBt1B94nvKs5ZzwANQwV4ix34f07MzVJ6FckHthHCdLGcWkrB2wdp5TPT6qkjjczxeDJ8r-9lGDCKLvcs-FdjeIogKCNwsu3kPcJC2vE22Eezi1C6fHRg5jpqO2NyZvHTBLGUV0tgpUorQ431-uGgVuv0hotHA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/LowCostGet3Min;4794,Microsoft.Compute/LowCostGet30Min;38348
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      X-Ms-Request-Id:
+      - 6b982b47-6763-4673-8abf-fbaf2639e52a
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14998'
+      X-Ms-Correlation-Request-Id:
+      - 010b492c-da4a-43c2-8ce1-0d3638f73bdd
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T135744Z:010b492c-da4a-43c2-8ce1-0d3638f73bdd
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:57:43 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"03e8467b-baab-4867-9cc4-157336b7e2e4\",\r\n
+        \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Basic_A0\"\r\n    },\r\n
+        \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
+        \"RedHat\",\r\n        \"offer\": \"RHEL\",\r\n        \"sku\": \"7.2\",\r\n
+        \       \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
+        \"Linux\",\r\n        \"name\": \"miq-test-rhel1\",\r\n        \"createOption\":
+        \"FromImage\",\r\n        \"vhd\": {\r\n          \"uri\": \"https://miqazuretest18686.blob.core.windows.net/vhds/miq-test-rhel12016218112243.vhd\"\r\n
+        \       },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n      \"dataDisks\":
+        []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"miq-test-rhel1\",\r\n
+        \     \"adminUsername\": \"dberger\",\r\n      \"linuxConfiguration\": {\r\n
+        \       \"disablePasswordAuthentication\": false\r\n      },\r\n      \"secrets\":
+        []\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390\"}]},\r\n
+        \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
+        true,\r\n        \"storageUri\": \"https://miqazuretest18686.blob.core.windows.net/\"\r\n
+        \     }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n
+        \ \"resources\": [\r\n    {\r\n      \"properties\": {\r\n        \"publisher\":
+        \"Microsoft.OSTCExtensions\",\r\n        \"type\": \"LinuxDiagnostic\",\r\n
+        \       \"typeHandlerVersion\": \"2.0\",\r\n        \"autoUpgradeMinorVersion\":
+        true,\r\n        \"settings\": {\"xmlCfg\":\"PFdhZENmZz48RGlhZ25vc3RpY01vbml0b3JDb25maWd1cmF0aW9uIG92ZXJhbGxRdW90YUluTUI9IjQwOTYiPjxEaWFnbm9zdGljSW5mcmFzdHJ1Y3R1cmVMb2dzIHNjaGVkdWxlZFRyYW5zZmVyUGVyaW9kPSJQVDFNIiBzY2hlZHVsZWRUcmFuc2ZlckxvZ0xldmVsRmlsdGVyPSJXYXJuaW5nIi8+PFBlcmZvcm1hbmNlQ291bnRlcnMgc2NoZWR1bGVkVHJhbnNmZXJQZXJpb2Q9IlBUMU0iPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlTWVtb3J5IiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQnl0ZXMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcUGVyY2VudEF2YWlsYWJsZU1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iTWVtb3J5IHVzZWQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50VXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgcGVyY2VudGFnZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkQnlDYWNoZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHVzZWQgYnkgY2FjaGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1BlclNlYyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50UGVyU2Vjb25kIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFnZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1JlYWRQZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2UgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1dyaXR0ZW5QZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2Ugd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iU3dhcCBhdmFpbGFibGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50QXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZFN3YXAiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlN3YXAgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRJZGxlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgaWRsZSB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFVzZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iUGVyY2VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkNQVSB1c2VyIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50TmljZVRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIG5pY2UgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRQcml2aWxlZ2VkVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgcHJpdmlsZWdlZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudEludGVycnVwdFRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIGludGVycnVwdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudERQQ1RpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIERQQyB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFByb2Nlc3NvclRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIHBlcmNlbnRhZ2UgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50SU9XYWl0VGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgSU8gd2FpdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xSZWFkQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCBndWVzdCBPUyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXFdyaXRlQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGUgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xUcmFuc2ZlcnNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXJzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcUmVhZHNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xXcml0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVJlYWRUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVdyaXRlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlNlY29uZHMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJEaXNrIHdyaXRlIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xBdmVyYWdlVHJhbnNmZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXIgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXEF2ZXJhZ2VEaXNrUXVldWVMZW5ndGgiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcXVldWUgbGVuZ3RoIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVHJhbnNtaXR0ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgb3V0IGd1ZXN0IE9TIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzUmVjZWl2ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgaW4gZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1RyYW5zbWl0dGVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHNlbnQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1JlY2VpdmVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHJlY2VpdmVkIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVG90YWwiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxSeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyByZWNlaXZlZCBlcnJvcnMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxUeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyBzZW50IGVycm9ycyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTmV0d29ya0ludGVyZmFjZVxUb3RhbENvbGxpc2lvbnMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgY29sbGlzaW9ucyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48L1BlcmZvcm1hbmNlQ291bnRlcnM+PE1ldHJpY3MgcmVzb3VyY2VJZD0iL3N1YnNjcmlwdGlvbnMvMjU4NmM2NGItMzhiNC00NTI3LWExNDAtMDEyZDQ5ZGZjMDJjL3Jlc291cmNlR3JvdXBzL21pcS1henVyZS10ZXN0MS9wcm92aWRlcnMvTWljcm9zb2Z0LkNvbXB1dGUvdmlydHVhbE1hY2hpbmVzL21pcS10ZXN0LXJoZWwxIj48TWV0cmljQWdncmVnYXRpb24gc2NoZWR1bGVkVHJhbnNmZXJQZXJpb2Q9IlBUMUgiLz48TWV0cmljQWdncmVnYXRpb24gc2NoZWR1bGVkVHJhbnNmZXJQZXJpb2Q9IlBUMU0iLz48L01ldHJpY3M+PC9EaWFnbm9zdGljTW9uaXRvckNvbmZpZ3VyYXRpb24+PC9XYWRDZmc+\",\"StorageAccount\":\"miqazuretest18686\"},\r\n
+        \       \"provisioningState\": \"Succeeded\"\r\n      },\r\n      \"type\":
+        \"Microsoft.Compute/virtualMachines/extensions\",\r\n      \"location\": \"eastus\",\r\n
+        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/extensions/Microsoft.Insights.VMDiagnosticsSettings\",\r\n
+        \     \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n    }\r\n
+        \ ],\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\":
+        \"eastus\",\r\n  \"tags\": {\r\n    \"Shutdown\": \"true\"\r\n  },\r\n  \"id\":
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1\",\r\n
+        \ \"name\": \"miq-test-rhel1\"\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:57:44 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1?api-version=2017-12-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjI3NTMsIm5iZiI6MTUyMDg2Mjc1MywiZXhwIjoxNTIwODY2NjUzLCJhaW8iOiJZMk5nWU5qQnVUVng5OU1Kai9QZUY0akhQV2xXQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoic2xpdHpFREFBME9rUUhZRTNFY1lBQSIsInZlciI6IjEuMCJ9.Qxnn-5NYOZmogiHt-I2F53zJrRBSHKuYBrutjin7QFLQo8dufzsLR3NrLvELmnt43-mpOR7pZv7OpKrkyfVtl9xaN2WlKDLVS7ZTnQQlB-C2KGavbhf_Od1Ab4k0S2xRMKymzQmdxDF2LBBe1G4B7FLm_OIBg-DLhULmdhjxSVFTylJP7tCGHxUPaBt1B94nvKs5ZzwANQwV4ix34f07MzVJ6FckHthHCdLGcWkrB2wdp5TPT6qkjjczxeDJ8r-9lGDCKLvcs-FdjeIogKCNwsu3kPcJC2vE22Eezi1C6fHRg5jpqO2NyZvHTBLGUV0tgpUorQ431-uGgVuv0hotHA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/LowCostGet3Min;4793,Microsoft.Compute/LowCostGet30Min;38347
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      X-Ms-Request-Id:
+      - 41561ef7-13f5-4b1b-8ac4-9cc216294379
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Correlation-Request-Id:
+      - b10bebcd-b12f-4e6c-a228-f0040805c1dc
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T135745Z:b10bebcd-b12f-4e6c-a228-f0040805c1dc
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:57:45 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"796c5bcc-338a-448d-b61c-165279a7fb3e\",\r\n
+        \   \"availabilitySet\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/MIQAZURE-AVAILSET-EAST\"\r\n
+        \   },\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Basic_A0\"\r\n
+        \   },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
+        \"OpenLogic\",\r\n        \"offer\": \"CentOS\",\r\n        \"sku\": \"7.1\",\r\n
+        \       \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
+        \"Linux\",\r\n        \"name\": \"miqazure-centos1\",\r\n        \"createOption\":
+        \"FromImage\",\r\n        \"vhd\": {\r\n          \"uri\": \"https://miqazuretest14047.blob.core.windows.net/vhds/miqazure-centos12016221104946.vhd\"\r\n
+        \       },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n      \"dataDisks\":
+        []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"miqazure-centos1\",\r\n
+        \     \"adminUsername\": \"dberger\",\r\n      \"linuxConfiguration\": {\r\n
+        \       \"disablePasswordAuthentication\": false\r\n      },\r\n      \"secrets\":
+        []\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611\"}]},\r\n
+        \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
+        true,\r\n        \"storageUri\": \"https://miqazuretest14047.blob.core.windows.net/\"\r\n
+        \     }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n
+        \ \"resources\": [\r\n    {\r\n      \"properties\": {\r\n        \"publisher\":
+        \"Microsoft.OSTCExtensions\",\r\n        \"type\": \"LinuxDiagnostic\",\r\n
+        \       \"typeHandlerVersion\": \"2.0\",\r\n        \"autoUpgradeMinorVersion\":
+        true,\r\n        \"settings\": {\"xmlCfg\":\"PFdhZENmZz48RGlhZ25vc3RpY01vbml0b3JDb25maWd1cmF0aW9uIG92ZXJhbGxRdW90YUluTUI9IjQwOTYiPjxEaWFnbm9zdGljSW5mcmFzdHJ1Y3R1cmVMb2dzIHNjaGVkdWxlZFRyYW5zZmVyUGVyaW9kPSJQVDFNIiBzY2hlZHVsZWRUcmFuc2ZlckxvZ0xldmVsRmlsdGVyPSJXYXJuaW5nIi8+PFBlcmZvcm1hbmNlQ291bnRlcnMgc2NoZWR1bGVkVHJhbnNmZXJQZXJpb2Q9IlBUMU0iPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlTWVtb3J5IiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQnl0ZXMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcUGVyY2VudEF2YWlsYWJsZU1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iTWVtb3J5IHVzZWQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50VXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgcGVyY2VudGFnZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkQnlDYWNoZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHVzZWQgYnkgY2FjaGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1BlclNlYyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50UGVyU2Vjb25kIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFnZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1JlYWRQZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2UgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1dyaXR0ZW5QZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2Ugd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iU3dhcCBhdmFpbGFibGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50QXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZFN3YXAiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlN3YXAgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRJZGxlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgaWRsZSB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFVzZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iUGVyY2VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkNQVSB1c2VyIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50TmljZVRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIG5pY2UgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRQcml2aWxlZ2VkVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgcHJpdmlsZWdlZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudEludGVycnVwdFRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIGludGVycnVwdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudERQQ1RpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIERQQyB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFByb2Nlc3NvclRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIHBlcmNlbnRhZ2UgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50SU9XYWl0VGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgSU8gd2FpdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xSZWFkQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCBndWVzdCBPUyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXFdyaXRlQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGUgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xUcmFuc2ZlcnNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXJzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcUmVhZHNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xXcml0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVJlYWRUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVdyaXRlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlNlY29uZHMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJEaXNrIHdyaXRlIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xBdmVyYWdlVHJhbnNmZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXIgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXEF2ZXJhZ2VEaXNrUXVldWVMZW5ndGgiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcXVldWUgbGVuZ3RoIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVHJhbnNtaXR0ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgb3V0IGd1ZXN0IE9TIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzUmVjZWl2ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgaW4gZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1RyYW5zbWl0dGVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHNlbnQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1JlY2VpdmVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHJlY2VpdmVkIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVG90YWwiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxSeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyByZWNlaXZlZCBlcnJvcnMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxUeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyBzZW50IGVycm9ycyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTmV0d29ya0ludGVyZmFjZVxUb3RhbENvbGxpc2lvbnMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgY29sbGlzaW9ucyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48L1BlcmZvcm1hbmNlQ291bnRlcnM+PE1ldHJpY3MgcmVzb3VyY2VJZD0iL3N1YnNjcmlwdGlvbnMvMjU4NmM2NGItMzhiNC00NTI3LWExNDAtMDEyZDQ5ZGZjMDJjL3Jlc291cmNlR3JvdXBzL21pcS1henVyZS10ZXN0MS9wcm92aWRlcnMvTWljcm9zb2Z0LkNvbXB1dGUvdmlydHVhbE1hY2hpbmVzL21pcWF6dXJlLWNlbnRvczEiPjxNZXRyaWNBZ2dyZWdhdGlvbiBzY2hlZHVsZWRUcmFuc2ZlclBlcmlvZD0iUFQxSCIvPjxNZXRyaWNBZ2dyZWdhdGlvbiBzY2hlZHVsZWRUcmFuc2ZlclBlcmlvZD0iUFQxTSIvPjwvTWV0cmljcz48L0RpYWdub3N0aWNNb25pdG9yQ29uZmlndXJhdGlvbj48L1dhZENmZz4=\",\"StorageAccount\":\"miqazuretest14047\"},\r\n
+        \       \"provisioningState\": \"Succeeded\"\r\n      },\r\n      \"type\":
+        \"Microsoft.Compute/virtualMachines/extensions\",\r\n      \"location\": \"eastus\",\r\n
+        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1/extensions/Microsoft.Insights.VMDiagnosticsSettings\",\r\n
+        \     \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n    }\r\n
+        \ ],\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\":
+        \"eastus\",\r\n  \"tags\": {\r\n    \"Shutdown\": \"true\"\r\n  },\r\n  \"id\":
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1\",\r\n
+        \ \"name\": \"miqazure-centos1\"\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:57:45 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/non_existent_vm_that_does_not_exist?api-version=2017-12-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjI3NTMsIm5iZiI6MTUyMDg2Mjc1MywiZXhwIjoxNTIwODY2NjUzLCJhaW8iOiJZMk5nWU5qQnVUVng5OU1Kai9QZUY0akhQV2xXQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoic2xpdHpFREFBME9rUUhZRTNFY1lBQSIsInZlciI6IjEuMCJ9.Qxnn-5NYOZmogiHt-I2F53zJrRBSHKuYBrutjin7QFLQo8dufzsLR3NrLvELmnt43-mpOR7pZv7OpKrkyfVtl9xaN2WlKDLVS7ZTnQQlB-C2KGavbhf_Od1Ab4k0S2xRMKymzQmdxDF2LBBe1G4B7FLm_OIBg-DLhULmdhjxSVFTylJP7tCGHxUPaBt1B94nvKs5ZzwANQwV4ix34f07MzVJ6FckHthHCdLGcWkrB2wdp5TPT6qkjjczxeDJ8r-9lGDCKLvcs-FdjeIogKCNwsu3kPcJC2vE22Eezi1C6fHRg5jpqO2NyZvHTBLGUV0tgpUorQ431-uGgVuv0hotHA
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      X-Ms-Failure-Cause:
+      - gateway
+      X-Ms-Request-Id:
+      - bc96c602-a553-40f4-b50f-0394f54bdf50
+      X-Ms-Correlation-Request-Id:
+      - bc96c602-a553-40f4-b50f-0394f54bdf50
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T135746Z:bc96c602-a553-40f4-b50f-0394f54bdf50
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:57:45 GMT
+      Content-Length:
+      - '188'
+    body:
+      encoding: UTF-8
+      string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Compute/virtualMachines/non_existent_vm_that_does_not_exist''
+        under resource group ''miq-azure-test4'' was not found."}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:57:46 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjI3NTMsIm5iZiI6MTUyMDg2Mjc1MywiZXhwIjoxNTIwODY2NjUzLCJhaW8iOiJZMk5nWU5qQnVUVng5OU1Kai9QZUY0akhQV2xXQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoic2xpdHpFREFBME9rUUhZRTNFY1lBQSIsInZlciI6IjEuMCJ9.Qxnn-5NYOZmogiHt-I2F53zJrRBSHKuYBrutjin7QFLQo8dufzsLR3NrLvELmnt43-mpOR7pZv7OpKrkyfVtl9xaN2WlKDLVS7ZTnQQlB-C2KGavbhf_Od1Ab4k0S2xRMKymzQmdxDF2LBBe1G4B7FLm_OIBg-DLhULmdhjxSVFTylJP7tCGHxUPaBt1B94nvKs5ZzwANQwV4ix34f07MzVJ6FckHthHCdLGcWkrB2wdp5TPT6qkjjczxeDJ8r-9lGDCKLvcs-FdjeIogKCNwsu3kPcJC2vE22Eezi1C6fHRg5jpqO2NyZvHTBLGUV0tgpUorQ431-uGgVuv0hotHA
   response:
     status:
       code: 200
@@ -2614,36 +2942,2962 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"cddd97d1-6111-4477-8a00-3dc885237a1d"
+      - W/"b6339880-8ead-4c9e-b5c0-f38c4f8612d5"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 1403e5b6-8fa0-4cd3-89b1-76b6c4fd805b
+      - 13750097-af73-4817-b561-628f02330ed7
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - '14998'
       X-Ms-Correlation-Request-Id:
-      - e4a5f369-a742-466f-bd8f-42e17eaaf9c9
+      - 9cdc9930-64ad-430e-a85f-a71a6c3526c8
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102421Z:e4a5f369-a742-466f-bd8f-42e17eaaf9c9
+      - WESTEUROPE:20180312T135747Z:9cdc9930-64ad-430e-a85f-a71a6c3526c8
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:21 GMT
+      - Mon, 12 Mar 2018 13:57:46 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb2-publicip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\",\r\n
-        \ \"etag\": \"W/\\\"cddd97d1-6111-4477-8a00-3dc885237a1d\\\"\",\r\n  \"location\":
+      string: "{\r\n  \"name\": \"miqazure-linux-manag944\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944\",\r\n
+        \ \"etag\": \"W/\\\"b6339880-8ead-4c9e-b5c0-f38c4f8612d5\\\"\",\r\n  \"location\":
         \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"83e7257d-ab94-4229-8eb5-4798f37ef28d\",\r\n    \"publicIPAddressVersion\":
+        \   \"resourceGuid\": \"c5e8b90e-5a78-49b0-b224-b70ed3fb45e5\",\r\n    \"ipConfigurations\":
+        [\r\n      {\r\n        \"name\": \"ipconfig1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944/ipConfigurations/ipconfig1\",\r\n
+        \       \"etag\": \"W/\\\"b6339880-8ead-4c9e-b5c0-f38c4f8612d5\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"privateIPAddress\": \"172.25.0.4\",\r\n          \"privateIPAllocationMethod\":
+        \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqazure-linux-managed-ip\"\r\n
+        \         },\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2/subnets/default\"\r\n
+        \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
+        \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\":
+        [],\r\n      \"appliedDnsServers\": []\r\n    },\r\n    \"enableAcceleratedNetworking\":
+        false,\r\n    \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\":
+        {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg\"\r\n
+        \   },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed\"\r\n
+        \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
+        \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:57:47 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/non_existent?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjI3NTMsIm5iZiI6MTUyMDg2Mjc1MywiZXhwIjoxNTIwODY2NjUzLCJhaW8iOiJZMk5nWU5qQnVUVng5OU1Kai9QZUY0akhQV2xXQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoic2xpdHpFREFBME9rUUhZRTNFY1lBQSIsInZlciI6IjEuMCJ9.Qxnn-5NYOZmogiHt-I2F53zJrRBSHKuYBrutjin7QFLQo8dufzsLR3NrLvELmnt43-mpOR7pZv7OpKrkyfVtl9xaN2WlKDLVS7ZTnQQlB-C2KGavbhf_Od1Ab4k0S2xRMKymzQmdxDF2LBBe1G4B7FLm_OIBg-DLhULmdhjxSVFTylJP7tCGHxUPaBt1B94nvKs5ZzwANQwV4ix34f07MzVJ6FckHthHCdLGcWkrB2wdp5TPT6qkjjczxeDJ8r-9lGDCKLvcs-FdjeIogKCNwsu3kPcJC2vE22Eezi1C6fHRg5jpqO2NyZvHTBLGUV0tgpUorQ431-uGgVuv0hotHA
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      X-Ms-Failure-Cause:
+      - gateway
+      X-Ms-Request-Id:
+      - f49d17e4-4f48-4136-9659-79c42cc92cda
+      X-Ms-Correlation-Request-Id:
+      - f49d17e4-4f48-4136-9659-79c42cc92cda
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T135747Z:f49d17e4-4f48-4136-9659-79c42cc92cda
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:57:47 GMT
+      Content-Length:
+      - '167'
+    body:
+      encoding: UTF-8
+      string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Network/networkInterfaces/non_existent''
+        under resource group ''miq-azure-test4'' was not found."}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:57:47 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjI3NTMsIm5iZiI6MTUyMDg2Mjc1MywiZXhwIjoxNTIwODY2NjUzLCJhaW8iOiJZMk5nWU5qQnVUVng5OU1Kai9QZUY0akhQV2xXQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoic2xpdHpFREFBME9rUUhZRTNFY1lBQSIsInZlciI6IjEuMCJ9.Qxnn-5NYOZmogiHt-I2F53zJrRBSHKuYBrutjin7QFLQo8dufzsLR3NrLvELmnt43-mpOR7pZv7OpKrkyfVtl9xaN2WlKDLVS7ZTnQQlB-C2KGavbhf_Od1Ab4k0S2xRMKymzQmdxDF2LBBe1G4B7FLm_OIBg-DLhULmdhjxSVFTylJP7tCGHxUPaBt1B94nvKs5ZzwANQwV4ix34f07MzVJ6FckHthHCdLGcWkrB2wdp5TPT6qkjjczxeDJ8r-9lGDCKLvcs-FdjeIogKCNwsu3kPcJC2vE22Eezi1C6fHRg5jpqO2NyZvHTBLGUV0tgpUorQ431-uGgVuv0hotHA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"f006e6f9-0292-42cd-99fc-f72f194553c1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - '0829dbc0-a0a2-49ae-a98f-554ab461166d'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14998'
+      X-Ms-Correlation-Request-Id:
+      - 84e3f7fb-b273-43fc-99d3-7a2af5982788
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T135750Z:84e3f7fb-b273-43fc-99d3-7a2af5982788
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:57:50 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"miq-test-rhel1390\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390\",\r\n
+        \ \"etag\": \"W/\\\"f006e6f9-0292-42cd-99fc-f72f194553c1\\\"\",\r\n  \"location\":
+        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"98853f48-2806-4065-be57-cf9159550440\",\r\n    \"ipConfigurations\":
+        [\r\n      {\r\n        \"name\": \"ipconfig1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1\",\r\n
+        \       \"etag\": \"W/\\\"f006e6f9-0292-42cd-99fc-f72f194553c1\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"privateIPAddress\": \"10.16.0.4\",\r\n          \"privateIPAllocationMethod\":
+        \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1\"\r\n
+        \         },\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\"\r\n
+        \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
+        \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\":
+        [],\r\n      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\":
+        \"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net\"\r\n    },\r\n    \"macAddress\":
+        \"00-0D-3A-10-EB-AB\",\r\n    \"enableAcceleratedNetworking\": false,\r\n
+        \   \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\": {\r\n
+        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1\"\r\n
+        \   },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1\"\r\n
+        \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
+        \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:57:50 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjI3NTMsIm5iZiI6MTUyMDg2Mjc1MywiZXhwIjoxNTIwODY2NjUzLCJhaW8iOiJZMk5nWU5qQnVUVng5OU1Kai9QZUY0akhQV2xXQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoic2xpdHpFREFBME9rUUhZRTNFY1lBQSIsInZlciI6IjEuMCJ9.Qxnn-5NYOZmogiHt-I2F53zJrRBSHKuYBrutjin7QFLQo8dufzsLR3NrLvELmnt43-mpOR7pZv7OpKrkyfVtl9xaN2WlKDLVS7ZTnQQlB-C2KGavbhf_Od1Ab4k0S2xRMKymzQmdxDF2LBBe1G4B7FLm_OIBg-DLhULmdhjxSVFTylJP7tCGHxUPaBt1B94nvKs5ZzwANQwV4ix34f07MzVJ6FckHthHCdLGcWkrB2wdp5TPT6qkjjczxeDJ8r-9lGDCKLvcs-FdjeIogKCNwsu3kPcJC2vE22Eezi1C6fHRg5jpqO2NyZvHTBLGUV0tgpUorQ431-uGgVuv0hotHA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"26031ef6-bb55-4019-8185-2dd1edcb207c"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 159cc6c0-5ebc-41d1-90b2-f2cad97324f8
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Correlation-Request-Id:
+      - 00dd613b-a894-4e10-b174-ac61c23124cf
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T135751Z:00dd613b-a894-4e10-b174-ac61c23124cf
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:57:50 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"miqazure-centos1611\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611\",\r\n
+        \ \"etag\": \"W/\\\"26031ef6-bb55-4019-8185-2dd1edcb207c\\\"\",\r\n  \"location\":
+        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"f1760e49-9853-4fdc-acfc-4ea232b9ed76\",\r\n    \"ipConfigurations\":
+        [\r\n      {\r\n        \"name\": \"ipconfig1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1\",\r\n
+        \       \"etag\": \"W/\\\"26031ef6-bb55-4019-8185-2dd1edcb207c\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"privateIPAddress\": \"10.16.0.5\",\r\n          \"privateIPAllocationMethod\":
+        \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1\"\r\n
+        \         },\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\"\r\n
+        \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
+        \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\":
+        [],\r\n      \"appliedDnsServers\": []\r\n    },\r\n    \"enableAcceleratedNetworking\":
+        false,\r\n    \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\":
+        {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1\"\r\n
+        \   },\r\n    \"virtualMachine\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1\"\r\n
+        \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
+        \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:57:51 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed/instanceView?api-version=2017-12-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjI3NTMsIm5iZiI6MTUyMDg2Mjc1MywiZXhwIjoxNTIwODY2NjUzLCJhaW8iOiJZMk5nWU5qQnVUVng5OU1Kai9QZUY0akhQV2xXQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoic2xpdHpFREFBME9rUUhZRTNFY1lBQSIsInZlciI6IjEuMCJ9.Qxnn-5NYOZmogiHt-I2F53zJrRBSHKuYBrutjin7QFLQo8dufzsLR3NrLvELmnt43-mpOR7pZv7OpKrkyfVtl9xaN2WlKDLVS7ZTnQQlB-C2KGavbhf_Od1Ab4k0S2xRMKymzQmdxDF2LBBe1G4B7FLm_OIBg-DLhULmdhjxSVFTylJP7tCGHxUPaBt1B94nvKs5ZzwANQwV4ix34f07MzVJ6FckHthHCdLGcWkrB2wdp5TPT6qkjjczxeDJ8r-9lGDCKLvcs-FdjeIogKCNwsu3kPcJC2vE22Eezi1C6fHRg5jpqO2NyZvHTBLGUV0tgpUorQ431-uGgVuv0hotHA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/GetInstanceView3Min;4799,Microsoft.Compute/GetInstanceView30Min;23809
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      X-Ms-Request-Id:
+      - ad8b80b5-c006-41c5-b573-f621c86038b3
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14998'
+      X-Ms-Correlation-Request-Id:
+      - b7f2adbc-9906-4568-8518-423512b40676
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T135755Z:b7f2adbc-9906-4568-8518-423512b40676
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:57:55 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"miqazure-linux-managed_OsDisk_1_7b2bdf790a7d4379ace2846d307730cd\",\r\n
+        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
+        succeeded\",\r\n          \"time\": \"2018-01-23T20:06:17.9818931+00:00\"\r\n
+        \       }\r\n      ]\r\n    },\r\n    {\r\n      \"name\": \"miqazure-linux-managed-data-disk\",\r\n
+        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
+        succeeded\",\r\n          \"time\": \"2018-01-23T20:06:17.9818931+00:00\"\r\n
+        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\":
+        \"ProvisioningState/succeeded\",\r\n      \"level\": \"Info\",\r\n      \"displayStatus\":
+        \"Provisioning succeeded\",\r\n      \"time\": \"2018-01-23T20:06:17.9975145+00:00\"\r\n
+        \   },\r\n    {\r\n      \"code\": \"PowerState/deallocated\",\r\n      \"level\":
+        \"Info\",\r\n      \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:57:55 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/instanceView?api-version=2017-12-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjI3NTMsIm5iZiI6MTUyMDg2Mjc1MywiZXhwIjoxNTIwODY2NjUzLCJhaW8iOiJZMk5nWU5qQnVUVng5OU1Kai9QZUY0akhQV2xXQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoic2xpdHpFREFBME9rUUhZRTNFY1lBQSIsInZlciI6IjEuMCJ9.Qxnn-5NYOZmogiHt-I2F53zJrRBSHKuYBrutjin7QFLQo8dufzsLR3NrLvELmnt43-mpOR7pZv7OpKrkyfVtl9xaN2WlKDLVS7ZTnQQlB-C2KGavbhf_Od1Ab4k0S2xRMKymzQmdxDF2LBBe1G4B7FLm_OIBg-DLhULmdhjxSVFTylJP7tCGHxUPaBt1B94nvKs5ZzwANQwV4ix34f07MzVJ6FckHthHCdLGcWkrB2wdp5TPT6qkjjczxeDJ8r-9lGDCKLvcs-FdjeIogKCNwsu3kPcJC2vE22Eezi1C6fHRg5jpqO2NyZvHTBLGUV0tgpUorQ431-uGgVuv0hotHA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/GetInstanceView3Min;4798,Microsoft.Compute/GetInstanceView30Min;23808
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      X-Ms-Request-Id:
+      - bcae8c32-ca51-4bcb-9f79-c702b512c2d5
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14997'
+      X-Ms-Correlation-Request-Id:
+      - 9b1b020e-7184-49b2-9e2b-6f12c43f449e
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T135756Z:9b1b020e-7184-49b2-9e2b-6f12c43f449e
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:57:56 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"vmAgent\": {\r\n    \"vmAgentVersion\": \"WALinuxAgent-2.0.16\",\r\n
+        \   \"statuses\": [\r\n      {\r\n        \"code\": \"ProvisioningState/succeeded\",\r\n
+        \       \"level\": \"Info\",\r\n        \"displayStatus\": \"Ready\",\r\n
+        \       \"message\": \"GuestAgent is running and accepting new configurations.\",\r\n
+        \       \"time\": \"2018-03-12T13:57:35+00:00\"\r\n      }\r\n    ],\r\n    \"extensionHandlers\":
+        [\r\n      {\r\n        \"type\": \"Microsoft.OSTCExtensions.LinuxDiagnostic\",\r\n
+        \       \"typeHandlerVersion\": \"2.3.9027\",\r\n        \"status\": {\r\n
+        \         \"code\": \"ProvisioningState/succeeded\",\r\n          \"level\":
+        \"Info\",\r\n          \"displayStatus\": \"Ready\"\r\n        }\r\n      }\r\n
+        \   ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"miq-test-rhel1\",\r\n
+        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
+        succeeded\",\r\n          \"time\": \"2018-01-17T18:00:29.9011002+00:00\"\r\n
+        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
+        \"https://miqazuretest18686.blob.core.windows.net/bootdiagnostics-miqtestrh-03e8467b-baab-4867-9cc4-157336b7e2e4/miq-test-rhel1.03e8467b-baab-4867-9cc4-157336b7e2e4.screenshot.bmp\",\r\n
+        \   \"serialConsoleLogBlobUri\": \"https://miqazuretest18686.blob.core.windows.net/bootdiagnostics-miqtestrh-03e8467b-baab-4867-9cc4-157336b7e2e4/miq-test-rhel1.03e8467b-baab-4867-9cc4-157336b7e2e4.serialconsole.log\"\r\n
+        \ },\r\n  \"extensions\": [\r\n    {\r\n      \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\",\r\n
+        \     \"type\": \"Microsoft.OSTCExtensions.LinuxDiagnostic\",\r\n      \"typeHandlerVersion\":
+        \"2.3.9027\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\":
+        \"ProvisioningState/succeeded\",\r\n          \"level\": \"Info\",\r\n          \"displayStatus\":
+        \"Provisioning succeeded\",\r\n          \"message\": \"Enable succeeded\"\r\n
+        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\":
+        \"ProvisioningState/succeeded\",\r\n      \"level\": \"Info\",\r\n      \"displayStatus\":
+        \"Provisioning succeeded\",\r\n      \"time\": \"2018-01-17T18:02:26.9167163+00:00\"\r\n
+        \   },\r\n    {\r\n      \"code\": \"PowerState/running\",\r\n      \"level\":
+        \"Info\",\r\n      \"displayStatus\": \"VM running\"\r\n    }\r\n  ]\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:57:56 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1/instanceView?api-version=2017-12-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjI3NTMsIm5iZiI6MTUyMDg2Mjc1MywiZXhwIjoxNTIwODY2NjUzLCJhaW8iOiJZMk5nWU5qQnVUVng5OU1Kai9QZUY0akhQV2xXQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoic2xpdHpFREFBME9rUUhZRTNFY1lBQSIsInZlciI6IjEuMCJ9.Qxnn-5NYOZmogiHt-I2F53zJrRBSHKuYBrutjin7QFLQo8dufzsLR3NrLvELmnt43-mpOR7pZv7OpKrkyfVtl9xaN2WlKDLVS7ZTnQQlB-C2KGavbhf_Od1Ab4k0S2xRMKymzQmdxDF2LBBe1G4B7FLm_OIBg-DLhULmdhjxSVFTylJP7tCGHxUPaBt1B94nvKs5ZzwANQwV4ix34f07MzVJ6FckHthHCdLGcWkrB2wdp5TPT6qkjjczxeDJ8r-9lGDCKLvcs-FdjeIogKCNwsu3kPcJC2vE22Eezi1C6fHRg5jpqO2NyZvHTBLGUV0tgpUorQ431-uGgVuv0hotHA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/GetInstanceView3Min;4797,Microsoft.Compute/GetInstanceView30Min;23807
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      X-Ms-Request-Id:
+      - 6a735e97-b6e3-48ac-8661-6f163f557c97
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14997'
+      X-Ms-Correlation-Request-Id:
+      - 4253f419-0ca4-425e-9672-dae031bdb6ff
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T135757Z:4253f419-0ca4-425e-9672-dae031bdb6ff
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:57:56 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"platformUpdateDomain\": 0,\r\n  \"platformFaultDomain\": 0,\r\n
+        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
+        [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
+        \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
+        \"Failed to fetch the VM status.\",\r\n        \"time\": \"2018-03-12T13:57:57+00:00\"\r\n
+        \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"miqazure-centos1\",\r\n
+        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
+        succeeded\",\r\n          \"time\": \"2016-06-22T21:18:47.2011229+00:00\"\r\n
+        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
+        \"https://miqazuretest14047.blob.core.windows.net/bootdiagnostics-miqazurec-796c5bcc-338a-448d-b61c-165279a7fb3e/miqazure-centos1.796c5bcc-338a-448d-b61c-165279a7fb3e.screenshot.bmp\",\r\n
+        \   \"serialConsoleLogBlobUri\": \"https://miqazuretest14047.blob.core.windows.net/bootdiagnostics-miqazurec-796c5bcc-338a-448d-b61c-165279a7fb3e/miqazure-centos1.796c5bcc-338a-448d-b61c-165279a7fb3e.serialconsole.log\"\r\n
+        \ },\r\n  \"extensions\": [\r\n    {\r\n      \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n
+        \   }\r\n  ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n
+        \     \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n
+        \     \"time\": \"2016-06-22T21:18:47.2636196+00:00\"\r\n    },\r\n    {\r\n
+        \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
+        \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:57:57 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups/miq-azure-test4?api-version=2017-08-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjI3NTMsIm5iZiI6MTUyMDg2Mjc1MywiZXhwIjoxNTIwODY2NjUzLCJhaW8iOiJZMk5nWU5qQnVUVng5OU1Kai9QZUY0akhQV2xXQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoic2xpdHpFREFBME9rUUhZRTNFY1lBQSIsInZlciI6IjEuMCJ9.Qxnn-5NYOZmogiHt-I2F53zJrRBSHKuYBrutjin7QFLQo8dufzsLR3NrLvELmnt43-mpOR7pZv7OpKrkyfVtl9xaN2WlKDLVS7ZTnQQlB-C2KGavbhf_Od1Ab4k0S2xRMKymzQmdxDF2LBBe1G4B7FLm_OIBg-DLhULmdhjxSVFTylJP7tCGHxUPaBt1B94nvKs5ZzwANQwV4ix34f07MzVJ6FckHthHCdLGcWkrB2wdp5TPT6qkjjczxeDJ8r-9lGDCKLvcs-FdjeIogKCNwsu3kPcJC2vE22Eezi1C6fHRg5jpqO2NyZvHTBLGUV0tgpUorQ431-uGgVuv0hotHA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14997'
+      X-Ms-Request-Id:
+      - 7cfc38d7-6b00-4c45-9227-43aa716a0387
+      X-Ms-Correlation-Request-Id:
+      - 7cfc38d7-6b00-4c45-9227-43aa716a0387
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T135757Z:7cfc38d7-6b00-4c45-9227-43aa716a0387
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:57:57 GMT
+      Content-Length:
+      - '183'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4","name":"miq-azure-test4","location":"eastus","properties":{"provisioningState":"Succeeded"}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:57:57 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups/miq-azure-test1?api-version=2017-08-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjI3NTMsIm5iZiI6MTUyMDg2Mjc1MywiZXhwIjoxNTIwODY2NjUzLCJhaW8iOiJZMk5nWU5qQnVUVng5OU1Kai9QZUY0akhQV2xXQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoic2xpdHpFREFBME9rUUhZRTNFY1lBQSIsInZlciI6IjEuMCJ9.Qxnn-5NYOZmogiHt-I2F53zJrRBSHKuYBrutjin7QFLQo8dufzsLR3NrLvELmnt43-mpOR7pZv7OpKrkyfVtl9xaN2WlKDLVS7ZTnQQlB-C2KGavbhf_Od1Ab4k0S2xRMKymzQmdxDF2LBBe1G4B7FLm_OIBg-DLhULmdhjxSVFTylJP7tCGHxUPaBt1B94nvKs5ZzwANQwV4ix34f07MzVJ6FckHthHCdLGcWkrB2wdp5TPT6qkjjczxeDJ8r-9lGDCKLvcs-FdjeIogKCNwsu3kPcJC2vE22Eezi1C6fHRg5jpqO2NyZvHTBLGUV0tgpUorQ431-uGgVuv0hotHA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Request-Id:
+      - f523e8f0-c197-499c-8c07-9b5111f157f0
+      X-Ms-Correlation-Request-Id:
+      - f523e8f0-c197-499c-8c07-9b5111f157f0
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T135757Z:f523e8f0-c197-499c-8c07-9b5111f157f0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:57:56 GMT
+      Content-Length:
+      - '183'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1","name":"miq-azure-test1","location":"eastus","properties":{"provisioningState":"Succeeded"}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:57:57 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups/miq-azure-test4?api-version=2017-08-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjI3NTMsIm5iZiI6MTUyMDg2Mjc1MywiZXhwIjoxNTIwODY2NjUzLCJhaW8iOiJZMk5nWU5qQnVUVng5OU1Kai9QZUY0akhQV2xXQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoic2xpdHpFREFBME9rUUhZRTNFY1lBQSIsInZlciI6IjEuMCJ9.Qxnn-5NYOZmogiHt-I2F53zJrRBSHKuYBrutjin7QFLQo8dufzsLR3NrLvELmnt43-mpOR7pZv7OpKrkyfVtl9xaN2WlKDLVS7ZTnQQlB-C2KGavbhf_Od1Ab4k0S2xRMKymzQmdxDF2LBBe1G4B7FLm_OIBg-DLhULmdhjxSVFTylJP7tCGHxUPaBt1B94nvKs5ZzwANQwV4ix34f07MzVJ6FckHthHCdLGcWkrB2wdp5TPT6qkjjczxeDJ8r-9lGDCKLvcs-FdjeIogKCNwsu3kPcJC2vE22Eezi1C6fHRg5jpqO2NyZvHTBLGUV0tgpUorQ431-uGgVuv0hotHA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14997'
+      X-Ms-Request-Id:
+      - 6986c3e3-84c5-4c67-930e-ff935cdb6c99
+      X-Ms-Correlation-Request-Id:
+      - 6986c3e3-84c5-4c67-930e-ff935cdb6c99
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T135758Z:6986c3e3-84c5-4c67-930e-ff935cdb6c99
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:57:58 GMT
+      Content-Length:
+      - '183'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4","name":"miq-azure-test4","location":"eastus","properties":{"provisioningState":"Succeeded"}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:57:58 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute/locations/eastus/vmSizes?api-version=2017-12-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjI3NTMsIm5iZiI6MTUyMDg2Mjc1MywiZXhwIjoxNTIwODY2NjUzLCJhaW8iOiJZMk5nWU5qQnVUVng5OU1Kai9QZUY0akhQV2xXQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoic2xpdHpFREFBME9rUUhZRTNFY1lBQSIsInZlciI6IjEuMCJ9.Qxnn-5NYOZmogiHt-I2F53zJrRBSHKuYBrutjin7QFLQo8dufzsLR3NrLvELmnt43-mpOR7pZv7OpKrkyfVtl9xaN2WlKDLVS7ZTnQQlB-C2KGavbhf_Od1Ab4k0S2xRMKymzQmdxDF2LBBe1G4B7FLm_OIBg-DLhULmdhjxSVFTylJP7tCGHxUPaBt1B94nvKs5ZzwANQwV4ix34f07MzVJ6FckHthHCdLGcWkrB2wdp5TPT6qkjjczxeDJ8r-9lGDCKLvcs-FdjeIogKCNwsu3kPcJC2vE22Eezi1C6fHRg5jpqO2NyZvHTBLGUV0tgpUorQ431-uGgVuv0hotHA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/LowCostGet3Min;4792,Microsoft.Compute/LowCostGet30Min;38346
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      X-Ms-Request-Id:
+      - 3c772753-dac3-4a84-b995-9b8395d96c06
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Correlation-Request-Id:
+      - 97d6724c-f602-43f8-b79d-4b172f30ad8a
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T135759Z:97d6724c-f602-43f8-b79d-4b172f30ad8a
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:57:59 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"Standard_B1ms\",\r\n
+        \     \"numberOfCores\": 1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        4096,\r\n      \"memoryInMB\": 2048,\r\n      \"maxDataDiskCount\": 2\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_B1s\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        2048,\r\n      \"memoryInMB\": 1024,\r\n      \"maxDataDiskCount\": 2\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_B2ms\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        16384,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_B2s\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        8192,\r\n      \"memoryInMB\": 4096,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_B4ms\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        32768,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_B8ms\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS1_v2\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        7168,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS2_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        14336,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS3_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS4_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS5_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS11-1_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS11_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS12-1_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS12-2_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS12_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS13-2_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS13-4_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS13_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS14-4_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        229376,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS14-8_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        229376,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS14_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        229376,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS15_v2\",\r\n      \"numberOfCores\":
+        20,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        286720,\r\n      \"memoryInMB\": 143360,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS2_v2_Promo\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        14336,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS3_v2_Promo\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS4_v2_Promo\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS5_v2_Promo\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS11_v2_Promo\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS12_v2_Promo\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS13_v2_Promo\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS14_v2_Promo\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        229376,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F1s\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        4096,\r\n      \"memoryInMB\": 2048,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F2s\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        8192,\r\n      \"memoryInMB\": 4096,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F4s\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        16384,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F8s\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        32768,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F16s\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D2s_v3\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        16384,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D4s_v3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        32768,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D8s_v3\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D16s_v3\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        131072,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D32s_v3\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        262144,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A0\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        20480,\r\n      \"memoryInMB\": 768,\r\n      \"maxDataDiskCount\": 1\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A1\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        71680,\r\n      \"memoryInMB\": 1792,\r\n      \"maxDataDiskCount\": 2\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        138240,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        291840,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A5\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        138240,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A4\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        619520,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A6\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        291840,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A7\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        619520,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Basic_A0\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        20480,\r\n      \"memoryInMB\": 768,\r\n      \"maxDataDiskCount\": 1\r\n
+        \   },\r\n    {\r\n      \"name\": \"Basic_A1\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        40960,\r\n      \"memoryInMB\": 1792,\r\n      \"maxDataDiskCount\": 2\r\n
+        \   },\r\n    {\r\n      \"name\": \"Basic_A2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        61440,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Basic_A3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        122880,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Basic_A4\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        245760,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D1_v2\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        51200,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D2_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D3_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D4_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D5_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D11_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D12_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D13_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D14_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D15_v2\",\r\n      \"numberOfCores\":
+        20,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        286720,\r\n      \"memoryInMB\": 143360,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D2_v2_Promo\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D3_v2_Promo\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D4_v2_Promo\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D5_v2_Promo\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D11_v2_Promo\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D12_v2_Promo\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D13_v2_Promo\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D14_v2_Promo\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F1\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        16384,\r\n      \"memoryInMB\": 2048,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        32768,\r\n      \"memoryInMB\": 4096,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F4\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F8\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        131072,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F16\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        262144,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A1_v2\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        10240,\r\n      \"memoryInMB\": 2048,\r\n      \"maxDataDiskCount\": 2\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A2m_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        20480,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A2_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        20480,\r\n      \"memoryInMB\": 4096,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A4m_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        40960,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A4_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        40960,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A8m_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        81920,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A8_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        81920,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D2_v3\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        51200,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D4_v3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D8_v3\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D16_v3\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 65636,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D32_v3\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_H8\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1024000,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_H16\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        2048000,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_H8m\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1024000,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_H16m\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        2048000,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_H16r\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        2048000,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_H16mr\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        2048000,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D1\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        51200,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D4\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D11\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D12\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D13\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D14\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NV6\",\r\n      \"numberOfCores\":
+        6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        389120,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 24\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NV12\",\r\n      \"numberOfCores\":
+        12,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        696320,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 48\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NV24\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1474560,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC6s_v2\",\r\n      \"numberOfCores\":
+        6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        344064,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 12\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC12s_v2\",\r\n      \"numberOfCores\":
+        12,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        688128,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 24\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC24rs_v2\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1376256,\r\n      \"memoryInMB\": 458752,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC24s_v2\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1376256,\r\n      \"memoryInMB\": 458752,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC6\",\r\n      \"numberOfCores\":
+        6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        389120,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 24\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC12\",\r\n      \"numberOfCores\":
+        12,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        696320,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 48\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC24\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1474560,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC24r\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1474560,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS1\",\r\n      \"numberOfCores\":
+        1,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        7168,\r\n      \"memoryInMB\": 3584,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        14336,\r\n      \"memoryInMB\": 7168,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS4\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS11\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        28672,\r\n      \"memoryInMB\": 14336,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS12\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        57344,\r\n      \"memoryInMB\": 28672,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS13\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        114688,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_DS14\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        229376,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC6s_v3\",\r\n      \"numberOfCores\":
+        6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        344064,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 12\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC12s_v3\",\r\n      \"numberOfCores\":
+        12,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        688128,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 24\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC24rs_v3\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1376256,\r\n      \"memoryInMB\": 458752,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_NC24s_v3\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1376256,\r\n      \"memoryInMB\": 458752,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D64_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1638400,\r\n      \"memoryInMB\": 262144,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_D64s_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        524288,\r\n      \"memoryInMB\": 262144,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E2_v3\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        51200,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E4_v3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        102400,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E8_v3\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        204800,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E16_v3\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        409600,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E32_v3\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        819200,\r\n      \"memoryInMB\": 262144,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E64i_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1638400,\r\n      \"memoryInMB\": 442368,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E64_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1638400,\r\n      \"memoryInMB\": 442368,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E2s_v3\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        32768,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E4-2s_v3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E4s_v3\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E8-2s_v3\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        131072,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E8-4s_v3\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        131072,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E8s_v3\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        131072,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E16-4s_v3\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        262144,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E16-8s_v3\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        262144,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E16s_v3\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        262144,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E32-8s_v3\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        524288,\r\n      \"memoryInMB\": 262144,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E32-16s_v3\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        524288,\r\n      \"memoryInMB\": 262144,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E32s_v3\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        524288,\r\n      \"memoryInMB\": 262144,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E64-16s_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        884736,\r\n      \"memoryInMB\": 442368,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E64-32s_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        884736,\r\n      \"memoryInMB\": 442368,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E64is_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        884736,\r\n      \"memoryInMB\": 442368,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_E64s_v3\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        884736,\r\n      \"memoryInMB\": 442368,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F2s_v2\",\r\n      \"numberOfCores\":
+        2,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        16384,\r\n      \"memoryInMB\": 4096,\r\n      \"maxDataDiskCount\": 4\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F4s_v2\",\r\n      \"numberOfCores\":
+        4,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        32768,\r\n      \"memoryInMB\": 8192,\r\n      \"maxDataDiskCount\": 8\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F8s_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        65536,\r\n      \"memoryInMB\": 16384,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F16s_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        131072,\r\n      \"memoryInMB\": 32768,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F32s_v2\",\r\n      \"numberOfCores\":
+        32,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        262144,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F64s_v2\",\r\n      \"numberOfCores\":
+        64,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        524288,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_F72s_v2\",\r\n      \"numberOfCores\":
+        72,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        589824,\r\n      \"memoryInMB\": 147456,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_L8s_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1811981,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_L16s_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        3623962,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_ND6s\",\r\n      \"numberOfCores\":
+        6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        344064,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 12\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_ND12s\",\r\n      \"numberOfCores\":
+        12,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        688128,\r\n      \"memoryInMB\": 229376,\r\n      \"maxDataDiskCount\": 24\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_ND24rs\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1376256,\r\n      \"memoryInMB\": 458752,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_ND24s\",\r\n      \"numberOfCores\":
+        24,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1376256,\r\n      \"memoryInMB\": 458752,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A8\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        391168,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A9\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        391168,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A10\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        391168,\r\n      \"memoryInMB\": 57344,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_A11\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        391168,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
+        \   }\r\n  ]\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:57:59 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/non_existent?api-version=2017-08-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjI3NTMsIm5iZiI6MTUyMDg2Mjc1MywiZXhwIjoxNTIwODY2NjUzLCJhaW8iOiJZMk5nWU5qQnVUVng5OU1Kai9QZUY0akhQV2xXQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoic2xpdHpFREFBME9rUUhZRTNFY1lBQSIsInZlciI6IjEuMCJ9.Qxnn-5NYOZmogiHt-I2F53zJrRBSHKuYBrutjin7QFLQo8dufzsLR3NrLvELmnt43-mpOR7pZv7OpKrkyfVtl9xaN2WlKDLVS7ZTnQQlB-C2KGavbhf_Od1Ab4k0S2xRMKymzQmdxDF2LBBe1G4B7FLm_OIBg-DLhULmdhjxSVFTylJP7tCGHxUPaBt1B94nvKs5ZzwANQwV4ix34f07MzVJ6FckHthHCdLGcWkrB2wdp5TPT6qkjjczxeDJ8r-9lGDCKLvcs-FdjeIogKCNwsu3kPcJC2vE22Eezi1C6fHRg5jpqO2NyZvHTBLGUV0tgpUorQ431-uGgVuv0hotHA
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      X-Ms-Failure-Cause:
+      - gateway
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14997'
+      X-Ms-Request-Id:
+      - 5dc524cf-9d9d-45db-888a-f6ad2edb15ce
+      X-Ms-Correlation-Request-Id:
+      - 5dc524cf-9d9d-45db-888a-f6ad2edb15ce
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T135800Z:5dc524cf-9d9d-45db-888a-f6ad2edb15ce
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:58:00 GMT
+      Content-Length:
+      - '97'
+    body:
+      encoding: UTF-8
+      string: '{"error":{"code":"DeploymentNotFound","message":"Deployment ''non_existent''
+        could not be found."}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:58:01 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux73-20170504152123?api-version=2017-08-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjI3NTMsIm5iZiI6MTUyMDg2Mjc1MywiZXhwIjoxNTIwODY2NjUzLCJhaW8iOiJZMk5nWU5qQnVUVng5OU1Kai9QZUY0akhQV2xXQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoic2xpdHpFREFBME9rUUhZRTNFY1lBQSIsInZlciI6IjEuMCJ9.Qxnn-5NYOZmogiHt-I2F53zJrRBSHKuYBrutjin7QFLQo8dufzsLR3NrLvELmnt43-mpOR7pZv7OpKrkyfVtl9xaN2WlKDLVS7ZTnQQlB-C2KGavbhf_Od1Ab4k0S2xRMKymzQmdxDF2LBBe1G4B7FLm_OIBg-DLhULmdhjxSVFTylJP7tCGHxUPaBt1B94nvKs5ZzwANQwV4ix34f07MzVJ6FckHthHCdLGcWkrB2wdp5TPT6qkjjczxeDJ8r-9lGDCKLvcs-FdjeIogKCNwsu3kPcJC2vE22Eezi1C6fHRg5jpqO2NyZvHTBLGUV0tgpUorQ431-uGgVuv0hotHA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14997'
+      X-Ms-Request-Id:
+      - a332a8a5-42ab-4525-b3f0-c4a1227bb417
+      X-Ms-Correlation-Request-Id:
+      - a332a8a5-42ab-4525-b3f0-c4a1227bb417
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T135801Z:a332a8a5-42ab-4525-b3f0-c4a1227bb417
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:58:00 GMT
+      Content-Length:
+      - '3655'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux73-20170504152123","name":"RedHat.RedHatEnterpriseLinux73-20170504152123","properties":{"templateHash":"17557892638005511562","parameters":{"location":{"type":"String","value":"eastus"},"virtualMachineName":{"type":"String","value":"miqazure-linux-managed"},"virtualMachineSize":{"type":"String","value":"Basic_A0"},"adminUsername":{"type":"String","value":"dberger"},"virtualNetworkName":{"type":"String","value":"miq-azure-test2"},"networkInterfaceName":{"type":"String","value":"miqazure-linux-manag944"},"networkSecurityGroupName":{"type":"String","value":"miqazure-linux-managed-nsg"},"adminPassword":{"type":"SecureString"},"subnetName":{"type":"String","value":"default"},"publicIpAddressName":{"type":"String","value":"miqazure-linux-managed-ip"},"publicIpAddressType":{"type":"String","value":"Dynamic"}},"mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
+        ResponseContent"},"provisioningState":"Succeeded","timestamp":"2017-05-04T21:24:59.0046283Z","duration":"PT3M31.8448945S","correlationId":"574cca40-c924-4c37-a5d7-8dba697b1afe","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkInterfaces","locations":["eastus"]},{"resourceType":"publicIpAddresses","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miqazure-linux-manag944"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miqazure-linux-managed"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIpAddresses/miqazure-linux-managed-ip","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miqazure-linux-managed-ip"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miqazure-linux-managed-nsg"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miqazure-linux-manag944"}],"outputs":{"adminUsername":{"type":"String","value":"dberger"}},"outputResources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIpAddresses/miqazure-linux-managed-ip"}]}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:58:01 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950?api-version=2017-08-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjI3NTMsIm5iZiI6MTUyMDg2Mjc1MywiZXhwIjoxNTIwODY2NjUzLCJhaW8iOiJZMk5nWU5qQnVUVng5OU1Kai9QZUY0akhQV2xXQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoic2xpdHpFREFBME9rUUhZRTNFY1lBQSIsInZlciI6IjEuMCJ9.Qxnn-5NYOZmogiHt-I2F53zJrRBSHKuYBrutjin7QFLQo8dufzsLR3NrLvELmnt43-mpOR7pZv7OpKrkyfVtl9xaN2WlKDLVS7ZTnQQlB-C2KGavbhf_Od1Ab4k0S2xRMKymzQmdxDF2LBBe1G4B7FLm_OIBg-DLhULmdhjxSVFTylJP7tCGHxUPaBt1B94nvKs5ZzwANQwV4ix34f07MzVJ6FckHthHCdLGcWkrB2wdp5TPT6qkjjczxeDJ8r-9lGDCKLvcs-FdjeIogKCNwsu3kPcJC2vE22Eezi1C6fHRg5jpqO2NyZvHTBLGUV0tgpUorQ431-uGgVuv0hotHA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14997'
+      X-Ms-Request-Id:
+      - a552a1de-1f88-4441-aa49-61b159992549
+      X-Ms-Correlation-Request-Id:
+      - a552a1de-1f88-4441-aa49-61b159992549
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T135802Z:a552a1de-1f88-4441-aa49-61b159992549
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:58:02 GMT
+      Content-Length:
+      - '5882'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950","name":"OpenLogic.CentOSbased71-20160221104950","properties":{"parameters":{"location":{"type":"String","value":"eastus"},"virtualMachineName":{"type":"String","value":"miqazure-centos1"},"virtualMachineSize":{"type":"String","value":"Basic_A0"},"adminUsername":{"type":"String","value":"dberger"},"storageAccountName":{"type":"String","value":"miqazuretest14047"},"virtualNetworkName":{"type":"String","value":"miq-azure-test1"},"networkInterfaceName":{"type":"String","value":"miqazure-centos1611"},"networkSecurityGroupName":{"type":"String","value":"miqazure-centos1"},"adminPassword":{"type":"SecureString"},"availabilitySetName":{"type":"String","value":"miqazure-availset-east"},"availabilitySetPlatformFaultDomainCount":{"type":"String","value":"3"},"availabilitySetPlatformUpdateDomainCount":{"type":"String","value":"5"},"diagnosticsStorageAccountName":{"type":"String","value":"miqazuretest14047"},"diagnosticsStorageAccountId":{"type":"String","value":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047"},"subnetName":{"type":"String","value":"default"},"publicIpAddressName":{"type":"String","value":"miqazure-centos1"},"publicIpAddressType":{"type":"String","value":"Dynamic"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-03-21T16:55:03.9867512Z","duration":"PT5M11.803863S","correlationId":"c3daf7bc-96ed-4987-89ba-ed85952a355c","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]},{"resourceType":"virtualMachines/extensions","locations":["eastus"]},{"resourceType":"availabilitySets","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkInterfaces","locations":["eastus"]},{"resourceType":"publicIpAddresses","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miqazure-centos1611"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/miqazure-availset-east","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"miqazure-availset-east"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miqazure-centos1"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miqazure-centos1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","actionName":"listKeys","apiVersion":"2015-05-01-preview"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miqazure-centos1/Microsoft.Insights.VMDiagnosticsSettings"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miqazure-centos1","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miqazure-centos1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miqazure-centos1"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miqazure-centos1611"}],"outputs":{"adminUsername":{"type":"String","value":"dberger"}},"outputResources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/miqazure-availset-east"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1/extensions/Microsoft.Insights.VMDiagnosticsSettings"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miqazure-centos1"}]}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:58:02 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250?api-version=2017-08-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjI3NTMsIm5iZiI6MTUyMDg2Mjc1MywiZXhwIjoxNTIwODY2NjUzLCJhaW8iOiJZMk5nWU5qQnVUVng5OU1Kai9QZUY0akhQV2xXQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoic2xpdHpFREFBME9rUUhZRTNFY1lBQSIsInZlciI6IjEuMCJ9.Qxnn-5NYOZmogiHt-I2F53zJrRBSHKuYBrutjin7QFLQo8dufzsLR3NrLvELmnt43-mpOR7pZv7OpKrkyfVtl9xaN2WlKDLVS7ZTnQQlB-C2KGavbhf_Od1Ab4k0S2xRMKymzQmdxDF2LBBe1G4B7FLm_OIBg-DLhULmdhjxSVFTylJP7tCGHxUPaBt1B94nvKs5ZzwANQwV4ix34f07MzVJ6FckHthHCdLGcWkrB2wdp5TPT6qkjjczxeDJ8r-9lGDCKLvcs-FdjeIogKCNwsu3kPcJC2vE22Eezi1C6fHRg5jpqO2NyZvHTBLGUV0tgpUorQ431-uGgVuv0hotHA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Request-Id:
+      - b86f7e4d-abad-445d-9d36-32593f75ab10
+      X-Ms-Correlation-Request-Id:
+      - b86f7e4d-abad-445d-9d36-32593f75ab10
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T135803Z:b86f7e4d-abad-445d-9d36-32593f75ab10
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:58:02 GMT
+      Content-Length:
+      - '6266'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250","name":"RedHat.RedHatEnterpriseLinux72-20160218112250","properties":{"parameters":{"location":{"type":"String","value":"eastus"},"virtualMachineName":{"type":"String","value":"miq-test-rhel1"},"virtualMachineSize":{"type":"String","value":"Basic_A0"},"adminUsername":{"type":"String","value":"dberger"},"storageAccountName":{"type":"String","value":"miqazuretest18686"},"virtualNetworkName":{"type":"String","value":"miq-azure-test1"},"networkInterfaceName":{"type":"String","value":"miq-test-rhel1390"},"networkSecurityGroupName":{"type":"String","value":"miq-test-rhel1"},"adminPassword":{"type":"SecureString"},"storageAccountType":{"type":"String","value":"Standard_LRS"},"diagnosticsStorageAccountName":{"type":"String","value":"miqazuretest18686"},"diagnosticsStorageAccountId":{"type":"String","value":"Microsoft.Storage/storageAccounts/miqazuretest18686"},"diagnosticsStorageAccountType":{"type":"String","value":"Standard_LRS"},"addressPrefix":{"type":"String","value":"10.16.0.0/16"},"subnetName":{"type":"String","value":"default"},"subnetPrefix":{"type":"String","value":"10.16.0.0/24"},"publicIpAddressName":{"type":"String","value":"miq-test-rhel1"},"publicIpAddressType":{"type":"String","value":"Dynamic"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-03-18T17:28:57.6212521Z","duration":"PT6M6.1062402S","correlationId":"3222315f-f31e-4ee7-b405-4d40dfd500a3","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]},{"resourceType":"virtualMachines/extensions","locations":["eastus"]}]},{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]},{"resourceType":"publicIpAddresses","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-rhel1390"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-rhel1"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-rhel1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686","actionName":"listKeys","apiVersion":"2015-05-01-preview"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-rhel1/Microsoft.Insights.VMDiagnosticsSettings"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"miq-azure-test1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-rhel1","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-rhel1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-rhel1"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-rhel1390"}],"outputs":{"adminUsername":{"type":"String","value":"dberger"}},"outputResources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/extensions/Microsoft.Insights.VMDiagnosticsSettings"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-rhel1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686"}]}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:58:03 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/non_existent?api-version=2017-08-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjI3NTMsIm5iZiI6MTUyMDg2Mjc1MywiZXhwIjoxNTIwODY2NjUzLCJhaW8iOiJZMk5nWU5qQnVUVng5OU1Kai9QZUY0akhQV2xXQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoic2xpdHpFREFBME9rUUhZRTNFY1lBQSIsInZlciI6IjEuMCJ9.Qxnn-5NYOZmogiHt-I2F53zJrRBSHKuYBrutjin7QFLQo8dufzsLR3NrLvELmnt43-mpOR7pZv7OpKrkyfVtl9xaN2WlKDLVS7ZTnQQlB-C2KGavbhf_Od1Ab4k0S2xRMKymzQmdxDF2LBBe1G4B7FLm_OIBg-DLhULmdhjxSVFTylJP7tCGHxUPaBt1B94nvKs5ZzwANQwV4ix34f07MzVJ6FckHthHCdLGcWkrB2wdp5TPT6qkjjczxeDJ8r-9lGDCKLvcs-FdjeIogKCNwsu3kPcJC2vE22Eezi1C6fHRg5jpqO2NyZvHTBLGUV0tgpUorQ431-uGgVuv0hotHA
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      X-Ms-Failure-Cause:
+      - gateway
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14997'
+      X-Ms-Request-Id:
+      - d215377e-6486-460d-8699-e35305ce326b
+      X-Ms-Correlation-Request-Id:
+      - d215377e-6486-460d-8699-e35305ce326b
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T135803Z:d215377e-6486-460d-8699-e35305ce326b
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:58:03 GMT
+      Content-Length:
+      - '97'
+    body:
+      encoding: UTF-8
+      string: '{"error":{"code":"DeploymentNotFound","message":"Deployment ''non_existent''
+        could not be found."}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:58:03 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjI3NTMsIm5iZiI6MTUyMDg2Mjc1MywiZXhwIjoxNTIwODY2NjUzLCJhaW8iOiJZMk5nWU5qQnVUVng5OU1Kai9QZUY0akhQV2xXQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoic2xpdHpFREFBME9rUUhZRTNFY1lBQSIsInZlciI6IjEuMCJ9.Qxnn-5NYOZmogiHt-I2F53zJrRBSHKuYBrutjin7QFLQo8dufzsLR3NrLvELmnt43-mpOR7pZv7OpKrkyfVtl9xaN2WlKDLVS7ZTnQQlB-C2KGavbhf_Od1Ab4k0S2xRMKymzQmdxDF2LBBe1G4B7FLm_OIBg-DLhULmdhjxSVFTylJP7tCGHxUPaBt1B94nvKs5ZzwANQwV4ix34f07MzVJ6FckHthHCdLGcWkrB2wdp5TPT6qkjjczxeDJ8r-9lGDCKLvcs-FdjeIogKCNwsu3kPcJC2vE22Eezi1C6fHRg5jpqO2NyZvHTBLGUV0tgpUorQ431-uGgVuv0hotHA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"2080997a-38a6-420d-ba86-e9582e1331c7"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 760b6a2c-2620-438f-b9ab-2001a89c79db
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Correlation-Request-Id:
+      - a3997115-190e-4c66-afdf-21a2e28fbf73
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T135804Z:a3997115-190e-4c66-afdf-21a2e28fbf73
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:58:03 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"spec0deply1ip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip\",\r\n
+        \ \"etag\": \"W/\\\"2080997a-38a6-420d-ba86-e9582e1331c7\\\"\",\r\n  \"location\":
+        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"a08b891e-e45a-4970-aefc-f6c996989490\",\r\n    \"publicIPAddressVersion\":
         \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
-        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
+        4,\r\n    \"dnsSettings\": {\r\n      \"domainNameLabel\": \"spec0deply1dns\",\r\n
+        \     \"fqdn\": \"spec0deply1dns.eastus.cloudapp.azure.com\"\r\n    },\r\n
+        \   \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
         \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
         \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:26 GMT
+  recorded_at: Mon, 12 Mar 2018 13:58:04 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqazure-linux-managed-ip?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjI3NTMsIm5iZiI6MTUyMDg2Mjc1MywiZXhwIjoxNTIwODY2NjUzLCJhaW8iOiJZMk5nWU5qQnVUVng5OU1Kai9QZUY0akhQV2xXQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoic2xpdHpFREFBME9rUUhZRTNFY1lBQSIsInZlciI6IjEuMCJ9.Qxnn-5NYOZmogiHt-I2F53zJrRBSHKuYBrutjin7QFLQo8dufzsLR3NrLvELmnt43-mpOR7pZv7OpKrkyfVtl9xaN2WlKDLVS7ZTnQQlB-C2KGavbhf_Od1Ab4k0S2xRMKymzQmdxDF2LBBe1G4B7FLm_OIBg-DLhULmdhjxSVFTylJP7tCGHxUPaBt1B94nvKs5ZzwANQwV4ix34f07MzVJ6FckHthHCdLGcWkrB2wdp5TPT6qkjjczxeDJ8r-9lGDCKLvcs-FdjeIogKCNwsu3kPcJC2vE22Eezi1C6fHRg5jpqO2NyZvHTBLGUV0tgpUorQ431-uGgVuv0hotHA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"0efc9684-fb7d-4fb7-b9b9-f33dbac04a28"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 1f6502a8-689e-4ed4-88c9-097bee7af192
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14997'
+      X-Ms-Correlation-Request-Id:
+      - 2b44985f-b4c1-45cc-a818-81a6b72b26fc
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T135804Z:2b44985f-b4c1-45cc-a818-81a6b72b26fc
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:58:04 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"miqazure-linux-managed-ip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqazure-linux-managed-ip\",\r\n
+        \ \"etag\": \"W/\\\"0efc9684-fb7d-4fb7-b9b9-f33dbac04a28\\\"\",\r\n  \"location\":
+        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"6a2a9142-26e8-45cd-93bf-7318192f3528\",\r\n    \"publicIPAddressVersion\":
+        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
+        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944/ipConfigurations/ipconfig1\"\r\n
+        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
+        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:58:05 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjI3NTMsIm5iZiI6MTUyMDg2Mjc1MywiZXhwIjoxNTIwODY2NjUzLCJhaW8iOiJZMk5nWU5qQnVUVng5OU1Kai9QZUY0akhQV2xXQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoic2xpdHpFREFBME9rUUhZRTNFY1lBQSIsInZlciI6IjEuMCJ9.Qxnn-5NYOZmogiHt-I2F53zJrRBSHKuYBrutjin7QFLQo8dufzsLR3NrLvELmnt43-mpOR7pZv7OpKrkyfVtl9xaN2WlKDLVS7ZTnQQlB-C2KGavbhf_Od1Ab4k0S2xRMKymzQmdxDF2LBBe1G4B7FLm_OIBg-DLhULmdhjxSVFTylJP7tCGHxUPaBt1B94nvKs5ZzwANQwV4ix34f07MzVJ6FckHthHCdLGcWkrB2wdp5TPT6qkjjczxeDJ8r-9lGDCKLvcs-FdjeIogKCNwsu3kPcJC2vE22Eezi1C6fHRg5jpqO2NyZvHTBLGUV0tgpUorQ431-uGgVuv0hotHA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"734a3944-a880-444c-8c92-cace6e28e303"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - a76e7f4b-29b2-4994-9e2b-d9f9d73f0d3e
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Correlation-Request-Id:
+      - 4663b880-6161-4844-ad34-b0716ba4688d
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T135805Z:4663b880-6161-4844-ad34-b0716ba4688d
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:58:05 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"miqazure-centos1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1\",\r\n
+        \ \"etag\": \"W/\\\"734a3944-a880-444c-8c92-cace6e28e303\\\"\",\r\n  \"location\":
+        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"475a66f0-9e89-4226-a9f0-9baaaf31d619\",\r\n    \"publicIPAddressVersion\":
+        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
+        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1\"\r\n
+        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
+        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:58:05 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjI3NTMsIm5iZiI6MTUyMDg2Mjc1MywiZXhwIjoxNTIwODY2NjUzLCJhaW8iOiJZMk5nWU5qQnVUVng5OU1Kai9QZUY0akhQV2xXQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoic2xpdHpFREFBME9rUUhZRTNFY1lBQSIsInZlciI6IjEuMCJ9.Qxnn-5NYOZmogiHt-I2F53zJrRBSHKuYBrutjin7QFLQo8dufzsLR3NrLvELmnt43-mpOR7pZv7OpKrkyfVtl9xaN2WlKDLVS7ZTnQQlB-C2KGavbhf_Od1Ab4k0S2xRMKymzQmdxDF2LBBe1G4B7FLm_OIBg-DLhULmdhjxSVFTylJP7tCGHxUPaBt1B94nvKs5ZzwANQwV4ix34f07MzVJ6FckHthHCdLGcWkrB2wdp5TPT6qkjjczxeDJ8r-9lGDCKLvcs-FdjeIogKCNwsu3kPcJC2vE22Eezi1C6fHRg5jpqO2NyZvHTBLGUV0tgpUorQ431-uGgVuv0hotHA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"054052bb-11ff-4f6e-ac1a-3427c2fd17aa"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 3256ef01-d0c0-4c81-8a17-a8b2fe6b775d
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Correlation-Request-Id:
+      - 5d822d7c-1a07-4abc-a7ac-20516bc135dc
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T135805Z:5d822d7c-1a07-4abc-a7ac-20516bc135dc
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:58:05 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"miq-test-rhel1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1\",\r\n
+        \ \"etag\": \"W/\\\"054052bb-11ff-4f6e-ac1a-3427c2fd17aa\\\"\",\r\n  \"location\":
+        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"f6cfc635-411e-48ce-a627-39a2fc0d3168\",\r\n    \"ipAddress\":
+        \"52.224.165.15\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\":
+        \"Dynamic\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipTags\": [],\r\n
+        \   \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1\"\r\n
+        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
+        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:58:06 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/disks/miqazure-linux-managed-data-disk?api-version=2017-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjI3NTMsIm5iZiI6MTUyMDg2Mjc1MywiZXhwIjoxNTIwODY2NjUzLCJhaW8iOiJZMk5nWU5qQnVUVng5OU1Kai9QZUY0akhQV2xXQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoic2xpdHpFREFBME9rUUhZRTNFY1lBQSIsInZlciI6IjEuMCJ9.Qxnn-5NYOZmogiHt-I2F53zJrRBSHKuYBrutjin7QFLQo8dufzsLR3NrLvELmnt43-mpOR7pZv7OpKrkyfVtl9xaN2WlKDLVS7ZTnQQlB-C2KGavbhf_Od1Ab4k0S2xRMKymzQmdxDF2LBBe1G4B7FLm_OIBg-DLhULmdhjxSVFTylJP7tCGHxUPaBt1B94nvKs5ZzwANQwV4ix34f07MzVJ6FckHthHCdLGcWkrB2wdp5TPT6qkjjczxeDJ8r-9lGDCKLvcs-FdjeIogKCNwsu3kPcJC2vE22Eezi1C6fHRg5jpqO2NyZvHTBLGUV0tgpUorQ431-uGgVuv0hotHA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/LowCostGet3Min;4999,Microsoft.Compute/LowCostGet30Min;19999
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131626781321631045
+      X-Ms-Request-Id:
+      - 4f44ee0e-74ac-49c3-b240-79f4a1e3c5e0
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Correlation-Request-Id:
+      - d5da4f3e-e9e7-4172-99e9-bfeaad627123
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T135806Z:d5da4f3e-e9e7-4172-99e9-bfeaad627123
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:58:06 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"managedBy\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed\",\r\n
+        \ \"sku\": {\r\n    \"name\": \"Standard_LRS\",\r\n    \"tier\": \"Standard\"\r\n
+        \ },\r\n  \"properties\": {\r\n    \"creationData\": {\r\n      \"createOption\":
+        \"Empty\"\r\n    },\r\n    \"diskSizeGB\": 1,\r\n    \"timeCreated\": \"2017-10-23T17:34:14.7022771+00:00\",\r\n
+        \   \"provisioningState\": \"Succeeded\",\r\n    \"diskState\": \"Reserved\"\r\n
+        \ },\r\n  \"type\": \"Microsoft.Compute/disks\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/disks/miqazure-linux-managed-data-disk\",\r\n
+        \ \"name\": \"miqazure-linux-managed-data-disk\"\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:58:06 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/disks/miqazure-linux-managed_OsDisk_1_7b2bdf790a7d4379ace2846d307730cd?api-version=2017-03-30
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjI3NTMsIm5iZiI6MTUyMDg2Mjc1MywiZXhwIjoxNTIwODY2NjUzLCJhaW8iOiJZMk5nWU5qQnVUVng5OU1Kai9QZUY0akhQV2xXQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoic2xpdHpFREFBME9rUUhZRTNFY1lBQSIsInZlciI6IjEuMCJ9.Qxnn-5NYOZmogiHt-I2F53zJrRBSHKuYBrutjin7QFLQo8dufzsLR3NrLvELmnt43-mpOR7pZv7OpKrkyfVtl9xaN2WlKDLVS7ZTnQQlB-C2KGavbhf_Od1Ab4k0S2xRMKymzQmdxDF2LBBe1G4B7FLm_OIBg-DLhULmdhjxSVFTylJP7tCGHxUPaBt1B94nvKs5ZzwANQwV4ix34f07MzVJ6FckHthHCdLGcWkrB2wdp5TPT6qkjjczxeDJ8r-9lGDCKLvcs-FdjeIogKCNwsu3kPcJC2vE22Eezi1C6fHRg5jpqO2NyZvHTBLGUV0tgpUorQ431-uGgVuv0hotHA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/LowCostGet3Min;4998,Microsoft.Compute/LowCostGet30Min;19998
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131626781321631045
+      X-Ms-Request-Id:
+      - b6dd6924-c141-46ee-b737-e765edd20951
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Correlation-Request-Id:
+      - 527f8f66-3f7f-44bb-b462-86a87c6dc854
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T135807Z:527f8f66-3f7f-44bb-b462-86a87c6dc854
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:58:06 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"managedBy\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed\",\r\n
+        \ \"sku\": {\r\n    \"name\": \"Standard_LRS\",\r\n    \"tier\": \"Standard\"\r\n
+        \ },\r\n  \"properties\": {\r\n    \"osType\": \"Linux\",\r\n    \"creationData\":
+        {\r\n      \"createOption\": \"FromImage\",\r\n      \"imageReference\": {\r\n
+        \       \"id\": \"/Subscriptions/AZURE_SUBSCRIPTION_ID/Providers/Microsoft.Compute/Locations/eastus/Publishers/RedHat/ArtifactTypes/VMImage/Offers/RHEL/Skus/7.3/Versions/latest\"\r\n
+        \     }\r\n    },\r\n    \"diskSizeGB\": 32,\r\n    \"timeCreated\": \"2017-05-04T21:21:55.7801928+00:00\",\r\n
+        \   \"provisioningState\": \"Succeeded\",\r\n    \"diskState\": \"Reserved\"\r\n
+        \ },\r\n  \"type\": \"Microsoft.Compute/disks\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"tags\": {\r\n    \"delete\": \"false\"\r\n  },\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/disks/miqazure-linux-managed_OsDisk_1_7b2bdf790a7d4379ace2846d307730cd\",\r\n
+        \ \"name\": \"miqazure-linux-managed_OsDisk_1_7b2bdf790a7d4379ace2846d307730cd\"\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:58:07 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686?api-version=2017-10-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjI3NTMsIm5iZiI6MTUyMDg2Mjc1MywiZXhwIjoxNTIwODY2NjUzLCJhaW8iOiJZMk5nWU5qQnVUVng5OU1Kai9QZUY0akhQV2xXQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoic2xpdHpFREFBME9rUUhZRTNFY1lBQSIsInZlciI6IjEuMCJ9.Qxnn-5NYOZmogiHt-I2F53zJrRBSHKuYBrutjin7QFLQo8dufzsLR3NrLvELmnt43-mpOR7pZv7OpKrkyfVtl9xaN2WlKDLVS7ZTnQQlB-C2KGavbhf_Od1Ab4k0S2xRMKymzQmdxDF2LBBe1G4B7FLm_OIBg-DLhULmdhjxSVFTylJP7tCGHxUPaBt1B94nvKs5ZzwANQwV4ix34f07MzVJ6FckHthHCdLGcWkrB2wdp5TPT6qkjjczxeDJ8r-9lGDCKLvcs-FdjeIogKCNwsu3kPcJC2vE22Eezi1C6fHRg5jpqO2NyZvHTBLGUV0tgpUorQ431-uGgVuv0hotHA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 204a9914-eb9a-4596-8e33-87ef31d1d11d
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Correlation-Request-Id:
+      - d5466fa9-598e-45d9-a3a2-1154f6bce14b
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T135808Z:d5466fa9-598e-45d9-a3a2-1154f6bce14b
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:58:08 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","name":"miqazuretest18686","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T17:22:54.7808677Z","primaryEndpoints":{"blob":"https://miqazuretest18686.blob.core.windows.net/","queue":"https://miqazuretest18686.queue.core.windows.net/","table":"https://miqazuretest18686.table.core.windows.net/","file":"https://miqazuretest18686.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:58:08 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047?api-version=2017-10-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjI3NTMsIm5iZiI6MTUyMDg2Mjc1MywiZXhwIjoxNTIwODY2NjUzLCJhaW8iOiJZMk5nWU5qQnVUVng5OU1Kai9QZUY0akhQV2xXQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoic2xpdHpFREFBME9rUUhZRTNFY1lBQSIsInZlciI6IjEuMCJ9.Qxnn-5NYOZmogiHt-I2F53zJrRBSHKuYBrutjin7QFLQo8dufzsLR3NrLvELmnt43-mpOR7pZv7OpKrkyfVtl9xaN2WlKDLVS7ZTnQQlB-C2KGavbhf_Od1Ab4k0S2xRMKymzQmdxDF2LBBe1G4B7FLm_OIBg-DLhULmdhjxSVFTylJP7tCGHxUPaBt1B94nvKs5ZzwANQwV4ix34f07MzVJ6FckHthHCdLGcWkrB2wdp5TPT6qkjjczxeDJ8r-9lGDCKLvcs-FdjeIogKCNwsu3kPcJC2vE22Eezi1C6fHRg5jpqO2NyZvHTBLGUV0tgpUorQ431-uGgVuv0hotHA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - df4ad0c9-5292-4f7a-933a-261af680019c
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Correlation-Request-Id:
+      - fce5e4e5-93f4-47fd-9af7-cee0c8efe41b
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T135808Z:fce5e4e5-93f4-47fd-9af7-cee0c8efe41b
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:58:08 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","name":"miqazuretest14047","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T17:30:25.7028008Z","primaryEndpoints":{"blob":"https://miqazuretest14047.blob.core.windows.net/","queue":"https://miqazuretest14047.queue.core.windows.net/","table":"https://miqazuretest14047.table.core.windows.net/","file":"https://miqazuretest14047.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:58:09 GMT
+- request:
+    method: post
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686/listKeys?api-version=2017-10-01
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjI3NTMsIm5iZiI6MTUyMDg2Mjc1MywiZXhwIjoxNTIwODY2NjUzLCJhaW8iOiJZMk5nWU5qQnVUVng5OU1Kai9QZUY0akhQV2xXQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoic2xpdHpFREFBME9rUUhZRTNFY1lBQSIsInZlciI6IjEuMCJ9.Qxnn-5NYOZmogiHt-I2F53zJrRBSHKuYBrutjin7QFLQo8dufzsLR3NrLvELmnt43-mpOR7pZv7OpKrkyfVtl9xaN2WlKDLVS7ZTnQQlB-C2KGavbhf_Od1Ab4k0S2xRMKymzQmdxDF2LBBe1G4B7FLm_OIBg-DLhULmdhjxSVFTylJP7tCGHxUPaBt1B94nvKs5ZzwANQwV4ix34f07MzVJ6FckHthHCdLGcWkrB2wdp5TPT6qkjjczxeDJ8r-9lGDCKLvcs-FdjeIogKCNwsu3kPcJC2vE22Eezi1C6fHRg5jpqO2NyZvHTBLGUV0tgpUorQ431-uGgVuv0hotHA
+      Content-Length:
+      - '0'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - f897eae9-3c28-4c4f-ba5f-e265a4c44dfe
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Writes:
+      - '1199'
+      X-Ms-Correlation-Request-Id:
+      - 8c53795e-beb9-478d-96cc-a56f610f511f
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T135809Z:8c53795e-beb9-478d-96cc-a56f610f511f
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:58:08 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"keys":[{"keyName":"key1","value":"32PV5jeBt8nw1XvFbZokY26SXchbD6H2tw/YrteEYVE0kpMLKrZ74VrwaIjDyucdi/RxDaAlf7dJIilLS7muNw==","permissions":"Full"},{"keyName":"key2","value":"Eo5x9CQJL1/wl6Tkj5N7M5eEdw6Hym6AeyTt3xjcDl30sV8Iadro6ywZzOHQwNDlmrDaBF6x2a9ZFL7zswxQ7w==","permissions":"Full"}]}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:58:09 GMT
+- request:
+    method: post
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047/listKeys?api-version=2017-10-01
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjI3NTMsIm5iZiI6MTUyMDg2Mjc1MywiZXhwIjoxNTIwODY2NjUzLCJhaW8iOiJZMk5nWU5qQnVUVng5OU1Kai9QZUY0akhQV2xXQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoic2xpdHpFREFBME9rUUhZRTNFY1lBQSIsInZlciI6IjEuMCJ9.Qxnn-5NYOZmogiHt-I2F53zJrRBSHKuYBrutjin7QFLQo8dufzsLR3NrLvELmnt43-mpOR7pZv7OpKrkyfVtl9xaN2WlKDLVS7ZTnQQlB-C2KGavbhf_Od1Ab4k0S2xRMKymzQmdxDF2LBBe1G4B7FLm_OIBg-DLhULmdhjxSVFTylJP7tCGHxUPaBt1B94nvKs5ZzwANQwV4ix34f07MzVJ6FckHthHCdLGcWkrB2wdp5TPT6qkjjczxeDJ8r-9lGDCKLvcs-FdjeIogKCNwsu3kPcJC2vE22Eezi1C6fHRg5jpqO2NyZvHTBLGUV0tgpUorQ431-uGgVuv0hotHA
+      Content-Length:
+      - '0'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 1325fa39-55af-4c1b-ab61-f4c92851fd38
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Writes:
+      - '1199'
+      X-Ms-Correlation-Request-Id:
+      - 873672c4-d99e-477e-be9c-155b71d512f7
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T135810Z:873672c4-d99e-477e-be9c-155b71d512f7
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:58:09 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"keys":[{"keyName":"key1","value":"9hGLwV9mjvAc1ARzeGwpsS9oZPLqOBzHCCHjeixyt1wpPYVn32cXmm3Gs9ogFPXZhDH61PAXxud0Dg/qwOnJ1w==","permissions":"Full"},{"keyName":"key2","value":"FfW8btVjJE2LkKHvN8Prr3FDX71BrS4SnMkONq2fLVPPm6x7vqqjeDSWDh17aI4CBLYf3Y1pc6njkbz53HdMYg==","permissions":"Full"}]}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:58:10 GMT
+- request:
+    method: head
+    uri: https://miqazuretest18686.blob.core.windows.net/vhds/miq-test-rhel12016218112243.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 13:58:10 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey miqazuretest18686:jAwgf0CmiaBWC6ORsOebCe8ruu6lWAq77yXMFItFhlI=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '32212255232'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - dQL+XHjFNPdoMEweI63fwQ==
+      Last-Modified:
+      - Mon, 12 Mar 2018 13:58:05 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D588214729BBEE"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 3c5e772c-001e-00e4-2d0a-ba3575000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Meta-Microsoftazurecompute-Resourcegroupname:
+      - miq-azure-test1
+      X-Ms-Meta-Microsoftazurecompute-Vmname:
+      - miq-test-rhel1
+      X-Ms-Meta-Microsoftazurecompute-Diskid:
+      - 0ea91415-9058-46c6-9792-3afcb4da976f
+      X-Ms-Meta-Microsoftazurecompute-Diskname:
+      - miq-test-rhel1
+      X-Ms-Meta-Microsoftazurecompute-Disktype:
+      - OSDisk
+      X-Ms-Lease-Status:
+      - locked
+      X-Ms-Lease-State:
+      - leased
+      X-Ms-Lease-Duration:
+      - infinite
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '372'
+      X-Ms-Copy-Id:
+      - b967ea05-82a2-405a-8df9-4615d59df4eb
+      X-Ms-Copy-Source:
+      - https://ardfepirv2bl5prdstr06.blob.core.windows.net/a879bbefc56a43abb0ce65052aac09f3/rhel-72-20160302?sv=2014-02-14&sr=b&si=PirCacheAccountPublisherContainerPolicy&sig=2TQ3SKHqVnqe4jVKB4qMCBOphv2nYelKworI7pfckrs%3D
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 32212255232/32212255232
+      X-Ms-Copy-Completion-Time:
+      - Fri, 18 Mar 2016 17:23:28 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Mon, 12 Mar 2018 13:58:11 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:58:11 GMT
+- request:
+    method: head
+    uri: https://miqazuretest14047.blob.core.windows.net/vhds/miqazure-centos12016221104946.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 13:58:11 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey miqazuretest14047:f6nmDdArO8ZLlkqYLP50QFG94EtT7v7OoYzU43Ys4a8=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '32212255232'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - bLK7rgT7IgMNX2YxL9BCyg==
+      Last-Modified:
+      - Fri, 22 Apr 2016 19:05:58 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D36AE123954B35"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 4bfa03b2-001e-003c-1d0a-ba92a4000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Meta-Microsoftazurecompute-Resourcegroupname:
+      - miq-azure-test1
+      X-Ms-Meta-Microsoftazurecompute-Vmname:
+      - miqazure-centos1
+      X-Ms-Meta-Microsoftazurecompute-Diskid:
+      - 66656abf-e460-45ac-a6f0-851d0a50b23a
+      X-Ms-Meta-Microsoftazurecompute-Diskname:
+      - miqazure-centos1
+      X-Ms-Meta-Microsoftazurecompute-Disktype:
+      - OSDisk
+      X-Ms-Lease-Status:
+      - locked
+      X-Ms-Lease-State:
+      - leased
+      X-Ms-Lease-Duration:
+      - infinite
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '1'
+      X-Ms-Copy-Id:
+      - 549dd428-4055-4337-a425-05293b903858
+      X-Ms-Copy-Source:
+      - https://ardfepirv2bl5prdstr06.blob.core.windows.net/5112500ae3b842c8b9c604889f8753c3/OpenLogic-CentOS-71-20160308?sv=2014-02-14&sr=b&si=PirCacheAccountPublisherContainerPolicy&sig=fxe20jiCl%2Foys9OSvljXlookVPi76KM8FYlTr%2BSY4IQ%3D
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 32212255232/32212255232
+      X-Ms-Copy-Completion-Time:
+      - Mon, 21 Mar 2016 16:50:14 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Mon, 12 Mar 2018 13:58:16 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:58:16 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjI3NTMsIm5iZiI6MTUyMDg2Mjc1MywiZXhwIjoxNTIwODY2NjUzLCJhaW8iOiJZMk5nWU5qQnVUVng5OU1Kai9QZUY0akhQV2xXQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoic2xpdHpFREFBME9rUUhZRTNFY1lBQSIsInZlciI6IjEuMCJ9.Qxnn-5NYOZmogiHt-I2F53zJrRBSHKuYBrutjin7QFLQo8dufzsLR3NrLvELmnt43-mpOR7pZv7OpKrkyfVtl9xaN2WlKDLVS7ZTnQQlB-C2KGavbhf_Od1Ab4k0S2xRMKymzQmdxDF2LBBe1G4B7FLm_OIBg-DLhULmdhjxSVFTylJP7tCGHxUPaBt1B94nvKs5ZzwANQwV4ix34f07MzVJ6FckHthHCdLGcWkrB2wdp5TPT6qkjjczxeDJ8r-9lGDCKLvcs-FdjeIogKCNwsu3kPcJC2vE22Eezi1C6fHRg5jpqO2NyZvHTBLGUV0tgpUorQ431-uGgVuv0hotHA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - f8fc69dd-fb63-45f8-aef5-eac0450d49ea
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Correlation-Request-Id:
+      - 1256967a-b50c-4efb-8e4b-fe1908467482
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T135817Z:1256967a-b50c-4efb-8e4b-fe1908467482
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:58:17 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"miqazure-linux-managed-nsg\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg\",\r\n
+        \ \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/networkSecurityGroups\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
+        \"b4611f96-94a8-4486-94c5-16bb6c7a5c84\",\r\n    \"securityRules\": [\r\n
+        \     {\r\n        \"name\": \"default-allow-ssh\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/securityRules/default-allow-ssh\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"protocol\": \"TCP\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"22\",\r\n          \"sourceAddressPrefix\":
+        \"*\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n          \"access\":
+        \"Allow\",\r\n          \"priority\": 1000,\r\n          \"direction\": \"Inbound\",\r\n
+        \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      }\r\n    ],\r\n    \"defaultSecurityRules\": [\r\n
+        \     {\r\n        \"name\": \"AllowVnetInBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/AllowVnetInBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow inbound traffic from all VMs in VNET\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"VirtualNetwork\",\r\n          \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n          \"direction\":
+        \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowAzureLoadBalancerInBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/AllowAzureLoadBalancerInBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow inbound traffic from azure load balancer\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"AzureLoadBalancer\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65001,\r\n          \"direction\":
+        \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllInBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/DenyAllInBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Deny all inbound traffic\",\r\n          \"protocol\":
+        \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\":
+        \"*\",\r\n          \"sourceAddressPrefix\": \"*\",\r\n          \"destinationAddressPrefix\":
+        \"*\",\r\n          \"access\": \"Deny\",\r\n          \"priority\": 65500,\r\n
+        \         \"direction\": \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n
+        \         \"destinationPortRanges\": [],\r\n          \"sourceAddressPrefixes\":
+        [],\r\n          \"destinationAddressPrefixes\": []\r\n        }\r\n      },\r\n
+        \     {\r\n        \"name\": \"AllowVnetOutBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/AllowVnetOutBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow outbound traffic from all VMs to all VMs
+        in VNET\",\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\":
+        \"*\",\r\n          \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"VirtualNetwork\",\r\n          \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n          \"direction\":
+        \"Outbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowInternetOutBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/AllowInternetOutBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow outbound traffic from all VMs to Internet\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"*\",\r\n          \"destinationAddressPrefix\": \"Internet\",\r\n          \"access\":
+        \"Allow\",\r\n          \"priority\": 65001,\r\n          \"direction\": \"Outbound\",\r\n
+        \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllOutBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/DenyAllOutBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Deny all outbound traffic\",\r\n          \"protocol\":
+        \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\":
+        \"*\",\r\n          \"sourceAddressPrefix\": \"*\",\r\n          \"destinationAddressPrefix\":
+        \"*\",\r\n          \"access\": \"Deny\",\r\n          \"priority\": 65500,\r\n
+        \         \"direction\": \"Outbound\",\r\n          \"sourcePortRanges\":
+        [],\r\n          \"destinationPortRanges\": [],\r\n          \"sourceAddressPrefixes\":
+        [],\r\n          \"destinationAddressPrefixes\": []\r\n        }\r\n      }\r\n
+        \   ],\r\n    \"networkInterfaces\": [\r\n      {\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944\"\r\n
+        \     }\r\n    ]\r\n  }\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:58:17 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/non_existent?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjI3NTMsIm5iZiI6MTUyMDg2Mjc1MywiZXhwIjoxNTIwODY2NjUzLCJhaW8iOiJZMk5nWU5qQnVUVng5OU1Kai9QZUY0akhQV2xXQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoic2xpdHpFREFBME9rUUhZRTNFY1lBQSIsInZlciI6IjEuMCJ9.Qxnn-5NYOZmogiHt-I2F53zJrRBSHKuYBrutjin7QFLQo8dufzsLR3NrLvELmnt43-mpOR7pZv7OpKrkyfVtl9xaN2WlKDLVS7ZTnQQlB-C2KGavbhf_Od1Ab4k0S2xRMKymzQmdxDF2LBBe1G4B7FLm_OIBg-DLhULmdhjxSVFTylJP7tCGHxUPaBt1B94nvKs5ZzwANQwV4ix34f07MzVJ6FckHthHCdLGcWkrB2wdp5TPT6qkjjczxeDJ8r-9lGDCKLvcs-FdjeIogKCNwsu3kPcJC2vE22Eezi1C6fHRg5jpqO2NyZvHTBLGUV0tgpUorQ431-uGgVuv0hotHA
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      X-Ms-Failure-Cause:
+      - gateway
+      X-Ms-Request-Id:
+      - d656fc98-4b28-4b86-97a9-d0ba4847d41e
+      X-Ms-Correlation-Request-Id:
+      - d656fc98-4b28-4b86-97a9-d0ba4847d41e
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T135817Z:d656fc98-4b28-4b86-97a9-d0ba4847d41e
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:58:17 GMT
+      Content-Length:
+      - '171'
+    body:
+      encoding: UTF-8
+      string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Network/networkSecurityGroups/non_existent''
+        under resource group ''miq-azure-test4'' was not found."}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:58:18 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjI3NTMsIm5iZiI6MTUyMDg2Mjc1MywiZXhwIjoxNTIwODY2NjUzLCJhaW8iOiJZMk5nWU5qQnVUVng5OU1Kai9QZUY0akhQV2xXQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoic2xpdHpFREFBME9rUUhZRTNFY1lBQSIsInZlciI6IjEuMCJ9.Qxnn-5NYOZmogiHt-I2F53zJrRBSHKuYBrutjin7QFLQo8dufzsLR3NrLvELmnt43-mpOR7pZv7OpKrkyfVtl9xaN2WlKDLVS7ZTnQQlB-C2KGavbhf_Od1Ab4k0S2xRMKymzQmdxDF2LBBe1G4B7FLm_OIBg-DLhULmdhjxSVFTylJP7tCGHxUPaBt1B94nvKs5ZzwANQwV4ix34f07MzVJ6FckHthHCdLGcWkrB2wdp5TPT6qkjjczxeDJ8r-9lGDCKLvcs-FdjeIogKCNwsu3kPcJC2vE22Eezi1C6fHRg5jpqO2NyZvHTBLGUV0tgpUorQ431-uGgVuv0hotHA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"5ad0e691-263e-42ca-8a93-833bd4dbf13f"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - a80a72d0-6365-4dcf-8c0a-8f66e14a7dfc
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Correlation-Request-Id:
+      - 5e423f0f-9eb9-4a4c-8501-bd01f9783725
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T135818Z:5e423f0f-9eb9-4a4c-8501-bd01f9783725
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:58:18 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"miq-test-rhel1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1\",\r\n
+        \ \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/networkSecurityGroups\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"f4a4a6a5-e2e8-47bd-b46f-00592f8fce53\",\r\n    \"securityRules\":
+        [\r\n      {\r\n        \"name\": \"default-allow-ssh\",\r\n        \"id\":
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/securityRules/default-allow-ssh\",\r\n
+        \       \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"protocol\": \"Tcp\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"22\",\r\n          \"sourceAddressPrefix\":
+        \"*\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n          \"access\":
+        \"Allow\",\r\n          \"priority\": 1000,\r\n          \"direction\": \"Inbound\",\r\n
+        \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"rhel1-inbound1\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/securityRules/rhel1-inbound1\",\r\n
+        \       \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"protocol\": \"Tcp\",\r\n          \"sourcePortRange\": \"80\",\r\n
+        \         \"destinationPortRange\": \"80\",\r\n          \"sourceAddressPrefix\":
+        \"*\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n          \"access\":
+        \"Allow\",\r\n          \"priority\": 100,\r\n          \"direction\": \"Inbound\",\r\n
+        \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"rhel1-inbound2\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/securityRules/rhel1-inbound2\",\r\n
+        \       \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"protocol\": \"Tcp\",\r\n          \"sourcePortRange\": \"443\",\r\n
+        \         \"destinationPortRange\": \"443\",\r\n          \"sourceAddressPrefix\":
+        \"*\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n          \"access\":
+        \"Allow\",\r\n          \"priority\": 200,\r\n          \"direction\": \"Inbound\",\r\n
+        \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      }\r\n    ],\r\n    \"defaultSecurityRules\": [\r\n
+        \     {\r\n        \"name\": \"AllowVnetInBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/defaultSecurityRules/AllowVnetInBound\",\r\n
+        \       \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow inbound traffic from all VMs in VNET\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"VirtualNetwork\",\r\n          \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n          \"direction\":
+        \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowAzureLoadBalancerInBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/defaultSecurityRules/AllowAzureLoadBalancerInBound\",\r\n
+        \       \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow inbound traffic from azure load balancer\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"AzureLoadBalancer\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65001,\r\n          \"direction\":
+        \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllInBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/defaultSecurityRules/DenyAllInBound\",\r\n
+        \       \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Deny all inbound traffic\",\r\n          \"protocol\":
+        \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\":
+        \"*\",\r\n          \"sourceAddressPrefix\": \"*\",\r\n          \"destinationAddressPrefix\":
+        \"*\",\r\n          \"access\": \"Deny\",\r\n          \"priority\": 65500,\r\n
+        \         \"direction\": \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n
+        \         \"destinationPortRanges\": [],\r\n          \"sourceAddressPrefixes\":
+        [],\r\n          \"destinationAddressPrefixes\": []\r\n        }\r\n      },\r\n
+        \     {\r\n        \"name\": \"AllowVnetOutBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/defaultSecurityRules/AllowVnetOutBound\",\r\n
+        \       \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow outbound traffic from all VMs to all VMs
+        in VNET\",\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\":
+        \"*\",\r\n          \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"VirtualNetwork\",\r\n          \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n          \"direction\":
+        \"Outbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowInternetOutBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/defaultSecurityRules/AllowInternetOutBound\",\r\n
+        \       \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow outbound traffic from all VMs to Internet\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"*\",\r\n          \"destinationAddressPrefix\": \"Internet\",\r\n          \"access\":
+        \"Allow\",\r\n          \"priority\": 65001,\r\n          \"direction\": \"Outbound\",\r\n
+        \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllOutBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1/defaultSecurityRules/DenyAllOutBound\",\r\n
+        \       \"etag\": \"W/\\\"5ad0e691-263e-42ca-8a93-833bd4dbf13f\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Deny all outbound traffic\",\r\n          \"protocol\":
+        \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\":
+        \"*\",\r\n          \"sourceAddressPrefix\": \"*\",\r\n          \"destinationAddressPrefix\":
+        \"*\",\r\n          \"access\": \"Deny\",\r\n          \"priority\": 65500,\r\n
+        \         \"direction\": \"Outbound\",\r\n          \"sourcePortRanges\":
+        [],\r\n          \"destinationPortRanges\": [],\r\n          \"sourceAddressPrefixes\":
+        [],\r\n          \"destinationAddressPrefixes\": []\r\n        }\r\n      }\r\n
+        \   ],\r\n    \"networkInterfaces\": [\r\n      {\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390\"\r\n
+        \     }\r\n    ]\r\n  }\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:58:18 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjI3NTMsIm5iZiI6MTUyMDg2Mjc1MywiZXhwIjoxNTIwODY2NjUzLCJhaW8iOiJZMk5nWU5qQnVUVng5OU1Kai9QZUY0akhQV2xXQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoic2xpdHpFREFBME9rUUhZRTNFY1lBQSIsInZlciI6IjEuMCJ9.Qxnn-5NYOZmogiHt-I2F53zJrRBSHKuYBrutjin7QFLQo8dufzsLR3NrLvELmnt43-mpOR7pZv7OpKrkyfVtl9xaN2WlKDLVS7ZTnQQlB-C2KGavbhf_Od1Ab4k0S2xRMKymzQmdxDF2LBBe1G4B7FLm_OIBg-DLhULmdhjxSVFTylJP7tCGHxUPaBt1B94nvKs5ZzwANQwV4ix34f07MzVJ6FckHthHCdLGcWkrB2wdp5TPT6qkjjczxeDJ8r-9lGDCKLvcs-FdjeIogKCNwsu3kPcJC2vE22Eezi1C6fHRg5jpqO2NyZvHTBLGUV0tgpUorQ431-uGgVuv0hotHA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"f1907e14-fcad-4f75-8faa-ab325bf879d9"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 70378e0d-e319-4a54-a370-6aac924db23a
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14994'
+      X-Ms-Correlation-Request-Id:
+      - 95956bd4-5a01-4268-b64d-f138ca88d33b
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T135818Z:95956bd4-5a01-4268-b64d-f138ca88d33b
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:58:18 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"miqazure-centos1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1\",\r\n
+        \ \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/networkSecurityGroups\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
+        \"9ca49a93-6f7d-464c-b23d-e61e847ce2d6\",\r\n    \"securityRules\": [\r\n
+        \     {\r\n        \"name\": \"default-allow-ssh\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/securityRules/default-allow-ssh\",\r\n
+        \       \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"protocol\": \"Tcp\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"22\",\r\n          \"sourceAddressPrefix\":
+        \"*\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n          \"access\":
+        \"Allow\",\r\n          \"priority\": 1000,\r\n          \"direction\": \"Inbound\",\r\n
+        \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      }\r\n    ],\r\n    \"defaultSecurityRules\": [\r\n
+        \     {\r\n        \"name\": \"AllowVnetInBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/defaultSecurityRules/AllowVnetInBound\",\r\n
+        \       \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow inbound traffic from all VMs in VNET\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"VirtualNetwork\",\r\n          \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n          \"direction\":
+        \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowAzureLoadBalancerInBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/defaultSecurityRules/AllowAzureLoadBalancerInBound\",\r\n
+        \       \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow inbound traffic from azure load balancer\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"AzureLoadBalancer\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65001,\r\n          \"direction\":
+        \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllInBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/defaultSecurityRules/DenyAllInBound\",\r\n
+        \       \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Deny all inbound traffic\",\r\n          \"protocol\":
+        \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\":
+        \"*\",\r\n          \"sourceAddressPrefix\": \"*\",\r\n          \"destinationAddressPrefix\":
+        \"*\",\r\n          \"access\": \"Deny\",\r\n          \"priority\": 65500,\r\n
+        \         \"direction\": \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n
+        \         \"destinationPortRanges\": [],\r\n          \"sourceAddressPrefixes\":
+        [],\r\n          \"destinationAddressPrefixes\": []\r\n        }\r\n      },\r\n
+        \     {\r\n        \"name\": \"AllowVnetOutBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/defaultSecurityRules/AllowVnetOutBound\",\r\n
+        \       \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow outbound traffic from all VMs to all VMs
+        in VNET\",\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\":
+        \"*\",\r\n          \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"VirtualNetwork\",\r\n          \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n          \"direction\":
+        \"Outbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowInternetOutBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/defaultSecurityRules/AllowInternetOutBound\",\r\n
+        \       \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow outbound traffic from all VMs to Internet\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"*\",\r\n          \"destinationAddressPrefix\": \"Internet\",\r\n          \"access\":
+        \"Allow\",\r\n          \"priority\": 65001,\r\n          \"direction\": \"Outbound\",\r\n
+        \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllOutBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1/defaultSecurityRules/DenyAllOutBound\",\r\n
+        \       \"etag\": \"W/\\\"f1907e14-fcad-4f75-8faa-ab325bf879d9\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Deny all outbound traffic\",\r\n          \"protocol\":
+        \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\":
+        \"*\",\r\n          \"sourceAddressPrefix\": \"*\",\r\n          \"destinationAddressPrefix\":
+        \"*\",\r\n          \"access\": \"Deny\",\r\n          \"priority\": 65500,\r\n
+        \         \"direction\": \"Outbound\",\r\n          \"sourcePortRanges\":
+        [],\r\n          \"destinationPortRanges\": [],\r\n          \"sourceAddressPrefixes\":
+        [],\r\n          \"destinationAddressPrefixes\": []\r\n        }\r\n      }\r\n
+        \   ],\r\n    \"networkInterfaces\": [\r\n      {\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611\"\r\n
+        \     }\r\n    ]\r\n  }\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:58:18 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjI3NTMsIm5iZiI6MTUyMDg2Mjc1MywiZXhwIjoxNTIwODY2NjUzLCJhaW8iOiJZMk5nWU5qQnVUVng5OU1Kai9QZUY0akhQV2xXQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoic2xpdHpFREFBME9rUUhZRTNFY1lBQSIsInZlciI6IjEuMCJ9.Qxnn-5NYOZmogiHt-I2F53zJrRBSHKuYBrutjin7QFLQo8dufzsLR3NrLvELmnt43-mpOR7pZv7OpKrkyfVtl9xaN2WlKDLVS7ZTnQQlB-C2KGavbhf_Od1Ab4k0S2xRMKymzQmdxDF2LBBe1G4B7FLm_OIBg-DLhULmdhjxSVFTylJP7tCGHxUPaBt1B94nvKs5ZzwANQwV4ix34f07MzVJ6FckHthHCdLGcWkrB2wdp5TPT6qkjjczxeDJ8r-9lGDCKLvcs-FdjeIogKCNwsu3kPcJC2vE22Eezi1C6fHRg5jpqO2NyZvHTBLGUV0tgpUorQ431-uGgVuv0hotHA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"f5bbd20f-7ae4-4b6d-89c8-eb3481fcbe05"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 41a7693f-d701-4a0d-8620-2c5ed8219735
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14995'
+      X-Ms-Correlation-Request-Id:
+      - 9d9c5452-bae2-475a-94e2-4170ae9d3376
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T135819Z:9d9c5452-bae2-475a-94e2-4170ae9d3376
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:58:19 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"miq-azure-test2\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2\",\r\n
+        \ \"etag\": \"W/\\\"f5bbd20f-7ae4-4b6d-89c8-eb3481fcbe05\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
+        \"f950a3cf-749a-49d5-a7fb-33a400b0e93c\",\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\":
+        [\r\n        \"172.25.0.0/16\"\r\n      ]\r\n    },\r\n    \"subnets\": [\r\n
+        \     {\r\n        \"name\": \"default\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2/subnets/default\",\r\n
+        \       \"etag\": \"W/\\\"f5bbd20f-7ae4-4b6d-89c8-eb3481fcbe05\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"addressPrefix\": \"172.25.0.0/24\",\r\n          \"ipConfigurations\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944/ipConfigurations/ipconfig1\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"virtualNetworkPeerings\":
+        [],\r\n    \"enableDdosProtection\": false,\r\n    \"enableVmProtection\":
+        false\r\n  }\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:58:19 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/non_existent?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjI3NTMsIm5iZiI6MTUyMDg2Mjc1MywiZXhwIjoxNTIwODY2NjUzLCJhaW8iOiJZMk5nWU5qQnVUVng5OU1Kai9QZUY0akhQV2xXQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoic2xpdHpFREFBME9rUUhZRTNFY1lBQSIsInZlciI6IjEuMCJ9.Qxnn-5NYOZmogiHt-I2F53zJrRBSHKuYBrutjin7QFLQo8dufzsLR3NrLvELmnt43-mpOR7pZv7OpKrkyfVtl9xaN2WlKDLVS7ZTnQQlB-C2KGavbhf_Od1Ab4k0S2xRMKymzQmdxDF2LBBe1G4B7FLm_OIBg-DLhULmdhjxSVFTylJP7tCGHxUPaBt1B94nvKs5ZzwANQwV4ix34f07MzVJ6FckHthHCdLGcWkrB2wdp5TPT6qkjjczxeDJ8r-9lGDCKLvcs-FdjeIogKCNwsu3kPcJC2vE22Eezi1C6fHRg5jpqO2NyZvHTBLGUV0tgpUorQ431-uGgVuv0hotHA
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      X-Ms-Failure-Cause:
+      - gateway
+      X-Ms-Request-Id:
+      - ebce34f7-a3c1-472c-9fde-ed761f354dc9
+      X-Ms-Correlation-Request-Id:
+      - ebce34f7-a3c1-472c-9fde-ed761f354dc9
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T135820Z:ebce34f7-a3c1-472c-9fde-ed761f354dc9
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:58:20 GMT
+      Content-Length:
+      - '165'
+    body:
+      encoding: UTF-8
+      string: '{"error":{"code":"ResourceNotFound","message":"The Resource ''Microsoft.Network/virtualNetworks/non_existent''
+        under resource group ''miq-azure-test2'' was not found."}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:58:21 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1?api-version=2018-01-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NjI3NTMsIm5iZiI6MTUyMDg2Mjc1MywiZXhwIjoxNTIwODY2NjUzLCJhaW8iOiJZMk5nWU5qQnVUVng5OU1Kai9QZUY0akhQV2xXQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoic2xpdHpFREFBME9rUUhZRTNFY1lBQSIsInZlciI6IjEuMCJ9.Qxnn-5NYOZmogiHt-I2F53zJrRBSHKuYBrutjin7QFLQo8dufzsLR3NrLvELmnt43-mpOR7pZv7OpKrkyfVtl9xaN2WlKDLVS7ZTnQQlB-C2KGavbhf_Od1Ab4k0S2xRMKymzQmdxDF2LBBe1G4B7FLm_OIBg-DLhULmdhjxSVFTylJP7tCGHxUPaBt1B94nvKs5ZzwANQwV4ix34f07MzVJ6FckHthHCdLGcWkrB2wdp5TPT6qkjjczxeDJ8r-9lGDCKLvcs-FdjeIogKCNwsu3kPcJC2vE22Eezi1C6fHRg5jpqO2NyZvHTBLGUV0tgpUorQ431-uGgVuv0hotHA
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"a8b09238-30fc-4b36-a58d-e3cc69e267c5"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - d53b8fb7-178d-4a7b-ad47-6b86c383ea7b
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14996'
+      X-Ms-Correlation-Request-Id:
+      - c0873842-a7bf-45ee-b67b-347aaace8dd7
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T135826Z:c0873842-a7bf-45ee-b67b-347aaace8dd7
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 13:58:26 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"miq-azure-test1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1\",\r\n
+        \ \"etag\": \"W/\\\"a8b09238-30fc-4b36-a58d-e3cc69e267c5\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
+        \"d74c1e5f-50e4-4c8a-a7fe-78eaddc6b915\",\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\":
+        [\r\n        \"10.16.0.0/16\"\r\n      ]\r\n    },\r\n    \"subnets\": [\r\n
+        \     {\r\n        \"name\": \"default\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\",\r\n
+        \       \"etag\": \"W/\\\"a8b09238-30fc-4b36-a58d-e3cc69e267c5\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"addressPrefix\": \"10.16.0.0/24\",\r\n          \"ipConfigurations\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241/ipConfigurations/ipconfig1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1/ipConfigurations/miqmismatch1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/dbergerprov1/ipConfigurations/dbergerprov1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/ladas_test_1/ipConfigurations/ladas_test_1\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"virtualNetworkPeerings\":
+        [],\r\n    \"enableDdosProtection\": false,\r\n    \"enableVmProtection\":
+        false\r\n  }\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 13:58:26 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted_scope/network_port_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted_scope/network_port_refresh.yml
@@ -1,6 +1,62 @@
 ---
 http_interactions:
 - request:
+    method: post
+    uri: https://login.microsoftonline.com/AZURE_TENANT_ID/oauth2/token
+    body:
+      encoding: UTF-8
+      string: grant_type=client_credentials&client_id=AZURE_CLIENT_ID&client_secret=AZURE_CLIENT_SECRET&resource=https%3A%2F%2Fmanagement.azure.com%2F
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Server:
+      - Microsoft-IIS/10.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Request-Id:
+      - e9efdd51-63f5-4a99-bf5c-efb849833500
+      P3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Set-Cookie:
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzof5DsjANIpyTTwUBym6OYQD6FuRmMrMZRiRAGYvben8Aj8iF4bPGBcVPN763wIaWcXzl4_KJ_lJndOIBxpuzDpXK6sf2Go9AIBf9ze-fES9b-eSmNcx5oSvpZvsZ3k86SI6CxTv7C4IEKWhna-Vi5tMyxnUMuBuynX-yyPGbyA8gAA;
+        domain=.login.microsoftonline.com; path=/; secure; HttpOnly
+      - stsservicecookie=ests; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=005; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Tue, 13 Mar 2018 09:04:30 GMT
+      Content-Length:
+      - '1505'
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"Bearer","expires_in":"3600","ext_expires_in":"0","expires_on":"1520935470","not_before":"1520931570","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA5MzE1NzAsIm5iZiI6MTUyMDkzMTU3MCwiZXhwIjoxNTIwOTM1NDcwLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVWQzdjZmVmptVXFfWE8tNFNZTTFBQSIsInZlciI6IjEuMCJ9.Sag7Azd8-5BvCVgt8BzHaAOt8qUSgfCcmd17qBZkB9WbFdcDcL9Eqewz9D2Q-e25gC1FXEUvjvdFMAdSY74xpFLI4_4Vbhp1E-JsUjyxa7rthxY7oiMCkRZWSJj8Vv_VUXimyS0CNzCmQPUnVZ89rdRajxjyWB1tuRP9przU10E_MwitgSHbVsVYXdooqCk-yGPfefXc1ZzUV2KCwWn3Mjfez6XmHRbgs4YSk1S1ZeDbPOQ6tpgWL9DaHBaYPU4N_NLYAcS4LrRHHaLsPT-RDfBYwx_Q_RKL5yPN0vOWVFDCp6RxyU0UOfopFwFFpmr8AZCN1ObA5DQi7BwlcodB_w"}'
+    http_version: 
+  recorded_at: Tue, 13 Mar 2018 09:04:30 GMT
+- request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
     body:
@@ -16,7 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MzgsIm5iZiI6MTUyMDQ1MzQzOCwiZXhwIjoxNTIwNDU3MzM4LCJhaW8iOiJZMk5nWUxEbUtXMDk5clB4cU9QdGorL1crV3NlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZHNPVmFSUXV2RTJjVVBpcEtWWUFBQSIsInZlciI6IjEuMCJ9.drT5CKw95WRF7LzC0WuhK-fTLpw3j61XMw_DZdrLOWP8sjjsrbn9kF7xjDSTUM0ooF5_1Y-j3dNjvI9crm_F3PMAyhYXmCsKjTJkc3DIK6URy3hqbKiRBNlrutwvILE777NY-uXK9PH-gcaVuV-mNrjrLuxxClMJ3OPpTU8Ux0fj3Nuyf3KrXC27Oks_M_RDqDaXHOTckrdz2m_LNLpi5x0nKCoxwR9r5C1m5IKZ25FSbvyRNwjwz5dReqnv5LxllQMHVWkpvO7i5438wAnnyaS2x211IBiE6_dnV2god8Sp3ZRinXc4aCimUnJl6tLa5EtT_VSmR2QcBSaq0wS_ZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA5MzE1NzAsIm5iZiI6MTUyMDkzMTU3MCwiZXhwIjoxNTIwOTM1NDcwLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVWQzdjZmVmptVXFfWE8tNFNZTTFBQSIsInZlciI6IjEuMCJ9.Sag7Azd8-5BvCVgt8BzHaAOt8qUSgfCcmd17qBZkB9WbFdcDcL9Eqewz9D2Q-e25gC1FXEUvjvdFMAdSY74xpFLI4_4Vbhp1E-JsUjyxa7rthxY7oiMCkRZWSJj8Vv_VUXimyS0CNzCmQPUnVZ89rdRajxjyWB1tuRP9przU10E_MwitgSHbVsVYXdooqCk-yGPfefXc1ZzUV2KCwWn3Mjfez6XmHRbgs4YSk1S1ZeDbPOQ6tpgWL9DaHBaYPU4N_NLYAcS4LrRHHaLsPT-RDfBYwx_Q_RKL5yPN0vOWVFDCp6RxyU0UOfopFwFFpmr8AZCN1ObA5DQi7BwlcodB_w
   response:
     status:
       code: 200
@@ -35,26 +91,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14999'
+      - '14998'
       X-Ms-Request-Id:
-      - def2dc25-a6d7-4399-a172-63bd1208fe97
+      - 5821e0d7-280c-4a27-b857-aa3ab5979330
       X-Ms-Correlation-Request-Id:
-      - def2dc25-a6d7-4399-a172-63bd1208fe97
+      - 5821e0d7-280c-4a27-b857-aa3ab5979330
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201939Z:def2dc25-a6d7-4399-a172-63bd1208fe97
+      - WESTEUROPE:20180313T090430Z:5821e0d7-280c-4a27-b857-aa3ab5979330
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:19:38 GMT
+      - Tue, 13 Mar 2018 09:04:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID","subscriptionId":"AZURE_SUBSCRIPTION_ID","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:19:39 GMT
+  recorded_at: Tue, 13 Mar 2018 09:04:30 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers?api-version=2015-01-01
@@ -71,7 +127,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MzgsIm5iZiI6MTUyMDQ1MzQzOCwiZXhwIjoxNTIwNDU3MzM4LCJhaW8iOiJZMk5nWUxEbUtXMDk5clB4cU9QdGorL1crV3NlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZHNPVmFSUXV2RTJjVVBpcEtWWUFBQSIsInZlciI6IjEuMCJ9.drT5CKw95WRF7LzC0WuhK-fTLpw3j61XMw_DZdrLOWP8sjjsrbn9kF7xjDSTUM0ooF5_1Y-j3dNjvI9crm_F3PMAyhYXmCsKjTJkc3DIK6URy3hqbKiRBNlrutwvILE777NY-uXK9PH-gcaVuV-mNrjrLuxxClMJ3OPpTU8Ux0fj3Nuyf3KrXC27Oks_M_RDqDaXHOTckrdz2m_LNLpi5x0nKCoxwR9r5C1m5IKZ25FSbvyRNwjwz5dReqnv5LxllQMHVWkpvO7i5438wAnnyaS2x211IBiE6_dnV2god8Sp3ZRinXc4aCimUnJl6tLa5EtT_VSmR2QcBSaq0wS_ZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA5MzE1NzAsIm5iZiI6MTUyMDkzMTU3MCwiZXhwIjoxNTIwOTM1NDcwLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVWQzdjZmVmptVXFfWE8tNFNZTTFBQSIsInZlciI6IjEuMCJ9.Sag7Azd8-5BvCVgt8BzHaAOt8qUSgfCcmd17qBZkB9WbFdcDcL9Eqewz9D2Q-e25gC1FXEUvjvdFMAdSY74xpFLI4_4Vbhp1E-JsUjyxa7rthxY7oiMCkRZWSJj8Vv_VUXimyS0CNzCmQPUnVZ89rdRajxjyWB1tuRP9przU10E_MwitgSHbVsVYXdooqCk-yGPfefXc1ZzUV2KCwWn3Mjfez6XmHRbgs4YSk1S1ZeDbPOQ6tpgWL9DaHBaYPU4N_NLYAcS4LrRHHaLsPT-RDfBYwx_Q_RKL5yPN0vOWVFDCp6RxyU0UOfopFwFFpmr8AZCN1ObA5DQi7BwlcodB_w
   response:
     status:
       code: 200
@@ -88,39 +144,37 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14982'
+      - '14910'
       X-Ms-Request-Id:
-      - d5f41620-533a-4f24-a72f-563aeee6a6a4
+      - '03852d28-a017-4a55-a7f1-eb433ea17606'
       X-Ms-Correlation-Request-Id:
-      - d5f41620-533a-4f24-a72f-563aeee6a6a4
+      - '03852d28-a017-4a55-a7f1-eb433ea17606'
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201940Z:d5f41620-533a-4f24-a72f-563aeee6a6a4
+      - WESTEUROPE:20180313T090431Z:03852d28-a017-4a55-a7f1-eb433ea17606
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:19:39 GMT
+      - Tue, 13 Mar 2018 09:04:30 GMT
       Content-Length:
-      - '310505'
+      - '322992'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"},{"applicationId":"d87dcbc6-a371-462e-88e3-28ad15ec4e64","roleDefinitionId":"861776c5-e0df-4f95-be4f-ac1eec193323"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
+      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"},{"applicationId":"d87dcbc6-a371-462e-88e3-28ad15ec4e64","roleDefinitionId":"861776c5-e0df-4f95-be4f-ac1eec193323"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["East
+        Asia","Southeast Asia","Australia East","Australia Southeast","Japan East","Japan
+        West","Central India","South India","West India","West Europe","North Europe","Canada
+        Central","Canada East","Brazil South","West US","Central US","East US","South
+        Central US","East US 2","West Central US","North Central US","West US 2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
         US","Central US","East US","South Central US","West Europe","North Europe","East
         Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
         Central US","North Central US","Japan East","Japan West","Brazil South","Central
         India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"operations","locations":["West
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["East
+        Asia","Southeast Asia","Australia East","Australia Southeast","Japan East","Japan
+        West","Central India","South India","West India","West Europe","North Europe","Canada
+        Central","Canada East","Brazil South","West US","Central US","East US","South
+        Central US","East US 2","West Central US","North Central US","West US 2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"operations","locations":["West
         US","Central US","East US","South Central US","West Europe","North Europe","East
         Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
         Central US","North Central US","Japan East","Japan West","Brazil South","Central
@@ -176,177 +230,177 @@ http_interactions:
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/internalLoadBalancers","locations":[],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"domainNames/slots/roles/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"domainNames/slots/roles/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"domainNames/capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"domainNames/serviceCertificates","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
         US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
         Central","Canada East","UK South","UK West","West US","Central US","South
         Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
-        East","Australia Southeast","West US 2","West Central US","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        East","Australia Southeast","West US 2","West Central US","France Central","South
+        India","Central India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
         US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
         Central","Canada East","UK South","UK West","West US","Central US","South
         Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
-        East","Australia Southeast","West US 2","West Central US","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metrics","locations":["North
+        East","Australia Southeast","West US 2","West Central US","France Central","South
+        India","Central India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metrics","locations":["North
         Central US","South Central US","East US","East US 2","Canada Central","Canada
         East","West US","West US 2","West Central US","Central US","East Asia","Southeast
         Asia","North Europe","West Europe","UK South","UK West","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"resourceTypes","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"moveSubscriptionResources","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"validateSubscriptionMoveAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operationStatuses","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operatingSystems","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"operatingSystemFamilies","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicNetwork","namespace":"Microsoft.ClassicNetwork","resourceTypes":[{"resourceType":"virtualNetworks","locations":["East
+        India","West India","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"resourceTypes","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"moveSubscriptionResources","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"validateSubscriptionMoveAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operationStatuses","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operatingSystems","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"operatingSystemFamilies","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicNetwork","namespace":"Microsoft.ClassicNetwork","resourceTypes":[{"resourceType":"virtualNetworks","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"virtualNetworks/remoteVirtualNetworkPeeringProxies","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01"]},{"resourceType":"virtualNetworks/remoteVirtualNetworkPeeringProxies","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"reservedIps","locations":["East
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01"]},{"resourceType":"reservedIps","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"gatewaySupportedDevices","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"networkSecurityGroups","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"gatewaySupportedDevices","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"networkSecurityGroups","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicStorage","namespace":"Microsoft.ClassicStorage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"expressRouteCrossConnections","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"expressRouteCrossConnections/peerings","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicStorage","namespace":"Microsoft.ClassicStorage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkStorageAccountAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"storageAccounts/services","locations":["West
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkStorageAccountAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"storageAccounts/services","locations":["West
         US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
         Asia","Australia East","Australia Southeast","South India","Central India","West
         India","West US 2","West Central US","East US","East US 2","North Central
         US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
-        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/diagnosticSettings","locations":["West
+        South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/diagnosticSettings","locations":["West
         US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
         Asia","Australia East","Australia Southeast","South India","Central India","West
         India","West US 2","West Central US","East US","East US 2","North Central
         US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
-        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"disks","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"images","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"vmImages","locations":[],"apiVersions":["2016-11-01"]},{"resourceType":"publicImages","locations":[],"apiVersions":["2016-11-01","2016-04-01"]},{"resourceType":"osImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"osPlatformImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute","namespace":"Microsoft.Compute","authorizations":[{"applicationId":"60e6cd67-9c8c-4951-9b3c-23c25a2169af","roleDefinitionId":"e4770acb-272e-4dc8-87f3-12f44a612224"},{"applicationId":"a303894e-f1d8-4a37-bf10-67aa654a0596","roleDefinitionId":"903ac751-8ad5-4e5a-bfc2-5e49f450a241"},{"applicationId":"a8b6bf88-1d1a-4626-b040-9a729ea93c65","roleDefinitionId":"45c8267c-80ba-4b96-9a43-115b8f49fccd"}],"resourceTypes":[{"resourceType":"availabilitySets","locations":["East
+        South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"disks","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"images","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"vmImages","locations":[],"apiVersions":["2016-11-01"]},{"resourceType":"storageAccounts/vmImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"publicImages","locations":[],"apiVersions":["2016-11-01","2016-04-01"]},{"resourceType":"osImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"osPlatformImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute","namespace":"Microsoft.Compute","authorizations":[{"applicationId":"60e6cd67-9c8c-4951-9b3c-23c25a2169af","roleDefinitionId":"e4770acb-272e-4dc8-87f3-12f44a612224"},{"applicationId":"a303894e-f1d8-4a37-bf10-67aa654a0596","roleDefinitionId":"903ac751-8ad5-4e5a-bfc2-5e49f450a241"},{"applicationId":"a8b6bf88-1d1a-4626-b040-9a729ea93c65","roleDefinitionId":"45c8267c-80ba-4b96-9a43-115b8f49fccd"}],"resourceTypes":[{"resourceType":"availabilitySets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations/usages","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations/usages","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"sharedVMImages","locations":["West
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"sharedVMImages","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"sharedVMImages/versions","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"locations/capsoperations","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"disks","locations":["Southeast
@@ -354,27 +408,27 @@ http_interactions:
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"snapshots","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"snapshots","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"locations/diskoperations","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"locations/diskoperations","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"images","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"images","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"]},{"resourceType":"locations/logAnalytics","locations":["East
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"]},{"resourceType":"locations/logAnalytics","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
         US","East US","South Central US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
@@ -444,7 +498,10 @@ http_interactions:
         Central US","West Europe","North Europe","East US","UK West","UK South","West
         Central US","West US 2","South India","Central India","West India","Canada
         East","Canada Central","Korea South","Korea Central"],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"managedClusters","locations":["East
-        US","West Europe","Central US","Canada Central","Canada East"],"apiVersions":["2017-08-31"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
+        US","West Europe","Central US","Canada Central","Canada East"],"apiVersions":["2017-08-31"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operationresults","locations":["East
+        US","West Europe","Central US","UK West","UK South","West Central US","West
+        US 2","South India","Central India","West India","Canada East","Canada Central","Korea
+        South","Korea Central"],"apiVersions":["2017-08-31","2016-03-30"]},{"resourceType":"locations/operations","locations":["Japan
         East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
@@ -491,7 +548,12 @@ http_interactions:
         US","East Asia","East US","East US 2","Japan East","Japan West","North Central
         US","North Europe","South Central US","South India","Southeast Asia","West
         Central US","West Europe","West India","West US","West US 2","UK West","UK
-        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"},{"applicationId":"f5c26e74-f226-4ae8-85f0-b4af0080ac9e","roleDefinitionId":"529d7ae6-e892-4d43-809d-8547aeb90643"}],"resourceTypes":[{"resourceType":"components","locations":["East
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/consumergroups","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/disasterrecoveryconfigs","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"},{"applicationId":"f5c26e74-f226-4ae8-85f0-b4af0080ac9e","roleDefinitionId":"529d7ae6-e892-4d43-809d-8547aeb90643"}],"resourceTypes":[{"resourceType":"components","locations":["East
         US","South Central US","North Europe","West Europe","Southeast Asia","West
         US 2"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
         US","South Central US","North Europe","West Europe","Southeast Asia","West
@@ -507,7 +569,7 @@ http_interactions:
         US","South Central US","North Europe","West Europe","Southeast Asia","West
         US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"listMigrationdate","locations":["East
         US","South Central US","North Europe","West Europe","Southeast Asia","West
-        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2018-03-01","2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
@@ -558,32 +620,32 @@ http_interactions:
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/accessPolicies","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"vaults/accessPolicies","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-10-01","2015-06-01","2014-12-19-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"deletedVaults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01","2014-12-19-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"deletedVaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-10-01"]},{"resourceType":"locations/deletedVaults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations/deletedVaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
         Central US","West Europe","Southeast Asia","Japan East","West Central US"],"apiVersions":["2016-04-01"]},{"resourceType":"webServices","locations":["South
         Central US","West Europe","Southeast Asia","Japan East","East US 2","West
         Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"operations","locations":["South
@@ -609,97 +671,102 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"networkWatchers/lenses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"networkWatchers/lenses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2018-02-01","2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"ddosProtectionPlans","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","West
         US 2","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
@@ -790,7 +857,7 @@ http_interactions:
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
         West","Korea Central","Korea South"],"apiVersions":["2017-07-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ResourceHealth","namespace":"Microsoft.ResourceHealth","authorizations":[{"applicationId":"8bdebf23-c0fe-4187-a378-717ad86f6a53","roleDefinitionId":"cc026344-c8b1-4561-83ba-59eba84b27cc"}],"resourceTypes":[{"resourceType":"availabilityStatuses","locations":[],"apiVersions":["2017-07-01","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"notifications","locations":["Australia
-        Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Security","namespace":"Microsoft.Security","authorization":{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
+        Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Security","namespace":"Microsoft.Security","authorizations":[{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},{"applicationId":"fc780465-2017-40d4-a0c5-307022471b92"}],"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatuses","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/virtualMachines","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/endpoints","locations":["Central
@@ -842,620 +909,650 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Central India","South
         India"],"apiVersions":["2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Sql","namespace":"Microsoft.Sql","authorizations":[{"applicationId":"e4ab13ed-33cb-41b4-9140-6e264582cf85","roleDefinitionId":"ec3ddc95-44dc-47a2-9926-5e9f5ffd44ec"},{"applicationId":"0130cc9f-7ac5-4026-bd5f-80a08a54e6d9","roleDefinitionId":"45e8abf8-0ec4-44f3-9c37-cff4f7779302"},{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},{"applicationId":"76c7f279-7959-468f-8943-3954880e0d8c","roleDefinitionId":"7f7513a8-73f9-4c5f-97a2-c41f0ea783ef"}],"resourceTypes":[{"resourceType":"operations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/capabilities","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/databaseAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/databaseOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverKeyOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/keys","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/encryptionProtector","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/usages","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01","2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/communicationLinks","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administrators","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administratorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/restorableDroppedDatabases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recoverableDatabases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/geoBackupPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/importExportOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/operationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/backupLongTermRetentionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/automaticTuning","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/automaticTuning","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/databases/transparentDataEncryption","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recommendedElasticPools","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/auditingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/connectionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/connectionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies/rules","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/securityAlertPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/securityAlertPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/auditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/extendedAuditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/elasticpools","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-09-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/jobAgentOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/jobAgentAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/disasterRecoveryConfiguration","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/dnsAliases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/failoverGroups","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/virtualNetworkRules","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/virtualNetworkRulesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/virtualNetworkRulesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/databaseRestoreAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metricDefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/aggregatedDatabaseMetrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metricdefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries/queryText","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPools/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/extensions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPoolEstimates","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditRecords","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentScans","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/vulnerabilityAssessments","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessment","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/syncGroups","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups/syncMembers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/syncAgents","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"managedInstances/administrators","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/databases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metricDefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/administratorAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/administratorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncMemberOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncAgentOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncDatabaseIds","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorizations":[{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},{"applicationId":"e406a681-f3d4-42a8-90b6-c2b029497af1"}],"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/capabilities","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/databaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"locations/databaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverKeyOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/keys","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/encryptionProtector","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01","2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/communicationLinks","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/restorableDroppedDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recoverableDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/geoBackupPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/importExportOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/operationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/backupLongTermRetentionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/databases/transparentDataEncryption","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recommendedElasticPools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies/rules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/extendedAuditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/elasticPoolAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/elasticPoolOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/elasticpools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-09-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/jobAgentOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/jobAgentAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/disasterRecoveryConfiguration","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/dnsAliases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/failoverGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/virtualNetworkRules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/virtualNetworkRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/virtualNetworkRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/databaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/aggregatedDatabaseMetrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metricdefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries/queryText","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPools/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/extensions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPoolEstimates","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditRecords","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentScans","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/vulnerabilityAssessments","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessment","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/syncGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups/syncMembers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/syncAgents","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"managedInstances/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/administratorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncMemberOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncAgentOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncDatabaseIds","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/longTermRetentionPolicyOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionPolicyAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionBackupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionBackupAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorizations":[{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},{"applicationId":"e406a681-f3d4-42a8-90b6-c2b029497af1"}],"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/asyncoperations","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/asyncoperations","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/listAccountSas","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/listAccountSas","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/listServiceSas","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/listServiceSas","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/blobServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/blobServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/tableServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/tableServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/queueServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/queueServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/fileServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/fileServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01","2016-01-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01","2016-01-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
         US","West US","West Europe","North Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":["East
         US","West US","West Europe","North Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.visualstudio","namespace":"microsoft.visualstudio","authorization":{"applicationId":"499b84ac-1321-427f-aa17-267ca6975798","roleDefinitionId":"6a18f445-86f0-4e2e-b8a9-6b9b5677e3d8"},"resourceTypes":[{"resourceType":"account","locations":["North
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.visualstudio","namespace":"microsoft.visualstudio","authorization":{"applicationId":"499b84ac-1321-427f-aa17-267ca6975798","roleDefinitionId":"6a18f445-86f0-4e2e-b8a9-6b9b5677e3d8"},"resourceTypes":[{"resourceType":"account","locations":["North
         Central US","South Central US","East US","West US","Central US","North Europe","West
         Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
         East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/project","locations":["North
@@ -1739,12 +1836,12 @@ http_interactions:
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","Canada Central","Canada East","UK South","UK West","West US 2","West
-        Central US","South India","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","South India","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","South India","Canada Central","Canada East","UK South","UK West","West
-        US 2","West Central US","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Capacity","namespace":"Microsoft.Capacity","authorization":{"applicationId":"4d0ad6c7-f6c3-46d8-ab0d-1406d5e6c86b","roleDefinitionId":"FD9C0A9A-4DB9-4F41-8A61-98385DEB6E2D"},"resourceTypes":[{"resourceType":"resources","locations":["South
+        US 2","West Central US","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Capacity","namespace":"Microsoft.Capacity","authorization":{"applicationId":"4d0ad6c7-f6c3-46d8-ab0d-1406d5e6c86b","roleDefinitionId":"FD9C0A9A-4DB9-4F41-8A61-98385DEB6E2D"},"resourceTypes":[{"resourceType":"resources","locations":["South
         Central US"],"apiVersions":["2017-11-01"]},{"resourceType":"reservationOrders","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/reservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/reservations/revisions","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"catalogs","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"appliedReservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"checkOffers","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"checkScopes","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"calculatePrice","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/calculateRefund","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/return","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/split","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/merge","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"validateReservationOrder","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/availableScopes","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Cdn","namespace":"Microsoft.Cdn","resourceTypes":[{"resourceType":"profiles","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
@@ -1820,9 +1917,9 @@ http_interactions:
         2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/updateAccountsCreationSettings","locations":["West
         US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/accountsCreationSettings","locations":["West
         US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2016-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Commerce","namespace":"Microsoft.Commerce","resourceTypes":[{"resourceType":"UsageAggregates","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]},{"resourceType":"RateCard","locations":[],"apiVersions":["2016-08-31-preview","2015-06-01-preview","2015-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Consumption","namespace":"Microsoft.Consumption","resourceTypes":[{"resourceType":"ReservationSummaries","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationTransactions","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Balances","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Marketplaces","locations":[],"apiVersions":["2018-01-31"]},{"resourceType":"Pricesheets","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationDetails","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Budgets","locations":[],"apiVersions":["2018-01-31","2017-12-30-preview"]},{"resourceType":"Terms","locations":[],"apiVersions":["2018-01-31","2017-12-30-preview"]},{"resourceType":"UsageDetails","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview","2017-04-24-preview"]},{"resourceType":"Operations","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview","2017-04-24-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerInstance","namespace":"Microsoft.ContainerInstance","resourceTypes":[{"resourceType":"containerGroups","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/usages","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/operations","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/operations","locations":["West
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
         US"],"apiVersions":["2016-04-08"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.CustomerInsights","namespace":"Microsoft.CustomerInsights","authorization":{"applicationId":"38c77d00-5fcb-4cce-9d93-af4738258e3c","roleDefinitionId":"E006F9C7-F333-477C-8AD6-1F3A9FE87F55"},"resourceTypes":[{"resourceType":"hubs","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/profiles","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/interactions","locations":["East
@@ -1839,7 +1936,9 @@ http_interactions:
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"operations","locations":["East
         US 2"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Databricks","namespace":"Microsoft.Databricks","authorizations":[{"applicationId":"d9327919-6775-4843-9037-3fb0fb0473cb","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},{"applicationId":"2ff814a6-3304-4ab8-85cb-cd0e6f879c1d","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"}],"resourceTypes":[{"resourceType":"workspaces","locations":["West
         US","East US 2","West Europe","East US","North Europe","Southeast Asia","East
-        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]},{"resourceType":"locations","locations":["West
+        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2017-09-01-preview"]},{"resourceType":"workspaces/virtualNetworkPeerings","locations":["West
+        US","East US 2","West Europe","North Europe","East US","Southeast Asia","East
+        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01"]},{"resourceType":"locations","locations":["West
         US","East US 2","West Europe","North Europe","East US","Southeast Asia"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
         US","East US 2","West Europe","East US","North Europe","Southeast Asia","East
         Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataCatalog","namespace":"Microsoft.DataCatalog","resourceTypes":[{"resourceType":"catalogs","locations":["East
@@ -1863,23 +1962,26 @@ http_interactions:
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers/listSasTokens","locations":["East
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataLakeStore","namespace":"Microsoft.DataLakeStore","authorization":{"applicationId":"e9f49c6b-5ce5-44c8-925d-015017e9f7ad","roleDefinitionId":"17eb9cca-f08a-4499-b2d3-852d175f614f"},"resourceTypes":[{"resourceType":"accounts","locations":["East
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/firewallRules","locations":["East
-        US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataMigration","namespace":"Microsoft.DataMigration","authorization":{"applicationId":"a4bad4aa-bf02-4631-9f78-a64ffdba8150","roleDefinitionId":"b831a21d-db98-4760-89cb-bef871952df1","managedByRoleDefinitionId":"6256fb55-9e59-4018-a9e1-76b11c0a4c89"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services/projects","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationStatuses","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
+        US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataMigration","namespace":"Microsoft.DataMigration","authorization":{"applicationId":"a4bad4aa-bf02-4631-9f78-a64ffdba8150","roleDefinitionId":"b831a21d-db98-4760-89cb-bef871952df1","managedByRoleDefinitionId":"6256fb55-9e59-4018-a9e1-76b11c0a4c89"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services/projects","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationStatuses","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
-        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/recoverableServers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
@@ -1903,7 +2005,10 @@ http_interactions:
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
-        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/recoverableServers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
@@ -1959,12 +2064,7 @@ http_interactions:
         US 2","East US","West US","Central US","East US 2","West Central US","West
         Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
         US 2","East US","West US","Central US","East US 2","West Central US","West
-        Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","West
-        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
-        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
-        India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/consumergroups","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/disasterrecoveryconfigs","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
         US 2","South Central US","Central US","Australia Southeast","Central India","West
         Central US","West US 2","Canada East","Canada Central","Brazil South","UK
         South","UK West","East Asia","Australia East","Japan East","Japan West","North
@@ -2075,7 +2175,7 @@ http_interactions:
         West","Japan East","East Asia","Southeast Asia","West Europe","North Europe","East
         US","West US","Australia East","Australia Southeast","Central US","Brazil
         South","Central India","West India","South India","South Central US","Canada
-        Central","Canada East","West Central US","West US 2"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
+        Central","Canada East","West Central US","West US 2"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-05","2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
         Central US","East US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"operations","locations":["West
         Central US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
         Central US","East US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.PolicyInsights","namespace":"Microsoft.PolicyInsights","authorization":{"applicationId":"1d78a85d-813d-46f0-b496-dd72f50a3ec0","roleDefinitionId":"63d2b225-4c34-4641-8768-21a1f7c68ce8"},"resourceTypes":[{"resourceType":"policyEvents","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"policyStates","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
@@ -2107,12 +2207,12 @@ http_interactions:
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
         Central US","South Central US","North Europe","West Europe","East Asia","Southeast
         Asia","West US","East US","Japan West","Japan East","Brazil South","Central
         US","East US 2","Australia East","Australia Southeast","South India","Central
@@ -2137,7 +2237,8 @@ http_interactions:
         US","West US 2","East US","East US 2","North Europe","West Europe","Southeast
         Asia","East Asia","North Central US","South Central US","Japan West","Australia
         East","Brazil South","Central India","West Central US","Canada Central","UK
-        South"],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ServiceBus","namespace":"Microsoft.ServiceBus","authorization":{"applicationId":"80a10ef9-8168-493d-abf9-3297c4ef6e3c","roleDefinitionId":"2b7763f7-bbe2-4e19-befe-28c79f1cf7f7"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        South"],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.SecurityGraph","namespace":"Microsoft.SecurityGraph","resourceTypes":[{"resourceType":"operations","locations":["West
+        US"],"apiVersions":["2017-04-01-preview"]},{"resourceType":"diagnosticSettings","locations":[],"apiVersions":["2017-04-01-preview"]},{"resourceType":"diagnosticSettingsCategories","locations":[],"apiVersions":["2017-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ServiceBus","namespace":"Microsoft.ServiceBus","authorization":{"applicationId":"80a10ef9-8168-493d-abf9-3297c4ef6e3c","roleDefinitionId":"2b7763f7-bbe2-4e19-befe-28c79f1cf7f7"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US 2","West
         US","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
@@ -2152,52 +2253,62 @@ http_interactions:
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/clusterVersions","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"clusters/applications","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operations","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/clusterVersions","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/environments","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operations","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
         Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applianceDefinitions","locations":["West
         Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applications","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
-        Central US"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
+        Central US"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
-        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
-        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups","locations":["West
-        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
-        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups/cloudEndpoints","locations":["West
-        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
-        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups/serverEndpoints","locations":["West
-        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
-        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/registeredServers","locations":["West
-        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
-        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/workflows","locations":["West
-        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
-        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
+        US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
+        US","Canada Central","Canada East","Central US","East US 2","UK South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups","locations":["West
+        US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
+        US","Canada Central","Canada East","Central US","East US 2","UK South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups/cloudEndpoints","locations":["West
+        US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
+        US","Canada Central","Canada East","Central US","East US 2","UK South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups/serverEndpoints","locations":["West
+        US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
+        US","Canada Central","Canada East","Central US","East US 2","UK South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/registeredServers","locations":["West
+        US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
+        US","Canada Central","Canada East","Central US","East US 2","UK South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/workflows","locations":["West
+        US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
+        US","Canada Central","Canada East","Central US","East US 2","UK South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","West Central US","Japan East","Japan West","Australia East","Australia
         Southeast"],"apiVersions":["2017-06-01","2017-05-15","2017-01-01","2016-10-01","2016-06-01","2015-03-15","2014-09-01"]},{"resourceType":"operations","locations":["West
@@ -2276,10 +2387,10 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:19:40 GMT
+  recorded_at: Tue, 13 Mar 2018 09:04:31 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944?api-version=2018-03-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2293,7 +2404,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MzgsIm5iZiI6MTUyMDQ1MzQzOCwiZXhwIjoxNTIwNDU3MzM4LCJhaW8iOiJZMk5nWUxEbUtXMDk5clB4cU9QdGorL1crV3NlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZHNPVmFSUXV2RTJjVVBpcEtWWUFBQSIsInZlciI6IjEuMCJ9.drT5CKw95WRF7LzC0WuhK-fTLpw3j61XMw_DZdrLOWP8sjjsrbn9kF7xjDSTUM0ooF5_1Y-j3dNjvI9crm_F3PMAyhYXmCsKjTJkc3DIK6URy3hqbKiRBNlrutwvILE777NY-uXK9PH-gcaVuV-mNrjrLuxxClMJ3OPpTU8Ux0fj3Nuyf3KrXC27Oks_M_RDqDaXHOTckrdz2m_LNLpi5x0nKCoxwR9r5C1m5IKZ25FSbvyRNwjwz5dReqnv5LxllQMHVWkpvO7i5438wAnnyaS2x211IBiE6_dnV2god8Sp3ZRinXc4aCimUnJl6tLa5EtT_VSmR2QcBSaq0wS_ZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA5MzE1NzAsIm5iZiI6MTUyMDkzMTU3MCwiZXhwIjoxNTIwOTM1NDcwLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVWQzdjZmVmptVXFfWE8tNFNZTTFBQSIsInZlciI6IjEuMCJ9.Sag7Azd8-5BvCVgt8BzHaAOt8qUSgfCcmd17qBZkB9WbFdcDcL9Eqewz9D2Q-e25gC1FXEUvjvdFMAdSY74xpFLI4_4Vbhp1E-JsUjyxa7rthxY7oiMCkRZWSJj8Vv_VUXimyS0CNzCmQPUnVZ89rdRajxjyWB1tuRP9przU10E_MwitgSHbVsVYXdooqCk-yGPfefXc1ZzUV2KCwWn3Mjfez6XmHRbgs4YSk1S1ZeDbPOQ6tpgWL9DaHBaYPU4N_NLYAcS4LrRHHaLsPT-RDfBYwx_Q_RKL5yPN0vOWVFDCp6RxyU0UOfopFwFFpmr8AZCN1ObA5DQi7BwlcodB_w
   response:
     status:
       code: 200
@@ -2310,398 +2421,321 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"92982330-0f29-406e-bba9-ad19198579a5"
+      - W/"b6339880-8ead-4c9e-b5c0-f38c4f8612d5"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - b40e43ed-954e-477e-9bbe-29767590a5d0
+      - a7992e3a-abdd-4f82-abca-d4a314ff3c64
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14989'
+      - '14928'
       X-Ms-Correlation-Request-Id:
-      - d1dded62-6d03-4235-a574-347097f01a7b
+      - 0d566818-790a-418f-9407-21be82b83f7b
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201940Z:d1dded62-6d03-4235-a574-347097f01a7b
+      - WESTEUROPE:20180313T090436Z:0d566818-790a-418f-9407-21be82b83f7b
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:19:40 GMT
+      - Tue, 13 Mar 2018 09:04:35 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"spec0deply1lb\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb\",\r\n
-        \ \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"8cd72f7c-03bd-4584-abc6-d9ce77ae6202\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip\"\r\n
-        \         },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
-        \           }\r\n          ],\r\n          \"inboundNatRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"BackendPool1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"backendIPConfigurations\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1\"\r\n
-        \           }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\":
-        [\r\n      {\r\n        \"name\": \"LBRule\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\":
-        80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        5,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\"\r\n
-        \         },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/probes/tcpProbe\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n
-        \       \"name\": \"tcpProbe\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/probes/tcpProbe\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Tcp\",\r\n          \"port\": 80,\r\n          \"intervalInSeconds\":
-        5,\r\n          \"numberOfProbes\": 2,\r\n          \"loadBalancingRules\":
-        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\":
-        [\r\n      {\r\n        \"name\": \"RDP-VM0\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 50001,\r\n          \"backendPort\":
-        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1\"\r\n
-        \         }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"RDP-VM1\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 50002,\r\n          \"backendPort\":
-        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:19:40 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MzgsIm5iZiI6MTUyMDQ1MzQzOCwiZXhwIjoxNTIwNDU3MzM4LCJhaW8iOiJZMk5nWUxEbUtXMDk5clB4cU9QdGorL1crV3NlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZHNPVmFSUXV2RTJjVVBpcEtWWUFBQSIsInZlciI6IjEuMCJ9.drT5CKw95WRF7LzC0WuhK-fTLpw3j61XMw_DZdrLOWP8sjjsrbn9kF7xjDSTUM0ooF5_1Y-j3dNjvI9crm_F3PMAyhYXmCsKjTJkc3DIK6URy3hqbKiRBNlrutwvILE777NY-uXK9PH-gcaVuV-mNrjrLuxxClMJ3OPpTU8Ux0fj3Nuyf3KrXC27Oks_M_RDqDaXHOTckrdz2m_LNLpi5x0nKCoxwR9r5C1m5IKZ25FSbvyRNwjwz5dReqnv5LxllQMHVWkpvO7i5438wAnnyaS2x211IBiE6_dnV2god8Sp3ZRinXc4aCimUnJl6tLa5EtT_VSmR2QcBSaq0wS_ZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"92982330-0f29-406e-bba9-ad19198579a5"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - ba23917c-6dd8-4b49-8ab0-ebb015c0bd8d
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14975'
-      X-Ms-Correlation-Request-Id:
-      - 42569b17-b49f-48dd-a183-3de35bd47f0c
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201941Z:42569b17-b49f-48dd-a183-3de35bd47f0c
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:19:41 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"spec0deply1lb\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb\",\r\n
-        \ \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"8cd72f7c-03bd-4584-abc6-d9ce77ae6202\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip\"\r\n
-        \         },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
-        \           }\r\n          ],\r\n          \"inboundNatRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"BackendPool1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"backendIPConfigurations\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1\"\r\n
-        \           }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\":
-        [\r\n      {\r\n        \"name\": \"LBRule\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\":
-        80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        5,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\"\r\n
-        \         },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/probes/tcpProbe\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n
-        \       \"name\": \"tcpProbe\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/probes/tcpProbe\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Tcp\",\r\n          \"port\": 80,\r\n          \"intervalInSeconds\":
-        5,\r\n          \"numberOfProbes\": 2,\r\n          \"loadBalancingRules\":
-        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\":
-        [\r\n      {\r\n        \"name\": \"RDP-VM0\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 50001,\r\n          \"backendPort\":
-        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1\"\r\n
-        \         }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"RDP-VM1\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 50002,\r\n          \"backendPort\":
-        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:19:41 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MzgsIm5iZiI6MTUyMDQ1MzQzOCwiZXhwIjoxNTIwNDU3MzM4LCJhaW8iOiJZMk5nWUxEbUtXMDk5clB4cU9QdGorL1crV3NlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZHNPVmFSUXV2RTJjVVBpcEtWWUFBQSIsInZlciI6IjEuMCJ9.drT5CKw95WRF7LzC0WuhK-fTLpw3j61XMw_DZdrLOWP8sjjsrbn9kF7xjDSTUM0ooF5_1Y-j3dNjvI9crm_F3PMAyhYXmCsKjTJkc3DIK6URy3hqbKiRBNlrutwvILE777NY-uXK9PH-gcaVuV-mNrjrLuxxClMJ3OPpTU8Ux0fj3Nuyf3KrXC27Oks_M_RDqDaXHOTckrdz2m_LNLpi5x0nKCoxwR9r5C1m5IKZ25FSbvyRNwjwz5dReqnv5LxllQMHVWkpvO7i5438wAnnyaS2x211IBiE6_dnV2god8Sp3ZRinXc4aCimUnJl6tLa5EtT_VSmR2QcBSaq0wS_ZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"92982330-0f29-406e-bba9-ad19198579a5"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 7f5af6d1-7772-44d9-a8b8-c67b87dd574f
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14977'
-      X-Ms-Correlation-Request-Id:
-      - aeb1e977-3e8f-404e-83b9-3904c35736f7
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201941Z:aeb1e977-3e8f-404e-83b9-3904c35736f7
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:19:41 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"spec0deply1lb\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb\",\r\n
-        \ \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"8cd72f7c-03bd-4584-abc6-d9ce77ae6202\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip\"\r\n
-        \         },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
-        \           }\r\n          ],\r\n          \"inboundNatRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"BackendPool1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"backendIPConfigurations\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1\"\r\n
-        \           }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\":
-        [\r\n      {\r\n        \"name\": \"LBRule\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\":
-        80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        5,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\"\r\n
-        \         },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/probes/tcpProbe\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n
-        \       \"name\": \"tcpProbe\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/probes/tcpProbe\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Tcp\",\r\n          \"port\": 80,\r\n          \"intervalInSeconds\":
-        5,\r\n          \"numberOfProbes\": 2,\r\n          \"loadBalancingRules\":
-        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\":
-        [\r\n      {\r\n        \"name\": \"RDP-VM0\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 50001,\r\n          \"backendPort\":
-        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1\"\r\n
-        \         }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"RDP-VM1\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 50002,\r\n          \"backendPort\":
-        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:19:42 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MzgsIm5iZiI6MTUyMDQ1MzQzOCwiZXhwIjoxNTIwNDU3MzM4LCJhaW8iOiJZMk5nWUxEbUtXMDk5clB4cU9QdGorL1crV3NlQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiZHNPVmFSUXV2RTJjVVBpcEtWWUFBQSIsInZlciI6IjEuMCJ9.drT5CKw95WRF7LzC0WuhK-fTLpw3j61XMw_DZdrLOWP8sjjsrbn9kF7xjDSTUM0ooF5_1Y-j3dNjvI9crm_F3PMAyhYXmCsKjTJkc3DIK6URy3hqbKiRBNlrutwvILE777NY-uXK9PH-gcaVuV-mNrjrLuxxClMJ3OPpTU8Ux0fj3Nuyf3KrXC27Oks_M_RDqDaXHOTckrdz2m_LNLpi5x0nKCoxwR9r5C1m5IKZ25FSbvyRNwjwz5dReqnv5LxllQMHVWkpvO7i5438wAnnyaS2x211IBiE6_dnV2god8Sp3ZRinXc4aCimUnJl6tLa5EtT_VSmR2QcBSaq0wS_ZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"2080997a-38a6-420d-ba86-e9582e1331c7"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 0d1981b5-81c9-4f53-9ecb-c600656f2920
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14976'
-      X-Ms-Correlation-Request-Id:
-      - 57b68513-837d-40ae-86d4-6dc6118c1a02
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201942Z:57b68513-837d-40ae-86d4-6dc6118c1a02
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:19:42 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"spec0deply1ip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip\",\r\n
-        \ \"etag\": \"W/\\\"2080997a-38a6-420d-ba86-e9582e1331c7\\\"\",\r\n  \"location\":
+      string: "{\r\n  \"name\": \"miqazure-linux-manag944\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944\",\r\n
+        \ \"etag\": \"W/\\\"b6339880-8ead-4c9e-b5c0-f38c4f8612d5\\\"\",\r\n  \"location\":
         \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"a08b891e-e45a-4970-aefc-f6c996989490\",\r\n    \"publicIPAddressVersion\":
+        \   \"resourceGuid\": \"c5e8b90e-5a78-49b0-b224-b70ed3fb45e5\",\r\n    \"ipConfigurations\":
+        [\r\n      {\r\n        \"name\": \"ipconfig1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944/ipConfigurations/ipconfig1\",\r\n
+        \       \"etag\": \"W/\\\"b6339880-8ead-4c9e-b5c0-f38c4f8612d5\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"privateIPAddress\": \"172.25.0.4\",\r\n          \"privateIPAllocationMethod\":
+        \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqazure-linux-managed-ip\"\r\n
+        \         },\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2/subnets/default\"\r\n
+        \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
+        \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\":
+        [],\r\n      \"appliedDnsServers\": []\r\n    },\r\n    \"enableAcceleratedNetworking\":
+        false,\r\n    \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\":
+        {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg\"\r\n
+        \   },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed\"\r\n
+        \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
+        \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
+    http_version: 
+  recorded_at: Tue, 13 Mar 2018 09:04:36 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg?api-version=2018-03-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA5MzE1NzAsIm5iZiI6MTUyMDkzMTU3MCwiZXhwIjoxNTIwOTM1NDcwLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVWQzdjZmVmptVXFfWE8tNFNZTTFBQSIsInZlciI6IjEuMCJ9.Sag7Azd8-5BvCVgt8BzHaAOt8qUSgfCcmd17qBZkB9WbFdcDcL9Eqewz9D2Q-e25gC1FXEUvjvdFMAdSY74xpFLI4_4Vbhp1E-JsUjyxa7rthxY7oiMCkRZWSJj8Vv_VUXimyS0CNzCmQPUnVZ89rdRajxjyWB1tuRP9przU10E_MwitgSHbVsVYXdooqCk-yGPfefXc1ZzUV2KCwWn3Mjfez6XmHRbgs4YSk1S1ZeDbPOQ6tpgWL9DaHBaYPU4N_NLYAcS4LrRHHaLsPT-RDfBYwx_Q_RKL5yPN0vOWVFDCp6RxyU0UOfopFwFFpmr8AZCN1ObA5DQi7BwlcodB_w
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - 2d575ed1-3d43-49f7-9a27-7ff0c40652eb
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14921'
+      X-Ms-Correlation-Request-Id:
+      - 3c19615f-f29a-4dd0-82db-4e1778ea56b8
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180313T090438Z:3c19615f-f29a-4dd0-82db-4e1778ea56b8
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Tue, 13 Mar 2018 09:04:38 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"miqazure-linux-managed-nsg\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg\",\r\n
+        \ \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/networkSecurityGroups\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
+        \"b4611f96-94a8-4486-94c5-16bb6c7a5c84\",\r\n    \"securityRules\": [\r\n
+        \     {\r\n        \"name\": \"default-allow-ssh\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/securityRules/default-allow-ssh\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"protocol\": \"TCP\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"22\",\r\n          \"sourceAddressPrefix\":
+        \"*\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n          \"access\":
+        \"Allow\",\r\n          \"priority\": 1000,\r\n          \"direction\": \"Inbound\",\r\n
+        \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      }\r\n    ],\r\n    \"defaultSecurityRules\": [\r\n
+        \     {\r\n        \"name\": \"AllowVnetInBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/AllowVnetInBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow inbound traffic from all VMs in VNET\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"VirtualNetwork\",\r\n          \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n          \"direction\":
+        \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowAzureLoadBalancerInBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/AllowAzureLoadBalancerInBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow inbound traffic from azure load balancer\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"AzureLoadBalancer\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65001,\r\n          \"direction\":
+        \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllInBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/DenyAllInBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Deny all inbound traffic\",\r\n          \"protocol\":
+        \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\":
+        \"*\",\r\n          \"sourceAddressPrefix\": \"*\",\r\n          \"destinationAddressPrefix\":
+        \"*\",\r\n          \"access\": \"Deny\",\r\n          \"priority\": 65500,\r\n
+        \         \"direction\": \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n
+        \         \"destinationPortRanges\": [],\r\n          \"sourceAddressPrefixes\":
+        [],\r\n          \"destinationAddressPrefixes\": []\r\n        }\r\n      },\r\n
+        \     {\r\n        \"name\": \"AllowVnetOutBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/AllowVnetOutBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow outbound traffic from all VMs to all VMs
+        in VNET\",\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\":
+        \"*\",\r\n          \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"VirtualNetwork\",\r\n          \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n          \"direction\":
+        \"Outbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowInternetOutBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/AllowInternetOutBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow outbound traffic from all VMs to Internet\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"*\",\r\n          \"destinationAddressPrefix\": \"Internet\",\r\n          \"access\":
+        \"Allow\",\r\n          \"priority\": 65001,\r\n          \"direction\": \"Outbound\",\r\n
+        \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllOutBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/DenyAllOutBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Deny all outbound traffic\",\r\n          \"protocol\":
+        \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\":
+        \"*\",\r\n          \"sourceAddressPrefix\": \"*\",\r\n          \"destinationAddressPrefix\":
+        \"*\",\r\n          \"access\": \"Deny\",\r\n          \"priority\": 65500,\r\n
+        \         \"direction\": \"Outbound\",\r\n          \"sourcePortRanges\":
+        [],\r\n          \"destinationPortRanges\": [],\r\n          \"sourceAddressPrefixes\":
+        [],\r\n          \"destinationAddressPrefixes\": []\r\n        }\r\n      }\r\n
+        \   ],\r\n    \"networkInterfaces\": [\r\n      {\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944\"\r\n
+        \     }\r\n    ]\r\n  }\r\n}"
+    http_version: 
+  recorded_at: Tue, 13 Mar 2018 09:04:39 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2?api-version=2018-03-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA5MzE1NzAsIm5iZiI6MTUyMDkzMTU3MCwiZXhwIjoxNTIwOTM1NDcwLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVWQzdjZmVmptVXFfWE8tNFNZTTFBQSIsInZlciI6IjEuMCJ9.Sag7Azd8-5BvCVgt8BzHaAOt8qUSgfCcmd17qBZkB9WbFdcDcL9Eqewz9D2Q-e25gC1FXEUvjvdFMAdSY74xpFLI4_4Vbhp1E-JsUjyxa7rthxY7oiMCkRZWSJj8Vv_VUXimyS0CNzCmQPUnVZ89rdRajxjyWB1tuRP9przU10E_MwitgSHbVsVYXdooqCk-yGPfefXc1ZzUV2KCwWn3Mjfez6XmHRbgs4YSk1S1ZeDbPOQ6tpgWL9DaHBaYPU4N_NLYAcS4LrRHHaLsPT-RDfBYwx_Q_RKL5yPN0vOWVFDCp6RxyU0UOfopFwFFpmr8AZCN1ObA5DQi7BwlcodB_w
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"f5bbd20f-7ae4-4b6d-89c8-eb3481fcbe05"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - e581c507-56cf-4330-ad5b-55253d03044d
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14918'
+      X-Ms-Correlation-Request-Id:
+      - f6098fc7-b2b7-4a8c-a27d-e322704bd0c2
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180313T090439Z:f6098fc7-b2b7-4a8c-a27d-e322704bd0c2
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Tue, 13 Mar 2018 09:04:39 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"miq-azure-test2\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2\",\r\n
+        \ \"etag\": \"W/\\\"f5bbd20f-7ae4-4b6d-89c8-eb3481fcbe05\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
+        \"f950a3cf-749a-49d5-a7fb-33a400b0e93c\",\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\":
+        [\r\n        \"172.25.0.0/16\"\r\n      ]\r\n    },\r\n    \"subnets\": [\r\n
+        \     {\r\n        \"name\": \"default\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2/subnets/default\",\r\n
+        \       \"etag\": \"W/\\\"f5bbd20f-7ae4-4b6d-89c8-eb3481fcbe05\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"addressPrefix\": \"172.25.0.0/24\",\r\n          \"ipConfigurations\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944/ipConfigurations/ipconfig1\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"virtualNetworkPeerings\":
+        [],\r\n    \"enableDdosProtection\": false,\r\n    \"enableVmProtection\":
+        false\r\n  }\r\n}"
+    http_version: 
+  recorded_at: Tue, 13 Mar 2018 09:04:39 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqazure-linux-managed-ip?api-version=2018-03-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA5MzE1NzAsIm5iZiI6MTUyMDkzMTU3MCwiZXhwIjoxNTIwOTM1NDcwLCJhaW8iOiJZMk5nWU5nKzk4QU81dldYUG1kc0ZqYTc4VFhxT2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVWQzdjZmVmptVXFfWE8tNFNZTTFBQSIsInZlciI6IjEuMCJ9.Sag7Azd8-5BvCVgt8BzHaAOt8qUSgfCcmd17qBZkB9WbFdcDcL9Eqewz9D2Q-e25gC1FXEUvjvdFMAdSY74xpFLI4_4Vbhp1E-JsUjyxa7rthxY7oiMCkRZWSJj8Vv_VUXimyS0CNzCmQPUnVZ89rdRajxjyWB1tuRP9przU10E_MwitgSHbVsVYXdooqCk-yGPfefXc1ZzUV2KCwWn3Mjfez6XmHRbgs4YSk1S1ZeDbPOQ6tpgWL9DaHBaYPU4N_NLYAcS4LrRHHaLsPT-RDfBYwx_Q_RKL5yPN0vOWVFDCp6RxyU0UOfopFwFFpmr8AZCN1ObA5DQi7BwlcodB_w
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Etag:
+      - W/"0efc9684-fb7d-4fb7-b9b9-f33dbac04a28"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Request-Id:
+      - c53ecbdc-9400-4df7-8d9a-19b726d3207f
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14928'
+      X-Ms-Correlation-Request-Id:
+      - 836379ef-4477-427a-bba9-f3c764539dea
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180313T090440Z:836379ef-4477-427a-bba9-f3c764539dea
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Tue, 13 Mar 2018 09:04:39 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"name\": \"miqazure-linux-managed-ip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqazure-linux-managed-ip\",\r\n
+        \ \"etag\": \"W/\\\"0efc9684-fb7d-4fb7-b9b9-f33dbac04a28\\\"\",\r\n  \"location\":
+        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"6a2a9142-26e8-45cd-93bf-7318192f3528\",\r\n    \"publicIPAddressVersion\":
         \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
-        4,\r\n    \"dnsSettings\": {\r\n      \"domainNameLabel\": \"spec0deply1dns\",\r\n
-        \     \"fqdn\": \"spec0deply1dns.eastus.cloudapp.azure.com\"\r\n    },\r\n
-        \   \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
+        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944/ipConfigurations/ipconfig1\"\r\n
         \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
         \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:19:42 GMT
+  recorded_at: Tue, 13 Mar 2018 09:04:40 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted_scope/orchestration_stack_lb_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted_scope/orchestration_stack_lb_refresh.yml
@@ -37,25 +37,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - db92410d-3087-4ced-bee0-c705935e0000
+      - f494d7a6-0457-46c7-b162-ac03ce322300
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHz2RxtZbjx3UT3xG7zJICfujZTTdzGBJNoiTPLqvqqsYTnSXcm9py2NyQ4Aavs_GvEVizY6hzI9eEZniVN9TDksxvWN1si6o7SrKJhZd5wFIT9T9GTNK-Xr_i7Nn35Pt8q-WFibQKMM64x-Id8xf8D8pMpvVcygEA-PS8_9Y8d7JQgAA;
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzbaPkDSFdRGB7fMIL_CwtVcjRZN8LDHTb3T28-_KFrQE8llTuyE7kLfF5IuDaN6wTbyTnflpxY8EwfXZka84xzjV0-V8vQYIYayIkZSuRYD0UFvCCrT_5XpubjnAAoewnGpl-TLgi3lju-2AeDBzAAX65qlFYJIajliquL_U_sK4gAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=008; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=002; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Wed, 07 Mar 2018 20:16:58 GMT
+      - Mon, 12 Mar 2018 10:24:45 GMT
       Content-Length:
       - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1520457419","not_before":"1520453519","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1MTksIm5iZiI6MTUyMDQ1MzUxOSwiZXhwIjoxNTIwNDU3NDE5LCJhaW8iOiJZMk5nWUVndU5CSXl1MXFVeEdEM2ZsSFpieWtHQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRFVHUzI0Y3c3VXktNE1jRmsxNEFBQSIsInZlciI6IjEuMCJ9.X0c8-x7koOzvjCLsUUVY7qEgIMOkgQtFN28a3YPd1YLmroj5Y3mvFfkKXmXXpfO3KAseRyz_11B_Bk8FGHl-CnFwBIRju-Aun2Bb07vJowCro-mGqFeRLSPG9Hsjx6FwBPqsvdycxKEMxfPD3eyvIb2FL2A7iViMtD8kysg8eoTN_wdlpglfnSfFxQdrnlehGcy2dxpXHQ5xjbjIijo34aHhVzh7ZJc3TwcYAuKSWi23fYU4fpRT5nDOugOoqCfxoK7kbUonOkbxiYZrOy56v3g7aJ9UPNyEN_GC5GEZGBb8QAxh51rr7ae2xL9vtPKWdB7p5JWRgw7jgGxCMS--YA"}'
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1520853886","not_before":"1520849986","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5ODYsIm5iZiI6MTUyMDg0OTk4NiwiZXhwIjoxNTIwODUzODg2LCJhaW8iOiJZMk5nWUxoellPWHF0WktxWGt5aTlYL21zTnhLQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoicHRlVTlGY0V4MGF4WXF3RHpqSWpBQSIsInZlciI6IjEuMCJ9.TMWxJdE0G3nFNiN3AlEVYYv5Uz4fv2HTtdDkEMz9lxirEJr948B0kDGlIdrWQhUHBKJz81bS-4NiR0257VZUTk0hdyGCDfqMpilfU02-R6LmoahnbejEO80vVMMIyYaXxVGvhOFLNCvTFgHTvGTke6AAnJgg8XlsNgmLVQaiAiYuVpdaus7QXmf-Oy6PDX_JxVfarS5H8O-BD5a76rpRlNfrxHJSjGgMcEo8AXuaViu7Bh0Xcg9nRWABE2rBEdOVCcib812YKlnr5rGRGukVj9YkNMrteTe0wltxfpcWb31keMrOSwZz7baqfAofTyPb524P3XZt275BvByO7PYWMw"}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:59 GMT
+  recorded_at: Mon, 12 Mar 2018 10:24:50 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -72,7 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1MTksIm5iZiI6MTUyMDQ1MzUxOSwiZXhwIjoxNTIwNDU3NDE5LCJhaW8iOiJZMk5nWUVndU5CSXl1MXFVeEdEM2ZsSFpieWtHQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRFVHUzI0Y3c3VXktNE1jRmsxNEFBQSIsInZlciI6IjEuMCJ9.X0c8-x7koOzvjCLsUUVY7qEgIMOkgQtFN28a3YPd1YLmroj5Y3mvFfkKXmXXpfO3KAseRyz_11B_Bk8FGHl-CnFwBIRju-Aun2Bb07vJowCro-mGqFeRLSPG9Hsjx6FwBPqsvdycxKEMxfPD3eyvIb2FL2A7iViMtD8kysg8eoTN_wdlpglfnSfFxQdrnlehGcy2dxpXHQ5xjbjIijo34aHhVzh7ZJc3TwcYAuKSWi23fYU4fpRT5nDOugOoqCfxoK7kbUonOkbxiYZrOy56v3g7aJ9UPNyEN_GC5GEZGBb8QAxh51rr7ae2xL9vtPKWdB7p5JWRgw7jgGxCMS--YA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5ODYsIm5iZiI6MTUyMDg0OTk4NiwiZXhwIjoxNTIwODUzODg2LCJhaW8iOiJZMk5nWUxoellPWHF0WktxWGt5aTlYL21zTnhLQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoicHRlVTlGY0V4MGF4WXF3RHpqSWpBQSIsInZlciI6IjEuMCJ9.TMWxJdE0G3nFNiN3AlEVYYv5Uz4fv2HTtdDkEMz9lxirEJr948B0kDGlIdrWQhUHBKJz81bS-4NiR0257VZUTk0hdyGCDfqMpilfU02-R6LmoahnbejEO80vVMMIyYaXxVGvhOFLNCvTFgHTvGTke6AAnJgg8XlsNgmLVQaiAiYuVpdaus7QXmf-Oy6PDX_JxVfarS5H8O-BD5a76rpRlNfrxHJSjGgMcEo8AXuaViu7Bh0Xcg9nRWABE2rBEdOVCcib812YKlnr5rGRGukVj9YkNMrteTe0wltxfpcWb31keMrOSwZz7baqfAofTyPb524P3XZt275BvByO7PYWMw
   response:
     status:
       code: 200
@@ -93,24 +93,24 @@ http_interactions:
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
       - '14997'
       X-Ms-Request-Id:
-      - c83eebca-c41b-4a14-8a6d-f5d082b6699e
+      - '09a18958-6064-4006-ba2b-da1b46a4474c'
       X-Ms-Correlation-Request-Id:
-      - c83eebca-c41b-4a14-8a6d-f5d082b6699e
+      - '09a18958-6064-4006-ba2b-da1b46a4474c'
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201659Z:c83eebca-c41b-4a14-8a6d-f5d082b6699e
+      - WESTEUROPE:20180312T102446Z:09a18958-6064-4006-ba2b-da1b46a4474c
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:16:59 GMT
+      - Mon, 12 Mar 2018 10:24:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID","subscriptionId":"AZURE_SUBSCRIPTION_ID","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:59 GMT
+  recorded_at: Mon, 12 Mar 2018 10:24:51 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers?api-version=2015-01-01
@@ -127,7 +127,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1MTksIm5iZiI6MTUyMDQ1MzUxOSwiZXhwIjoxNTIwNDU3NDE5LCJhaW8iOiJZMk5nWUVndU5CSXl1MXFVeEdEM2ZsSFpieWtHQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRFVHUzI0Y3c3VXktNE1jRmsxNEFBQSIsInZlciI6IjEuMCJ9.X0c8-x7koOzvjCLsUUVY7qEgIMOkgQtFN28a3YPd1YLmroj5Y3mvFfkKXmXXpfO3KAseRyz_11B_Bk8FGHl-CnFwBIRju-Aun2Bb07vJowCro-mGqFeRLSPG9Hsjx6FwBPqsvdycxKEMxfPD3eyvIb2FL2A7iViMtD8kysg8eoTN_wdlpglfnSfFxQdrnlehGcy2dxpXHQ5xjbjIijo34aHhVzh7ZJc3TwcYAuKSWi23fYU4fpRT5nDOugOoqCfxoK7kbUonOkbxiYZrOy56v3g7aJ9UPNyEN_GC5GEZGBb8QAxh51rr7ae2xL9vtPKWdB7p5JWRgw7jgGxCMS--YA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5ODYsIm5iZiI6MTUyMDg0OTk4NiwiZXhwIjoxNTIwODUzODg2LCJhaW8iOiJZMk5nWUxoellPWHF0WktxWGt5aTlYL21zTnhLQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoicHRlVTlGY0V4MGF4WXF3RHpqSWpBQSIsInZlciI6IjEuMCJ9.TMWxJdE0G3nFNiN3AlEVYYv5Uz4fv2HTtdDkEMz9lxirEJr948B0kDGlIdrWQhUHBKJz81bS-4NiR0257VZUTk0hdyGCDfqMpilfU02-R6LmoahnbejEO80vVMMIyYaXxVGvhOFLNCvTFgHTvGTke6AAnJgg8XlsNgmLVQaiAiYuVpdaus7QXmf-Oy6PDX_JxVfarS5H8O-BD5a76rpRlNfrxHJSjGgMcEo8AXuaViu7Bh0Xcg9nRWABE2rBEdOVCcib812YKlnr5rGRGukVj9YkNMrteTe0wltxfpcWb31keMrOSwZz7baqfAofTyPb524P3XZt275BvByO7PYWMw
   response:
     status:
       code: 200
@@ -144,39 +144,37 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14980'
+      - '14987'
       X-Ms-Request-Id:
-      - 3efe92c4-2746-4a5a-b5e8-9bd9d03f6b00
+      - ef36e8c9-d62d-494d-9d0b-2543cb9a8e15
       X-Ms-Correlation-Request-Id:
-      - 3efe92c4-2746-4a5a-b5e8-9bd9d03f6b00
+      - ef36e8c9-d62d-494d-9d0b-2543cb9a8e15
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201700Z:3efe92c4-2746-4a5a-b5e8-9bd9d03f6b00
+      - WESTEUROPE:20180312T102448Z:ef36e8c9-d62d-494d-9d0b-2543cb9a8e15
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:16:59 GMT
+      - Mon, 12 Mar 2018 10:24:48 GMT
       Content-Length:
-      - '310901'
+      - '320853'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"},{"applicationId":"d87dcbc6-a371-462e-88e3-28ad15ec4e64","roleDefinitionId":"861776c5-e0df-4f95-be4f-ac1eec193323"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
+      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"},{"applicationId":"d87dcbc6-a371-462e-88e3-28ad15ec4e64","roleDefinitionId":"861776c5-e0df-4f95-be4f-ac1eec193323"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["East
+        Asia","Southeast Asia","Australia East","Australia Southeast","Japan East","Japan
+        West","Central India","South India","West India","West Europe","North Europe","Canada
+        Central","Canada East","Brazil South","West US","Central US","East US","South
+        Central US","East US 2","West Central US","North Central US","West US 2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
         US","Central US","East US","South Central US","West Europe","North Europe","East
         Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
         Central US","North Central US","Japan East","Japan West","Brazil South","Central
         India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"operations","locations":["West
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["East
+        Asia","Southeast Asia","Australia East","Australia Southeast","Japan East","Japan
+        West","Central India","South India","West India","West Europe","North Europe","Canada
+        Central","Canada East","Brazil South","West US","Central US","East US","South
+        Central US","East US 2","West Central US","North Central US","West US 2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"operations","locations":["West
         US","Central US","East US","South Central US","West Europe","North Europe","East
         Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
         Central US","North Central US","Japan East","Japan West","Brazil South","Central
@@ -232,177 +230,177 @@ http_interactions:
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/internalLoadBalancers","locations":[],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"domainNames/slots/roles/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"domainNames/slots/roles/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"domainNames/capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"domainNames/serviceCertificates","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
         US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
         Central","Canada East","UK South","UK West","West US","Central US","South
         Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
-        East","Australia Southeast","West US 2","West Central US","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        East","Australia Southeast","West US 2","West Central US","France Central","South
+        India","Central India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
         US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
         Central","Canada East","UK South","UK West","West US","Central US","South
         Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
-        East","Australia Southeast","West US 2","West Central US","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metrics","locations":["North
+        East","Australia Southeast","West US 2","West Central US","France Central","South
+        India","Central India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metrics","locations":["North
         Central US","South Central US","East US","East US 2","Canada Central","Canada
         East","West US","West US 2","West Central US","Central US","East Asia","Southeast
         Asia","North Europe","West Europe","UK South","UK West","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"resourceTypes","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"moveSubscriptionResources","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"validateSubscriptionMoveAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operationStatuses","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operatingSystems","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"operatingSystemFamilies","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicNetwork","namespace":"Microsoft.ClassicNetwork","resourceTypes":[{"resourceType":"virtualNetworks","locations":["East
+        India","West India","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"resourceTypes","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"moveSubscriptionResources","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"validateSubscriptionMoveAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operationStatuses","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operatingSystems","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"operatingSystemFamilies","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicNetwork","namespace":"Microsoft.ClassicNetwork","resourceTypes":[{"resourceType":"virtualNetworks","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"virtualNetworks/remoteVirtualNetworkPeeringProxies","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01"]},{"resourceType":"virtualNetworks/remoteVirtualNetworkPeeringProxies","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"reservedIps","locations":["East
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01"]},{"resourceType":"reservedIps","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"gatewaySupportedDevices","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"networkSecurityGroups","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"gatewaySupportedDevices","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"networkSecurityGroups","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicStorage","namespace":"Microsoft.ClassicStorage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"expressRouteCrossConnections","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"expressRouteCrossConnections/peerings","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicStorage","namespace":"Microsoft.ClassicStorage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkStorageAccountAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"storageAccounts/services","locations":["West
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkStorageAccountAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"storageAccounts/services","locations":["West
         US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
         Asia","Australia East","Australia Southeast","South India","Central India","West
         India","West US 2","West Central US","East US","East US 2","North Central
         US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
-        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/diagnosticSettings","locations":["West
+        South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/diagnosticSettings","locations":["West
         US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
         Asia","Australia East","Australia Southeast","South India","Central India","West
         India","West US 2","West Central US","East US","East US 2","North Central
         US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
-        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"disks","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"images","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"vmImages","locations":[],"apiVersions":["2016-11-01"]},{"resourceType":"publicImages","locations":[],"apiVersions":["2016-11-01","2016-04-01"]},{"resourceType":"osImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"osPlatformImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute","namespace":"Microsoft.Compute","authorizations":[{"applicationId":"60e6cd67-9c8c-4951-9b3c-23c25a2169af","roleDefinitionId":"e4770acb-272e-4dc8-87f3-12f44a612224"},{"applicationId":"a303894e-f1d8-4a37-bf10-67aa654a0596","roleDefinitionId":"903ac751-8ad5-4e5a-bfc2-5e49f450a241"},{"applicationId":"a8b6bf88-1d1a-4626-b040-9a729ea93c65","roleDefinitionId":"45c8267c-80ba-4b96-9a43-115b8f49fccd"}],"resourceTypes":[{"resourceType":"availabilitySets","locations":["East
+        South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"disks","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"images","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"vmImages","locations":[],"apiVersions":["2016-11-01"]},{"resourceType":"storageAccounts/vmImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"publicImages","locations":[],"apiVersions":["2016-11-01","2016-04-01"]},{"resourceType":"osImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"osPlatformImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute","namespace":"Microsoft.Compute","authorizations":[{"applicationId":"60e6cd67-9c8c-4951-9b3c-23c25a2169af","roleDefinitionId":"e4770acb-272e-4dc8-87f3-12f44a612224"},{"applicationId":"a303894e-f1d8-4a37-bf10-67aa654a0596","roleDefinitionId":"903ac751-8ad5-4e5a-bfc2-5e49f450a241"},{"applicationId":"a8b6bf88-1d1a-4626-b040-9a729ea93c65","roleDefinitionId":"45c8267c-80ba-4b96-9a43-115b8f49fccd"}],"resourceTypes":[{"resourceType":"availabilitySets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations/usages","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations/usages","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"sharedVMImages","locations":["West
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"sharedVMImages","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"sharedVMImages/versions","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"locations/capsoperations","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"disks","locations":["Southeast
@@ -410,27 +408,27 @@ http_interactions:
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"snapshots","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"snapshots","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"locations/diskoperations","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"locations/diskoperations","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"images","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"images","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"]},{"resourceType":"locations/logAnalytics","locations":["East
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"]},{"resourceType":"locations/logAnalytics","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
         US","East US","South Central US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
@@ -547,7 +545,12 @@ http_interactions:
         US","East Asia","East US","East US 2","Japan East","Japan West","North Central
         US","North Europe","South Central US","South India","Southeast Asia","West
         Central US","West Europe","West India","West US","West US 2","UK West","UK
-        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"},{"applicationId":"f5c26e74-f226-4ae8-85f0-b4af0080ac9e","roleDefinitionId":"529d7ae6-e892-4d43-809d-8547aeb90643"}],"resourceTypes":[{"resourceType":"components","locations":["East
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/consumergroups","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/disasterrecoveryconfigs","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"},{"applicationId":"f5c26e74-f226-4ae8-85f0-b4af0080ac9e","roleDefinitionId":"529d7ae6-e892-4d43-809d-8547aeb90643"}],"resourceTypes":[{"resourceType":"components","locations":["East
         US","South Central US","North Europe","West Europe","Southeast Asia","West
         US 2"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
         US","South Central US","North Europe","West Europe","Southeast Asia","West
@@ -614,32 +617,32 @@ http_interactions:
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/accessPolicies","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"vaults/accessPolicies","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-10-01","2015-06-01","2014-12-19-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"deletedVaults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01","2014-12-19-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"deletedVaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-10-01"]},{"resourceType":"locations/deletedVaults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations/deletedVaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
         Central US","West Europe","Southeast Asia","Japan East","West Central US"],"apiVersions":["2016-04-01"]},{"resourceType":"webServices","locations":["South
         Central US","West Europe","Southeast Asia","Japan East","East US 2","West
         Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"operations","locations":["South
@@ -665,97 +668,97 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"networkWatchers/lenses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"networkWatchers/lenses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","West
         US 2","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
@@ -846,7 +849,7 @@ http_interactions:
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
         West","Korea Central","Korea South"],"apiVersions":["2017-07-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ResourceHealth","namespace":"Microsoft.ResourceHealth","authorizations":[{"applicationId":"8bdebf23-c0fe-4187-a378-717ad86f6a53","roleDefinitionId":"cc026344-c8b1-4561-83ba-59eba84b27cc"}],"resourceTypes":[{"resourceType":"availabilityStatuses","locations":[],"apiVersions":["2017-07-01","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"notifications","locations":["Australia
-        Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Security","namespace":"Microsoft.Security","authorization":{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
+        Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Security","namespace":"Microsoft.Security","authorizations":[{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},{"applicationId":"fc780465-2017-40d4-a0c5-307022471b92"}],"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatuses","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/virtualMachines","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/endpoints","locations":["Central
@@ -898,565 +901,595 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Central India","South
         India"],"apiVersions":["2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Sql","namespace":"Microsoft.Sql","authorizations":[{"applicationId":"e4ab13ed-33cb-41b4-9140-6e264582cf85","roleDefinitionId":"ec3ddc95-44dc-47a2-9926-5e9f5ffd44ec"},{"applicationId":"0130cc9f-7ac5-4026-bd5f-80a08a54e6d9","roleDefinitionId":"45e8abf8-0ec4-44f3-9c37-cff4f7779302"},{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},{"applicationId":"76c7f279-7959-468f-8943-3954880e0d8c","roleDefinitionId":"7f7513a8-73f9-4c5f-97a2-c41f0ea783ef"}],"resourceTypes":[{"resourceType":"operations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/capabilities","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/databaseAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/databaseOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverKeyOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/keys","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/encryptionProtector","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/usages","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01","2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/communicationLinks","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administrators","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administratorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/restorableDroppedDatabases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recoverableDatabases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/geoBackupPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/importExportOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/operationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/backupLongTermRetentionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/automaticTuning","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/automaticTuning","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/databases/transparentDataEncryption","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recommendedElasticPools","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/auditingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/connectionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/connectionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies/rules","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/securityAlertPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/securityAlertPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/auditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/extendedAuditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/elasticpools","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-09-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/jobAgentOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/jobAgentAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/disasterRecoveryConfiguration","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/dnsAliases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/failoverGroups","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/virtualNetworkRules","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/virtualNetworkRulesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/virtualNetworkRulesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/databaseRestoreAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metricDefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/aggregatedDatabaseMetrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metricdefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries/queryText","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPools/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/extensions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPoolEstimates","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditRecords","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentScans","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/vulnerabilityAssessments","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessment","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/syncGroups","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups/syncMembers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/syncAgents","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"managedInstances/administrators","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/databases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metricDefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/administratorAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/administratorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncMemberOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncAgentOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncDatabaseIds","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorizations":[{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},{"applicationId":"e406a681-f3d4-42a8-90b6-c2b029497af1"}],"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/capabilities","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/databaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"locations/databaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverKeyOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/keys","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/encryptionProtector","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01","2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/communicationLinks","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/restorableDroppedDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recoverableDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/geoBackupPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/importExportOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/operationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/backupLongTermRetentionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/databases/transparentDataEncryption","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recommendedElasticPools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies/rules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/extendedAuditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/elasticPoolAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/elasticPoolOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/elasticpools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-09-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/jobAgentOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/jobAgentAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/disasterRecoveryConfiguration","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/dnsAliases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/failoverGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/virtualNetworkRules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/virtualNetworkRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/virtualNetworkRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/databaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/aggregatedDatabaseMetrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metricdefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries/queryText","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPools/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/extensions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPoolEstimates","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditRecords","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentScans","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/vulnerabilityAssessments","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessment","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/syncGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups/syncMembers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/syncAgents","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"managedInstances/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/administratorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncMemberOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncAgentOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncDatabaseIds","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/longTermRetentionPolicyOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionPolicyAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionBackupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionBackupAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorizations":[{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},{"applicationId":"e406a681-f3d4-42a8-90b6-c2b029497af1"}],"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
@@ -1795,12 +1828,12 @@ http_interactions:
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","Canada Central","Canada East","UK South","UK West","West US 2","West
-        Central US","South India","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","South India","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","South India","Canada Central","Canada East","UK South","UK West","West
-        US 2","West Central US","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Capacity","namespace":"Microsoft.Capacity","authorization":{"applicationId":"4d0ad6c7-f6c3-46d8-ab0d-1406d5e6c86b","roleDefinitionId":"FD9C0A9A-4DB9-4F41-8A61-98385DEB6E2D"},"resourceTypes":[{"resourceType":"resources","locations":["South
+        US 2","West Central US","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Capacity","namespace":"Microsoft.Capacity","authorization":{"applicationId":"4d0ad6c7-f6c3-46d8-ab0d-1406d5e6c86b","roleDefinitionId":"FD9C0A9A-4DB9-4F41-8A61-98385DEB6E2D"},"resourceTypes":[{"resourceType":"resources","locations":["South
         Central US"],"apiVersions":["2017-11-01"]},{"resourceType":"reservationOrders","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/reservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/reservations/revisions","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"catalogs","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"appliedReservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"checkOffers","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"checkScopes","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"calculatePrice","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/calculateRefund","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/return","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/split","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/merge","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"validateReservationOrder","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/availableScopes","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Cdn","namespace":"Microsoft.Cdn","resourceTypes":[{"resourceType":"profiles","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
@@ -1876,9 +1909,9 @@ http_interactions:
         2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/updateAccountsCreationSettings","locations":["West
         US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/accountsCreationSettings","locations":["West
         US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2016-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Commerce","namespace":"Microsoft.Commerce","resourceTypes":[{"resourceType":"UsageAggregates","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]},{"resourceType":"RateCard","locations":[],"apiVersions":["2016-08-31-preview","2015-06-01-preview","2015-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Consumption","namespace":"Microsoft.Consumption","resourceTypes":[{"resourceType":"ReservationSummaries","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationTransactions","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Balances","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Marketplaces","locations":[],"apiVersions":["2018-01-31"]},{"resourceType":"Pricesheets","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationDetails","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Budgets","locations":[],"apiVersions":["2018-01-31","2017-12-30-preview"]},{"resourceType":"Terms","locations":[],"apiVersions":["2018-01-31","2017-12-30-preview"]},{"resourceType":"UsageDetails","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview","2017-04-24-preview"]},{"resourceType":"Operations","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview","2017-04-24-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerInstance","namespace":"Microsoft.ContainerInstance","resourceTypes":[{"resourceType":"containerGroups","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/usages","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/operations","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/operations","locations":["West
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
         US"],"apiVersions":["2016-04-08"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.CustomerInsights","namespace":"Microsoft.CustomerInsights","authorization":{"applicationId":"38c77d00-5fcb-4cce-9d93-af4738258e3c","roleDefinitionId":"E006F9C7-F333-477C-8AD6-1F3A9FE87F55"},"resourceTypes":[{"resourceType":"hubs","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/profiles","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/interactions","locations":["East
@@ -1895,7 +1928,9 @@ http_interactions:
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"operations","locations":["East
         US 2"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Databricks","namespace":"Microsoft.Databricks","authorizations":[{"applicationId":"d9327919-6775-4843-9037-3fb0fb0473cb","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},{"applicationId":"2ff814a6-3304-4ab8-85cb-cd0e6f879c1d","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"}],"resourceTypes":[{"resourceType":"workspaces","locations":["West
         US","East US 2","West Europe","East US","North Europe","Southeast Asia","East
-        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]},{"resourceType":"locations","locations":["West
+        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2017-09-01-preview"]},{"resourceType":"workspaces/virtualNetworkPeerings","locations":["West
+        US","East US 2","West Europe","North Europe","East US","Southeast Asia","East
+        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01"]},{"resourceType":"locations","locations":["West
         US","East US 2","West Europe","North Europe","East US","Southeast Asia"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
         US","East US 2","West Europe","East US","North Europe","Southeast Asia","East
         Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataCatalog","namespace":"Microsoft.DataCatalog","resourceTypes":[{"resourceType":"catalogs","locations":["East
@@ -1919,23 +1954,26 @@ http_interactions:
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers/listSasTokens","locations":["East
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataLakeStore","namespace":"Microsoft.DataLakeStore","authorization":{"applicationId":"e9f49c6b-5ce5-44c8-925d-015017e9f7ad","roleDefinitionId":"17eb9cca-f08a-4499-b2d3-852d175f614f"},"resourceTypes":[{"resourceType":"accounts","locations":["East
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/firewallRules","locations":["East
-        US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataMigration","namespace":"Microsoft.DataMigration","authorization":{"applicationId":"a4bad4aa-bf02-4631-9f78-a64ffdba8150","roleDefinitionId":"b831a21d-db98-4760-89cb-bef871952df1","managedByRoleDefinitionId":"6256fb55-9e59-4018-a9e1-76b11c0a4c89"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services/projects","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationStatuses","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
+        US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataMigration","namespace":"Microsoft.DataMigration","authorization":{"applicationId":"a4bad4aa-bf02-4631-9f78-a64ffdba8150","roleDefinitionId":"b831a21d-db98-4760-89cb-bef871952df1","managedByRoleDefinitionId":"6256fb55-9e59-4018-a9e1-76b11c0a4c89"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services/projects","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationStatuses","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
-        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/recoverableServers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
@@ -1959,7 +1997,10 @@ http_interactions:
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
-        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/recoverableServers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
@@ -2015,12 +2056,7 @@ http_interactions:
         US 2","East US","West US","Central US","East US 2","West Central US","West
         Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
         US 2","East US","West US","Central US","East US 2","West Central US","West
-        Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","West
-        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
-        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
-        India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/consumergroups","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/disasterrecoveryconfigs","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
         US 2","South Central US","Central US","Australia Southeast","Central India","West
         Central US","West US 2","Canada East","Canada Central","Brazil South","UK
         South","UK West","East Asia","Australia East","Japan East","Japan West","North
@@ -2131,7 +2167,7 @@ http_interactions:
         West","Japan East","East Asia","Southeast Asia","West Europe","North Europe","East
         US","West US","Australia East","Australia Southeast","Central US","Brazil
         South","Central India","West India","South India","South Central US","Canada
-        Central","Canada East","West Central US","West US 2"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
+        Central","Canada East","West Central US","West US 2"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-05","2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
         Central US","East US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"operations","locations":["West
         Central US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
         Central US","East US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.PolicyInsights","namespace":"Microsoft.PolicyInsights","authorization":{"applicationId":"1d78a85d-813d-46f0-b496-dd72f50a3ec0","roleDefinitionId":"63d2b225-4c34-4641-8768-21a1f7c68ce8"},"resourceTypes":[{"resourceType":"policyEvents","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"policyStates","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
@@ -2163,12 +2199,12 @@ http_interactions:
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
         Central US","South Central US","North Europe","West Europe","East Asia","Southeast
         Asia","West US","East US","Japan West","Japan East","Brazil South","Central
         US","East US 2","Australia East","Australia Southeast","South India","Central
@@ -2208,40 +2244,50 @@ http_interactions:
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/clusterVersions","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"clusters/applications","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operations","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/clusterVersions","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/environments","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operations","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
         Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applianceDefinitions","locations":["West
         Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applications","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
-        Central US"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
+        Central US"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
         US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
         US","Canada Central","Canada East","Central US","East US 2","UK South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups","locations":["West
         US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
@@ -2332,7 +2378,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:17:00 GMT
+  recorded_at: Mon, 12 Mar 2018 10:24:53 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb?api-version=2018-01-01
@@ -2349,7 +2395,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1MTksIm5iZiI6MTUyMDQ1MzUxOSwiZXhwIjoxNTIwNDU3NDE5LCJhaW8iOiJZMk5nWUVndU5CSXl1MXFVeEdEM2ZsSFpieWtHQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRFVHUzI0Y3c3VXktNE1jRmsxNEFBQSIsInZlciI6IjEuMCJ9.X0c8-x7koOzvjCLsUUVY7qEgIMOkgQtFN28a3YPd1YLmroj5Y3mvFfkKXmXXpfO3KAseRyz_11B_Bk8FGHl-CnFwBIRju-Aun2Bb07vJowCro-mGqFeRLSPG9Hsjx6FwBPqsvdycxKEMxfPD3eyvIb2FL2A7iViMtD8kysg8eoTN_wdlpglfnSfFxQdrnlehGcy2dxpXHQ5xjbjIijo34aHhVzh7ZJc3TwcYAuKSWi23fYU4fpRT5nDOugOoqCfxoK7kbUonOkbxiYZrOy56v3g7aJ9UPNyEN_GC5GEZGBb8QAxh51rr7ae2xL9vtPKWdB7p5JWRgw7jgGxCMS--YA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5ODYsIm5iZiI6MTUyMDg0OTk4NiwiZXhwIjoxNTIwODUzODg2LCJhaW8iOiJZMk5nWUxoellPWHF0WktxWGt5aTlYL21zTnhLQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoicHRlVTlGY0V4MGF4WXF3RHpqSWpBQSIsInZlciI6IjEuMCJ9.TMWxJdE0G3nFNiN3AlEVYYv5Uz4fv2HTtdDkEMz9lxirEJr948B0kDGlIdrWQhUHBKJz81bS-4NiR0257VZUTk0hdyGCDfqMpilfU02-R6LmoahnbejEO80vVMMIyYaXxVGvhOFLNCvTFgHTvGTke6AAnJgg8XlsNgmLVQaiAiYuVpdaus7QXmf-Oy6PDX_JxVfarS5H8O-BD5a76rpRlNfrxHJSjGgMcEo8AXuaViu7Bh0Xcg9nRWABE2rBEdOVCcib812YKlnr5rGRGukVj9YkNMrteTe0wltxfpcWb31keMrOSwZz7baqfAofTyPb524P3XZt275BvByO7PYWMw
   response:
     status:
       code: 200
@@ -2370,22 +2416,22 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - f8b26e54-27b3-421b-ad4e-c91bbf0d4887
+      - 7e9cb951-85a3-4140-961a-9138c51019c8
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14979'
+      - '14987'
       X-Ms-Correlation-Request-Id:
-      - 9c21c192-5ea1-48fb-9bd1-73acc74e3ae4
+      - 33d024a0-7b78-4637-afbf-9c9aac64869c
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201701Z:9c21c192-5ea1-48fb-9bd1-73acc74e3ae4
+      - WESTEUROPE:20180312T102450Z:33d024a0-7b78-4637-afbf-9c9aac64869c
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:17:01 GMT
+      - Mon, 12 Mar 2018 10:24:49 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"spec0deply1lb\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb\",\r\n
@@ -2452,247 +2498,7 @@ http_interactions:
         [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
         \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:17:01 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1MTksIm5iZiI6MTUyMDQ1MzUxOSwiZXhwIjoxNTIwNDU3NDE5LCJhaW8iOiJZMk5nWUVndU5CSXl1MXFVeEdEM2ZsSFpieWtHQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRFVHUzI0Y3c3VXktNE1jRmsxNEFBQSIsInZlciI6IjEuMCJ9.X0c8-x7koOzvjCLsUUVY7qEgIMOkgQtFN28a3YPd1YLmroj5Y3mvFfkKXmXXpfO3KAseRyz_11B_Bk8FGHl-CnFwBIRju-Aun2Bb07vJowCro-mGqFeRLSPG9Hsjx6FwBPqsvdycxKEMxfPD3eyvIb2FL2A7iViMtD8kysg8eoTN_wdlpglfnSfFxQdrnlehGcy2dxpXHQ5xjbjIijo34aHhVzh7ZJc3TwcYAuKSWi23fYU4fpRT5nDOugOoqCfxoK7kbUonOkbxiYZrOy56v3g7aJ9UPNyEN_GC5GEZGBb8QAxh51rr7ae2xL9vtPKWdB7p5JWRgw7jgGxCMS--YA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"92982330-0f29-406e-bba9-ad19198579a5"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - f0855c68-4e08-4371-8228-29e1cbe7468c
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14978'
-      X-Ms-Correlation-Request-Id:
-      - f067f496-4058-40f0-9346-936ac0d9cd95
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201702Z:f067f496-4058-40f0-9346-936ac0d9cd95
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:17:01 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"spec0deply1lb\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb\",\r\n
-        \ \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"8cd72f7c-03bd-4584-abc6-d9ce77ae6202\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip\"\r\n
-        \         },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
-        \           }\r\n          ],\r\n          \"inboundNatRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"BackendPool1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"backendIPConfigurations\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1\"\r\n
-        \           }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\":
-        [\r\n      {\r\n        \"name\": \"LBRule\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\":
-        80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        5,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\"\r\n
-        \         },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/probes/tcpProbe\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n
-        \       \"name\": \"tcpProbe\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/probes/tcpProbe\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Tcp\",\r\n          \"port\": 80,\r\n          \"intervalInSeconds\":
-        5,\r\n          \"numberOfProbes\": 2,\r\n          \"loadBalancingRules\":
-        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\":
-        [\r\n      {\r\n        \"name\": \"RDP-VM0\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 50001,\r\n          \"backendPort\":
-        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1\"\r\n
-        \         }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"RDP-VM1\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 50002,\r\n          \"backendPort\":
-        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:17:02 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1MTksIm5iZiI6MTUyMDQ1MzUxOSwiZXhwIjoxNTIwNDU3NDE5LCJhaW8iOiJZMk5nWUVndU5CSXl1MXFVeEdEM2ZsSFpieWtHQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRFVHUzI0Y3c3VXktNE1jRmsxNEFBQSIsInZlciI6IjEuMCJ9.X0c8-x7koOzvjCLsUUVY7qEgIMOkgQtFN28a3YPd1YLmroj5Y3mvFfkKXmXXpfO3KAseRyz_11B_Bk8FGHl-CnFwBIRju-Aun2Bb07vJowCro-mGqFeRLSPG9Hsjx6FwBPqsvdycxKEMxfPD3eyvIb2FL2A7iViMtD8kysg8eoTN_wdlpglfnSfFxQdrnlehGcy2dxpXHQ5xjbjIijo34aHhVzh7ZJc3TwcYAuKSWi23fYU4fpRT5nDOugOoqCfxoK7kbUonOkbxiYZrOy56v3g7aJ9UPNyEN_GC5GEZGBb8QAxh51rr7ae2xL9vtPKWdB7p5JWRgw7jgGxCMS--YA
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"92982330-0f29-406e-bba9-ad19198579a5"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 13a46071-ee69-47b4-b4bb-02ce40b4e1c1
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14978'
-      X-Ms-Correlation-Request-Id:
-      - 1e1ccb01-fe7f-47ad-afca-1a71dcdff776
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201702Z:1e1ccb01-fe7f-47ad-afca-1a71dcdff776
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:17:01 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"spec0deply1lb\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb\",\r\n
-        \ \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"8cd72f7c-03bd-4584-abc6-d9ce77ae6202\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip\"\r\n
-        \         },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
-        \           }\r\n          ],\r\n          \"inboundNatRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"BackendPool1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"backendIPConfigurations\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1\"\r\n
-        \           }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\":
-        [\r\n      {\r\n        \"name\": \"LBRule\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\":
-        80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        5,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\"\r\n
-        \         },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/probes/tcpProbe\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n
-        \       \"name\": \"tcpProbe\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/probes/tcpProbe\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Tcp\",\r\n          \"port\": 80,\r\n          \"intervalInSeconds\":
-        5,\r\n          \"numberOfProbes\": 2,\r\n          \"loadBalancingRules\":
-        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\":
-        [\r\n      {\r\n        \"name\": \"RDP-VM0\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 50001,\r\n          \"backendPort\":
-        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1\"\r\n
-        \         }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"RDP-VM1\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 50002,\r\n          \"backendPort\":
-        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:17:02 GMT
+  recorded_at: Mon, 12 Mar 2018 10:24:54 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip?api-version=2018-01-01
@@ -2709,7 +2515,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1MTksIm5iZiI6MTUyMDQ1MzUxOSwiZXhwIjoxNTIwNDU3NDE5LCJhaW8iOiJZMk5nWUVndU5CSXl1MXFVeEdEM2ZsSFpieWtHQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiRFVHUzI0Y3c3VXktNE1jRmsxNEFBQSIsInZlciI6IjEuMCJ9.X0c8-x7koOzvjCLsUUVY7qEgIMOkgQtFN28a3YPd1YLmroj5Y3mvFfkKXmXXpfO3KAseRyz_11B_Bk8FGHl-CnFwBIRju-Aun2Bb07vJowCro-mGqFeRLSPG9Hsjx6FwBPqsvdycxKEMxfPD3eyvIb2FL2A7iViMtD8kysg8eoTN_wdlpglfnSfFxQdrnlehGcy2dxpXHQ5xjbjIijo34aHhVzh7ZJc3TwcYAuKSWi23fYU4fpRT5nDOugOoqCfxoK7kbUonOkbxiYZrOy56v3g7aJ9UPNyEN_GC5GEZGBb8QAxh51rr7ae2xL9vtPKWdB7p5JWRgw7jgGxCMS--YA
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5ODYsIm5iZiI6MTUyMDg0OTk4NiwiZXhwIjoxNTIwODUzODg2LCJhaW8iOiJZMk5nWUxoellPWHF0WktxWGt5aTlYL21zTnhLQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoicHRlVTlGY0V4MGF4WXF3RHpqSWpBQSIsInZlciI6IjEuMCJ9.TMWxJdE0G3nFNiN3AlEVYYv5Uz4fv2HTtdDkEMz9lxirEJr948B0kDGlIdrWQhUHBKJz81bS-4NiR0257VZUTk0hdyGCDfqMpilfU02-R6LmoahnbejEO80vVMMIyYaXxVGvhOFLNCvTFgHTvGTke6AAnJgg8XlsNgmLVQaiAiYuVpdaus7QXmf-Oy6PDX_JxVfarS5H8O-BD5a76rpRlNfrxHJSjGgMcEo8AXuaViu7Bh0Xcg9nRWABE2rBEdOVCcib812YKlnr5rGRGukVj9YkNMrteTe0wltxfpcWb31keMrOSwZz7baqfAofTyPb524P3XZt275BvByO7PYWMw
   response:
     status:
       code: 200
@@ -2730,22 +2536,22 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 8ab019f1-7c6c-485a-8cd2-61da7fa0ca48
+      - 2d8a35c0-c3ed-4a68-b772-fd18514e8510
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14978'
+      - '14984'
       X-Ms-Correlation-Request-Id:
-      - 7754d700-484a-4e05-b98b-56de9d7c40b7
+      - 75475882-c3a7-4d56-ab33-3ea5896ed0e6
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201703Z:7754d700-484a-4e05-b98b-56de9d7c40b7
+      - WESTEUROPE:20180312T102450Z:75475882-c3a7-4d56-ab33-3ea5896ed0e6
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:17:02 GMT
+      - Mon, 12 Mar 2018 10:24:49 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"spec0deply1ip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip\",\r\n
@@ -2759,5 +2565,5 @@ http_interactions:
         \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
         \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:17:03 GMT
+  recorded_at: Mon, 12 Mar 2018 10:24:55 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted_scope/orchestration_stack_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted_scope/orchestration_stack_refresh.yml
@@ -37,25 +37,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - b0eb64e1-0456-425c-887d-d00019530000
+      - 93634dc6-51e3-42bd-86d1-829a69f01d00
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzE-1Sde1R6llutJ4DU7aLOybhuy6jQzhWniWpU-JlP0mToY5a5jkh6msZGqP95GMQwTeYqPjvoQrs8V22sI_FK8CHcUJS8hC48GBg0YjR9Rp94_ADcY5q2dSTVYac0XZi4rQq2eFCYIV0nehRbQSVYoO4cya9m5if4IR17ZNO_7MgAA;
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzVt2D3vLOm6rKKjETvv2dBu6dXqgO_Q7DibiRyxuAnwLKeJiPNTAWnjKBCSJOGNwSSSTUscZQGmH-PfsUmogWIR3JHRz4ek9aUgzhhii2dx86sbfAgADQ5_bjoZjJqCkZ20_rnCwJbYgU-bz8_C3oRladh_2Sf8eFftVEZ-IQxHYgAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
       - x-ms-gateway-slice=004; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Wed, 07 Mar 2018 20:16:12 GMT
+      - Mon, 12 Mar 2018 10:20:55 GMT
       Content-Length:
       - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3600","ext_expires_in":"0","expires_on":"1520457373","not_before":"1520453473","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0NzMsIm5iZiI6MTUyMDQ1MzQ3MywiZXhwIjoxNTIwNDU3MzczLCJhaW8iOiJZMk5nWU5qWTM4RStWU2lPKzlxT2duY0JKOWN0QlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNFdUcnNGWUVYRUtJZmRBQUdWTUFBQSIsInZlciI6IjEuMCJ9.ArxfPNTq5GDkmFBppDjfAq99t5AKHpkiomJyFlFNwYavrQxfd66kamPOrTK4LUxqE7dufAUhjQG5zQLqcZPvtl1SS4zIppFRih0g1Iur45O6WRCd5hv4r9n0sZVLlSnyIsza0haM5o5Sz5ic2k-cBTw0-HwWuTwFz8ALJmG8x0lxKaY8uxuuD13yghFGHL5eoIIZ0WsMIuOSzx8bqSAvXctOpvg6d8r73UECp7ugreyMFj0o_RWgO7UlOlp9rfa0io1kOcsz620m7evOgR42aEh-B6ga-nscmo53D_vXoOFeB0u9_WoUGLB4bb1831b4nBT9dYhV8HL7tvYLQqR8Ig"}'
+      string: '{"token_type":"Bearer","expires_in":"3600","ext_expires_in":"0","expires_on":"1520853655","not_before":"1520849755","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk3NTUsIm5iZiI6MTUyMDg0OTc1NSwiZXhwIjoxNTIwODUzNjU1LCJhaW8iOiJZMk5nWUhnU3QvT29SR0tTa2t5aS80UzNIY3JMQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieGsxamstTlJ2VUtHMFlLYWFmQWRBQSIsInZlciI6IjEuMCJ9.ADT-9qZlaX4MDV07ntM5ibfPXZ63OeoRAoNBbFZmQtrp-S15bXoIC9vgBM8Z7S-8C3rEe3Y6n10LoMCUxTiixfn6zlPn82JobgdO8ksXbX4z5uYvTIv4fYi14dtIwJBMgF2MA1zN2sErSREp1jZ3axzq7ZxG14K2vMsezi8bcTHCLWiM0VUpd_AVT23FOmDsls-WKsTM1zK0Fzjz1vrv1446EJZSg3xIQmEghD3ijAz9qJIojkR-xxdEEpDhtB6s4daub6Tjg9_YjTUdKiRcO6sJJfQetnxRRNLQi-5zYdBBQyC7ovmXuPitPGTKLDuJo2Xn9HUe9Hu-Flccmk_pWQ"}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:13 GMT
+  recorded_at: Mon, 12 Mar 2018 10:21:00 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -72,7 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0NzMsIm5iZiI6MTUyMDQ1MzQ3MywiZXhwIjoxNTIwNDU3MzczLCJhaW8iOiJZMk5nWU5qWTM4RStWU2lPKzlxT2duY0JKOWN0QlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNFdUcnNGWUVYRUtJZmRBQUdWTUFBQSIsInZlciI6IjEuMCJ9.ArxfPNTq5GDkmFBppDjfAq99t5AKHpkiomJyFlFNwYavrQxfd66kamPOrTK4LUxqE7dufAUhjQG5zQLqcZPvtl1SS4zIppFRih0g1Iur45O6WRCd5hv4r9n0sZVLlSnyIsza0haM5o5Sz5ic2k-cBTw0-HwWuTwFz8ALJmG8x0lxKaY8uxuuD13yghFGHL5eoIIZ0WsMIuOSzx8bqSAvXctOpvg6d8r73UECp7ugreyMFj0o_RWgO7UlOlp9rfa0io1kOcsz620m7evOgR42aEh-B6ga-nscmo53D_vXoOFeB0u9_WoUGLB4bb1831b4nBT9dYhV8HL7tvYLQqR8Ig
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk3NTUsIm5iZiI6MTUyMDg0OTc1NSwiZXhwIjoxNTIwODUzNjU1LCJhaW8iOiJZMk5nWUhnU3QvT29SR0tTa2t5aS80UzNIY3JMQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieGsxamstTlJ2VUtHMFlLYWFmQWRBQSIsInZlciI6IjEuMCJ9.ADT-9qZlaX4MDV07ntM5ibfPXZ63OeoRAoNBbFZmQtrp-S15bXoIC9vgBM8Z7S-8C3rEe3Y6n10LoMCUxTiixfn6zlPn82JobgdO8ksXbX4z5uYvTIv4fYi14dtIwJBMgF2MA1zN2sErSREp1jZ3axzq7ZxG14K2vMsezi8bcTHCLWiM0VUpd_AVT23FOmDsls-WKsTM1zK0Fzjz1vrv1446EJZSg3xIQmEghD3ijAz9qJIojkR-xxdEEpDhtB6s4daub6Tjg9_YjTUdKiRcO6sJJfQetnxRRNLQi-5zYdBBQyC7ovmXuPitPGTKLDuJo2Xn9HUe9Hu-Flccmk_pWQ
   response:
     status:
       code: 200
@@ -93,24 +93,24 @@ http_interactions:
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
       - '14999'
       X-Ms-Request-Id:
-      - 26debcbb-0c14-41f6-abf4-768de9ed5c1c
+      - 3e2c3cb4-818a-44b5-b257-06affcbc7b3c
       X-Ms-Correlation-Request-Id:
-      - 26debcbb-0c14-41f6-abf4-768de9ed5c1c
+      - 3e2c3cb4-818a-44b5-b257-06affcbc7b3c
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201613Z:26debcbb-0c14-41f6-abf4-768de9ed5c1c
+      - WESTEUROPE:20180312T102057Z:3e2c3cb4-818a-44b5-b257-06affcbc7b3c
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:16:13 GMT
+      - Mon, 12 Mar 2018 10:20:57 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID","subscriptionId":"AZURE_SUBSCRIPTION_ID","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:14 GMT
+  recorded_at: Mon, 12 Mar 2018 10:21:02 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers?api-version=2015-01-01
@@ -127,7 +127,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0NzMsIm5iZiI6MTUyMDQ1MzQ3MywiZXhwIjoxNTIwNDU3MzczLCJhaW8iOiJZMk5nWU5qWTM4RStWU2lPKzlxT2duY0JKOWN0QlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNFdUcnNGWUVYRUtJZmRBQUdWTUFBQSIsInZlciI6IjEuMCJ9.ArxfPNTq5GDkmFBppDjfAq99t5AKHpkiomJyFlFNwYavrQxfd66kamPOrTK4LUxqE7dufAUhjQG5zQLqcZPvtl1SS4zIppFRih0g1Iur45O6WRCd5hv4r9n0sZVLlSnyIsza0haM5o5Sz5ic2k-cBTw0-HwWuTwFz8ALJmG8x0lxKaY8uxuuD13yghFGHL5eoIIZ0WsMIuOSzx8bqSAvXctOpvg6d8r73UECp7ugreyMFj0o_RWgO7UlOlp9rfa0io1kOcsz620m7evOgR42aEh-B6ga-nscmo53D_vXoOFeB0u9_WoUGLB4bb1831b4nBT9dYhV8HL7tvYLQqR8Ig
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk3NTUsIm5iZiI6MTUyMDg0OTc1NSwiZXhwIjoxNTIwODUzNjU1LCJhaW8iOiJZMk5nWUhnU3QvT29SR0tTa2t5aS80UzNIY3JMQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieGsxamstTlJ2VUtHMFlLYWFmQWRBQSIsInZlciI6IjEuMCJ9.ADT-9qZlaX4MDV07ntM5ibfPXZ63OeoRAoNBbFZmQtrp-S15bXoIC9vgBM8Z7S-8C3rEe3Y6n10LoMCUxTiixfn6zlPn82JobgdO8ksXbX4z5uYvTIv4fYi14dtIwJBMgF2MA1zN2sErSREp1jZ3axzq7ZxG14K2vMsezi8bcTHCLWiM0VUpd_AVT23FOmDsls-WKsTM1zK0Fzjz1vrv1446EJZSg3xIQmEghD3ijAz9qJIojkR-xxdEEpDhtB6s4daub6Tjg9_YjTUdKiRcO6sJJfQetnxRRNLQi-5zYdBBQyC7ovmXuPitPGTKLDuJo2Xn9HUe9Hu-Flccmk_pWQ
   response:
     status:
       code: 200
@@ -144,39 +144,37 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14983'
+      - '14989'
       X-Ms-Request-Id:
-      - 9add4332-a428-45c3-bd30-a6563daa3e34
+      - c0957b76-3a1f-424b-8d3e-766bd2374298
       X-Ms-Correlation-Request-Id:
-      - 9add4332-a428-45c3-bd30-a6563daa3e34
+      - c0957b76-3a1f-424b-8d3e-766bd2374298
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201615Z:9add4332-a428-45c3-bd30-a6563daa3e34
+      - WESTEUROPE:20180312T102102Z:c0957b76-3a1f-424b-8d3e-766bd2374298
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:16:15 GMT
+      - Mon, 12 Mar 2018 10:21:02 GMT
       Content-Length:
-      - '310901'
+      - '320853'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"},{"applicationId":"d87dcbc6-a371-462e-88e3-28ad15ec4e64","roleDefinitionId":"861776c5-e0df-4f95-be4f-ac1eec193323"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
+      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"},{"applicationId":"d87dcbc6-a371-462e-88e3-28ad15ec4e64","roleDefinitionId":"861776c5-e0df-4f95-be4f-ac1eec193323"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["East
+        Asia","Southeast Asia","Australia East","Australia Southeast","Japan East","Japan
+        West","Central India","South India","West India","West Europe","North Europe","Canada
+        Central","Canada East","Brazil South","West US","Central US","East US","South
+        Central US","East US 2","West Central US","North Central US","West US 2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
         US","Central US","East US","South Central US","West Europe","North Europe","East
         Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
         Central US","North Central US","Japan East","Japan West","Brazil South","Central
         India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"operations","locations":["West
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["East
+        Asia","Southeast Asia","Australia East","Australia Southeast","Japan East","Japan
+        West","Central India","South India","West India","West Europe","North Europe","Canada
+        Central","Canada East","Brazil South","West US","Central US","East US","South
+        Central US","East US 2","West Central US","North Central US","West US 2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"operations","locations":["West
         US","Central US","East US","South Central US","West Europe","North Europe","East
         Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
         Central US","North Central US","Japan East","Japan West","Brazil South","Central
@@ -232,177 +230,177 @@ http_interactions:
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/internalLoadBalancers","locations":[],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"domainNames/slots/roles/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"domainNames/slots/roles/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"domainNames/capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"domainNames/serviceCertificates","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
         US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
         Central","Canada East","UK South","UK West","West US","Central US","South
         Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
-        East","Australia Southeast","West US 2","West Central US","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        East","Australia Southeast","West US 2","West Central US","France Central","South
+        India","Central India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
         US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
         Central","Canada East","UK South","UK West","West US","Central US","South
         Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
-        East","Australia Southeast","West US 2","West Central US","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metrics","locations":["North
+        East","Australia Southeast","West US 2","West Central US","France Central","South
+        India","Central India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metrics","locations":["North
         Central US","South Central US","East US","East US 2","Canada Central","Canada
         East","West US","West US 2","West Central US","Central US","East Asia","Southeast
         Asia","North Europe","West Europe","UK South","UK West","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"resourceTypes","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"moveSubscriptionResources","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"validateSubscriptionMoveAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operationStatuses","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operatingSystems","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"operatingSystemFamilies","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicNetwork","namespace":"Microsoft.ClassicNetwork","resourceTypes":[{"resourceType":"virtualNetworks","locations":["East
+        India","West India","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"resourceTypes","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"moveSubscriptionResources","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"validateSubscriptionMoveAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operationStatuses","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operatingSystems","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"operatingSystemFamilies","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicNetwork","namespace":"Microsoft.ClassicNetwork","resourceTypes":[{"resourceType":"virtualNetworks","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"virtualNetworks/remoteVirtualNetworkPeeringProxies","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01"]},{"resourceType":"virtualNetworks/remoteVirtualNetworkPeeringProxies","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"reservedIps","locations":["East
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01"]},{"resourceType":"reservedIps","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"gatewaySupportedDevices","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"networkSecurityGroups","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"gatewaySupportedDevices","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"networkSecurityGroups","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicStorage","namespace":"Microsoft.ClassicStorage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"expressRouteCrossConnections","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"expressRouteCrossConnections/peerings","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicStorage","namespace":"Microsoft.ClassicStorage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkStorageAccountAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"storageAccounts/services","locations":["West
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkStorageAccountAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"storageAccounts/services","locations":["West
         US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
         Asia","Australia East","Australia Southeast","South India","Central India","West
         India","West US 2","West Central US","East US","East US 2","North Central
         US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
-        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/diagnosticSettings","locations":["West
+        South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/diagnosticSettings","locations":["West
         US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
         Asia","Australia East","Australia Southeast","South India","Central India","West
         India","West US 2","West Central US","East US","East US 2","North Central
         US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
-        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"disks","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"images","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"vmImages","locations":[],"apiVersions":["2016-11-01"]},{"resourceType":"publicImages","locations":[],"apiVersions":["2016-11-01","2016-04-01"]},{"resourceType":"osImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"osPlatformImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute","namespace":"Microsoft.Compute","authorizations":[{"applicationId":"60e6cd67-9c8c-4951-9b3c-23c25a2169af","roleDefinitionId":"e4770acb-272e-4dc8-87f3-12f44a612224"},{"applicationId":"a303894e-f1d8-4a37-bf10-67aa654a0596","roleDefinitionId":"903ac751-8ad5-4e5a-bfc2-5e49f450a241"},{"applicationId":"a8b6bf88-1d1a-4626-b040-9a729ea93c65","roleDefinitionId":"45c8267c-80ba-4b96-9a43-115b8f49fccd"}],"resourceTypes":[{"resourceType":"availabilitySets","locations":["East
+        South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"disks","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"images","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"vmImages","locations":[],"apiVersions":["2016-11-01"]},{"resourceType":"storageAccounts/vmImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"publicImages","locations":[],"apiVersions":["2016-11-01","2016-04-01"]},{"resourceType":"osImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"osPlatformImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute","namespace":"Microsoft.Compute","authorizations":[{"applicationId":"60e6cd67-9c8c-4951-9b3c-23c25a2169af","roleDefinitionId":"e4770acb-272e-4dc8-87f3-12f44a612224"},{"applicationId":"a303894e-f1d8-4a37-bf10-67aa654a0596","roleDefinitionId":"903ac751-8ad5-4e5a-bfc2-5e49f450a241"},{"applicationId":"a8b6bf88-1d1a-4626-b040-9a729ea93c65","roleDefinitionId":"45c8267c-80ba-4b96-9a43-115b8f49fccd"}],"resourceTypes":[{"resourceType":"availabilitySets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations/usages","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations/usages","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"sharedVMImages","locations":["West
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"sharedVMImages","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"sharedVMImages/versions","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"locations/capsoperations","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"disks","locations":["Southeast
@@ -410,27 +408,27 @@ http_interactions:
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"snapshots","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"snapshots","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"locations/diskoperations","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"locations/diskoperations","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"images","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"images","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"]},{"resourceType":"locations/logAnalytics","locations":["East
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"]},{"resourceType":"locations/logAnalytics","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
         US","East US","South Central US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
@@ -547,7 +545,12 @@ http_interactions:
         US","East Asia","East US","East US 2","Japan East","Japan West","North Central
         US","North Europe","South Central US","South India","Southeast Asia","West
         Central US","West Europe","West India","West US","West US 2","UK West","UK
-        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"},{"applicationId":"f5c26e74-f226-4ae8-85f0-b4af0080ac9e","roleDefinitionId":"529d7ae6-e892-4d43-809d-8547aeb90643"}],"resourceTypes":[{"resourceType":"components","locations":["East
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/consumergroups","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/disasterrecoveryconfigs","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"},{"applicationId":"f5c26e74-f226-4ae8-85f0-b4af0080ac9e","roleDefinitionId":"529d7ae6-e892-4d43-809d-8547aeb90643"}],"resourceTypes":[{"resourceType":"components","locations":["East
         US","South Central US","North Europe","West Europe","Southeast Asia","West
         US 2"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
         US","South Central US","North Europe","West Europe","Southeast Asia","West
@@ -614,32 +617,32 @@ http_interactions:
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/accessPolicies","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"vaults/accessPolicies","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-10-01","2015-06-01","2014-12-19-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"deletedVaults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01","2014-12-19-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"deletedVaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-10-01"]},{"resourceType":"locations/deletedVaults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations/deletedVaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
         Central US","West Europe","Southeast Asia","Japan East","West Central US"],"apiVersions":["2016-04-01"]},{"resourceType":"webServices","locations":["South
         Central US","West Europe","Southeast Asia","Japan East","East US 2","West
         Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"operations","locations":["South
@@ -665,97 +668,97 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"networkWatchers/lenses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"networkWatchers/lenses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","West
         US 2","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
@@ -846,7 +849,7 @@ http_interactions:
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
         West","Korea Central","Korea South"],"apiVersions":["2017-07-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ResourceHealth","namespace":"Microsoft.ResourceHealth","authorizations":[{"applicationId":"8bdebf23-c0fe-4187-a378-717ad86f6a53","roleDefinitionId":"cc026344-c8b1-4561-83ba-59eba84b27cc"}],"resourceTypes":[{"resourceType":"availabilityStatuses","locations":[],"apiVersions":["2017-07-01","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"notifications","locations":["Australia
-        Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Security","namespace":"Microsoft.Security","authorization":{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
+        Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Security","namespace":"Microsoft.Security","authorizations":[{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},{"applicationId":"fc780465-2017-40d4-a0c5-307022471b92"}],"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatuses","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/virtualMachines","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/endpoints","locations":["Central
@@ -898,565 +901,595 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Central India","South
         India"],"apiVersions":["2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Sql","namespace":"Microsoft.Sql","authorizations":[{"applicationId":"e4ab13ed-33cb-41b4-9140-6e264582cf85","roleDefinitionId":"ec3ddc95-44dc-47a2-9926-5e9f5ffd44ec"},{"applicationId":"0130cc9f-7ac5-4026-bd5f-80a08a54e6d9","roleDefinitionId":"45e8abf8-0ec4-44f3-9c37-cff4f7779302"},{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},{"applicationId":"76c7f279-7959-468f-8943-3954880e0d8c","roleDefinitionId":"7f7513a8-73f9-4c5f-97a2-c41f0ea783ef"}],"resourceTypes":[{"resourceType":"operations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/capabilities","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/databaseAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/databaseOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverKeyOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/keys","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/encryptionProtector","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/usages","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01","2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/communicationLinks","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administrators","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administratorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/restorableDroppedDatabases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recoverableDatabases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/geoBackupPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/importExportOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/operationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/backupLongTermRetentionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/automaticTuning","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/automaticTuning","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/databases/transparentDataEncryption","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recommendedElasticPools","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/auditingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/connectionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/connectionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies/rules","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/securityAlertPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/securityAlertPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/auditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/extendedAuditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/elasticpools","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-09-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/jobAgentOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/jobAgentAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/disasterRecoveryConfiguration","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/dnsAliases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/failoverGroups","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/virtualNetworkRules","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/virtualNetworkRulesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/virtualNetworkRulesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/databaseRestoreAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metricDefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/aggregatedDatabaseMetrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metricdefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries/queryText","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPools/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/extensions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPoolEstimates","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditRecords","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentScans","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/vulnerabilityAssessments","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessment","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/syncGroups","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups/syncMembers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/syncAgents","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"managedInstances/administrators","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/databases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metricDefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/administratorAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/administratorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncMemberOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncAgentOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncDatabaseIds","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorizations":[{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},{"applicationId":"e406a681-f3d4-42a8-90b6-c2b029497af1"}],"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/capabilities","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/databaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"locations/databaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverKeyOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/keys","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/encryptionProtector","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01","2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/communicationLinks","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/restorableDroppedDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recoverableDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/geoBackupPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/importExportOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/operationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/backupLongTermRetentionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/databases/transparentDataEncryption","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recommendedElasticPools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies/rules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/extendedAuditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/elasticPoolAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/elasticPoolOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/elasticpools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-09-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/jobAgentOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/jobAgentAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/disasterRecoveryConfiguration","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/dnsAliases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/failoverGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/virtualNetworkRules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/virtualNetworkRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/virtualNetworkRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/databaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/aggregatedDatabaseMetrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metricdefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries/queryText","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPools/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/extensions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPoolEstimates","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditRecords","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentScans","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/vulnerabilityAssessments","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessment","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/syncGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups/syncMembers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/syncAgents","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"managedInstances/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/administratorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncMemberOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncAgentOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncDatabaseIds","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/longTermRetentionPolicyOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionPolicyAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionBackupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionBackupAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorizations":[{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},{"applicationId":"e406a681-f3d4-42a8-90b6-c2b029497af1"}],"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
@@ -1795,12 +1828,12 @@ http_interactions:
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","Canada Central","Canada East","UK South","UK West","West US 2","West
-        Central US","South India","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","South India","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","South India","Canada Central","Canada East","UK South","UK West","West
-        US 2","West Central US","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Capacity","namespace":"Microsoft.Capacity","authorization":{"applicationId":"4d0ad6c7-f6c3-46d8-ab0d-1406d5e6c86b","roleDefinitionId":"FD9C0A9A-4DB9-4F41-8A61-98385DEB6E2D"},"resourceTypes":[{"resourceType":"resources","locations":["South
+        US 2","West Central US","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Capacity","namespace":"Microsoft.Capacity","authorization":{"applicationId":"4d0ad6c7-f6c3-46d8-ab0d-1406d5e6c86b","roleDefinitionId":"FD9C0A9A-4DB9-4F41-8A61-98385DEB6E2D"},"resourceTypes":[{"resourceType":"resources","locations":["South
         Central US"],"apiVersions":["2017-11-01"]},{"resourceType":"reservationOrders","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/reservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/reservations/revisions","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"catalogs","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"appliedReservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"checkOffers","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"checkScopes","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"calculatePrice","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/calculateRefund","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/return","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/split","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/merge","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"validateReservationOrder","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/availableScopes","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Cdn","namespace":"Microsoft.Cdn","resourceTypes":[{"resourceType":"profiles","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
@@ -1876,9 +1909,9 @@ http_interactions:
         2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/updateAccountsCreationSettings","locations":["West
         US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/accountsCreationSettings","locations":["West
         US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2016-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Commerce","namespace":"Microsoft.Commerce","resourceTypes":[{"resourceType":"UsageAggregates","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]},{"resourceType":"RateCard","locations":[],"apiVersions":["2016-08-31-preview","2015-06-01-preview","2015-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Consumption","namespace":"Microsoft.Consumption","resourceTypes":[{"resourceType":"ReservationSummaries","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationTransactions","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Balances","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Marketplaces","locations":[],"apiVersions":["2018-01-31"]},{"resourceType":"Pricesheets","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationDetails","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Budgets","locations":[],"apiVersions":["2018-01-31","2017-12-30-preview"]},{"resourceType":"Terms","locations":[],"apiVersions":["2018-01-31","2017-12-30-preview"]},{"resourceType":"UsageDetails","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview","2017-04-24-preview"]},{"resourceType":"Operations","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview","2017-04-24-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerInstance","namespace":"Microsoft.ContainerInstance","resourceTypes":[{"resourceType":"containerGroups","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/usages","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/operations","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/operations","locations":["West
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
         US"],"apiVersions":["2016-04-08"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.CustomerInsights","namespace":"Microsoft.CustomerInsights","authorization":{"applicationId":"38c77d00-5fcb-4cce-9d93-af4738258e3c","roleDefinitionId":"E006F9C7-F333-477C-8AD6-1F3A9FE87F55"},"resourceTypes":[{"resourceType":"hubs","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/profiles","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/interactions","locations":["East
@@ -1895,7 +1928,9 @@ http_interactions:
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"operations","locations":["East
         US 2"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Databricks","namespace":"Microsoft.Databricks","authorizations":[{"applicationId":"d9327919-6775-4843-9037-3fb0fb0473cb","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},{"applicationId":"2ff814a6-3304-4ab8-85cb-cd0e6f879c1d","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"}],"resourceTypes":[{"resourceType":"workspaces","locations":["West
         US","East US 2","West Europe","East US","North Europe","Southeast Asia","East
-        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]},{"resourceType":"locations","locations":["West
+        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2017-09-01-preview"]},{"resourceType":"workspaces/virtualNetworkPeerings","locations":["West
+        US","East US 2","West Europe","North Europe","East US","Southeast Asia","East
+        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01"]},{"resourceType":"locations","locations":["West
         US","East US 2","West Europe","North Europe","East US","Southeast Asia"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
         US","East US 2","West Europe","East US","North Europe","Southeast Asia","East
         Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataCatalog","namespace":"Microsoft.DataCatalog","resourceTypes":[{"resourceType":"catalogs","locations":["East
@@ -1919,23 +1954,26 @@ http_interactions:
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers/listSasTokens","locations":["East
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataLakeStore","namespace":"Microsoft.DataLakeStore","authorization":{"applicationId":"e9f49c6b-5ce5-44c8-925d-015017e9f7ad","roleDefinitionId":"17eb9cca-f08a-4499-b2d3-852d175f614f"},"resourceTypes":[{"resourceType":"accounts","locations":["East
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/firewallRules","locations":["East
-        US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataMigration","namespace":"Microsoft.DataMigration","authorization":{"applicationId":"a4bad4aa-bf02-4631-9f78-a64ffdba8150","roleDefinitionId":"b831a21d-db98-4760-89cb-bef871952df1","managedByRoleDefinitionId":"6256fb55-9e59-4018-a9e1-76b11c0a4c89"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services/projects","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationStatuses","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
+        US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataMigration","namespace":"Microsoft.DataMigration","authorization":{"applicationId":"a4bad4aa-bf02-4631-9f78-a64ffdba8150","roleDefinitionId":"b831a21d-db98-4760-89cb-bef871952df1","managedByRoleDefinitionId":"6256fb55-9e59-4018-a9e1-76b11c0a4c89"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services/projects","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationStatuses","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
-        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/recoverableServers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
@@ -1959,7 +1997,10 @@ http_interactions:
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
-        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/recoverableServers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
@@ -2015,12 +2056,7 @@ http_interactions:
         US 2","East US","West US","Central US","East US 2","West Central US","West
         Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
         US 2","East US","West US","Central US","East US 2","West Central US","West
-        Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","West
-        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
-        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
-        India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/consumergroups","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/disasterrecoveryconfigs","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
         US 2","South Central US","Central US","Australia Southeast","Central India","West
         Central US","West US 2","Canada East","Canada Central","Brazil South","UK
         South","UK West","East Asia","Australia East","Japan East","Japan West","North
@@ -2131,7 +2167,7 @@ http_interactions:
         West","Japan East","East Asia","Southeast Asia","West Europe","North Europe","East
         US","West US","Australia East","Australia Southeast","Central US","Brazil
         South","Central India","West India","South India","South Central US","Canada
-        Central","Canada East","West Central US","West US 2"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
+        Central","Canada East","West Central US","West US 2"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-05","2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
         Central US","East US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"operations","locations":["West
         Central US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
         Central US","East US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.PolicyInsights","namespace":"Microsoft.PolicyInsights","authorization":{"applicationId":"1d78a85d-813d-46f0-b496-dd72f50a3ec0","roleDefinitionId":"63d2b225-4c34-4641-8768-21a1f7c68ce8"},"resourceTypes":[{"resourceType":"policyEvents","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"policyStates","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
@@ -2163,12 +2199,12 @@ http_interactions:
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
         Central US","South Central US","North Europe","West Europe","East Asia","Southeast
         Asia","West US","East US","Japan West","Japan East","Brazil South","Central
         US","East US 2","Australia East","Australia Southeast","South India","Central
@@ -2208,40 +2244,50 @@ http_interactions:
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/clusterVersions","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"clusters/applications","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operations","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/clusterVersions","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/environments","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operations","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
         Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applianceDefinitions","locations":["West
         Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applications","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
-        Central US"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
+        Central US"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
         US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
         US","Canada Central","Canada East","Central US","East US 2","UK South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups","locations":["West
         US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
@@ -2332,7 +2378,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:15 GMT
+  recorded_at: Mon, 12 Mar 2018 10:21:07 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-deployment-dont-delete?api-version=2017-08-01
@@ -2349,7 +2395,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0NzMsIm5iZiI6MTUyMDQ1MzQ3MywiZXhwIjoxNTIwNDU3MzczLCJhaW8iOiJZMk5nWU5qWTM4RStWU2lPKzlxT2duY0JKOWN0QlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNFdUcnNGWUVYRUtJZmRBQUdWTUFBQSIsInZlciI6IjEuMCJ9.ArxfPNTq5GDkmFBppDjfAq99t5AKHpkiomJyFlFNwYavrQxfd66kamPOrTK4LUxqE7dufAUhjQG5zQLqcZPvtl1SS4zIppFRih0g1Iur45O6WRCd5hv4r9n0sZVLlSnyIsza0haM5o5Sz5ic2k-cBTw0-HwWuTwFz8ALJmG8x0lxKaY8uxuuD13yghFGHL5eoIIZ0WsMIuOSzx8bqSAvXctOpvg6d8r73UECp7ugreyMFj0o_RWgO7UlOlp9rfa0io1kOcsz620m7evOgR42aEh-B6ga-nscmo53D_vXoOFeB0u9_WoUGLB4bb1831b4nBT9dYhV8HL7tvYLQqR8Ig
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk3NTUsIm5iZiI6MTUyMDg0OTc1NSwiZXhwIjoxNTIwODUzNjU1LCJhaW8iOiJZMk5nWUhnU3QvT29SR0tTa2t5aS80UzNIY3JMQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieGsxamstTlJ2VUtHMFlLYWFmQWRBQSIsInZlciI6IjEuMCJ9.ADT-9qZlaX4MDV07ntM5ibfPXZ63OeoRAoNBbFZmQtrp-S15bXoIC9vgBM8Z7S-8C3rEe3Y6n10LoMCUxTiixfn6zlPn82JobgdO8ksXbX4z5uYvTIv4fYi14dtIwJBMgF2MA1zN2sErSREp1jZ3axzq7ZxG14K2vMsezi8bcTHCLWiM0VUpd_AVT23FOmDsls-WKsTM1zK0Fzjz1vrv1446EJZSg3xIQmEghD3ijAz9qJIojkR-xxdEEpDhtB6s4daub6Tjg9_YjTUdKiRcO6sJJfQetnxRRNLQi-5zYdBBQyC7ovmXuPitPGTKLDuJo2Xn9HUe9Hu-Flccmk_pWQ
   response:
     status:
       code: 200
@@ -2366,19 +2412,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14982'
+      - '14990'
       X-Ms-Request-Id:
-      - 0dc2964a-326e-419f-8781-09714d1df43e
+      - 95d2a862-10a2-4047-a1a5-9e44f428a22c
       X-Ms-Correlation-Request-Id:
-      - 0dc2964a-326e-419f-8781-09714d1df43e
+      - 95d2a862-10a2-4047-a1a5-9e44f428a22c
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201616Z:0dc2964a-326e-419f-8781-09714d1df43e
+      - WESTEUROPE:20180312T102104Z:95d2a862-10a2-4047-a1a5-9e44f428a22c
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:16:16 GMT
+      - Mon, 12 Mar 2018 10:21:04 GMT
       Content-Length:
       - '3083'
     body:
@@ -2386,114 +2432,7 @@ http_interactions:
       string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-deployment-dont-delete","name":"spec-deployment-dont-delete","properties":{"templateLink":{"uri":"https://gist.githubusercontent.com/bzwei/e6ccc4d641d6afab8e26ef55c37c498e/raw/769505e37256e926a9b581a100c90bb657ff45ff/azure-parent-spec.json","contentVersion":"1.0.0.0"},"parameters":{"childDeployName":{"type":"String","value":"spec-nested-deployment-dont-delete"},"storageAccountName":{"type":"String","value":"spec0deply1stor"},"availabilitySetName":{"type":"String","value":"spec0deply1as"},"adminUsername":{"type":"String","value":"deploy1admin"},"adminPassword":{"type":"SecureString"},"dnsNameforLBIP":{"type":"String","value":"spec0deply1dns"},"vmNamePrefix":{"type":"String","value":"spec0deply1vm"},"imagePublisher":{"type":"String","value":"MicrosoftWindowsServer"},"imageOffer":{"type":"String","value":"WindowsServer"},"imageSKU":{"type":"String","value":"2012-R2-Datacenter"},"lbName":{"type":"String","value":"spec0deply1lb"},"nicNamePrefix":{"type":"String","value":"spec0deply1nic"},"publicIPAddressName":{"type":"String","value":"spec0deply1ip"},"vnetName":{"type":"String","value":"spec0deply1vnet"},"vmSize":{"type":"String","value":"Standard_D1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-04-04T23:29:05.0043846Z","duration":"PT24M6.1512983S","correlationId":"3a55e6b5-4a3b-431e-8144-53698bf6f1dc","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[],"outputs":{"siteUri":{"type":"String","value":"hard-coded
         output for test"}},"outputResources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor"}]}}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:16 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-deployment-dont-delete/operations?api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0NzMsIm5iZiI6MTUyMDQ1MzQ3MywiZXhwIjoxNTIwNDU3MzczLCJhaW8iOiJZMk5nWU5qWTM4RStWU2lPKzlxT2duY0JKOWN0QlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNFdUcnNGWUVYRUtJZmRBQUdWTUFBQSIsInZlciI6IjEuMCJ9.ArxfPNTq5GDkmFBppDjfAq99t5AKHpkiomJyFlFNwYavrQxfd66kamPOrTK4LUxqE7dufAUhjQG5zQLqcZPvtl1SS4zIppFRih0g1Iur45O6WRCd5hv4r9n0sZVLlSnyIsza0haM5o5Sz5ic2k-cBTw0-HwWuTwFz8ALJmG8x0lxKaY8uxuuD13yghFGHL5eoIIZ0WsMIuOSzx8bqSAvXctOpvg6d8r73UECp7ugreyMFj0o_RWgO7UlOlp9rfa0io1kOcsz620m7evOgR42aEh-B6ga-nscmo53D_vXoOFeB0u9_WoUGLB4bb1831b4nBT9dYhV8HL7tvYLQqR8Ig
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14982'
-      X-Ms-Request-Id:
-      - 55946441-82ff-403e-830c-f512c97d569e
-      X-Ms-Correlation-Request-Id:
-      - 55946441-82ff-403e-830c-f512c97d569e
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201617Z:55946441-82ff-403e-830c-f512c97d569e
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:16:16 GMT
-      Content-Length:
-      - '801'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-deployment-dont-delete/operations/6AF613CA61ABB553","operationId":"6AF613CA61ABB553","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:29:04.6934934Z","duration":"PT24M3.4746371S","trackingId":"a0997dbb-9578-4dd9-bad6-1286c02855c8","serviceRequestId":"08b8faec-0f0f-4cb2-8453-fabbd3448cb9","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete","resourceType":"Microsoft.Resources/deployments","resourceName":"spec-nested-deployment-dont-delete"}}}]}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:17 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-deployment-dont-delete?api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0NzMsIm5iZiI6MTUyMDQ1MzQ3MywiZXhwIjoxNTIwNDU3MzczLCJhaW8iOiJZMk5nWU5qWTM4RStWU2lPKzlxT2duY0JKOWN0QlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNFdUcnNGWUVYRUtJZmRBQUdWTUFBQSIsInZlciI6IjEuMCJ9.ArxfPNTq5GDkmFBppDjfAq99t5AKHpkiomJyFlFNwYavrQxfd66kamPOrTK4LUxqE7dufAUhjQG5zQLqcZPvtl1SS4zIppFRih0g1Iur45O6WRCd5hv4r9n0sZVLlSnyIsza0haM5o5Sz5ic2k-cBTw0-HwWuTwFz8ALJmG8x0lxKaY8uxuuD13yghFGHL5eoIIZ0WsMIuOSzx8bqSAvXctOpvg6d8r73UECp7ugreyMFj0o_RWgO7UlOlp9rfa0io1kOcsz620m7evOgR42aEh-B6ga-nscmo53D_vXoOFeB0u9_WoUGLB4bb1831b4nBT9dYhV8HL7tvYLQqR8Ig
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14985'
-      X-Ms-Request-Id:
-      - aae8acfc-455c-451f-84d6-ffecb95c4616
-      X-Ms-Correlation-Request-Id:
-      - aae8acfc-455c-451f-84d6-ffecb95c4616
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201618Z:aae8acfc-455c-451f-84d6-ffecb95c4616
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:16:17 GMT
-      Content-Length:
-      - '3083'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-deployment-dont-delete","name":"spec-deployment-dont-delete","properties":{"templateLink":{"uri":"https://gist.githubusercontent.com/bzwei/e6ccc4d641d6afab8e26ef55c37c498e/raw/769505e37256e926a9b581a100c90bb657ff45ff/azure-parent-spec.json","contentVersion":"1.0.0.0"},"parameters":{"childDeployName":{"type":"String","value":"spec-nested-deployment-dont-delete"},"storageAccountName":{"type":"String","value":"spec0deply1stor"},"availabilitySetName":{"type":"String","value":"spec0deply1as"},"adminUsername":{"type":"String","value":"deploy1admin"},"adminPassword":{"type":"SecureString"},"dnsNameforLBIP":{"type":"String","value":"spec0deply1dns"},"vmNamePrefix":{"type":"String","value":"spec0deply1vm"},"imagePublisher":{"type":"String","value":"MicrosoftWindowsServer"},"imageOffer":{"type":"String","value":"WindowsServer"},"imageSKU":{"type":"String","value":"2012-R2-Datacenter"},"lbName":{"type":"String","value":"spec0deply1lb"},"nicNamePrefix":{"type":"String","value":"spec0deply1nic"},"publicIPAddressName":{"type":"String","value":"spec0deply1ip"},"vnetName":{"type":"String","value":"spec0deply1vnet"},"vmSize":{"type":"String","value":"Standard_D1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-04-04T23:29:05.0043846Z","duration":"PT24M6.1512983S","correlationId":"3a55e6b5-4a3b-431e-8144-53698bf6f1dc","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[],"outputs":{"siteUri":{"type":"String","value":"hard-coded
-        output for test"}},"outputResources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor"}]}}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:18 GMT
+  recorded_at: Mon, 12 Mar 2018 10:21:08 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete?api-version=2017-08-01
@@ -2510,7 +2449,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0NzMsIm5iZiI6MTUyMDQ1MzQ3MywiZXhwIjoxNTIwNDU3MzczLCJhaW8iOiJZMk5nWU5qWTM4RStWU2lPKzlxT2duY0JKOWN0QlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNFdUcnNGWUVYRUtJZmRBQUdWTUFBQSIsInZlciI6IjEuMCJ9.ArxfPNTq5GDkmFBppDjfAq99t5AKHpkiomJyFlFNwYavrQxfd66kamPOrTK4LUxqE7dufAUhjQG5zQLqcZPvtl1SS4zIppFRih0g1Iur45O6WRCd5hv4r9n0sZVLlSnyIsza0haM5o5Sz5ic2k-cBTw0-HwWuTwFz8ALJmG8x0lxKaY8uxuuD13yghFGHL5eoIIZ0WsMIuOSzx8bqSAvXctOpvg6d8r73UECp7ugreyMFj0o_RWgO7UlOlp9rfa0io1kOcsz620m7evOgR42aEh-B6ga-nscmo53D_vXoOFeB0u9_WoUGLB4bb1831b4nBT9dYhV8HL7tvYLQqR8Ig
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk3NTUsIm5iZiI6MTUyMDg0OTc1NSwiZXhwIjoxNTIwODUzNjU1LCJhaW8iOiJZMk5nWUhnU3QvT29SR0tTa2t5aS80UzNIY3JMQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieGsxamstTlJ2VUtHMFlLYWFmQWRBQSIsInZlciI6IjEuMCJ9.ADT-9qZlaX4MDV07ntM5ibfPXZ63OeoRAoNBbFZmQtrp-S15bXoIC9vgBM8Z7S-8C3rEe3Y6n10LoMCUxTiixfn6zlPn82JobgdO8ksXbX4z5uYvTIv4fYi14dtIwJBMgF2MA1zN2sErSREp1jZ3axzq7ZxG14K2vMsezi8bcTHCLWiM0VUpd_AVT23FOmDsls-WKsTM1zK0Fzjz1vrv1446EJZSg3xIQmEghD3ijAz9qJIojkR-xxdEEpDhtB6s4daub6Tjg9_YjTUdKiRcO6sJJfQetnxRRNLQi-5zYdBBQyC7ovmXuPitPGTKLDuJo2Xn9HUe9Hu-Flccmk_pWQ
   response:
     status:
       code: 200
@@ -2527,79 +2466,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14982'
+      - '14988'
       X-Ms-Request-Id:
-      - abb43466-ca28-4e60-8a5e-12d3cb2810e7
+      - 26f955d7-4424-485c-a8cc-26d99d262676
       X-Ms-Correlation-Request-Id:
-      - abb43466-ca28-4e60-8a5e-12d3cb2810e7
+      - 26f955d7-4424-485c-a8cc-26d99d262676
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201618Z:abb43466-ca28-4e60-8a5e-12d3cb2810e7
+      - WESTEUROPE:20180312T102105Z:26f955d7-4424-485c-a8cc-26d99d262676
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:16:18 GMT
+      - Mon, 12 Mar 2018 10:21:04 GMT
       Content-Length:
       - '7230'
     body:
       encoding: ASCII-8BIT
       string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete","name":"spec-nested-deployment-dont-delete","properties":{"templateLink":{"uri":"https://gist.githubusercontent.com/bzwei/c09f906306399d238762bce711781200/raw/3558b735da03c1c030023d70b78ec3451dab5689/azure-loadbalancer.json","contentVersion":"1.0.0.0"},"parameters":{"storageAccountName":{"type":"String","value":"spec0deply1stor"},"availabilitySetName":{"type":"String","value":"spec0deply1as"},"adminUsername":{"type":"String","value":"deploy1admin"},"adminPassword":{"type":"SecureString"},"dnsNameforLBIP":{"type":"String","value":"spec0deply1dns"},"vmNamePrefix":{"type":"String","value":"spec0deply1vm"},"imagePublisher":{"type":"String","value":"MicrosoftWindowsServer"},"imageOffer":{"type":"String","value":"WindowsServer"},"imageSKU":{"type":"String","value":"2012-R2-Datacenter"},"lbName":{"type":"String","value":"spec0deply1lb"},"nicNamePrefix":{"type":"String","value":"spec0deply1nic"},"publicIPAddressName":{"type":"String","value":"spec0deply1ip"},"vnetName":{"type":"String","value":"spec0deply1vnet"},"vmSize":{"type":"String","value":"Standard_D1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-04-04T23:28:59.2682474Z","duration":"PT23M55.442141S","correlationId":"3a55e6b5-4a3b-431e-8144-53698bf6f1dc","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["eastus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"availabilitySets","locations":["eastus"]},{"resourceType":"virtualMachines","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"publicIPAddresses","locations":["eastus"]},{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"loadBalancers","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"spec0deply1ip"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic0"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic1"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"spec0deply1stor"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"spec0deply1as"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"spec0deply1vm0"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"spec0deply1stor"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"spec0deply1as"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"spec0deply1vm1"}],"outputResources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor"}]}}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:19 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations?api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0NzMsIm5iZiI6MTUyMDQ1MzQ3MywiZXhwIjoxNTIwNDU3MzczLCJhaW8iOiJZMk5nWU5qWTM4RStWU2lPKzlxT2duY0JKOWN0QlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNFdUcnNGWUVYRUtJZmRBQUdWTUFBQSIsInZlciI6IjEuMCJ9.ArxfPNTq5GDkmFBppDjfAq99t5AKHpkiomJyFlFNwYavrQxfd66kamPOrTK4LUxqE7dufAUhjQG5zQLqcZPvtl1SS4zIppFRih0g1Iur45O6WRCd5hv4r9n0sZVLlSnyIsza0haM5o5Sz5ic2k-cBTw0-HwWuTwFz8ALJmG8x0lxKaY8uxuuD13yghFGHL5eoIIZ0WsMIuOSzx8bqSAvXctOpvg6d8r73UECp7ugreyMFj0o_RWgO7UlOlp9rfa0io1kOcsz620m7evOgR42aEh-B6ga-nscmo53D_vXoOFeB0u9_WoUGLB4bb1831b4nBT9dYhV8HL7tvYLQqR8Ig
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14992'
-      X-Ms-Request-Id:
-      - 1741b85a-83bd-4607-824b-b9dd4b4567e3
-      X-Ms-Correlation-Request-Id:
-      - 1741b85a-83bd-4607-824b-b9dd4b4567e3
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201620Z:1741b85a-83bd-4607-824b-b9dd4b4567e3
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:16:19 GMT
-      Content-Length:
-      - '6866'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/2A5D9DB48CB9B87D","operationId":"2A5D9DB48CB9B87D","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:28:58.871396Z","duration":"PT4M5.2351465S","trackingId":"413c1acd-4a86-42aa-8371-2f7fe7760fba","serviceRequestId":"520c4ff7-a725-4e8f-946e-d203617aa3f9","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"spec0deply1vm1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/F59DBCC8F57674DA","operationId":"F59DBCC8F57674DA","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:28:57.3638022Z","duration":"PT4M3.6342685S","trackingId":"a7e62d93-ed67-4f9f-93bc-d7ca4451f6f9","serviceRequestId":"5b58ce6a-8aa5-45a1-b7a3-9c82b6150bd7","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"spec0deply1vm0"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/727DE014666F097A","operationId":"727DE014666F097A","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:28.2942519Z","duration":"PT3.4353223S","trackingId":"dda58292-47ab-4139-8d67-8c99aae9c93c","serviceRequestId":"7b1ba585-6ce8-4e35-83cf-27d7a344ff40","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/8984B6C47B4DBB63","operationId":"8984B6C47B4DBB63","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:26.6945925Z","duration":"PT1.75149S","trackingId":"cf689996-82e8-4740-87f0-8f820b4d153a","serviceRequestId":"831312e5-eaf1-417d-9fdb-5723d493b396","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic0"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/5BB7F6FEF271DCC5","operationId":"5BB7F6FEF271DCC5","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:24.7522379Z","duration":"PT1.8393589S","trackingId":"f42ecee0-2ab0-44d0-9748-44249046b29e","serviceRequestId":"2c6c9788-7fc1-4e6b-928f-241a44e192ea","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/ACBE290D4E246F6C","operationId":"ACBE290D4E246F6C","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:22.8224458Z","duration":"PT16.8373612S","trackingId":"a7759f29-cf9e-4892-bb7b-3e08f64e4ff7","serviceRequestId":"25c16d1d-b611-4fc3-ad7c-eedb21574599","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"spec0deply1ip"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/CDA31B5D53DE7D18","operationId":"CDA31B5D53DE7D18","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:24:53.5717985Z","duration":"PT19M47.4658028S","trackingId":"1ce6f839-7da9-4e40-97d4-2693cfbbc796","serviceRequestId":"3a55e6b5-4a3b-431e-8144-53698bf6f1dc","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"spec0deply1stor"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/07A1436712650187","operationId":"07A1436712650187","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:22.0339723Z","duration":"PT16.0077667S","trackingId":"89200282-9510-4328-ac23-a73df06aea3e","serviceRequestId":"86d89b1a-900e-4719-8d9b-7f18bc963ec7","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"spec0deply1vnet"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/C35E071B1E2FC92A","operationId":"C35E071B1E2FC92A","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:08.170721Z","duration":"PT2.1819157S","trackingId":"a2495990-63ae-4ea3-8904-866b7e01ec18","serviceRequestId":"97334c1c-6e32-4bc5-b96c-25314a5fef57","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"spec0deply1as"}}}]}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:20 GMT
+  recorded_at: Mon, 12 Mar 2018 10:21:09 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb?api-version=2018-01-01
@@ -2616,7 +2502,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0NzMsIm5iZiI6MTUyMDQ1MzQ3MywiZXhwIjoxNTIwNDU3MzczLCJhaW8iOiJZMk5nWU5qWTM4RStWU2lPKzlxT2duY0JKOWN0QlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNFdUcnNGWUVYRUtJZmRBQUdWTUFBQSIsInZlciI6IjEuMCJ9.ArxfPNTq5GDkmFBppDjfAq99t5AKHpkiomJyFlFNwYavrQxfd66kamPOrTK4LUxqE7dufAUhjQG5zQLqcZPvtl1SS4zIppFRih0g1Iur45O6WRCd5hv4r9n0sZVLlSnyIsza0haM5o5Sz5ic2k-cBTw0-HwWuTwFz8ALJmG8x0lxKaY8uxuuD13yghFGHL5eoIIZ0WsMIuOSzx8bqSAvXctOpvg6d8r73UECp7ugreyMFj0o_RWgO7UlOlp9rfa0io1kOcsz620m7evOgR42aEh-B6ga-nscmo53D_vXoOFeB0u9_WoUGLB4bb1831b4nBT9dYhV8HL7tvYLQqR8Ig
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk3NTUsIm5iZiI6MTUyMDg0OTc1NSwiZXhwIjoxNTIwODUzNjU1LCJhaW8iOiJZMk5nWUhnU3QvT29SR0tTa2t5aS80UzNIY3JMQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieGsxamstTlJ2VUtHMFlLYWFmQWRBQSIsInZlciI6IjEuMCJ9.ADT-9qZlaX4MDV07ntM5ibfPXZ63OeoRAoNBbFZmQtrp-S15bXoIC9vgBM8Z7S-8C3rEe3Y6n10LoMCUxTiixfn6zlPn82JobgdO8ksXbX4z5uYvTIv4fYi14dtIwJBMgF2MA1zN2sErSREp1jZ3axzq7ZxG14K2vMsezi8bcTHCLWiM0VUpd_AVT23FOmDsls-WKsTM1zK0Fzjz1vrv1446EJZSg3xIQmEghD3ijAz9qJIojkR-xxdEEpDhtB6s4daub6Tjg9_YjTUdKiRcO6sJJfQetnxRRNLQi-5zYdBBQyC7ovmXuPitPGTKLDuJo2Xn9HUe9Hu-Flccmk_pWQ
   response:
     status:
       code: 200
@@ -2637,22 +2523,22 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - b082bde3-f0bd-4e5f-a6b4-3225685b7f7b
+      - 21bd1f49-d53b-4326-af40-416be448f68f
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14981'
+      - '14989'
       X-Ms-Correlation-Request-Id:
-      - 5f756ce2-5b8e-43f2-b9fa-55d1c57c8b84
+      - 78f8b8bc-263b-49ab-bf7c-39f86a9aa79e
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201620Z:5f756ce2-5b8e-43f2-b9fa-55d1c57c8b84
+      - WESTEUROPE:20180312T102109Z:78f8b8bc-263b-49ab-bf7c-39f86a9aa79e
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:16:20 GMT
+      - Mon, 12 Mar 2018 10:21:09 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"spec0deply1lb\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb\",\r\n
@@ -2719,87 +2605,7 @@ http_interactions:
         [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
         \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:20 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1?api-version=2017-12-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0NzMsIm5iZiI6MTUyMDQ1MzQ3MywiZXhwIjoxNTIwNDU3MzczLCJhaW8iOiJZMk5nWU5qWTM4RStWU2lPKzlxT2duY0JKOWN0QlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNFdUcnNGWUVYRUtJZmRBQUdWTUFBQSIsInZlciI6IjEuMCJ9.ArxfPNTq5GDkmFBppDjfAq99t5AKHpkiomJyFlFNwYavrQxfd66kamPOrTK4LUxqE7dufAUhjQG5zQLqcZPvtl1SS4zIppFRih0g1Iur45O6WRCd5hv4r9n0sZVLlSnyIsza0haM5o5Sz5ic2k-cBTw0-HwWuTwFz8ALJmG8x0lxKaY8uxuuD13yghFGHL5eoIIZ0WsMIuOSzx8bqSAvXctOpvg6d8r73UECp7ugreyMFj0o_RWgO7UlOlp9rfa0io1kOcsz620m7evOgR42aEh-B6ga-nscmo53D_vXoOFeB0u9_WoUGLB4bb1831b4nBT9dYhV8HL7tvYLQqR8Ig
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/LowCostGet3Min;4747,Microsoft.Compute/LowCostGet30Min;37927
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
-      X-Ms-Request-Id:
-      - 8ca60eac-0a6c-4c80-8998-ef2967a2c9ff
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14981'
-      X-Ms-Correlation-Request-Id:
-      - 6e2d728d-82fb-4f52-a366-2ca7f3581b03
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201623Z:6e2d728d-82fb-4f52-a366-2ca7f3581b03
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:16:23 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"4d1502d5-351a-42f4-8569-22284f906d68\",\r\n
-        \   \"availabilitySet\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/SPEC0DEPLY1AS\"\r\n
-        \   },\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_D1\"\r\n
-        \   },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
-        \"MicrosoftWindowsServer\",\r\n        \"offer\": \"WindowsServer\",\r\n        \"sku\":
-        \"2012-R2-Datacenter\",\r\n        \"version\": \"latest\"\r\n      },\r\n
-        \     \"osDisk\": {\r\n        \"osType\": \"Windows\",\r\n        \"name\":
-        \"osdisk\",\r\n        \"createOption\": \"FromImage\",\r\n        \"vhd\":
-        {\r\n          \"uri\": \"http://spec0deply1stor.blob.core.windows.net/vhds/osdisk1.vhd\"\r\n
-        \       },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n      \"dataDisks\":
-        []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"spec0deply1vm1\",\r\n
-        \     \"adminUsername\": \"deploy1admin\",\r\n      \"windowsConfiguration\":
-        {\r\n        \"provisionVMAgent\": true,\r\n        \"enableAutomaticUpdates\":
-        true\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\":
-        {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1\"}]},\r\n
-        \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
-        true,\r\n        \"storageUri\": \"http://spec0deply1stor.blob.core.windows.net\"\r\n
-        \     }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n
-        \ \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"eastus\",\r\n
-        \ \"tags\": {\r\n    \"Shutdown\": \"true\"\r\n  },\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1\",\r\n
-        \ \"name\": \"spec0deply1vm1\"\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:24 GMT
+  recorded_at: Mon, 12 Mar 2018 10:21:14 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0?api-version=2017-12-01
@@ -2816,7 +2622,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0NzMsIm5iZiI6MTUyMDQ1MzQ3MywiZXhwIjoxNTIwNDU3MzczLCJhaW8iOiJZMk5nWU5qWTM4RStWU2lPKzlxT2duY0JKOWN0QlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNFdUcnNGWUVYRUtJZmRBQUdWTUFBQSIsInZlciI6IjEuMCJ9.ArxfPNTq5GDkmFBppDjfAq99t5AKHpkiomJyFlFNwYavrQxfd66kamPOrTK4LUxqE7dufAUhjQG5zQLqcZPvtl1SS4zIppFRih0g1Iur45O6WRCd5hv4r9n0sZVLlSnyIsza0haM5o5Sz5ic2k-cBTw0-HwWuTwFz8ALJmG8x0lxKaY8uxuuD13yghFGHL5eoIIZ0WsMIuOSzx8bqSAvXctOpvg6d8r73UECp7ugreyMFj0o_RWgO7UlOlp9rfa0io1kOcsz620m7evOgR42aEh-B6ga-nscmo53D_vXoOFeB0u9_WoUGLB4bb1831b4nBT9dYhV8HL7tvYLQqR8Ig
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk3NTUsIm5iZiI6MTUyMDg0OTc1NSwiZXhwIjoxNTIwODUzNjU1LCJhaW8iOiJZMk5nWUhnU3QvT29SR0tTa2t5aS80UzNIY3JMQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieGsxamstTlJ2VUtHMFlLYWFmQWRBQSIsInZlciI6IjEuMCJ9.ADT-9qZlaX4MDV07ntM5ibfPXZ63OeoRAoNBbFZmQtrp-S15bXoIC9vgBM8Z7S-8C3rEe3Y6n10LoMCUxTiixfn6zlPn82JobgdO8ksXbX4z5uYvTIv4fYi14dtIwJBMgF2MA1zN2sErSREp1jZ3axzq7ZxG14K2vMsezi8bcTHCLWiM0VUpd_AVT23FOmDsls-WKsTM1zK0Fzjz1vrv1446EJZSg3xIQmEghD3ijAz9qJIojkR-xxdEEpDhtB6s4daub6Tjg9_YjTUdKiRcO6sJJfQetnxRRNLQi-5zYdBBQyC7ovmXuPitPGTKLDuJo2Xn9HUe9Hu-Flccmk_pWQ
   response:
     status:
       code: 200
@@ -2835,26 +2641,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/LowCostGet3Min;4744,Microsoft.Compute/LowCostGet30Min;37924
+      - Microsoft.Compute/LowCostGet3Min;4753,Microsoft.Compute/LowCostGet30Min;37812
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344652126238
       X-Ms-Request-Id:
-      - 23a4ad65-5500-413c-8caa-392216841e6e
+      - 55fabeb7-a4bc-4a32-8248-9a11d240ca0e
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14987'
+      - '14985'
       X-Ms-Correlation-Request-Id:
-      - 89af58ff-6910-482b-9ef7-ced818cbf6d9
+      - e7ec2cd3-5d6e-4eac-be6a-7efe387e5501
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201630Z:89af58ff-6910-482b-9ef7-ced818cbf6d9
+      - WESTEUROPE:20180312T102115Z:e7ec2cd3-5d6e-4eac-be6a-7efe387e5501
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:16:29 GMT
+      - Mon, 12 Mar 2018 10:21:15 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"d7022008-f6b1-4f4c-8be8-e2d677ef3261\",\r\n
@@ -2879,10 +2685,10 @@ http_interactions:
         \ \"tags\": {\r\n    \"Shutdown\": \"true\"\r\n  },\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0\",\r\n
         \ \"name\": \"spec0deply1vm0\"\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:30 GMT
+  recorded_at: Mon, 12 Mar 2018 10:21:20 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1?api-version=2017-12-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2896,7 +2702,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0NzMsIm5iZiI6MTUyMDQ1MzQ3MywiZXhwIjoxNTIwNDU3MzczLCJhaW8iOiJZMk5nWU5qWTM4RStWU2lPKzlxT2duY0JKOWN0QlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNFdUcnNGWUVYRUtJZmRBQUdWTUFBQSIsInZlciI6IjEuMCJ9.ArxfPNTq5GDkmFBppDjfAq99t5AKHpkiomJyFlFNwYavrQxfd66kamPOrTK4LUxqE7dufAUhjQG5zQLqcZPvtl1SS4zIppFRih0g1Iur45O6WRCd5hv4r9n0sZVLlSnyIsza0haM5o5Sz5ic2k-cBTw0-HwWuTwFz8ALJmG8x0lxKaY8uxuuD13yghFGHL5eoIIZ0WsMIuOSzx8bqSAvXctOpvg6d8r73UECp7ugreyMFj0o_RWgO7UlOlp9rfa0io1kOcsz620m7evOgR42aEh-B6ga-nscmo53D_vXoOFeB0u9_WoUGLB4bb1831b4nBT9dYhV8HL7tvYLQqR8Ig
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk3NTUsIm5iZiI6MTUyMDg0OTc1NSwiZXhwIjoxNTIwODUzNjU1LCJhaW8iOiJZMk5nWUhnU3QvT29SR0tTa2t5aS80UzNIY3JMQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieGsxamstTlJ2VUtHMFlLYWFmQWRBQSIsInZlciI6IjEuMCJ9.ADT-9qZlaX4MDV07ntM5ibfPXZ63OeoRAoNBbFZmQtrp-S15bXoIC9vgBM8Z7S-8C3rEe3Y6n10LoMCUxTiixfn6zlPn82JobgdO8ksXbX4z5uYvTIv4fYi14dtIwJBMgF2MA1zN2sErSREp1jZ3axzq7ZxG14K2vMsezi8bcTHCLWiM0VUpd_AVT23FOmDsls-WKsTM1zK0Fzjz1vrv1446EJZSg3xIQmEghD3ijAz9qJIojkR-xxdEEpDhtB6s4daub6Tjg9_YjTUdKiRcO6sJJfQetnxRRNLQi-5zYdBBQyC7ovmXuPitPGTKLDuJo2Xn9HUe9Hu-Flccmk_pWQ
   response:
     status:
       code: 200
@@ -2912,52 +2718,54 @@ http_interactions:
       - application/json; charset=utf-8
       Expires:
       - "-1"
-      Etag:
-      - W/"2ec58a0b-4c03-4d0a-b788-9daffd54e7b2"
       Vary:
       - Accept-Encoding
-      X-Ms-Request-Id:
-      - c4638dab-ebcf-430a-b6d9-aa704193627f
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/LowCostGet3Min;4752,Microsoft.Compute/LowCostGet30Min;37811
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344652126238
+      X-Ms-Request-Id:
+      - a7435db8-964e-48e5-9270-7629234f5b3b
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14980'
+      - '14988'
       X-Ms-Correlation-Request-Id:
-      - fc556d19-ae2a-4166-a166-a3d14827bdff
+      - bf01df02-7d7d-4bf7-aac0-2b84134b4f55
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201630Z:fc556d19-ae2a-4166-a166-a3d14827bdff
+      - WESTEUROPE:20180312T102120Z:bf01df02-7d7d-4bf7-aac0-2b84134b4f55
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:16:30 GMT
+      - Mon, 12 Mar 2018 10:21:19 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"spec0deply1nic1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1\",\r\n
-        \ \"etag\": \"W/\\\"2ec58a0b-4c03-4d0a-b788-9daffd54e7b2\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"57bbf7aa-d6c4-4f56-8f6a-089d15334221\",\r\n    \"ipConfigurations\":
-        [\r\n      {\r\n        \"name\": \"ipconfig1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1\",\r\n
-        \       \"etag\": \"W/\\\"2ec58a0b-4c03-4d0a-b788-9daffd54e7b2\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAddress\": \"10.0.0.5\",\r\n          \"privateIPAllocationMethod\":
-        \"Dynamic\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1\"\r\n
-        \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
-        \"IPv4\",\r\n          \"loadBalancerBackendAddressPools\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\"\r\n
-        \           }\r\n          ],\r\n          \"loadBalancerInboundNatRules\":
-        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\":
-        {\r\n      \"dnsServers\": [],\r\n      \"appliedDnsServers\": []\r\n    },\r\n
-        \   \"enableAcceleratedNetworking\": false,\r\n    \"enableIPForwarding\":
-        false,\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1\"\r\n
-        \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
-        \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
+      string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"4d1502d5-351a-42f4-8569-22284f906d68\",\r\n
+        \   \"availabilitySet\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/SPEC0DEPLY1AS\"\r\n
+        \   },\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_D1\"\r\n
+        \   },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
+        \"MicrosoftWindowsServer\",\r\n        \"offer\": \"WindowsServer\",\r\n        \"sku\":
+        \"2012-R2-Datacenter\",\r\n        \"version\": \"latest\"\r\n      },\r\n
+        \     \"osDisk\": {\r\n        \"osType\": \"Windows\",\r\n        \"name\":
+        \"osdisk\",\r\n        \"createOption\": \"FromImage\",\r\n        \"vhd\":
+        {\r\n          \"uri\": \"http://spec0deply1stor.blob.core.windows.net/vhds/osdisk1.vhd\"\r\n
+        \       },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n      \"dataDisks\":
+        []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"spec0deply1vm1\",\r\n
+        \     \"adminUsername\": \"deploy1admin\",\r\n      \"windowsConfiguration\":
+        {\r\n        \"provisionVMAgent\": true,\r\n        \"enableAutomaticUpdates\":
+        true\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\":
+        {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1\"}]},\r\n
+        \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
+        true,\r\n        \"storageUri\": \"http://spec0deply1stor.blob.core.windows.net\"\r\n
+        \     }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n
+        \ \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"tags\": {\r\n    \"Shutdown\": \"true\"\r\n  },\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1\",\r\n
+        \ \"name\": \"spec0deply1vm1\"\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:30 GMT
+  recorded_at: Mon, 12 Mar 2018 10:21:24 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0?api-version=2018-01-01
@@ -2974,7 +2782,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0NzMsIm5iZiI6MTUyMDQ1MzQ3MywiZXhwIjoxNTIwNDU3MzczLCJhaW8iOiJZMk5nWU5qWTM4RStWU2lPKzlxT2duY0JKOWN0QlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNFdUcnNGWUVYRUtJZmRBQUdWTUFBQSIsInZlciI6IjEuMCJ9.ArxfPNTq5GDkmFBppDjfAq99t5AKHpkiomJyFlFNwYavrQxfd66kamPOrTK4LUxqE7dufAUhjQG5zQLqcZPvtl1SS4zIppFRih0g1Iur45O6WRCd5hv4r9n0sZVLlSnyIsza0haM5o5Sz5ic2k-cBTw0-HwWuTwFz8ALJmG8x0lxKaY8uxuuD13yghFGHL5eoIIZ0WsMIuOSzx8bqSAvXctOpvg6d8r73UECp7ugreyMFj0o_RWgO7UlOlp9rfa0io1kOcsz620m7evOgR42aEh-B6ga-nscmo53D_vXoOFeB0u9_WoUGLB4bb1831b4nBT9dYhV8HL7tvYLQqR8Ig
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk3NTUsIm5iZiI6MTUyMDg0OTc1NSwiZXhwIjoxNTIwODUzNjU1LCJhaW8iOiJZMk5nWUhnU3QvT29SR0tTa2t5aS80UzNIY3JMQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieGsxamstTlJ2VUtHMFlLYWFmQWRBQSIsInZlciI6IjEuMCJ9.ADT-9qZlaX4MDV07ntM5ibfPXZ63OeoRAoNBbFZmQtrp-S15bXoIC9vgBM8Z7S-8C3rEe3Y6n10LoMCUxTiixfn6zlPn82JobgdO8ksXbX4z5uYvTIv4fYi14dtIwJBMgF2MA1zN2sErSREp1jZ3axzq7ZxG14K2vMsezi8bcTHCLWiM0VUpd_AVT23FOmDsls-WKsTM1zK0Fzjz1vrv1446EJZSg3xIQmEghD3ijAz9qJIojkR-xxdEEpDhtB6s4daub6Tjg9_YjTUdKiRcO6sJJfQetnxRRNLQi-5zYdBBQyC7ovmXuPitPGTKLDuJo2Xn9HUe9Hu-Flccmk_pWQ
   response:
     status:
       code: 200
@@ -2995,22 +2803,22 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 1732b363-8c1e-4366-92cf-70cfa9fa2028
+      - 9c74da4c-15cf-411e-9d16-ee66e824f96d
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14980'
+      - '14988'
       X-Ms-Correlation-Request-Id:
-      - cd3acf29-dae7-49ec-8625-8c65bf649936
+      - '076817ba-cc99-4400-b6d6-c3a56767ed08'
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201630Z:cd3acf29-dae7-49ec-8625-8c65bf649936
+      - WESTEUROPE:20180312T102120Z:076817ba-cc99-4400-b6d6-c3a56767ed08
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:16:30 GMT
+      - Mon, 12 Mar 2018 10:21:20 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"spec0deply1nic0\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0\",\r\n
@@ -3035,10 +2843,10 @@ http_interactions:
         \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
         \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:31 GMT
+  recorded_at: Mon, 12 Mar 2018 10:21:25 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups/miq-azure-test1?api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1?api-version=2018-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3052,7 +2860,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0NzMsIm5iZiI6MTUyMDQ1MzQ3MywiZXhwIjoxNTIwNDU3MzczLCJhaW8iOiJZMk5nWU5qWTM4RStWU2lPKzlxT2duY0JKOWN0QlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNFdUcnNGWUVYRUtJZmRBQUdWTUFBQSIsInZlciI6IjEuMCJ9.ArxfPNTq5GDkmFBppDjfAq99t5AKHpkiomJyFlFNwYavrQxfd66kamPOrTK4LUxqE7dufAUhjQG5zQLqcZPvtl1SS4zIppFRih0g1Iur45O6WRCd5hv4r9n0sZVLlSnyIsza0haM5o5Sz5ic2k-cBTw0-HwWuTwFz8ALJmG8x0lxKaY8uxuuD13yghFGHL5eoIIZ0WsMIuOSzx8bqSAvXctOpvg6d8r73UECp7ugreyMFj0o_RWgO7UlOlp9rfa0io1kOcsz620m7evOgR42aEh-B6ga-nscmo53D_vXoOFeB0u9_WoUGLB4bb1831b4nBT9dYhV8HL7tvYLQqR8Ig
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk3NTUsIm5iZiI6MTUyMDg0OTc1NSwiZXhwIjoxNTIwODUzNjU1LCJhaW8iOiJZMk5nWUhnU3QvT29SR0tTa2t5aS80UzNIY3JMQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieGsxamstTlJ2VUtHMFlLYWFmQWRBQSIsInZlciI6IjEuMCJ9.ADT-9qZlaX4MDV07ntM5ibfPXZ63OeoRAoNBbFZmQtrp-S15bXoIC9vgBM8Z7S-8C3rEe3Y6n10LoMCUxTiixfn6zlPn82JobgdO8ksXbX4z5uYvTIv4fYi14dtIwJBMgF2MA1zN2sErSREp1jZ3axzq7ZxG14K2vMsezi8bcTHCLWiM0VUpd_AVT23FOmDsls-WKsTM1zK0Fzjz1vrv1446EJZSg3xIQmEghD3ijAz9qJIojkR-xxdEEpDhtB6s4daub6Tjg9_YjTUdKiRcO6sJJfQetnxRRNLQi-5zYdBBQyC7ovmXuPitPGTKLDuJo2Xn9HUe9Hu-Flccmk_pWQ
   response:
     status:
       code: 200
@@ -3062,36 +2870,61 @@ http_interactions:
       - no-cache
       Pragma:
       - no-cache
+      Transfer-Encoding:
+      - chunked
       Content-Type:
       - application/json; charset=utf-8
       Expires:
       - "-1"
+      Etag:
+      - W/"2ec58a0b-4c03-4d0a-b788-9daffd54e7b2"
       Vary:
       - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14981'
       X-Ms-Request-Id:
-      - a2950f25-8dc0-451e-b61f-63e93095ddaf
-      X-Ms-Correlation-Request-Id:
-      - a2950f25-8dc0-451e-b61f-63e93095ddaf
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201631Z:a2950f25-8dc0-451e-b61f-63e93095ddaf
+      - f167a541-e5f3-45e0-ab68-d3bcbe422eca
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14990'
+      X-Ms-Correlation-Request-Id:
+      - 52805a2b-aeca-4304-bc10-1c468932e66b
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T102121Z:52805a2b-aeca-4304-bc10-1c468932e66b
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:16:30 GMT
-      Content-Length:
-      - '183'
+      - Mon, 12 Mar 2018 10:21:21 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1","name":"miq-azure-test1","location":"eastus","properties":{"provisioningState":"Succeeded"}}'
+      string: "{\r\n  \"name\": \"spec0deply1nic1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1\",\r\n
+        \ \"etag\": \"W/\\\"2ec58a0b-4c03-4d0a-b788-9daffd54e7b2\\\"\",\r\n  \"location\":
+        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"57bbf7aa-d6c4-4f56-8f6a-089d15334221\",\r\n    \"ipConfigurations\":
+        [\r\n      {\r\n        \"name\": \"ipconfig1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1\",\r\n
+        \       \"etag\": \"W/\\\"2ec58a0b-4c03-4d0a-b788-9daffd54e7b2\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"privateIPAddress\": \"10.0.0.5\",\r\n          \"privateIPAllocationMethod\":
+        \"Dynamic\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1\"\r\n
+        \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
+        \"IPv4\",\r\n          \"loadBalancerBackendAddressPools\": [\r\n            {\r\n
+        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\"\r\n
+        \           }\r\n          ],\r\n          \"loadBalancerInboundNatRules\":
+        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1\"\r\n
+        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\":
+        {\r\n      \"dnsServers\": [],\r\n      \"appliedDnsServers\": []\r\n    },\r\n
+        \   \"enableAcceleratedNetworking\": false,\r\n    \"enableIPForwarding\":
+        false,\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
+        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1\"\r\n
+        \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
+        \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:31 GMT
+  recorded_at: Mon, 12 Mar 2018 10:21:26 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute/locations/eastus/vmSizes?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0/instanceView?api-version=2017-12-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3105,7 +2938,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0NzMsIm5iZiI6MTUyMDQ1MzQ3MywiZXhwIjoxNTIwNDU3MzczLCJhaW8iOiJZMk5nWU5qWTM4RStWU2lPKzlxT2duY0JKOWN0QlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNFdUcnNGWUVYRUtJZmRBQUdWTUFBQSIsInZlciI6IjEuMCJ9.ArxfPNTq5GDkmFBppDjfAq99t5AKHpkiomJyFlFNwYavrQxfd66kamPOrTK4LUxqE7dufAUhjQG5zQLqcZPvtl1SS4zIppFRih0g1Iur45O6WRCd5hv4r9n0sZVLlSnyIsza0haM5o5Sz5ic2k-cBTw0-HwWuTwFz8ALJmG8x0lxKaY8uxuuD13yghFGHL5eoIIZ0WsMIuOSzx8bqSAvXctOpvg6d8r73UECp7ugreyMFj0o_RWgO7UlOlp9rfa0io1kOcsz620m7evOgR42aEh-B6ga-nscmo53D_vXoOFeB0u9_WoUGLB4bb1831b4nBT9dYhV8HL7tvYLQqR8Ig
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk3NTUsIm5iZiI6MTUyMDg0OTc1NSwiZXhwIjoxNTIwODUzNjU1LCJhaW8iOiJZMk5nWUhnU3QvT29SR0tTa2t5aS80UzNIY3JMQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieGsxamstTlJ2VUtHMFlLYWFmQWRBQSIsInZlciI6IjEuMCJ9.ADT-9qZlaX4MDV07ntM5ibfPXZ63OeoRAoNBbFZmQtrp-S15bXoIC9vgBM8Z7S-8C3rEe3Y6n10LoMCUxTiixfn6zlPn82JobgdO8ksXbX4z5uYvTIv4fYi14dtIwJBMgF2MA1zN2sErSREp1jZ3axzq7ZxG14K2vMsezi8bcTHCLWiM0VUpd_AVT23FOmDsls-WKsTM1zK0Fzjz1vrv1446EJZSg3xIQmEghD3ijAz9qJIojkR-xxdEEpDhtB6s4daub6Tjg9_YjTUdKiRcO6sJJfQetnxRRNLQi-5zYdBBQyC7ovmXuPitPGTKLDuJo2Xn9HUe9Hu-Flccmk_pWQ
   response:
     status:
       code: 200
@@ -3124,26 +2957,231 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/LowCostGet3Min;4749,Microsoft.Compute/LowCostGet30Min;37921
+      - Microsoft.Compute/GetInstanceView3Min;4724,Microsoft.Compute/GetInstanceView30Min;23770
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344652126238
       X-Ms-Request-Id:
-      - 32b73e76-8b83-4a05-bbe1-fa0a2030b842
+      - 1aeb9c6a-62d9-4fac-b79c-011035d0362f
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14981'
+      - '14984'
       X-Ms-Correlation-Request-Id:
-      - 4dda0156-9b0b-45a6-bb5d-ed5b1ce465b9
+      - b1f1cebf-a1a2-4991-8f88-5ef4b8f9e0bc
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201631Z:4dda0156-9b0b-45a6-bb5d-ed5b1ce465b9
+      - WESTEUROPE:20180312T102127Z:b1f1cebf-a1a2-4991-8f88-5ef4b8f9e0bc
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:16:30 GMT
+      - Mon, 12 Mar 2018 10:21:26 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"platformUpdateDomain\": 1,\r\n  \"platformFaultDomain\": 1,\r\n
+        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
+        [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
+        \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
+        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2018-03-12T10:21:22+00:00\"\r\n
+        \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"osdisk\",\r\n
+        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
+        succeeded\",\r\n          \"time\": \"2016-09-03T02:05:35.0977796+00:00\"\r\n
+        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
+        \"https://spec0deply1stor.blob.core.windows.net/bootdiagnostics-spec0depl-d7022008-f6b1-4f4c-8be8-e2d677ef3261/spec0deply1vm0.d7022008-f6b1-4f4c-8be8-e2d677ef3261.screenshot.bmp\",\r\n
+        \   \"serialConsoleLogBlobUri\": \"https://spec0deply1stor.blob.core.windows.net/bootdiagnostics-spec0depl-d7022008-f6b1-4f4c-8be8-e2d677ef3261/spec0deply1vm0.d7022008-f6b1-4f4c-8be8-e2d677ef3261.serialconsole.log\"\r\n
+        \ },\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n
+        \     \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n
+        \     \"time\": \"2016-09-03T02:05:35.1602741+00:00\"\r\n    },\r\n    {\r\n
+        \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
+        \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 10:21:31 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1/instanceView?api-version=2017-12-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk3NTUsIm5iZiI6MTUyMDg0OTc1NSwiZXhwIjoxNTIwODUzNjU1LCJhaW8iOiJZMk5nWUhnU3QvT29SR0tTa2t5aS80UzNIY3JMQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieGsxamstTlJ2VUtHMFlLYWFmQWRBQSIsInZlciI6IjEuMCJ9.ADT-9qZlaX4MDV07ntM5ibfPXZ63OeoRAoNBbFZmQtrp-S15bXoIC9vgBM8Z7S-8C3rEe3Y6n10LoMCUxTiixfn6zlPn82JobgdO8ksXbX4z5uYvTIv4fYi14dtIwJBMgF2MA1zN2sErSREp1jZ3axzq7ZxG14K2vMsezi8bcTHCLWiM0VUpd_AVT23FOmDsls-WKsTM1zK0Fzjz1vrv1446EJZSg3xIQmEghD3ijAz9qJIojkR-xxdEEpDhtB6s4daub6Tjg9_YjTUdKiRcO6sJJfQetnxRRNLQi-5zYdBBQyC7ovmXuPitPGTKLDuJo2Xn9HUe9Hu-Flccmk_pWQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/GetInstanceView3Min;4723,Microsoft.Compute/GetInstanceView30Min;23769
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344652126238
+      X-Ms-Request-Id:
+      - cd6544da-164e-402e-ad25-4d9908e985df
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14984'
+      X-Ms-Correlation-Request-Id:
+      - 5bc9d034-4b3b-460a-b9f8-5a686d8a84c3
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T102132Z:5bc9d034-4b3b-460a-b9f8-5a686d8a84c3
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 10:21:31 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"platformUpdateDomain\": 0,\r\n  \"platformFaultDomain\": 0,\r\n
+        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
+        [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
+        \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
+        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2018-03-12T10:21:27+00:00\"\r\n
+        \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"osdisk\",\r\n
+        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
+        succeeded\",\r\n          \"time\": \"2016-09-03T02:09:09.3853413+00:00\"\r\n
+        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
+        \"https://spec0deply1stor.blob.core.windows.net/bootdiagnostics-spec0depl-4d1502d5-351a-42f4-8569-22284f906d68/spec0deply1vm1.4d1502d5-351a-42f4-8569-22284f906d68.screenshot.bmp\",\r\n
+        \   \"serialConsoleLogBlobUri\": \"https://spec0deply1stor.blob.core.windows.net/bootdiagnostics-spec0depl-4d1502d5-351a-42f4-8569-22284f906d68/spec0deply1vm1.4d1502d5-351a-42f4-8569-22284f906d68.serialconsole.log\"\r\n
+        \ },\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n
+        \     \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n
+        \     \"time\": \"2016-09-03T02:09:09.4478672+00:00\"\r\n    },\r\n    {\r\n
+        \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
+        \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 10:21:36 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups/miq-azure-test1?api-version=2017-08-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk3NTUsIm5iZiI6MTUyMDg0OTc1NSwiZXhwIjoxNTIwODUzNjU1LCJhaW8iOiJZMk5nWUhnU3QvT29SR0tTa2t5aS80UzNIY3JMQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieGsxamstTlJ2VUtHMFlLYWFmQWRBQSIsInZlciI6IjEuMCJ9.ADT-9qZlaX4MDV07ntM5ibfPXZ63OeoRAoNBbFZmQtrp-S15bXoIC9vgBM8Z7S-8C3rEe3Y6n10LoMCUxTiixfn6zlPn82JobgdO8ksXbX4z5uYvTIv4fYi14dtIwJBMgF2MA1zN2sErSREp1jZ3axzq7ZxG14K2vMsezi8bcTHCLWiM0VUpd_AVT23FOmDsls-WKsTM1zK0Fzjz1vrv1446EJZSg3xIQmEghD3ijAz9qJIojkR-xxdEEpDhtB6s4daub6Tjg9_YjTUdKiRcO6sJJfQetnxRRNLQi-5zYdBBQyC7ovmXuPitPGTKLDuJo2Xn9HUe9Hu-Flccmk_pWQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14988'
+      X-Ms-Request-Id:
+      - a95df1ae-e9df-4d74-9acb-d75e34d13901
+      X-Ms-Correlation-Request-Id:
+      - a95df1ae-e9df-4d74-9acb-d75e34d13901
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T102132Z:a95df1ae-e9df-4d74-9acb-d75e34d13901
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 10:21:32 GMT
+      Content-Length:
+      - '183'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1","name":"miq-azure-test1","location":"eastus","properties":{"provisioningState":"Succeeded"}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 10:21:37 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute/locations/eastus/vmSizes?api-version=2017-12-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk3NTUsIm5iZiI6MTUyMDg0OTc1NSwiZXhwIjoxNTIwODUzNjU1LCJhaW8iOiJZMk5nWUhnU3QvT29SR0tTa2t5aS80UzNIY3JMQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieGsxamstTlJ2VUtHMFlLYWFmQWRBQSIsInZlciI6IjEuMCJ9.ADT-9qZlaX4MDV07ntM5ibfPXZ63OeoRAoNBbFZmQtrp-S15bXoIC9vgBM8Z7S-8C3rEe3Y6n10LoMCUxTiixfn6zlPn82JobgdO8ksXbX4z5uYvTIv4fYi14dtIwJBMgF2MA1zN2sErSREp1jZ3axzq7ZxG14K2vMsezi8bcTHCLWiM0VUpd_AVT23FOmDsls-WKsTM1zK0Fzjz1vrv1446EJZSg3xIQmEghD3ijAz9qJIojkR-xxdEEpDhtB6s4daub6Tjg9_YjTUdKiRcO6sJJfQetnxRRNLQi-5zYdBBQyC7ovmXuPitPGTKLDuJo2Xn9HUe9Hu-Flccmk_pWQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/LowCostGet3Min;4751,Microsoft.Compute/LowCostGet30Min;37803
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344652126238
+      X-Ms-Request-Id:
+      - 29ae4870-3b3f-4ed2-bf62-92ffa6998de4
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14985'
+      X-Ms-Correlation-Request-Id:
+      - 772bc6aa-25b7-4e75-a602-3a289970491a
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T102133Z:772bc6aa-25b7-4e75-a602-3a289970491a
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 10:21:32 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"Standard_B1ms\",\r\n
@@ -3620,6 +3658,12 @@ http_interactions:
         \   },\r\n    {\r\n      \"name\": \"Standard_F72s_v2\",\r\n      \"numberOfCores\":
         72,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
         589824,\r\n      \"memoryInMB\": 147456,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_L8s_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1811981,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_L16s_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        3623962,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
         \   },\r\n    {\r\n      \"name\": \"Standard_ND6s\",\r\n      \"numberOfCores\":
         6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
         344064,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 12\r\n
@@ -3646,10 +3690,10 @@ http_interactions:
         391168,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
         \   }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:32 GMT
+  recorded_at: Mon, 12 Mar 2018 10:21:38 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-deployment-dont-delete?api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor?api-version=2017-10-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3663,223 +3707,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0NzMsIm5iZiI6MTUyMDQ1MzQ3MywiZXhwIjoxNTIwNDU3MzczLCJhaW8iOiJZMk5nWU5qWTM4RStWU2lPKzlxT2duY0JKOWN0QlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNFdUcnNGWUVYRUtJZmRBQUdWTUFBQSIsInZlciI6IjEuMCJ9.ArxfPNTq5GDkmFBppDjfAq99t5AKHpkiomJyFlFNwYavrQxfd66kamPOrTK4LUxqE7dufAUhjQG5zQLqcZPvtl1SS4zIppFRih0g1Iur45O6WRCd5hv4r9n0sZVLlSnyIsza0haM5o5Sz5ic2k-cBTw0-HwWuTwFz8ALJmG8x0lxKaY8uxuuD13yghFGHL5eoIIZ0WsMIuOSzx8bqSAvXctOpvg6d8r73UECp7ugreyMFj0o_RWgO7UlOlp9rfa0io1kOcsz620m7evOgR42aEh-B6ga-nscmo53D_vXoOFeB0u9_WoUGLB4bb1831b4nBT9dYhV8HL7tvYLQqR8Ig
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14983'
-      X-Ms-Request-Id:
-      - 4277b53d-d52d-42cd-b6fe-ed4f345e9176
-      X-Ms-Correlation-Request-Id:
-      - 4277b53d-d52d-42cd-b6fe-ed4f345e9176
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201632Z:4277b53d-d52d-42cd-b6fe-ed4f345e9176
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:16:31 GMT
-      Content-Length:
-      - '3083'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-deployment-dont-delete","name":"spec-deployment-dont-delete","properties":{"templateLink":{"uri":"https://gist.githubusercontent.com/bzwei/e6ccc4d641d6afab8e26ef55c37c498e/raw/769505e37256e926a9b581a100c90bb657ff45ff/azure-parent-spec.json","contentVersion":"1.0.0.0"},"parameters":{"childDeployName":{"type":"String","value":"spec-nested-deployment-dont-delete"},"storageAccountName":{"type":"String","value":"spec0deply1stor"},"availabilitySetName":{"type":"String","value":"spec0deply1as"},"adminUsername":{"type":"String","value":"deploy1admin"},"adminPassword":{"type":"SecureString"},"dnsNameforLBIP":{"type":"String","value":"spec0deply1dns"},"vmNamePrefix":{"type":"String","value":"spec0deply1vm"},"imagePublisher":{"type":"String","value":"MicrosoftWindowsServer"},"imageOffer":{"type":"String","value":"WindowsServer"},"imageSKU":{"type":"String","value":"2012-R2-Datacenter"},"lbName":{"type":"String","value":"spec0deply1lb"},"nicNamePrefix":{"type":"String","value":"spec0deply1nic"},"publicIPAddressName":{"type":"String","value":"spec0deply1ip"},"vnetName":{"type":"String","value":"spec0deply1vnet"},"vmSize":{"type":"String","value":"Standard_D1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-04-04T23:29:05.0043846Z","duration":"PT24M6.1512983S","correlationId":"3a55e6b5-4a3b-431e-8144-53698bf6f1dc","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[],"outputs":{"siteUri":{"type":"String","value":"hard-coded
-        output for test"}},"outputResources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor"}]}}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:32 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete?api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0NzMsIm5iZiI6MTUyMDQ1MzQ3MywiZXhwIjoxNTIwNDU3MzczLCJhaW8iOiJZMk5nWU5qWTM4RStWU2lPKzlxT2duY0JKOWN0QlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNFdUcnNGWUVYRUtJZmRBQUdWTUFBQSIsInZlciI6IjEuMCJ9.ArxfPNTq5GDkmFBppDjfAq99t5AKHpkiomJyFlFNwYavrQxfd66kamPOrTK4LUxqE7dufAUhjQG5zQLqcZPvtl1SS4zIppFRih0g1Iur45O6WRCd5hv4r9n0sZVLlSnyIsza0haM5o5Sz5ic2k-cBTw0-HwWuTwFz8ALJmG8x0lxKaY8uxuuD13yghFGHL5eoIIZ0WsMIuOSzx8bqSAvXctOpvg6d8r73UECp7ugreyMFj0o_RWgO7UlOlp9rfa0io1kOcsz620m7evOgR42aEh-B6ga-nscmo53D_vXoOFeB0u9_WoUGLB4bb1831b4nBT9dYhV8HL7tvYLQqR8Ig
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Request-Id:
-      - 19a4d28d-7433-447a-87a5-7b86f6268079
-      X-Ms-Correlation-Request-Id:
-      - 19a4d28d-7433-447a-87a5-7b86f6268079
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201632Z:19a4d28d-7433-447a-87a5-7b86f6268079
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:16:32 GMT
-      Content-Length:
-      - '7230'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete","name":"spec-nested-deployment-dont-delete","properties":{"templateLink":{"uri":"https://gist.githubusercontent.com/bzwei/c09f906306399d238762bce711781200/raw/3558b735da03c1c030023d70b78ec3451dab5689/azure-loadbalancer.json","contentVersion":"1.0.0.0"},"parameters":{"storageAccountName":{"type":"String","value":"spec0deply1stor"},"availabilitySetName":{"type":"String","value":"spec0deply1as"},"adminUsername":{"type":"String","value":"deploy1admin"},"adminPassword":{"type":"SecureString"},"dnsNameforLBIP":{"type":"String","value":"spec0deply1dns"},"vmNamePrefix":{"type":"String","value":"spec0deply1vm"},"imagePublisher":{"type":"String","value":"MicrosoftWindowsServer"},"imageOffer":{"type":"String","value":"WindowsServer"},"imageSKU":{"type":"String","value":"2012-R2-Datacenter"},"lbName":{"type":"String","value":"spec0deply1lb"},"nicNamePrefix":{"type":"String","value":"spec0deply1nic"},"publicIPAddressName":{"type":"String","value":"spec0deply1ip"},"vnetName":{"type":"String","value":"spec0deply1vnet"},"vmSize":{"type":"String","value":"Standard_D1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-04-04T23:28:59.2682474Z","duration":"PT23M55.442141S","correlationId":"3a55e6b5-4a3b-431e-8144-53698bf6f1dc","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["eastus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"availabilitySets","locations":["eastus"]},{"resourceType":"virtualMachines","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"publicIPAddresses","locations":["eastus"]},{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"loadBalancers","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"spec0deply1ip"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic0"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic1"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"spec0deply1stor"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"spec0deply1as"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"spec0deply1vm0"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"spec0deply1stor"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"spec0deply1as"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"spec0deply1vm1"}],"outputResources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor"}]}}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:33 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-deployment-dont-delete?api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0NzMsIm5iZiI6MTUyMDQ1MzQ3MywiZXhwIjoxNTIwNDU3MzczLCJhaW8iOiJZMk5nWU5qWTM4RStWU2lPKzlxT2duY0JKOWN0QlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNFdUcnNGWUVYRUtJZmRBQUdWTUFBQSIsInZlciI6IjEuMCJ9.ArxfPNTq5GDkmFBppDjfAq99t5AKHpkiomJyFlFNwYavrQxfd66kamPOrTK4LUxqE7dufAUhjQG5zQLqcZPvtl1SS4zIppFRih0g1Iur45O6WRCd5hv4r9n0sZVLlSnyIsza0haM5o5Sz5ic2k-cBTw0-HwWuTwFz8ALJmG8x0lxKaY8uxuuD13yghFGHL5eoIIZ0WsMIuOSzx8bqSAvXctOpvg6d8r73UECp7ugreyMFj0o_RWgO7UlOlp9rfa0io1kOcsz620m7evOgR42aEh-B6ga-nscmo53D_vXoOFeB0u9_WoUGLB4bb1831b4nBT9dYhV8HL7tvYLQqR8Ig
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
-      X-Ms-Request-Id:
-      - d2d5fcf5-1ce8-452f-9123-30bfa6fb1cc6
-      X-Ms-Correlation-Request-Id:
-      - d2d5fcf5-1ce8-452f-9123-30bfa6fb1cc6
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201633Z:d2d5fcf5-1ce8-452f-9123-30bfa6fb1cc6
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:16:33 GMT
-      Content-Length:
-      - '3083'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-deployment-dont-delete","name":"spec-deployment-dont-delete","properties":{"templateLink":{"uri":"https://gist.githubusercontent.com/bzwei/e6ccc4d641d6afab8e26ef55c37c498e/raw/769505e37256e926a9b581a100c90bb657ff45ff/azure-parent-spec.json","contentVersion":"1.0.0.0"},"parameters":{"childDeployName":{"type":"String","value":"spec-nested-deployment-dont-delete"},"storageAccountName":{"type":"String","value":"spec0deply1stor"},"availabilitySetName":{"type":"String","value":"spec0deply1as"},"adminUsername":{"type":"String","value":"deploy1admin"},"adminPassword":{"type":"SecureString"},"dnsNameforLBIP":{"type":"String","value":"spec0deply1dns"},"vmNamePrefix":{"type":"String","value":"spec0deply1vm"},"imagePublisher":{"type":"String","value":"MicrosoftWindowsServer"},"imageOffer":{"type":"String","value":"WindowsServer"},"imageSKU":{"type":"String","value":"2012-R2-Datacenter"},"lbName":{"type":"String","value":"spec0deply1lb"},"nicNamePrefix":{"type":"String","value":"spec0deply1nic"},"publicIPAddressName":{"type":"String","value":"spec0deply1ip"},"vnetName":{"type":"String","value":"spec0deply1vnet"},"vmSize":{"type":"String","value":"Standard_D1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-04-04T23:29:05.0043846Z","duration":"PT24M6.1512983S","correlationId":"3a55e6b5-4a3b-431e-8144-53698bf6f1dc","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[],"outputs":{"siteUri":{"type":"String","value":"hard-coded
-        output for test"}},"outputResources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor"}]}}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:33 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete?api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0NzMsIm5iZiI6MTUyMDQ1MzQ3MywiZXhwIjoxNTIwNDU3MzczLCJhaW8iOiJZMk5nWU5qWTM4RStWU2lPKzlxT2duY0JKOWN0QlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNFdUcnNGWUVYRUtJZmRBQUdWTUFBQSIsInZlciI6IjEuMCJ9.ArxfPNTq5GDkmFBppDjfAq99t5AKHpkiomJyFlFNwYavrQxfd66kamPOrTK4LUxqE7dufAUhjQG5zQLqcZPvtl1SS4zIppFRih0g1Iur45O6WRCd5hv4r9n0sZVLlSnyIsza0haM5o5Sz5ic2k-cBTw0-HwWuTwFz8ALJmG8x0lxKaY8uxuuD13yghFGHL5eoIIZ0WsMIuOSzx8bqSAvXctOpvg6d8r73UECp7ugreyMFj0o_RWgO7UlOlp9rfa0io1kOcsz620m7evOgR42aEh-B6ga-nscmo53D_vXoOFeB0u9_WoUGLB4bb1831b4nBT9dYhV8HL7tvYLQqR8Ig
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14981'
-      X-Ms-Request-Id:
-      - 511b8b60-6507-4119-85be-a936584d12a1
-      X-Ms-Correlation-Request-Id:
-      - 511b8b60-6507-4119-85be-a936584d12a1
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201634Z:511b8b60-6507-4119-85be-a936584d12a1
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:16:33 GMT
-      Content-Length:
-      - '7230'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete","name":"spec-nested-deployment-dont-delete","properties":{"templateLink":{"uri":"https://gist.githubusercontent.com/bzwei/c09f906306399d238762bce711781200/raw/3558b735da03c1c030023d70b78ec3451dab5689/azure-loadbalancer.json","contentVersion":"1.0.0.0"},"parameters":{"storageAccountName":{"type":"String","value":"spec0deply1stor"},"availabilitySetName":{"type":"String","value":"spec0deply1as"},"adminUsername":{"type":"String","value":"deploy1admin"},"adminPassword":{"type":"SecureString"},"dnsNameforLBIP":{"type":"String","value":"spec0deply1dns"},"vmNamePrefix":{"type":"String","value":"spec0deply1vm"},"imagePublisher":{"type":"String","value":"MicrosoftWindowsServer"},"imageOffer":{"type":"String","value":"WindowsServer"},"imageSKU":{"type":"String","value":"2012-R2-Datacenter"},"lbName":{"type":"String","value":"spec0deply1lb"},"nicNamePrefix":{"type":"String","value":"spec0deply1nic"},"publicIPAddressName":{"type":"String","value":"spec0deply1ip"},"vnetName":{"type":"String","value":"spec0deply1vnet"},"vmSize":{"type":"String","value":"Standard_D1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-04-04T23:28:59.2682474Z","duration":"PT23M55.442141S","correlationId":"3a55e6b5-4a3b-431e-8144-53698bf6f1dc","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["eastus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"availabilitySets","locations":["eastus"]},{"resourceType":"virtualMachines","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"publicIPAddresses","locations":["eastus"]},{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"loadBalancers","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"spec0deply1ip"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic0"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic1"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"spec0deply1stor"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"spec0deply1as"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"spec0deply1vm0"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"spec0deply1stor"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"spec0deply1as"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"spec0deply1vm1"}],"outputResources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor"}]}}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:34 GMT
-- request:
-    method: post
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-deployment-dont-delete/exportTemplate?api-version=2017-08-01
-    body:
-      encoding: ASCII-8BIT
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0NzMsIm5iZiI6MTUyMDQ1MzQ3MywiZXhwIjoxNTIwNDU3MzczLCJhaW8iOiJZMk5nWU5qWTM4RStWU2lPKzlxT2duY0JKOWN0QlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNFdUcnNGWUVYRUtJZmRBQUdWTUFBQSIsInZlciI6IjEuMCJ9.ArxfPNTq5GDkmFBppDjfAq99t5AKHpkiomJyFlFNwYavrQxfd66kamPOrTK4LUxqE7dufAUhjQG5zQLqcZPvtl1SS4zIppFRih0g1Iur45O6WRCd5hv4r9n0sZVLlSnyIsza0haM5o5Sz5ic2k-cBTw0-HwWuTwFz8ALJmG8x0lxKaY8uxuuD13yghFGHL5eoIIZ0WsMIuOSzx8bqSAvXctOpvg6d8r73UECp7ugreyMFj0o_RWgO7UlOlp9rfa0io1kOcsz620m7evOgR42aEh-B6ga-nscmo53D_vXoOFeB0u9_WoUGLB4bb1831b4nBT9dYhV8HL7tvYLQqR8Ig
-      Content-Length:
-      - '0'
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk3NTUsIm5iZiI6MTUyMDg0OTc1NSwiZXhwIjoxNTIwODUzNjU1LCJhaW8iOiJZMk5nWUhnU3QvT29SR0tTa2t5aS80UzNIY3JMQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieGsxamstTlJ2VUtHMFlLYWFmQWRBQSIsInZlciI6IjEuMCJ9.ADT-9qZlaX4MDV07ntM5ibfPXZ63OeoRAoNBbFZmQtrp-S15bXoIC9vgBM8Z7S-8C3rEe3Y6n10LoMCUxTiixfn6zlPn82JobgdO8ksXbX4z5uYvTIv4fYi14dtIwJBMgF2MA1zN2sErSREp1jZ3axzq7ZxG14K2vMsezi8bcTHCLWiM0VUpd_AVT23FOmDsls-WKsTM1zK0Fzjz1vrv1446EJZSg3xIQmEghD3ijAz9qJIojkR-xxdEEpDhtB6s4daub6Tjg9_YjTUdKiRcO6sJJfQetnxRRNLQi-5zYdBBQyC7ovmXuPitPGTKLDuJo2Xn9HUe9Hu-Flccmk_pWQ
   response:
     status:
       code: 200
@@ -3892,465 +3720,32 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Content-Type:
-      - application/json; charset=utf-8
+      - application/json
       Expires:
       - "-1"
       Vary:
       - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1198'
       X-Ms-Request-Id:
-      - 8305e943-6186-45a9-b004-f5d90ff0b248
-      X-Ms-Correlation-Request-Id:
-      - 8305e943-6186-45a9-b004-f5d90ff0b248
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201635Z:8305e943-6186-45a9-b004-f5d90ff0b248
+      - b33ea62a-7f42-4333-8149-f0a120185aa8
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:16:34 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"template":{"$schema":"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#","contentVersion":"1.0.0.0","parameters":{"childDeployName":{"type":"String"},"storageAccountName":{"type":"String","metadata":{"description":"Name
-        of storage account"}},"availabilitySetName":{"type":"String","metadata":{"description":"Name
-        of availability set"}},"adminUsername":{"type":"String","metadata":{"description":"Admin
-        username"}},"adminPassword":{"type":"SecureString","metadata":{"description":"Admin
-        password"}},"dnsNameforLBIP":{"type":"String","metadata":{"description":"DNS
-        for Load Balancer IP"}},"vmNamePrefix":{"defaultValue":"myVM","type":"String","metadata":{"description":"Prefix
-        to use for VM names"}},"imagePublisher":{"defaultValue":"MicrosoftWindowsServer","type":"String","metadata":{"description":"Image
-        Publisher"}},"imageOffer":{"defaultValue":"WindowsServer","type":"String","metadata":{"description":"Image
-        Offer"}},"imageSKU":{"defaultValue":"2012-R2-Datacenter","type":"String","metadata":{"description":"Image
-        SKU"}},"lbName":{"defaultValue":"myLB","type":"String","metadata":{"description":"Load
-        Balancer name"}},"nicNamePrefix":{"defaultValue":"nic","type":"String","metadata":{"description":"Network
-        Interface name prefix"}},"publicIPAddressName":{"defaultValue":"myPublicIP","type":"String","metadata":{"description":"Public
-        IP Name"}},"vnetName":{"defaultValue":"myVNET","type":"String","metadata":{"description":"VNET
-        name"}},"vmSize":{"defaultValue":"Standard_D1","type":"String","metadata":{"description":"Size
-        of the VM"}}},"resources":[{"type":"Microsoft.Resources/deployments","name":"[parameters(''childDeployName'')]","apiVersion":"2015-01-01","properties":{"mode":"Incremental","templateLink":{"uri":"https://gist.githubusercontent.com/bzwei/c09f906306399d238762bce711781200/raw/3558b735da03c1c030023d70b78ec3451dab5689/azure-loadbalancer.json","contentVersion":"1.0.0.0"},"parameters":{"storageAccountName":{"value":"[parameters(''storageAccountName'')]"},"availabilitySetName":{"value":"[parameters(''availabilitySetName'')]"},"adminUsername":{"value":"[parameters(''adminUsername'')]"},"adminPassword":{"value":"[parameters(''adminPassword'')]"},"dnsNameforLBIP":{"value":"[parameters(''dnsNameforLBIP'')]"},"vmNamePrefix":{"value":"[parameters(''vmNamePrefix'')]"},"imagePublisher":{"value":"[parameters(''imagePublisher'')]"},"imageOffer":{"value":"[parameters(''imageOffer'')]"},"imageSKU":{"value":"[parameters(''imageSKU'')]"},"lbName":{"value":"[parameters(''lbName'')]"},"nicNamePrefix":{"value":"[parameters(''nicNamePrefix'')]"},"publicIPAddressName":{"value":"[parameters(''publicIPAddressName'')]"},"vnetName":{"value":"[parameters(''vnetName'')]"},"vmSize":{"value":"[parameters(''vmSize'')]"}}}}],"outputs":{"siteUri":{"type":"String","value":"hard-coded
-        output for test"}}}}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:35 GMT
-- request:
-    method: post
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/exportTemplate?api-version=2017-08-01
-    body:
-      encoding: ASCII-8BIT
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0NzMsIm5iZiI6MTUyMDQ1MzQ3MywiZXhwIjoxNTIwNDU3MzczLCJhaW8iOiJZMk5nWU5qWTM4RStWU2lPKzlxT2duY0JKOWN0QlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNFdUcnNGWUVYRUtJZmRBQUdWTUFBQSIsInZlciI6IjEuMCJ9.ArxfPNTq5GDkmFBppDjfAq99t5AKHpkiomJyFlFNwYavrQxfd66kamPOrTK4LUxqE7dufAUhjQG5zQLqcZPvtl1SS4zIppFRih0g1Iur45O6WRCd5hv4r9n0sZVLlSnyIsza0haM5o5Sz5ic2k-cBTw0-HwWuTwFz8ALJmG8x0lxKaY8uxuuD13yghFGHL5eoIIZ0WsMIuOSzx8bqSAvXctOpvg6d8r73UECp7ugreyMFj0o_RWgO7UlOlp9rfa0io1kOcsz620m7evOgR42aEh-B6ga-nscmo53D_vXoOFeB0u9_WoUGLB4bb1831b4nBT9dYhV8HL7tvYLQqR8Ig
-      Content-Length:
-      - '0'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1199'
-      X-Ms-Request-Id:
-      - a688467f-c3c0-461d-ac56-5774b2ae47f2
-      X-Ms-Correlation-Request-Id:
-      - a688467f-c3c0-461d-ac56-5774b2ae47f2
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201635Z:a688467f-c3c0-461d-ac56-5774b2ae47f2
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:16:35 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"template":{"$schema":"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json","contentVersion":"1.0.0.0","parameters":{"storageAccountName":{"type":"String","metadata":{"description":"Name
-        of storage account"}},"availabilitySetName":{"type":"String","metadata":{"description":"Name
-        of availability set"}},"adminUsername":{"type":"String","metadata":{"description":"Admin
-        username"}},"adminPassword":{"type":"SecureString","metadata":{"description":"Admin
-        password"}},"dnsNameforLBIP":{"type":"String","metadata":{"description":"DNS
-        for Load Balancer IP"}},"vmNamePrefix":{"defaultValue":"myVM","type":"String","metadata":{"description":"Prefix
-        to use for VM names"}},"imagePublisher":{"defaultValue":"MicrosoftWindowsServer","type":"String","metadata":{"description":"Image
-        Publisher"}},"imageOffer":{"defaultValue":"WindowsServer","type":"String","metadata":{"description":"Image
-        Offer"}},"imageSKU":{"defaultValue":"2012-R2-Datacenter","type":"String","metadata":{"description":"Image
-        SKU"}},"lbName":{"defaultValue":"myLB","type":"String","metadata":{"description":"Load
-        Balancer name"}},"nicNamePrefix":{"defaultValue":"nic","type":"String","metadata":{"description":"Network
-        Interface name prefix"}},"publicIPAddressName":{"defaultValue":"myPublicIP","type":"String","metadata":{"description":"Public
-        IP Name"}},"vnetName":{"defaultValue":"myVNET","type":"String","metadata":{"description":"VNET
-        name"}},"vmSize":{"defaultValue":"Standard_D1","type":"String","metadata":{"description":"Size
-        of the VM"}}},"variables":{"storageAccountType":"Standard_LRS","addressPrefix":"10.0.0.0/16","subnetName":"Subnet-1","subnetPrefix":"10.0.0.0/24","publicIPAddressType":"Dynamic","vnetID":"[resourceId(''Microsoft.Network/virtualNetworks'',parameters(''vnetName''))]","subnetRef":"[concat(variables(''vnetID''),''/subnets/'',variables
-        (''subnetName''))]","publicIPAddressID":"[resourceId(''Microsoft.Network/publicIPAddresses'',parameters(''publicIPAddressName''))]","numberOfInstances":2,"lbID":"[resourceId(''Microsoft.Network/loadBalancers'',parameters(''lbName''))]","frontEndIPConfigID":"[concat(variables(''lbID''),''/frontendIPConfigurations/LoadBalancerFrontEnd'')]","lbPoolID":"[concat(variables(''lbID''),''/backendAddressPools/BackendPool1'')]","lbProbeID":"[concat(variables(''lbID''),''/probes/tcpProbe'')]"},"resources":[{"type":"Microsoft.Storage/storageAccounts","name":"[parameters(''storageAccountName'')]","apiVersion":"2015-05-01-preview","location":"[resourceGroup().location]","properties":{"accountType":"[variables(''storageAccountType'')]"}},{"type":"Microsoft.Compute/availabilitySets","name":"[parameters(''availabilitySetName'')]","apiVersion":"2015-05-01-preview","location":"[resourceGroup().location]","properties":{}},{"type":"Microsoft.Network/publicIPAddresses","name":"[parameters(''publicIPAddressName'')]","apiVersion":"2015-05-01-preview","location":"[resourceGroup().location]","properties":{"publicIPAllocationMethod":"[variables(''publicIPAddressType'')]","dnsSettings":{"domainNameLabel":"[parameters(''dnsNameforLBIP'')]"}}},{"type":"Microsoft.Network/virtualNetworks","name":"[parameters(''vnetName'')]","apiVersion":"2015-05-01-preview","location":"[resourceGroup().location]","properties":{"addressSpace":{"addressPrefixes":["[variables(''addressPrefix'')]"]},"subnets":[{"name":"[variables(''subnetName'')]","properties":{"addressPrefix":"[variables(''subnetPrefix'')]"}}]}},{"type":"Microsoft.Network/networkInterfaces","name":"[concat(parameters(''nicNamePrefix''),
-        copyindex())]","apiVersion":"2015-05-01-preview","location":"[resourceGroup().location]","copy":{"name":"nicLoop","count":"[variables(''numberOfInstances'')]"},"properties":{"ipConfigurations":[{"name":"ipconfig1","properties":{"privateIPAllocationMethod":"Dynamic","subnet":{"id":"[variables(''subnetRef'')]"},"loadBalancerBackendAddressPools":[{"id":"[concat(variables(''lbID''),
-        ''/backendAddressPools/BackendPool1'')]"}],"loadBalancerInboundNatRules":[{"id":"[concat(variables(''lbID''),''/inboundNatRules/RDP-VM'',
-        copyindex())]"}]}}]},"dependsOn":["[concat(''Microsoft.Network/virtualNetworks/'',
-        parameters(''vnetName''))]","[concat(''Microsoft.Network/loadBalancers/'',
-        parameters(''lbName''))]"]},{"type":"Microsoft.Network/loadBalancers","name":"[parameters(''lbName'')]","apiVersion":"2015-05-01-preview","location":"[resourceGroup().location]","properties":{"frontendIPConfigurations":[{"name":"LoadBalancerFrontEnd","properties":{"publicIPAddress":{"id":"[variables(''publicIPAddressID'')]"}}}],"backendAddressPools":[{"name":"BackendPool1"}],"inboundNatRules":[{"name":"RDP-VM0","properties":{"frontendIPConfiguration":{"id":"[variables(''frontEndIPConfigID'')]"},"protocol":"tcp","frontendPort":50001,"backendPort":3389,"enableFloatingIP":false}},{"name":"RDP-VM1","properties":{"frontendIPConfiguration":{"id":"[variables(''frontEndIPConfigID'')]"},"protocol":"tcp","frontendPort":50002,"backendPort":3389,"enableFloatingIP":false}}],"loadBalancingRules":[{"name":"LBRule","properties":{"frontendIPConfiguration":{"id":"[variables(''frontEndIPConfigID'')]"},"backendAddressPool":{"id":"[variables(''lbPoolID'')]"},"protocol":"tcp","frontendPort":80,"backendPort":80,"enableFloatingIP":false,"idleTimeoutInMinutes":5,"probe":{"id":"[variables(''lbProbeID'')]"}}}],"probes":[{"name":"tcpProbe","properties":{"protocol":"tcp","port":80,"intervalInSeconds":5,"numberOfProbes":2}}]},"dependsOn":["[concat(''Microsoft.Network/publicIPAddresses/'',
-        parameters(''publicIPAddressName''))]"]},{"type":"Microsoft.Compute/virtualMachines","name":"[concat(parameters(''vmNamePrefix''),
-        copyindex())]","apiVersion":"2015-06-15","location":"[resourceGroup().location]","copy":{"name":"virtualMachineLoop","count":"[variables(''numberOfInstances'')]"},"properties":{"availabilitySet":{"id":"[resourceId(''Microsoft.Compute/availabilitySets'',parameters(''availabilitySetName''))]"},"hardwareProfile":{"vmSize":"[parameters(''vmSize'')]"},"osProfile":{"computerName":"[concat(parameters(''vmNamePrefix''),
-        copyIndex())]","adminUsername":"[parameters(''adminUsername'')]","adminPassword":"[parameters(''adminPassword'')]"},"storageProfile":{"imageReference":{"publisher":"[parameters(''imagePublisher'')]","offer":"[parameters(''imageOffer'')]","sku":"[parameters(''imageSKU'')]","version":"latest"},"osDisk":{"name":"osdisk","vhd":{"uri":"[concat(''http://'',parameters(''storageAccountName''),''.blob.core.windows.net/vhds/'',''osdisk'',
-        copyindex(), ''.vhd'')]"},"caching":"ReadWrite","createOption":"FromImage"}},"networkProfile":{"networkInterfaces":[{"id":"[resourceId(''Microsoft.Network/networkInterfaces'',concat(parameters(''nicNamePrefix''),copyindex()))]"}]},"diagnosticsProfile":{"bootDiagnostics":{"enabled":"true","storageUri":"[concat(''http://'',parameters(''storageAccountName''),''.blob.core.windows.net'')]"}}},"dependsOn":["[concat(''Microsoft.Storage/storageAccounts/'',
-        parameters(''storageAccountName''))]","[concat(''Microsoft.Network/networkInterfaces/'',
-        parameters(''nicNamePrefix''), copyindex())]","[concat(''Microsoft.Compute/availabilitySets/'',
-        parameters(''availabilitySetName''))]"]}]}}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:35 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1?api-version=2017-12-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0NzMsIm5iZiI6MTUyMDQ1MzQ3MywiZXhwIjoxNTIwNDU3MzczLCJhaW8iOiJZMk5nWU5qWTM4RStWU2lPKzlxT2duY0JKOWN0QlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNFdUcnNGWUVYRUtJZmRBQUdWTUFBQSIsInZlciI6IjEuMCJ9.ArxfPNTq5GDkmFBppDjfAq99t5AKHpkiomJyFlFNwYavrQxfd66kamPOrTK4LUxqE7dufAUhjQG5zQLqcZPvtl1SS4zIppFRih0g1Iur45O6WRCd5hv4r9n0sZVLlSnyIsza0haM5o5Sz5ic2k-cBTw0-HwWuTwFz8ALJmG8x0lxKaY8uxuuD13yghFGHL5eoIIZ0WsMIuOSzx8bqSAvXctOpvg6d8r73UECp7ugreyMFj0o_RWgO7UlOlp9rfa0io1kOcsz620m7evOgR42aEh-B6ga-nscmo53D_vXoOFeB0u9_WoUGLB4bb1831b4nBT9dYhV8HL7tvYLQqR8Ig
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/LowCostGet3Min;4744,Microsoft.Compute/LowCostGet30Min;37916
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
-      X-Ms-Request-Id:
-      - 908d0e0f-7b7f-46f0-80c2-5a387bf0a7ce
       Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14979'
+      - '14985'
       X-Ms-Correlation-Request-Id:
-      - b11d67dc-89d3-4235-8b93-78a0ccfe141e
+      - b0f9b2c0-6de5-4ece-92b5-5903bc2199b1
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201636Z:b11d67dc-89d3-4235-8b93-78a0ccfe141e
+      - WESTEUROPE:20180312T102138Z:b0f9b2c0-6de5-4ece-92b5-5903bc2199b1
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:16:35 GMT
+      - Mon, 12 Mar 2018 10:21:37 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"4d1502d5-351a-42f4-8569-22284f906d68\",\r\n
-        \   \"availabilitySet\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/SPEC0DEPLY1AS\"\r\n
-        \   },\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_D1\"\r\n
-        \   },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
-        \"MicrosoftWindowsServer\",\r\n        \"offer\": \"WindowsServer\",\r\n        \"sku\":
-        \"2012-R2-Datacenter\",\r\n        \"version\": \"latest\"\r\n      },\r\n
-        \     \"osDisk\": {\r\n        \"osType\": \"Windows\",\r\n        \"name\":
-        \"osdisk\",\r\n        \"createOption\": \"FromImage\",\r\n        \"vhd\":
-        {\r\n          \"uri\": \"http://spec0deply1stor.blob.core.windows.net/vhds/osdisk1.vhd\"\r\n
-        \       },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n      \"dataDisks\":
-        []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"spec0deply1vm1\",\r\n
-        \     \"adminUsername\": \"deploy1admin\",\r\n      \"windowsConfiguration\":
-        {\r\n        \"provisionVMAgent\": true,\r\n        \"enableAutomaticUpdates\":
-        true\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\":
-        {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1\"}]},\r\n
-        \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
-        true,\r\n        \"storageUri\": \"http://spec0deply1stor.blob.core.windows.net\"\r\n
-        \     }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n
-        \ \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"eastus\",\r\n
-        \ \"tags\": {\r\n    \"Shutdown\": \"true\"\r\n  },\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1\",\r\n
-        \ \"name\": \"spec0deply1vm1\"\r\n}"
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","name":"spec0deply1stor","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-04-04T23:05:07.8274794Z","primaryEndpoints":{"blob":"https://spec0deply1stor.blob.core.windows.net/","queue":"https://spec0deply1stor.queue.core.windows.net/","table":"https://spec0deply1stor.table.core.windows.net/","file":"https://spec0deply1stor.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:36 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0?api-version=2017-12-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0NzMsIm5iZiI6MTUyMDQ1MzQ3MywiZXhwIjoxNTIwNDU3MzczLCJhaW8iOiJZMk5nWU5qWTM4RStWU2lPKzlxT2duY0JKOWN0QlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNFdUcnNGWUVYRUtJZmRBQUdWTUFBQSIsInZlciI6IjEuMCJ9.ArxfPNTq5GDkmFBppDjfAq99t5AKHpkiomJyFlFNwYavrQxfd66kamPOrTK4LUxqE7dufAUhjQG5zQLqcZPvtl1SS4zIppFRih0g1Iur45O6WRCd5hv4r9n0sZVLlSnyIsza0haM5o5Sz5ic2k-cBTw0-HwWuTwFz8ALJmG8x0lxKaY8uxuuD13yghFGHL5eoIIZ0WsMIuOSzx8bqSAvXctOpvg6d8r73UECp7ugreyMFj0o_RWgO7UlOlp9rfa0io1kOcsz620m7evOgR42aEh-B6ga-nscmo53D_vXoOFeB0u9_WoUGLB4bb1831b4nBT9dYhV8HL7tvYLQqR8Ig
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/LowCostGet3Min;4743,Microsoft.Compute/LowCostGet30Min;37915
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
-      X-Ms-Request-Id:
-      - 5a46c185-5622-4f9c-99d5-63557fa724bc
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14979'
-      X-Ms-Correlation-Request-Id:
-      - d606c961-f65d-4267-8e07-33cf450c9b10
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201642Z:d606c961-f65d-4267-8e07-33cf450c9b10
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:16:41 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"d7022008-f6b1-4f4c-8be8-e2d677ef3261\",\r\n
-        \   \"availabilitySet\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/SPEC0DEPLY1AS\"\r\n
-        \   },\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_D1\"\r\n
-        \   },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
-        \"MicrosoftWindowsServer\",\r\n        \"offer\": \"WindowsServer\",\r\n        \"sku\":
-        \"2012-R2-Datacenter\",\r\n        \"version\": \"latest\"\r\n      },\r\n
-        \     \"osDisk\": {\r\n        \"osType\": \"Windows\",\r\n        \"name\":
-        \"osdisk\",\r\n        \"createOption\": \"FromImage\",\r\n        \"vhd\":
-        {\r\n          \"uri\": \"http://spec0deply1stor.blob.core.windows.net/vhds/osdisk0.vhd\"\r\n
-        \       },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n      \"dataDisks\":
-        []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"spec0deply1vm0\",\r\n
-        \     \"adminUsername\": \"deploy1admin\",\r\n      \"windowsConfiguration\":
-        {\r\n        \"provisionVMAgent\": true,\r\n        \"enableAutomaticUpdates\":
-        true\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\":
-        {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0\"}]},\r\n
-        \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
-        true,\r\n        \"storageUri\": \"http://spec0deply1stor.blob.core.windows.net\"\r\n
-        \     }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n
-        \ \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"eastus\",\r\n
-        \ \"tags\": {\r\n    \"Shutdown\": \"true\"\r\n  },\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0\",\r\n
-        \ \"name\": \"spec0deply1vm0\"\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:42 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1/instanceView?api-version=2017-12-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0NzMsIm5iZiI6MTUyMDQ1MzQ3MywiZXhwIjoxNTIwNDU3MzczLCJhaW8iOiJZMk5nWU5qWTM4RStWU2lPKzlxT2duY0JKOWN0QlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNFdUcnNGWUVYRUtJZmRBQUdWTUFBQSIsInZlciI6IjEuMCJ9.ArxfPNTq5GDkmFBppDjfAq99t5AKHpkiomJyFlFNwYavrQxfd66kamPOrTK4LUxqE7dufAUhjQG5zQLqcZPvtl1SS4zIppFRih0g1Iur45O6WRCd5hv4r9n0sZVLlSnyIsza0haM5o5Sz5ic2k-cBTw0-HwWuTwFz8ALJmG8x0lxKaY8uxuuD13yghFGHL5eoIIZ0WsMIuOSzx8bqSAvXctOpvg6d8r73UECp7ugreyMFj0o_RWgO7UlOlp9rfa0io1kOcsz620m7evOgR42aEh-B6ga-nscmo53D_vXoOFeB0u9_WoUGLB4bb1831b4nBT9dYhV8HL7tvYLQqR8Ig
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/GetInstanceView3Min;4797,Microsoft.Compute/GetInstanceView30Min;23926
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
-      X-Ms-Request-Id:
-      - a301562d-1590-4805-80a9-11d2fc642232
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14980'
-      X-Ms-Correlation-Request-Id:
-      - fef477b2-f1e2-412f-9a15-04102060287e
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201648Z:fef477b2-f1e2-412f-9a15-04102060287e
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:16:48 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"platformUpdateDomain\": 0,\r\n  \"platformFaultDomain\": 0,\r\n
-        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
-        [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
-        \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
-        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2018-03-07T20:16:42+00:00\"\r\n
-        \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"osdisk\",\r\n
-        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
-        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"time\": \"2016-09-03T02:09:09.3853413+00:00\"\r\n
-        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
-        \"https://spec0deply1stor.blob.core.windows.net/bootdiagnostics-spec0depl-4d1502d5-351a-42f4-8569-22284f906d68/spec0deply1vm1.4d1502d5-351a-42f4-8569-22284f906d68.screenshot.bmp\",\r\n
-        \   \"serialConsoleLogBlobUri\": \"https://spec0deply1stor.blob.core.windows.net/bootdiagnostics-spec0depl-4d1502d5-351a-42f4-8569-22284f906d68/spec0deply1vm1.4d1502d5-351a-42f4-8569-22284f906d68.serialconsole.log\"\r\n
-        \ },\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n
-        \     \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n
-        \     \"time\": \"2016-09-03T02:09:09.4478672+00:00\"\r\n    },\r\n    {\r\n
-        \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
-        \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:48 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Network/networkInterfaces?api-version=2017-11-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0NzMsIm5iZiI6MTUyMDQ1MzQ3MywiZXhwIjoxNTIwNDU3MzczLCJhaW8iOiJZMk5nWU5qWTM4RStWU2lPKzlxT2duY0JKOWN0QlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNFdUcnNGWUVYRUtJZmRBQUdWTUFBQSIsInZlciI6IjEuMCJ9.ArxfPNTq5GDkmFBppDjfAq99t5AKHpkiomJyFlFNwYavrQxfd66kamPOrTK4LUxqE7dufAUhjQG5zQLqcZPvtl1SS4zIppFRih0g1Iur45O6WRCd5hv4r9n0sZVLlSnyIsza0haM5o5Sz5ic2k-cBTw0-HwWuTwFz8ALJmG8x0lxKaY8uxuuD13yghFGHL5eoIIZ0WsMIuOSzx8bqSAvXctOpvg6d8r73UECp7ugreyMFj0o_RWgO7UlOlp9rfa0io1kOcsz620m7evOgR42aEh-B6ga-nscmo53D_vXoOFeB0u9_WoUGLB4bb1831b4nBT9dYhV8HL7tvYLQqR8Ig
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 6b9ebf89-1352-45df-851d-3d61838cb89a
-      X-Ms-Correlation-Request-Id:
-      - 6b9ebf89-1352-45df-851d-3d61838cb89a
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201649Z:6b9ebf89-1352-45df-851d-3d61838cb89a
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:16:49 GMT
-      Content-Length:
-      - '31614'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[{"name":"miqazure-coreos1235","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235","etag":"W/\"4a6546ab-a4c0-4d27-bccd-f6ebf3c405a2\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"fb0a5e60-a6c2-4bb8-a2f5-0c16216a49b0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235/ipConfigurations/ipconfig1","etag":"W/\"4a6546ab-a4c0-4d27-bccd-f6ebf3c405a2\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.20.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/publicIPAddresses/miqazure-coreos1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/virtualNetworks/miq-azure-test3/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"rliadcyr3l1elbnsw4rabxqg1f.dx.internal.cloudapp.net"},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkSecurityGroups/miqazure-coreos1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Compute/virtualMachines/miqazure-coreos1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"dbergerprov1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/dbergerprov1","etag":"W/\"074dd836-918c-4e40-a118-94f0d366e175\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"ecdcd2f0-91bb-4c40-91cd-a3d76fc5e455","ipConfigurations":[{"name":"dbergerprov1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/dbergerprov1/ipConfigurations/dbergerprov1","etag":"W/\"074dd836-918c-4e40-a118-94f0d366e175\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.9","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/dbergerprov1-publicIp"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/virtualMachines/dbergerprov1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-rhel1390","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390","etag":"W/\"f006e6f9-0292-42cd-99fc-f72f194553c1\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"98853f48-2806-4065-be57-cf9159550440","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1","etag":"W/\"f006e6f9-0292-42cd-99fc-f72f194553c1\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"macAddress":"00-0D-3A-10-EB-AB","enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-ubuntu1989","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989","etag":"W/\"64e07488-15a2-4cec-b84a-6fd5ef04323c\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"134a6669-ac4a-4d08-a0db-387bc4c49537","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989/ipConfigurations/ipconfig1","etag":"W/\"64e07488-15a2-4cec-b84a-6fd5ef04323c\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.17.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-ubuntu1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest18687/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-win12610","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610","etag":"W/\"dd925ef5-33d1-402c-a0f4-18c78c2641f4\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"5c2eef2c-0b36-4277-a940-957ed4d13be0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610/ipConfigurations/ipconfig1","etag":"W/\"dd925ef5-33d1-402c-a0f4-18c78c2641f4\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.18.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-win12"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest19881/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-winimg241","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241","etag":"W/\"4a17a745-16a9-42d9-88c9-17a518959525\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"8ed2f3b0-4a4b-49ae-9f1d-ff7890dbd396","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241/ipConfigurations/ipconfig1","etag":"W/\"4a17a745-16a9-42d9-88c9-17a518959525\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.7","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqtestwinimg6202"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-centos1611","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611","etag":"W/\"26031ef6-bb55-4019-8185-2dd1edcb207c\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"f1760e49-9853-4fdc-acfc-4ea232b9ed76","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1","etag":"W/\"26031ef6-bb55-4019-8185-2dd1edcb207c\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.5","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqmismatch1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1","etag":"W/\"3a72d0c3-bfda-4da5-a61b-e8c33e43de79\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"23d804a8-b623-49e7-9c8d-1d64245bef1e","ipConfigurations":[{"name":"miqmismatch1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1/ipConfigurations/miqmismatch1","etag":"W/\"3a72d0c3-bfda-4da5-a61b-e8c33e43de79\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.8","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqmismatch1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqmismatch1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"rspec-lb-a670","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670","etag":"W/\"cf3a0b0d-d596-4f33-bc31-749f92ba4f00\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"46cb8216-786e-408e-9d86-c0855b357349","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1","etag":"W/\"cf3a0b0d-d596-4f33-bc31-749f92ba4f00\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.6","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-a-ip"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"rspec-lb-b843","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843","etag":"W/\"76aabe0c-8678-43f0-81a5-2f15784a4b99\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"3ef6fa01-ac34-43a1-8fd7-67c706b4d8ef","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1","etag":"W/\"76aabe0c-8678-43f0-81a5-2f15784a4b99\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.11","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-b-ip"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"spec0deply1nic0","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","etag":"W/\"b817491c-aab8-4aab-b41d-b07bfffa5639\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"80ad9866-071d-4e3f-91d0-d47954eccee0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1","etag":"W/\"b817491c-aab8-4aab-b41d-b07bfffa5639\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.4","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"spec0deply1nic1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","etag":"W/\"2ec58a0b-4c03-4d0a-b788-9daffd54e7b2\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"57bbf7aa-d6c4-4f56-8f6a-089d15334221","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1","etag":"W/\"2ec58a0b-4c03-4d0a-b788-9daffd54e7b2\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.5","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqmismatch2656","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqmismatch2656","etag":"W/\"fef6a836-2802-4897-90c3-b3d71f133384\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"969dde6c-73c0-4340-877d-2b5fe2060026","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqmismatch2656/ipConfigurations/ipconfig1","etag":"W/\"fef6a836-2802-4897-90c3-b3d71f133384\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"172.23.0.4","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/virtualNetworks/miqazuretest33606/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkSecurityGroups/miqmismatch2-nsg"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Compute/virtualMachines/miqmismatch2"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-linux-manag944","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944","etag":"W/\"b6339880-8ead-4c9e-b5c0-f38c4f8612d5\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"c5e8b90e-5a78-49b0-b224-b70ed3fb45e5","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944/ipConfigurations/ipconfig1","etag":"W/\"b6339880-8ead-4c9e-b5c0-f38c4f8612d5\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"172.25.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqazure-linux-managed-ip"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"jf-metrics-2751","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751","etag":"W/\"c5f6f02a-b17c-4f34-882b-11c7adef0b44\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"207a58d3-f18d-4dab-8168-919877297a52","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751/ipConfigurations/ipconfig1","etag":"W/\"c5f6f02a-b17c-4f34-882b-11c7adef0b44\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.7","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-2"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-2"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/jf-metrics-2"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"jf-metrics-3421","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421","etag":"W/\"0b6f160b-ad10-48f8-9d0c-657193bb823f\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"b8b345e8-a353-4700-992e-be48a717b4e2","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421/ipConfigurations/ipconfig1","etag":"W/\"0b6f160b-ad10-48f8-9d0c-657193bb823f\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.8","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-3"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-3"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/jf-metrics-3"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-oraclelinux310","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310","etag":"W/\"54cd4fe1-3ed5-4a8c-bc8d-527679c7a631\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"6a3fc1d7-4532-4ca0-b5c2-546cc8f7f313","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310/ipConfigurations/ipconfig1","etag":"W/\"54cd4fe1-3ed5-4a8c-bc8d-527679c7a631\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.5","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-oraclelinux993","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993","etag":"W/\"a9432274-7b40-4eb3-a64f-a04267a423ff\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"75d8ed14-e0ae-4d84-99f6-e3f43d073e76","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993/ipConfigurations/ipconfig1","etag":"W/\"a9432274-7b40-4eb3-a64f-a04267a423ff\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.6","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux2"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux2"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"}]}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:50 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Storage/storageAccounts?api-version=2017-10-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0NzMsIm5iZiI6MTUyMDQ1MzQ3MywiZXhwIjoxNTIwNDU3MzczLCJhaW8iOiJZMk5nWU5qWTM4RStWU2lPKzlxT2duY0JKOWN0QlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNFdUcnNGWUVYRUtJZmRBQUdWTUFBQSIsInZlciI6IjEuMCJ9.ArxfPNTq5GDkmFBppDjfAq99t5AKHpkiomJyFlFNwYavrQxfd66kamPOrTK4LUxqE7dufAUhjQG5zQLqcZPvtl1SS4zIppFRih0g1Iur45O6WRCd5hv4r9n0sZVLlSnyIsza0haM5o5Sz5ic2k-cBTw0-HwWuTwFz8ALJmG8x0lxKaY8uxuuD13yghFGHL5eoIIZ0WsMIuOSzx8bqSAvXctOpvg6d8r73UECp7ugreyMFj0o_RWgO7UlOlp9rfa0io1kOcsz620m7evOgR42aEh-B6ga-nscmo53D_vXoOFeB0u9_WoUGLB4bb1831b4nBT9dYhV8HL7tvYLQqR8Ig
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 668ec3dc-abba-441d-94b3-7aade34501ba
-      X-Ms-Correlation-Request-Id:
-      - 668ec3dc-abba-441d-94b3-7aade34501ba
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201651Z:668ec3dc-abba-441d-94b3-7aade34501ba
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:16:51 GMT
-      Content-Length:
-      - '8649'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","name":"miqazuretest18686","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T17:22:54.7808677Z","primaryEndpoints":{"blob":"https://miqazuretest18686.blob.core.windows.net/","queue":"https://miqazuretest18686.queue.core.windows.net/","table":"https://miqazuretest18686.table.core.windows.net/","file":"https://miqazuretest18686.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","name":"miqazuretest14047","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T17:30:25.7028008Z","primaryEndpoints":{"blob":"https://miqazuretest14047.blob.core.windows.net/","queue":"https://miqazuretest14047.queue.core.windows.net/","table":"https://miqazuretest14047.table.core.windows.net/","file":"https://miqazuretest14047.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Premium_LRS","tier":"Premium"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb","name":"rspeclb","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-09-02T16:29:11.6823797Z","primaryEndpoints":{"blob":"https://rspeclb.blob.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","name":"spec0deply1stor","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-04-04T23:05:07.8274794Z","primaryEndpoints":{"blob":"https://spec0deply1stor.blob.core.windows.net/","queue":"https://spec0deply1stor.queue.core.windows.net/","table":"https://spec0deply1stor.table.core.windows.net/","file":"https://spec0deply1stor.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Storage/storageAccounts/miqazuretest26611","name":"miqazuretest26611","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2211656Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2211656Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-05-02T18:01:29.2743021Z","primaryEndpoints":{"blob":"https://miqazuretest26611.blob.core.windows.net/","queue":"https://miqazuretest26611.queue.core.windows.net/","table":"https://miqazuretest26611.table.core.windows.net/","file":"https://miqazuretest26611.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","name":"miqazuretest16487","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T17:26:55.3231669Z","primaryEndpoints":{"blob":"https://miqazuretest16487.blob.core.windows.net/","queue":"https://miqazuretest16487.queue.core.windows.net/","table":"https://miqazuretest16487.table.core.windows.net/","file":"https://miqazuretest16487.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Storage/storageAccounts/miqazuretest32946","name":"miqazuretest32946","type":"Microsoft.Storage/storageAccounts","location":"westus","tags":{"delete":"false"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.0404359Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.0404359Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T21:18:37.0793411Z","primaryEndpoints":{"blob":"https://miqazuretest32946.blob.core.windows.net/","queue":"https://miqazuretest32946.queue.core.windows.net/","table":"https://miqazuretest32946.table.core.windows.net/","file":"https://miqazuretest32946.file.core.windows.net/"},"primaryLocation":"westus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Storage/storageAccounts/miqazureshared1","name":"miqazureshared1","type":"Microsoft.Storage/storageAccounts","location":"centralus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.1935084Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.1935084Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T20:42:52.498085Z","primaryEndpoints":{"blob":"https://miqazureshared1.blob.core.windows.net/","queue":"https://miqazureshared1.queue.core.windows.net/","table":"https://miqazureshared1.table.core.windows.net/","file":"https://miqazureshared1.file.core.windows.net/"},"primaryLocation":"centralus","statusOfPrimary":"available","secondaryLocation":"eastus2","statusOfSecondary":"available","secondaryEndpoints":{"blob":"https://miqazureshared1-secondary.blob.core.windows.net/","queue":"https://miqazureshared1-secondary.queue.core.windows.net/","table":"https://miqazureshared1-secondary.table.core.windows.net/"}}}]}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:52 GMT
+  recorded_at: Mon, 12 Mar 2018 10:21:42 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor/listKeys?api-version=2017-10-01
@@ -4367,7 +3762,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0NzMsIm5iZiI6MTUyMDQ1MzQ3MywiZXhwIjoxNTIwNDU3MzczLCJhaW8iOiJZMk5nWU5qWTM4RStWU2lPKzlxT2duY0JKOWN0QlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNFdUcnNGWUVYRUtJZmRBQUdWTUFBQSIsInZlciI6IjEuMCJ9.ArxfPNTq5GDkmFBppDjfAq99t5AKHpkiomJyFlFNwYavrQxfd66kamPOrTK4LUxqE7dufAUhjQG5zQLqcZPvtl1SS4zIppFRih0g1Iur45O6WRCd5hv4r9n0sZVLlSnyIsza0haM5o5Sz5ic2k-cBTw0-HwWuTwFz8ALJmG8x0lxKaY8uxuuD13yghFGHL5eoIIZ0WsMIuOSzx8bqSAvXctOpvg6d8r73UECp7ugreyMFj0o_RWgO7UlOlp9rfa0io1kOcsz620m7evOgR42aEh-B6ga-nscmo53D_vXoOFeB0u9_WoUGLB4bb1831b4nBT9dYhV8HL7tvYLQqR8Ig
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk3NTUsIm5iZiI6MTUyMDg0OTc1NSwiZXhwIjoxNTIwODUzNjU1LCJhaW8iOiJZMk5nWUhnU3QvT29SR0tTa2t5aS80UzNIY3JMQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieGsxamstTlJ2VUtHMFlLYWFmQWRBQSIsInZlciI6IjEuMCJ9.ADT-9qZlaX4MDV07ntM5ibfPXZ63OeoRAoNBbFZmQtrp-S15bXoIC9vgBM8Z7S-8C3rEe3Y6n10LoMCUxTiixfn6zlPn82JobgdO8ksXbX4z5uYvTIv4fYi14dtIwJBMgF2MA1zN2sErSREp1jZ3axzq7ZxG14K2vMsezi8bcTHCLWiM0VUpd_AVT23FOmDsls-WKsTM1zK0Fzjz1vrv1446EJZSg3xIQmEghD3ijAz9qJIojkR-xxdEEpDhtB6s4daub6Tjg9_YjTUdKiRcO6sJJfQetnxRRNLQi-5zYdBBQyC7ovmXuPitPGTKLDuJo2Xn9HUe9Hu-Flccmk_pWQ
       Content-Length:
       - '0'
   response:
@@ -4388,7 +3783,7 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 30ca5af0-241f-4d47-8bdf-14157bb6ac6b
+      - 87130f08-9f0e-4d29-a9d5-4f71e45aa24f
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
@@ -4396,238 +3791,18 @@ http_interactions:
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
       - '1198'
       X-Ms-Correlation-Request-Id:
-      - 9073c3fd-c0ae-4fd7-a61b-18551f6815bb
+      - 1e27c4e4-8f21-417c-aae7-100d62e142ff
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201652Z:9073c3fd-c0ae-4fd7-a61b-18551f6815bb
+      - WESTEUROPE:20180312T102138Z:1e27c4e4-8f21-417c-aae7-100d62e142ff
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:16:51 GMT
+      - Mon, 12 Mar 2018 10:21:38 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keys":[{"keyName":"key1","value":"68JHlwL/JgyPmvNCqop65JbepxzK0RGKJ4uD6EKszcgv1nRUJKkxO6u4OoyW/6YPT+FMJxvzEBrCGD/bduFGJQ==","permissions":"Full"},{"keyName":"key2","value":"NCT/sPC/+mrVRzXq/V5IwjN2SPaWRF4kY2coPHzJ8f+IkWMUIyfUgYTAN//h4KnxeWuX9OkY1CPyssDhDs91fw==","permissions":"Full"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:52 GMT
-- request:
-    method: head
-    uri: https://spec0deply1stor.blob.core.windows.net/vhds/osdisk1.vhd
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - ''
-      X-Ms-Date:
-      - Wed, 07 Mar 2018 20:16:52 GMT
-      X-Ms-Version:
-      - '2016-05-31'
-      Auth-String:
-      - 'true'
-      Verb:
-      - HEAD
-      Authorization:
-      - SharedKey spec0deply1stor:GArt9Rz0GVilwvGzscwMXr9DpLll6mbEmOjZEEdhBy8=
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Length:
-      - '136367309312'
-      Content-Type:
-      - application/octet-stream
-      Content-Md5:
-      - VbYhW9/6NOXzQVK/vQkdvg==
-      Last-Modified:
-      - Sat, 03 Sep 2016 02:06:37 GMT
-      Accept-Ranges:
-      - bytes
-      Etag:
-      - '"0x8D3D39EF02E16B7"'
-      Server:
-      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
-      X-Ms-Request-Id:
-      - 0a4dcf4f-001e-0100-5851-b6602a000000
-      X-Ms-Version:
-      - '2016-05-31'
-      X-Ms-Meta-Microsoftazurecompute-Resourcegroupname:
-      - miq-azure-test1
-      X-Ms-Meta-Microsoftazurecompute-Vmname:
-      - spec0deply1vm1
-      X-Ms-Meta-Microsoftazurecompute-Diskid:
-      - 3ce1f79e-7ba1-43e5-a97d-5a49a1a1a02e
-      X-Ms-Meta-Microsoftazurecompute-Diskname:
-      - osdisk
-      X-Ms-Meta-Microsoftazurecompute-Disktype:
-      - OSDisk
-      X-Ms-Lease-Status:
-      - locked
-      X-Ms-Lease-State:
-      - leased
-      X-Ms-Lease-Duration:
-      - infinite
-      X-Ms-Blob-Type:
-      - PageBlob
-      X-Ms-Blob-Sequence-Number:
-      - '53'
-      X-Ms-Copy-Id:
-      - 36fd9dad-148c-4f34-b2af-561feb937d76
-      X-Ms-Copy-Source:
-      - https://ardfepirv2bl5prdstr06.blob.core.windows.net/a699494373c04fc0bc8f2bb1389d6106/Windows-Server-2012-R2-20160229-en.us-127GB.vhd?sv=2014-02-14&sr=b&si=PirCacheAccountPublisherContainerPolicy&sig=ipib%2Bgp2Sh4hS%2BBx5OUKgXSymDC0Tu0Ge60PGFuy5uk%3D
-      X-Ms-Copy-Status:
-      - success
-      X-Ms-Copy-Progress:
-      - 136367309312/136367309312
-      X-Ms-Copy-Completion-Time:
-      - Mon, 04 Apr 2016 23:24:57 GMT
-      X-Ms-Server-Encrypted:
-      - 'false'
-      Date:
-      - Wed, 07 Mar 2018 20:16:52 GMT
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:53 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0/instanceView?api-version=2017-12-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0NzMsIm5iZiI6MTUyMDQ1MzQ3MywiZXhwIjoxNTIwNDU3MzczLCJhaW8iOiJZMk5nWU5qWTM4RStWU2lPKzlxT2duY0JKOWN0QlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNFdUcnNGWUVYRUtJZmRBQUdWTUFBQSIsInZlciI6IjEuMCJ9.ArxfPNTq5GDkmFBppDjfAq99t5AKHpkiomJyFlFNwYavrQxfd66kamPOrTK4LUxqE7dufAUhjQG5zQLqcZPvtl1SS4zIppFRih0g1Iur45O6WRCd5hv4r9n0sZVLlSnyIsza0haM5o5Sz5ic2k-cBTw0-HwWuTwFz8ALJmG8x0lxKaY8uxuuD13yghFGHL5eoIIZ0WsMIuOSzx8bqSAvXctOpvg6d8r73UECp7ugreyMFj0o_RWgO7UlOlp9rfa0io1kOcsz620m7evOgR42aEh-B6ga-nscmo53D_vXoOFeB0u9_WoUGLB4bb1831b4nBT9dYhV8HL7tvYLQqR8Ig
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/GetInstanceView3Min;4796,Microsoft.Compute/GetInstanceView30Min;23925
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
-      X-Ms-Request-Id:
-      - '084e51f9-3c2b-4033-aa58-158fa774caf5'
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14980'
-      X-Ms-Correlation-Request-Id:
-      - d99d0e96-ee05-41d9-ab6a-80e785f898c5
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201654Z:d99d0e96-ee05-41d9-ab6a-80e785f898c5
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:16:53 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"platformUpdateDomain\": 1,\r\n  \"platformFaultDomain\": 1,\r\n
-        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
-        [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
-        \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
-        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2018-03-07T20:16:53+00:00\"\r\n
-        \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"osdisk\",\r\n
-        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
-        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"time\": \"2016-09-03T02:05:35.0977796+00:00\"\r\n
-        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
-        \"https://spec0deply1stor.blob.core.windows.net/bootdiagnostics-spec0depl-d7022008-f6b1-4f4c-8be8-e2d677ef3261/spec0deply1vm0.d7022008-f6b1-4f4c-8be8-e2d677ef3261.screenshot.bmp\",\r\n
-        \   \"serialConsoleLogBlobUri\": \"https://spec0deply1stor.blob.core.windows.net/bootdiagnostics-spec0depl-d7022008-f6b1-4f4c-8be8-e2d677ef3261/spec0deply1vm0.d7022008-f6b1-4f4c-8be8-e2d677ef3261.serialconsole.log\"\r\n
-        \ },\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n
-        \     \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n
-        \     \"time\": \"2016-09-03T02:05:35.1602741+00:00\"\r\n    },\r\n    {\r\n
-        \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
-        \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:54 GMT
-- request:
-    method: post
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor/listKeys?api-version=2017-10-01
-    body:
-      encoding: ASCII-8BIT
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0NzMsIm5iZiI6MTUyMDQ1MzQ3MywiZXhwIjoxNTIwNDU3MzczLCJhaW8iOiJZMk5nWU5qWTM4RStWU2lPKzlxT2duY0JKOWN0QlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNFdUcnNGWUVYRUtJZmRBQUdWTUFBQSIsInZlciI6IjEuMCJ9.ArxfPNTq5GDkmFBppDjfAq99t5AKHpkiomJyFlFNwYavrQxfd66kamPOrTK4LUxqE7dufAUhjQG5zQLqcZPvtl1SS4zIppFRih0g1Iur45O6WRCd5hv4r9n0sZVLlSnyIsza0haM5o5Sz5ic2k-cBTw0-HwWuTwFz8ALJmG8x0lxKaY8uxuuD13yghFGHL5eoIIZ0WsMIuOSzx8bqSAvXctOpvg6d8r73UECp7ugreyMFj0o_RWgO7UlOlp9rfa0io1kOcsz620m7evOgR42aEh-B6ga-nscmo53D_vXoOFeB0u9_WoUGLB4bb1831b4nBT9dYhV8HL7tvYLQqR8Ig
-      Content-Length:
-      - '0'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 1ae95760-0ee6-42d4-9df0-f4a549748346
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1199'
-      X-Ms-Correlation-Request-Id:
-      - 5d822782-672a-4d44-a0ed-9129f0250205
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201654Z:5d822782-672a-4d44-a0ed-9129f0250205
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:16:53 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"keys":[{"keyName":"key1","value":"68JHlwL/JgyPmvNCqop65JbepxzK0RGKJ4uD6EKszcgv1nRUJKkxO6u4OoyW/6YPT+FMJxvzEBrCGD/bduFGJQ==","permissions":"Full"},{"keyName":"key2","value":"NCT/sPC/+mrVRzXq/V5IwjN2SPaWRF4kY2coPHzJ8f+IkWMUIyfUgYTAN//h4KnxeWuX9OkY1CPyssDhDs91fw==","permissions":"Full"}]}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:54 GMT
+  recorded_at: Mon, 12 Mar 2018 10:21:43 GMT
 - request:
     method: head
     uri: https://spec0deply1stor.blob.core.windows.net/vhds/osdisk0.vhd
@@ -4644,7 +3819,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:16:54 GMT
+      - Mon, 12 Mar 2018 10:21:43 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -4652,7 +3827,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey spec0deply1stor:0dRzwx9ndR5FFy6FCVlEa1ZRX3aZsrBz9zREtEBshwU=
+      - SharedKey spec0deply1stor:cQJ+4wFDbv0sTwHXUTn4VGAerBZGclPAMdkp06INXQk=
   response:
     status:
       code: 200
@@ -4673,7 +3848,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 47c6dea7-001e-007f-5351-b6b84d000000
+      - c9012ef6-001e-0069-54eb-b979d3000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Microsoftazurecompute-Resourcegroupname:
@@ -4709,12 +3884,99 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:16:54 GMT
+      - Mon, 12 Mar 2018 10:21:38 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:55 GMT
+  recorded_at: Mon, 12 Mar 2018 10:21:44 GMT
+- request:
+    method: head
+    uri: https://spec0deply1stor.blob.core.windows.net/vhds/osdisk1.vhd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - ''
+      X-Ms-Date:
+      - Mon, 12 Mar 2018 10:21:44 GMT
+      X-Ms-Version:
+      - '2016-05-31'
+      Auth-String:
+      - 'true'
+      Verb:
+      - HEAD
+      Authorization:
+      - SharedKey spec0deply1stor:nCp8TW7rEygi7OE5/ZrYAdQxP4Zh1F+ApifQoxegQ9Q=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '136367309312'
+      Content-Type:
+      - application/octet-stream
+      Content-Md5:
+      - VbYhW9/6NOXzQVK/vQkdvg==
+      Last-Modified:
+      - Sat, 03 Sep 2016 02:06:37 GMT
+      Accept-Ranges:
+      - bytes
+      Etag:
+      - '"0x8D3D39EF02E16B7"'
+      Server:
+      - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
+      X-Ms-Request-Id:
+      - 846b7779-001e-001d-33eb-b9ff95000000
+      X-Ms-Version:
+      - '2016-05-31'
+      X-Ms-Meta-Microsoftazurecompute-Resourcegroupname:
+      - miq-azure-test1
+      X-Ms-Meta-Microsoftazurecompute-Vmname:
+      - spec0deply1vm1
+      X-Ms-Meta-Microsoftazurecompute-Diskid:
+      - 3ce1f79e-7ba1-43e5-a97d-5a49a1a1a02e
+      X-Ms-Meta-Microsoftazurecompute-Diskname:
+      - osdisk
+      X-Ms-Meta-Microsoftazurecompute-Disktype:
+      - OSDisk
+      X-Ms-Lease-Status:
+      - locked
+      X-Ms-Lease-State:
+      - leased
+      X-Ms-Lease-Duration:
+      - infinite
+      X-Ms-Blob-Type:
+      - PageBlob
+      X-Ms-Blob-Sequence-Number:
+      - '53'
+      X-Ms-Copy-Id:
+      - 36fd9dad-148c-4f34-b2af-561feb937d76
+      X-Ms-Copy-Source:
+      - https://ardfepirv2bl5prdstr06.blob.core.windows.net/a699494373c04fc0bc8f2bb1389d6106/Windows-Server-2012-R2-20160229-en.us-127GB.vhd?sv=2014-02-14&sr=b&si=PirCacheAccountPublisherContainerPolicy&sig=ipib%2Bgp2Sh4hS%2BBx5OUKgXSymDC0Tu0Ge60PGFuy5uk%3D
+      X-Ms-Copy-Status:
+      - success
+      X-Ms-Copy-Progress:
+      - 136367309312/136367309312
+      X-Ms-Copy-Completion-Time:
+      - Mon, 04 Apr 2016 23:24:57 GMT
+      X-Ms-Server-Encrypted:
+      - 'false'
+      Date:
+      - Mon, 12 Mar 2018 10:21:39 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 10:21:45 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet?api-version=2018-01-01
@@ -4731,7 +3993,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0NzMsIm5iZiI6MTUyMDQ1MzQ3MywiZXhwIjoxNTIwNDU3MzczLCJhaW8iOiJZMk5nWU5qWTM4RStWU2lPKzlxT2duY0JKOWN0QlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNFdUcnNGWUVYRUtJZmRBQUdWTUFBQSIsInZlciI6IjEuMCJ9.ArxfPNTq5GDkmFBppDjfAq99t5AKHpkiomJyFlFNwYavrQxfd66kamPOrTK4LUxqE7dufAUhjQG5zQLqcZPvtl1SS4zIppFRih0g1Iur45O6WRCd5hv4r9n0sZVLlSnyIsza0haM5o5Sz5ic2k-cBTw0-HwWuTwFz8ALJmG8x0lxKaY8uxuuD13yghFGHL5eoIIZ0WsMIuOSzx8bqSAvXctOpvg6d8r73UECp7ugreyMFj0o_RWgO7UlOlp9rfa0io1kOcsz620m7evOgR42aEh-B6ga-nscmo53D_vXoOFeB0u9_WoUGLB4bb1831b4nBT9dYhV8HL7tvYLQqR8Ig
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk3NTUsIm5iZiI6MTUyMDg0OTc1NSwiZXhwIjoxNTIwODUzNjU1LCJhaW8iOiJZMk5nWUhnU3QvT29SR0tTa2t5aS80UzNIY3JMQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieGsxamstTlJ2VUtHMFlLYWFmQWRBQSIsInZlciI6IjEuMCJ9.ADT-9qZlaX4MDV07ntM5ibfPXZ63OeoRAoNBbFZmQtrp-S15bXoIC9vgBM8Z7S-8C3rEe3Y6n10LoMCUxTiixfn6zlPn82JobgdO8ksXbX4z5uYvTIv4fYi14dtIwJBMgF2MA1zN2sErSREp1jZ3axzq7ZxG14K2vMsezi8bcTHCLWiM0VUpd_AVT23FOmDsls-WKsTM1zK0Fzjz1vrv1446EJZSg3xIQmEghD3ijAz9qJIojkR-xxdEEpDhtB6s4daub6Tjg9_YjTUdKiRcO6sJJfQetnxRRNLQi-5zYdBBQyC7ovmXuPitPGTKLDuJo2Xn9HUe9Hu-Flccmk_pWQ
   response:
     status:
       code: 200
@@ -4752,22 +4014,22 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 61e1b752-3f0a-4dc7-9a7a-edab748e08c2
+      - 11e79516-6b61-4100-8eff-df9a9720e2ad
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14979'
+      - '14981'
       X-Ms-Correlation-Request-Id:
-      - 9f7a9b70-950a-4855-9691-3568aa52a3ca
+      - 4c48d386-af32-44ee-825f-b426c7029e82
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201655Z:9f7a9b70-950a-4855-9691-3568aa52a3ca
+      - WESTEUROPE:20180312T102142Z:4c48d386-af32-44ee-825f-b426c7029e82
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:16:55 GMT
+      - Mon, 12 Mar 2018 10:21:41 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"spec0deply1vnet\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet\",\r\n
@@ -4786,403 +4048,7 @@ http_interactions:
         [],\r\n    \"enableDdosProtection\": false,\r\n    \"enableVmProtection\":
         false\r\n  }\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:55 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0NzMsIm5iZiI6MTUyMDQ1MzQ3MywiZXhwIjoxNTIwNDU3MzczLCJhaW8iOiJZMk5nWU5qWTM4RStWU2lPKzlxT2duY0JKOWN0QlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNFdUcnNGWUVYRUtJZmRBQUdWTUFBQSIsInZlciI6IjEuMCJ9.ArxfPNTq5GDkmFBppDjfAq99t5AKHpkiomJyFlFNwYavrQxfd66kamPOrTK4LUxqE7dufAUhjQG5zQLqcZPvtl1SS4zIppFRih0g1Iur45O6WRCd5hv4r9n0sZVLlSnyIsza0haM5o5Sz5ic2k-cBTw0-HwWuTwFz8ALJmG8x0lxKaY8uxuuD13yghFGHL5eoIIZ0WsMIuOSzx8bqSAvXctOpvg6d8r73UECp7ugreyMFj0o_RWgO7UlOlp9rfa0io1kOcsz620m7evOgR42aEh-B6ga-nscmo53D_vXoOFeB0u9_WoUGLB4bb1831b4nBT9dYhV8HL7tvYLQqR8Ig
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"2ec58a0b-4c03-4d0a-b788-9daffd54e7b2"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 6fe6a424-d960-4598-9e6f-3c0a9f736d92
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14981'
-      X-Ms-Correlation-Request-Id:
-      - b81601dc-e8a4-4045-b979-208695683bd1
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201656Z:b81601dc-e8a4-4045-b979-208695683bd1
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:16:55 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"spec0deply1nic1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1\",\r\n
-        \ \"etag\": \"W/\\\"2ec58a0b-4c03-4d0a-b788-9daffd54e7b2\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"57bbf7aa-d6c4-4f56-8f6a-089d15334221\",\r\n    \"ipConfigurations\":
-        [\r\n      {\r\n        \"name\": \"ipconfig1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1\",\r\n
-        \       \"etag\": \"W/\\\"2ec58a0b-4c03-4d0a-b788-9daffd54e7b2\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAddress\": \"10.0.0.5\",\r\n          \"privateIPAllocationMethod\":
-        \"Dynamic\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1\"\r\n
-        \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
-        \"IPv4\",\r\n          \"loadBalancerBackendAddressPools\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\"\r\n
-        \           }\r\n          ],\r\n          \"loadBalancerInboundNatRules\":
-        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\":
-        {\r\n      \"dnsServers\": [],\r\n      \"appliedDnsServers\": []\r\n    },\r\n
-        \   \"enableAcceleratedNetworking\": false,\r\n    \"enableIPForwarding\":
-        false,\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1\"\r\n
-        \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
-        \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:56 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0NzMsIm5iZiI6MTUyMDQ1MzQ3MywiZXhwIjoxNTIwNDU3MzczLCJhaW8iOiJZMk5nWU5qWTM4RStWU2lPKzlxT2duY0JKOWN0QlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNFdUcnNGWUVYRUtJZmRBQUdWTUFBQSIsInZlciI6IjEuMCJ9.ArxfPNTq5GDkmFBppDjfAq99t5AKHpkiomJyFlFNwYavrQxfd66kamPOrTK4LUxqE7dufAUhjQG5zQLqcZPvtl1SS4zIppFRih0g1Iur45O6WRCd5hv4r9n0sZVLlSnyIsza0haM5o5Sz5ic2k-cBTw0-HwWuTwFz8ALJmG8x0lxKaY8uxuuD13yghFGHL5eoIIZ0WsMIuOSzx8bqSAvXctOpvg6d8r73UECp7ugreyMFj0o_RWgO7UlOlp9rfa0io1kOcsz620m7evOgR42aEh-B6ga-nscmo53D_vXoOFeB0u9_WoUGLB4bb1831b4nBT9dYhV8HL7tvYLQqR8Ig
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"b817491c-aab8-4aab-b41d-b07bfffa5639"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 6731f93d-166c-47d7-8162-221e30cfe3c0
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14984'
-      X-Ms-Correlation-Request-Id:
-      - a9a369ff-2df9-4f05-bb80-f31b800d98e2
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201656Z:a9a369ff-2df9-4f05-bb80-f31b800d98e2
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:16:56 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"spec0deply1nic0\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0\",\r\n
-        \ \"etag\": \"W/\\\"b817491c-aab8-4aab-b41d-b07bfffa5639\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"80ad9866-071d-4e3f-91d0-d47954eccee0\",\r\n    \"ipConfigurations\":
-        [\r\n      {\r\n        \"name\": \"ipconfig1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1\",\r\n
-        \       \"etag\": \"W/\\\"b817491c-aab8-4aab-b41d-b07bfffa5639\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAddress\": \"10.0.0.4\",\r\n          \"privateIPAllocationMethod\":
-        \"Dynamic\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1\"\r\n
-        \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
-        \"IPv4\",\r\n          \"loadBalancerBackendAddressPools\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\"\r\n
-        \           }\r\n          ],\r\n          \"loadBalancerInboundNatRules\":
-        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\":
-        {\r\n      \"dnsServers\": [],\r\n      \"appliedDnsServers\": []\r\n    },\r\n
-        \   \"enableAcceleratedNetworking\": false,\r\n    \"enableIPForwarding\":
-        false,\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0\"\r\n
-        \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
-        \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:56 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0NzMsIm5iZiI6MTUyMDQ1MzQ3MywiZXhwIjoxNTIwNDU3MzczLCJhaW8iOiJZMk5nWU5qWTM4RStWU2lPKzlxT2duY0JKOWN0QlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNFdUcnNGWUVYRUtJZmRBQUdWTUFBQSIsInZlciI6IjEuMCJ9.ArxfPNTq5GDkmFBppDjfAq99t5AKHpkiomJyFlFNwYavrQxfd66kamPOrTK4LUxqE7dufAUhjQG5zQLqcZPvtl1SS4zIppFRih0g1Iur45O6WRCd5hv4r9n0sZVLlSnyIsza0haM5o5Sz5ic2k-cBTw0-HwWuTwFz8ALJmG8x0lxKaY8uxuuD13yghFGHL5eoIIZ0WsMIuOSzx8bqSAvXctOpvg6d8r73UECp7ugreyMFj0o_RWgO7UlOlp9rfa0io1kOcsz620m7evOgR42aEh-B6ga-nscmo53D_vXoOFeB0u9_WoUGLB4bb1831b4nBT9dYhV8HL7tvYLQqR8Ig
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"92982330-0f29-406e-bba9-ad19198579a5"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 6d2d7ec4-09bc-4a58-9f8b-c710213d8beb
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Correlation-Request-Id:
-      - 372e9f07-b2c8-4726-aaaf-7ceed2187d36
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201657Z:372e9f07-b2c8-4726-aaaf-7ceed2187d36
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:16:56 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"spec0deply1lb\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb\",\r\n
-        \ \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"8cd72f7c-03bd-4584-abc6-d9ce77ae6202\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip\"\r\n
-        \         },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
-        \           }\r\n          ],\r\n          \"inboundNatRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"BackendPool1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"backendIPConfigurations\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1\"\r\n
-        \           }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\":
-        [\r\n      {\r\n        \"name\": \"LBRule\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\":
-        80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        5,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\"\r\n
-        \         },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/probes/tcpProbe\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n
-        \       \"name\": \"tcpProbe\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/probes/tcpProbe\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Tcp\",\r\n          \"port\": 80,\r\n          \"intervalInSeconds\":
-        5,\r\n          \"numberOfProbes\": 2,\r\n          \"loadBalancingRules\":
-        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\":
-        [\r\n      {\r\n        \"name\": \"RDP-VM0\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 50001,\r\n          \"backendPort\":
-        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1\"\r\n
-        \         }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"RDP-VM1\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 50002,\r\n          \"backendPort\":
-        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:57 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0NzMsIm5iZiI6MTUyMDQ1MzQ3MywiZXhwIjoxNTIwNDU3MzczLCJhaW8iOiJZMk5nWU5qWTM4RStWU2lPKzlxT2duY0JKOWN0QlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNFdUcnNGWUVYRUtJZmRBQUdWTUFBQSIsInZlciI6IjEuMCJ9.ArxfPNTq5GDkmFBppDjfAq99t5AKHpkiomJyFlFNwYavrQxfd66kamPOrTK4LUxqE7dufAUhjQG5zQLqcZPvtl1SS4zIppFRih0g1Iur45O6WRCd5hv4r9n0sZVLlSnyIsza0haM5o5Sz5ic2k-cBTw0-HwWuTwFz8ALJmG8x0lxKaY8uxuuD13yghFGHL5eoIIZ0WsMIuOSzx8bqSAvXctOpvg6d8r73UECp7ugreyMFj0o_RWgO7UlOlp9rfa0io1kOcsz620m7evOgR42aEh-B6ga-nscmo53D_vXoOFeB0u9_WoUGLB4bb1831b4nBT9dYhV8HL7tvYLQqR8Ig
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"92982330-0f29-406e-bba9-ad19198579a5"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 25d8f2ce-7731-443a-90fd-c42e851328ba
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14979'
-      X-Ms-Correlation-Request-Id:
-      - b22c008c-9414-4993-a5e4-ac4531266e75
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201657Z:b22c008c-9414-4993-a5e4-ac4531266e75
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:16:57 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"spec0deply1lb\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb\",\r\n
-        \ \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"8cd72f7c-03bd-4584-abc6-d9ce77ae6202\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip\"\r\n
-        \         },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
-        \           }\r\n          ],\r\n          \"inboundNatRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"BackendPool1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"backendIPConfigurations\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1\"\r\n
-        \           }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\":
-        [\r\n      {\r\n        \"name\": \"LBRule\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\":
-        80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        5,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\"\r\n
-        \         },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/probes/tcpProbe\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n
-        \       \"name\": \"tcpProbe\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/probes/tcpProbe\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Tcp\",\r\n          \"port\": 80,\r\n          \"intervalInSeconds\":
-        5,\r\n          \"numberOfProbes\": 2,\r\n          \"loadBalancingRules\":
-        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/loadBalancingRules/LBRule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\":
-        [\r\n      {\r\n        \"name\": \"RDP-VM0\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 50001,\r\n          \"backendPort\":
-        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1\"\r\n
-        \         }\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"RDP-VM1\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1\",\r\n
-        \       \"etag\": \"W/\\\"92982330-0f29-406e-bba9-ad19198579a5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 50002,\r\n          \"backendPort\":
-        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:57 GMT
+  recorded_at: Mon, 12 Mar 2018 10:21:47 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip?api-version=2018-01-01
@@ -5199,7 +4065,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0NzMsIm5iZiI6MTUyMDQ1MzQ3MywiZXhwIjoxNTIwNDU3MzczLCJhaW8iOiJZMk5nWU5qWTM4RStWU2lPKzlxT2duY0JKOWN0QlFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNFdUcnNGWUVYRUtJZmRBQUdWTUFBQSIsInZlciI6IjEuMCJ9.ArxfPNTq5GDkmFBppDjfAq99t5AKHpkiomJyFlFNwYavrQxfd66kamPOrTK4LUxqE7dufAUhjQG5zQLqcZPvtl1SS4zIppFRih0g1Iur45O6WRCd5hv4r9n0sZVLlSnyIsza0haM5o5Sz5ic2k-cBTw0-HwWuTwFz8ALJmG8x0lxKaY8uxuuD13yghFGHL5eoIIZ0WsMIuOSzx8bqSAvXctOpvg6d8r73UECp7ugreyMFj0o_RWgO7UlOlp9rfa0io1kOcsz620m7evOgR42aEh-B6ga-nscmo53D_vXoOFeB0u9_WoUGLB4bb1831b4nBT9dYhV8HL7tvYLQqR8Ig
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk3NTUsIm5iZiI6MTUyMDg0OTc1NSwiZXhwIjoxNTIwODUzNjU1LCJhaW8iOiJZMk5nWUhnU3QvT29SR0tTa2t5aS80UzNIY3JMQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieGsxamstTlJ2VUtHMFlLYWFmQWRBQSIsInZlciI6IjEuMCJ9.ADT-9qZlaX4MDV07ntM5ibfPXZ63OeoRAoNBbFZmQtrp-S15bXoIC9vgBM8Z7S-8C3rEe3Y6n10LoMCUxTiixfn6zlPn82JobgdO8ksXbX4z5uYvTIv4fYi14dtIwJBMgF2MA1zN2sErSREp1jZ3axzq7ZxG14K2vMsezi8bcTHCLWiM0VUpd_AVT23FOmDsls-WKsTM1zK0Fzjz1vrv1446EJZSg3xIQmEghD3ijAz9qJIojkR-xxdEEpDhtB6s4daub6Tjg9_YjTUdKiRcO6sJJfQetnxRRNLQi-5zYdBBQyC7ovmXuPitPGTKLDuJo2Xn9HUe9Hu-Flccmk_pWQ
   response:
     status:
       code: 200
@@ -5220,22 +4086,22 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 608038c2-8d87-4bed-a123-1c642cf6c7f0
+      - e4fa1cdf-e3ec-47c9-b6d8-fc96a4a8bfb1
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14984'
+      - '14987'
       X-Ms-Correlation-Request-Id:
-      - bdee7497-e273-4a43-a74d-297ef46d4bfe
+      - 2c455758-95e6-4525-a696-b4baf434cddc
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201658Z:bdee7497-e273-4a43-a74d-297ef46d4bfe
+      - WESTEUROPE:20180312T102143Z:2c455758-95e6-4525-a696-b4baf434cddc
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:16:57 GMT
+      - Mon, 12 Mar 2018 10:21:43 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"spec0deply1ip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip\",\r\n
@@ -5249,5 +4115,5 @@ http_interactions:
         \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
         \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:58 GMT
+  recorded_at: Mon, 12 Mar 2018 10:21:47 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted_scope/orchestration_stack_vm_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted_scope/orchestration_stack_vm_refresh.yml
@@ -37,25 +37,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - c74d6c4d-34f4-4154-966f-63a9c9550000
+      - 6b33df00-ad8e-4ae5-912b-eb019ed82300
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzHIeL_BxqSR4_BJkqVZWi7cJ8HyETS9vbKAFTCExoRcL_jX7qUPjo7E6P_lSr-D01caqARpQ5Nds2ranzMA32mDMAYQbPDNlKQEz4Eb2TwKSm9_pO1fbiCBoO2QTTwRUDy4_L2PcDfZQmfKHKfEi7AJE8yDdaVJg9PouLZltZMqUgAA;
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzRamYXiOFjFyGWkgwDF6WOigZC36iWoD5ZSJ3J5j2JzcsDb_tDcFN2NHGa7ZVTJ68NZ4qxf_toSPWgolsJGj31463HatlT4-FKdfXkLV4y3oKgir5vgCnVY5E9E-CrFjID4OQvIx1D4xT5xNxLDBrp3g3cLhCo9ihxc7vp1qktZ4gAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=002; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=006; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Wed, 07 Mar 2018 20:17:14 GMT
+      - Mon, 12 Mar 2018 10:26:45 GMT
       Content-Length:
       - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3600","ext_expires_in":"0","expires_on":"1520457435","not_before":"1520453535","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1MzUsIm5iZiI6MTUyMDQ1MzUzNSwiZXhwIjoxNTIwNDU3NDM1LCJhaW8iOiJZMk5nWUhqUi9lQnphZnNXNW5XM1pSNXRZNHllQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVFd4TnhfUTBWRUdXYjJPcHlWVUFBQSIsInZlciI6IjEuMCJ9.e2i3GxEmeuslxOYYf0jlT3wxfYslqa2SqFf3GBB02OpL6V5R_rVg27O1b8Bub6Q1dsMaxtOpFunWINuSnFDkgoEOi9sT4WvEn8XAyd-t7-iUq73k2PSsCCUvawfaoI1eQlwp54csbi9pmPbEP14eB7MQlRe_1wSgpvjq-a8FBnt1kTNeXQMt6tseqBKp3SRJqf4HZPJ5_LUPoPdNKUriutw-0WyHJunOG7AG3mw4Z2BFZT5G2eyJslWG03SQ2i6nmnVsLZSvkmf3RrBTOCnVHvV31cZHBB6eiKf_B5pkM_adNl8xfPRg5KN-0CxyIBFkNY0y67kqnfh4KjQuA0kDyw"}'
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1520854006","not_before":"1520850106","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAxMDYsIm5iZiI6MTUyMDg1MDEwNiwiZXhwIjoxNTIwODU0MDA2LCJhaW8iOiJZMk5nWURqZHZsNHJValF5WExMUitlTVN4WHc3QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQU44emE0NnQ1VXFSSy1zQm50Z2pBQSIsInZlciI6IjEuMCJ9.F4V-68IPzBvISzR9WLBCZSRPedJ9RmecoD01csWdNVOsKDxjdoei_iYP8c6C_Bu7Vk-YGJ3BR5rARTuPNxwUfcsbeQL5nI6IJZa1pDvBcK0JRVDSiXRsw3_dp5NjquqwdWSzAUFfCGnclZf_Z9ohC_hLIdu3E0kfvvbVyEivA2NZ1jpF4BpeRwTUXp_vj2n0Y1S9y3d5ooDLsNY0lBjGC5hAhgxx-IAEPGyHN0HQIkUXi3WUE0CoDjXGjqbIlDCSbbXUyfM6qdXTV73GlNEVJM6ukiVN_hgWtxnJooKM7oNVLzQus7YCpIw7D8kU_Q3qBrSBjncBFoSvn4ocnhQU8A"}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:17:15 GMT
+  recorded_at: Mon, 12 Mar 2018 10:26:50 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -72,7 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1MzUsIm5iZiI6MTUyMDQ1MzUzNSwiZXhwIjoxNTIwNDU3NDM1LCJhaW8iOiJZMk5nWUhqUi9lQnphZnNXNW5XM1pSNXRZNHllQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVFd4TnhfUTBWRUdXYjJPcHlWVUFBQSIsInZlciI6IjEuMCJ9.e2i3GxEmeuslxOYYf0jlT3wxfYslqa2SqFf3GBB02OpL6V5R_rVg27O1b8Bub6Q1dsMaxtOpFunWINuSnFDkgoEOi9sT4WvEn8XAyd-t7-iUq73k2PSsCCUvawfaoI1eQlwp54csbi9pmPbEP14eB7MQlRe_1wSgpvjq-a8FBnt1kTNeXQMt6tseqBKp3SRJqf4HZPJ5_LUPoPdNKUriutw-0WyHJunOG7AG3mw4Z2BFZT5G2eyJslWG03SQ2i6nmnVsLZSvkmf3RrBTOCnVHvV31cZHBB6eiKf_B5pkM_adNl8xfPRg5KN-0CxyIBFkNY0y67kqnfh4KjQuA0kDyw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAxMDYsIm5iZiI6MTUyMDg1MDEwNiwiZXhwIjoxNTIwODU0MDA2LCJhaW8iOiJZMk5nWURqZHZsNHJValF5WExMUitlTVN4WHc3QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQU44emE0NnQ1VXFSSy1zQm50Z2pBQSIsInZlciI6IjEuMCJ9.F4V-68IPzBvISzR9WLBCZSRPedJ9RmecoD01csWdNVOsKDxjdoei_iYP8c6C_Bu7Vk-YGJ3BR5rARTuPNxwUfcsbeQL5nI6IJZa1pDvBcK0JRVDSiXRsw3_dp5NjquqwdWSzAUFfCGnclZf_Z9ohC_hLIdu3E0kfvvbVyEivA2NZ1jpF4BpeRwTUXp_vj2n0Y1S9y3d5ooDLsNY0lBjGC5hAhgxx-IAEPGyHN0HQIkUXi3WUE0CoDjXGjqbIlDCSbbXUyfM6qdXTV73GlNEVJM6ukiVN_hgWtxnJooKM7oNVLzQus7YCpIw7D8kU_Q3qBrSBjncBFoSvn4ocnhQU8A
   response:
     status:
       code: 200
@@ -91,26 +91,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14997'
+      - '14995'
       X-Ms-Request-Id:
-      - 7ca0a110-b06c-4363-a5d8-ab6a4e9626af
+      - d591a168-a64a-414b-8ed5-5489174133ab
       X-Ms-Correlation-Request-Id:
-      - 7ca0a110-b06c-4363-a5d8-ab6a4e9626af
+      - d591a168-a64a-414b-8ed5-5489174133ab
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201715Z:7ca0a110-b06c-4363-a5d8-ab6a4e9626af
+      - WESTEUROPE:20180312T102646Z:d591a168-a64a-414b-8ed5-5489174133ab
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:17:15 GMT
+      - Mon, 12 Mar 2018 10:26:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID","subscriptionId":"AZURE_SUBSCRIPTION_ID","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:17:16 GMT
+  recorded_at: Mon, 12 Mar 2018 10:26:51 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers?api-version=2015-01-01
@@ -127,7 +127,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1MzUsIm5iZiI6MTUyMDQ1MzUzNSwiZXhwIjoxNTIwNDU3NDM1LCJhaW8iOiJZMk5nWUhqUi9lQnphZnNXNW5XM1pSNXRZNHllQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVFd4TnhfUTBWRUdXYjJPcHlWVUFBQSIsInZlciI6IjEuMCJ9.e2i3GxEmeuslxOYYf0jlT3wxfYslqa2SqFf3GBB02OpL6V5R_rVg27O1b8Bub6Q1dsMaxtOpFunWINuSnFDkgoEOi9sT4WvEn8XAyd-t7-iUq73k2PSsCCUvawfaoI1eQlwp54csbi9pmPbEP14eB7MQlRe_1wSgpvjq-a8FBnt1kTNeXQMt6tseqBKp3SRJqf4HZPJ5_LUPoPdNKUriutw-0WyHJunOG7AG3mw4Z2BFZT5G2eyJslWG03SQ2i6nmnVsLZSvkmf3RrBTOCnVHvV31cZHBB6eiKf_B5pkM_adNl8xfPRg5KN-0CxyIBFkNY0y67kqnfh4KjQuA0kDyw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAxMDYsIm5iZiI6MTUyMDg1MDEwNiwiZXhwIjoxNTIwODU0MDA2LCJhaW8iOiJZMk5nWURqZHZsNHJValF5WExMUitlTVN4WHc3QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQU44emE0NnQ1VXFSSy1zQm50Z2pBQSIsInZlciI6IjEuMCJ9.F4V-68IPzBvISzR9WLBCZSRPedJ9RmecoD01csWdNVOsKDxjdoei_iYP8c6C_Bu7Vk-YGJ3BR5rARTuPNxwUfcsbeQL5nI6IJZa1pDvBcK0JRVDSiXRsw3_dp5NjquqwdWSzAUFfCGnclZf_Z9ohC_hLIdu3E0kfvvbVyEivA2NZ1jpF4BpeRwTUXp_vj2n0Y1S9y3d5ooDLsNY0lBjGC5hAhgxx-IAEPGyHN0HQIkUXi3WUE0CoDjXGjqbIlDCSbbXUyfM6qdXTV73GlNEVJM6ukiVN_hgWtxnJooKM7oNVLzQus7YCpIw7D8kU_Q3qBrSBjncBFoSvn4ocnhQU8A
   response:
     status:
       code: 200
@@ -146,37 +146,35 @@ http_interactions:
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
       - '14983'
       X-Ms-Request-Id:
-      - a6e6a51f-d6b4-408c-b31c-c96d4906d2b6
+      - b22fa7b9-cf67-4d70-9917-167dbc5438f3
       X-Ms-Correlation-Request-Id:
-      - a6e6a51f-d6b4-408c-b31c-c96d4906d2b6
+      - b22fa7b9-cf67-4d70-9917-167dbc5438f3
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201717Z:a6e6a51f-d6b4-408c-b31c-c96d4906d2b6
+      - WESTEUROPE:20180312T102648Z:b22fa7b9-cf67-4d70-9917-167dbc5438f3
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:17:16 GMT
+      - Mon, 12 Mar 2018 10:26:47 GMT
       Content-Length:
-      - '310505'
+      - '320853'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"},{"applicationId":"d87dcbc6-a371-462e-88e3-28ad15ec4e64","roleDefinitionId":"861776c5-e0df-4f95-be4f-ac1eec193323"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
+      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"},{"applicationId":"d87dcbc6-a371-462e-88e3-28ad15ec4e64","roleDefinitionId":"861776c5-e0df-4f95-be4f-ac1eec193323"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["East
+        Asia","Southeast Asia","Australia East","Australia Southeast","Japan East","Japan
+        West","Central India","South India","West India","West Europe","North Europe","Canada
+        Central","Canada East","Brazil South","West US","Central US","East US","South
+        Central US","East US 2","West Central US","North Central US","West US 2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
         US","Central US","East US","South Central US","West Europe","North Europe","East
         Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
         Central US","North Central US","Japan East","Japan West","Brazil South","Central
         India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"operations","locations":["West
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["East
+        Asia","Southeast Asia","Australia East","Australia Southeast","Japan East","Japan
+        West","Central India","South India","West India","West Europe","North Europe","Canada
+        Central","Canada East","Brazil South","West US","Central US","East US","South
+        Central US","East US 2","West Central US","North Central US","West US 2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"operations","locations":["West
         US","Central US","East US","South Central US","West Europe","North Europe","East
         Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
         Central US","North Central US","Japan East","Japan West","Brazil South","Central
@@ -232,177 +230,177 @@ http_interactions:
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/internalLoadBalancers","locations":[],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"domainNames/slots/roles/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"domainNames/slots/roles/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"domainNames/capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"domainNames/serviceCertificates","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
         US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
         Central","Canada East","UK South","UK West","West US","Central US","South
         Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
-        East","Australia Southeast","West US 2","West Central US","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        East","Australia Southeast","West US 2","West Central US","France Central","South
+        India","Central India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
         US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
         Central","Canada East","UK South","UK West","West US","Central US","South
         Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
-        East","Australia Southeast","West US 2","West Central US","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metrics","locations":["North
+        East","Australia Southeast","West US 2","West Central US","France Central","South
+        India","Central India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metrics","locations":["North
         Central US","South Central US","East US","East US 2","Canada Central","Canada
         East","West US","West US 2","West Central US","Central US","East Asia","Southeast
         Asia","North Europe","West Europe","UK South","UK West","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"resourceTypes","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"moveSubscriptionResources","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"validateSubscriptionMoveAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operationStatuses","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operatingSystems","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"operatingSystemFamilies","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicNetwork","namespace":"Microsoft.ClassicNetwork","resourceTypes":[{"resourceType":"virtualNetworks","locations":["East
+        India","West India","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"resourceTypes","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"moveSubscriptionResources","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"validateSubscriptionMoveAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operationStatuses","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operatingSystems","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"operatingSystemFamilies","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicNetwork","namespace":"Microsoft.ClassicNetwork","resourceTypes":[{"resourceType":"virtualNetworks","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"virtualNetworks/remoteVirtualNetworkPeeringProxies","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01"]},{"resourceType":"virtualNetworks/remoteVirtualNetworkPeeringProxies","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"reservedIps","locations":["East
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01"]},{"resourceType":"reservedIps","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"gatewaySupportedDevices","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"networkSecurityGroups","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"gatewaySupportedDevices","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"networkSecurityGroups","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicStorage","namespace":"Microsoft.ClassicStorage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"expressRouteCrossConnections","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"expressRouteCrossConnections/peerings","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicStorage","namespace":"Microsoft.ClassicStorage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkStorageAccountAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"storageAccounts/services","locations":["West
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkStorageAccountAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"storageAccounts/services","locations":["West
         US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
         Asia","Australia East","Australia Southeast","South India","Central India","West
         India","West US 2","West Central US","East US","East US 2","North Central
         US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
-        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/diagnosticSettings","locations":["West
+        South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/diagnosticSettings","locations":["West
         US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
         Asia","Australia East","Australia Southeast","South India","Central India","West
         India","West US 2","West Central US","East US","East US 2","North Central
         US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
-        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"disks","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"images","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"vmImages","locations":[],"apiVersions":["2016-11-01"]},{"resourceType":"publicImages","locations":[],"apiVersions":["2016-11-01","2016-04-01"]},{"resourceType":"osImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"osPlatformImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute","namespace":"Microsoft.Compute","authorizations":[{"applicationId":"60e6cd67-9c8c-4951-9b3c-23c25a2169af","roleDefinitionId":"e4770acb-272e-4dc8-87f3-12f44a612224"},{"applicationId":"a303894e-f1d8-4a37-bf10-67aa654a0596","roleDefinitionId":"903ac751-8ad5-4e5a-bfc2-5e49f450a241"},{"applicationId":"a8b6bf88-1d1a-4626-b040-9a729ea93c65","roleDefinitionId":"45c8267c-80ba-4b96-9a43-115b8f49fccd"}],"resourceTypes":[{"resourceType":"availabilitySets","locations":["East
+        South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"disks","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"images","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"vmImages","locations":[],"apiVersions":["2016-11-01"]},{"resourceType":"storageAccounts/vmImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"publicImages","locations":[],"apiVersions":["2016-11-01","2016-04-01"]},{"resourceType":"osImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"osPlatformImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute","namespace":"Microsoft.Compute","authorizations":[{"applicationId":"60e6cd67-9c8c-4951-9b3c-23c25a2169af","roleDefinitionId":"e4770acb-272e-4dc8-87f3-12f44a612224"},{"applicationId":"a303894e-f1d8-4a37-bf10-67aa654a0596","roleDefinitionId":"903ac751-8ad5-4e5a-bfc2-5e49f450a241"},{"applicationId":"a8b6bf88-1d1a-4626-b040-9a729ea93c65","roleDefinitionId":"45c8267c-80ba-4b96-9a43-115b8f49fccd"}],"resourceTypes":[{"resourceType":"availabilitySets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations/usages","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations/usages","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"sharedVMImages","locations":["West
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"sharedVMImages","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"sharedVMImages/versions","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"locations/capsoperations","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"disks","locations":["Southeast
@@ -410,27 +408,27 @@ http_interactions:
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"snapshots","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"snapshots","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"locations/diskoperations","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"locations/diskoperations","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"images","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"images","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"]},{"resourceType":"locations/logAnalytics","locations":["East
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"]},{"resourceType":"locations/logAnalytics","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
         US","East US","South Central US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
@@ -547,7 +545,12 @@ http_interactions:
         US","East Asia","East US","East US 2","Japan East","Japan West","North Central
         US","North Europe","South Central US","South India","Southeast Asia","West
         Central US","West Europe","West India","West US","West US 2","UK West","UK
-        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"},{"applicationId":"f5c26e74-f226-4ae8-85f0-b4af0080ac9e","roleDefinitionId":"529d7ae6-e892-4d43-809d-8547aeb90643"}],"resourceTypes":[{"resourceType":"components","locations":["East
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/consumergroups","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/disasterrecoveryconfigs","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"},{"applicationId":"f5c26e74-f226-4ae8-85f0-b4af0080ac9e","roleDefinitionId":"529d7ae6-e892-4d43-809d-8547aeb90643"}],"resourceTypes":[{"resourceType":"components","locations":["East
         US","South Central US","North Europe","West Europe","Southeast Asia","West
         US 2"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
         US","South Central US","North Europe","West Europe","Southeast Asia","West
@@ -614,32 +617,32 @@ http_interactions:
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/accessPolicies","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"vaults/accessPolicies","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-10-01","2015-06-01","2014-12-19-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"deletedVaults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01","2014-12-19-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"deletedVaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-10-01"]},{"resourceType":"locations/deletedVaults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations/deletedVaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
         Central US","West Europe","Southeast Asia","Japan East","West Central US"],"apiVersions":["2016-04-01"]},{"resourceType":"webServices","locations":["South
         Central US","West Europe","Southeast Asia","Japan East","East US 2","West
         Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"operations","locations":["South
@@ -665,97 +668,97 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"networkWatchers/lenses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"networkWatchers/lenses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","West
         US 2","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
@@ -846,7 +849,7 @@ http_interactions:
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
         West","Korea Central","Korea South"],"apiVersions":["2017-07-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ResourceHealth","namespace":"Microsoft.ResourceHealth","authorizations":[{"applicationId":"8bdebf23-c0fe-4187-a378-717ad86f6a53","roleDefinitionId":"cc026344-c8b1-4561-83ba-59eba84b27cc"}],"resourceTypes":[{"resourceType":"availabilityStatuses","locations":[],"apiVersions":["2017-07-01","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"notifications","locations":["Australia
-        Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Security","namespace":"Microsoft.Security","authorization":{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
+        Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Security","namespace":"Microsoft.Security","authorizations":[{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},{"applicationId":"fc780465-2017-40d4-a0c5-307022471b92"}],"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatuses","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/virtualMachines","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/endpoints","locations":["Central
@@ -898,565 +901,595 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Central India","South
         India"],"apiVersions":["2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Sql","namespace":"Microsoft.Sql","authorizations":[{"applicationId":"e4ab13ed-33cb-41b4-9140-6e264582cf85","roleDefinitionId":"ec3ddc95-44dc-47a2-9926-5e9f5ffd44ec"},{"applicationId":"0130cc9f-7ac5-4026-bd5f-80a08a54e6d9","roleDefinitionId":"45e8abf8-0ec4-44f3-9c37-cff4f7779302"},{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},{"applicationId":"76c7f279-7959-468f-8943-3954880e0d8c","roleDefinitionId":"7f7513a8-73f9-4c5f-97a2-c41f0ea783ef"}],"resourceTypes":[{"resourceType":"operations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/capabilities","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/databaseAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/databaseOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverKeyOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/keys","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/encryptionProtector","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/usages","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01","2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/communicationLinks","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administrators","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administratorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/restorableDroppedDatabases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recoverableDatabases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/geoBackupPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/importExportOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/operationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/backupLongTermRetentionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/automaticTuning","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/automaticTuning","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/databases/transparentDataEncryption","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recommendedElasticPools","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/auditingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/connectionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/connectionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies/rules","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/securityAlertPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/securityAlertPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/auditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/extendedAuditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/elasticpools","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-09-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/jobAgentOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/jobAgentAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/disasterRecoveryConfiguration","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/dnsAliases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/failoverGroups","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/virtualNetworkRules","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/virtualNetworkRulesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/virtualNetworkRulesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/databaseRestoreAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metricDefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/aggregatedDatabaseMetrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metricdefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries/queryText","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPools/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/extensions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPoolEstimates","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditRecords","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentScans","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/vulnerabilityAssessments","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessment","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/syncGroups","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups/syncMembers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/syncAgents","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"managedInstances/administrators","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/databases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metricDefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/administratorAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/administratorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncMemberOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncAgentOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncDatabaseIds","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorizations":[{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},{"applicationId":"e406a681-f3d4-42a8-90b6-c2b029497af1"}],"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/capabilities","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/databaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"locations/databaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverKeyOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/keys","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/encryptionProtector","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01","2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/communicationLinks","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/restorableDroppedDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recoverableDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/geoBackupPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/importExportOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/operationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/backupLongTermRetentionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/databases/transparentDataEncryption","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recommendedElasticPools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies/rules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/extendedAuditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/elasticPoolAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/elasticPoolOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/elasticpools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-09-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/jobAgentOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/jobAgentAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/disasterRecoveryConfiguration","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/dnsAliases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/failoverGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/virtualNetworkRules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/virtualNetworkRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/virtualNetworkRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/databaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/aggregatedDatabaseMetrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metricdefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries/queryText","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPools/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/extensions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPoolEstimates","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditRecords","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentScans","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/vulnerabilityAssessments","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessment","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/syncGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups/syncMembers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/syncAgents","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"managedInstances/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/administratorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncMemberOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncAgentOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncDatabaseIds","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/longTermRetentionPolicyOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionPolicyAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionBackupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionBackupAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorizations":[{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},{"applicationId":"e406a681-f3d4-42a8-90b6-c2b029497af1"}],"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
@@ -1795,12 +1828,12 @@ http_interactions:
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","Canada Central","Canada East","UK South","UK West","West US 2","West
-        Central US","South India","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","South India","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","South India","Canada Central","Canada East","UK South","UK West","West
-        US 2","West Central US","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Capacity","namespace":"Microsoft.Capacity","authorization":{"applicationId":"4d0ad6c7-f6c3-46d8-ab0d-1406d5e6c86b","roleDefinitionId":"FD9C0A9A-4DB9-4F41-8A61-98385DEB6E2D"},"resourceTypes":[{"resourceType":"resources","locations":["South
+        US 2","West Central US","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Capacity","namespace":"Microsoft.Capacity","authorization":{"applicationId":"4d0ad6c7-f6c3-46d8-ab0d-1406d5e6c86b","roleDefinitionId":"FD9C0A9A-4DB9-4F41-8A61-98385DEB6E2D"},"resourceTypes":[{"resourceType":"resources","locations":["South
         Central US"],"apiVersions":["2017-11-01"]},{"resourceType":"reservationOrders","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/reservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/reservations/revisions","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"catalogs","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"appliedReservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"checkOffers","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"checkScopes","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"calculatePrice","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/calculateRefund","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/return","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/split","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/merge","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"validateReservationOrder","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/availableScopes","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Cdn","namespace":"Microsoft.Cdn","resourceTypes":[{"resourceType":"profiles","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
@@ -1876,9 +1909,9 @@ http_interactions:
         2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/updateAccountsCreationSettings","locations":["West
         US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/accountsCreationSettings","locations":["West
         US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2016-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Commerce","namespace":"Microsoft.Commerce","resourceTypes":[{"resourceType":"UsageAggregates","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]},{"resourceType":"RateCard","locations":[],"apiVersions":["2016-08-31-preview","2015-06-01-preview","2015-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Consumption","namespace":"Microsoft.Consumption","resourceTypes":[{"resourceType":"ReservationSummaries","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationTransactions","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Balances","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Marketplaces","locations":[],"apiVersions":["2018-01-31"]},{"resourceType":"Pricesheets","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationDetails","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Budgets","locations":[],"apiVersions":["2018-01-31","2017-12-30-preview"]},{"resourceType":"Terms","locations":[],"apiVersions":["2018-01-31","2017-12-30-preview"]},{"resourceType":"UsageDetails","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview","2017-04-24-preview"]},{"resourceType":"Operations","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview","2017-04-24-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerInstance","namespace":"Microsoft.ContainerInstance","resourceTypes":[{"resourceType":"containerGroups","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/usages","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/operations","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/operations","locations":["West
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
         US"],"apiVersions":["2016-04-08"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.CustomerInsights","namespace":"Microsoft.CustomerInsights","authorization":{"applicationId":"38c77d00-5fcb-4cce-9d93-af4738258e3c","roleDefinitionId":"E006F9C7-F333-477C-8AD6-1F3A9FE87F55"},"resourceTypes":[{"resourceType":"hubs","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/profiles","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/interactions","locations":["East
@@ -1895,7 +1928,9 @@ http_interactions:
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"operations","locations":["East
         US 2"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Databricks","namespace":"Microsoft.Databricks","authorizations":[{"applicationId":"d9327919-6775-4843-9037-3fb0fb0473cb","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},{"applicationId":"2ff814a6-3304-4ab8-85cb-cd0e6f879c1d","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"}],"resourceTypes":[{"resourceType":"workspaces","locations":["West
         US","East US 2","West Europe","East US","North Europe","Southeast Asia","East
-        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]},{"resourceType":"locations","locations":["West
+        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2017-09-01-preview"]},{"resourceType":"workspaces/virtualNetworkPeerings","locations":["West
+        US","East US 2","West Europe","North Europe","East US","Southeast Asia","East
+        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01"]},{"resourceType":"locations","locations":["West
         US","East US 2","West Europe","North Europe","East US","Southeast Asia"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
         US","East US 2","West Europe","East US","North Europe","Southeast Asia","East
         Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataCatalog","namespace":"Microsoft.DataCatalog","resourceTypes":[{"resourceType":"catalogs","locations":["East
@@ -1919,23 +1954,26 @@ http_interactions:
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers/listSasTokens","locations":["East
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataLakeStore","namespace":"Microsoft.DataLakeStore","authorization":{"applicationId":"e9f49c6b-5ce5-44c8-925d-015017e9f7ad","roleDefinitionId":"17eb9cca-f08a-4499-b2d3-852d175f614f"},"resourceTypes":[{"resourceType":"accounts","locations":["East
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/firewallRules","locations":["East
-        US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataMigration","namespace":"Microsoft.DataMigration","authorization":{"applicationId":"a4bad4aa-bf02-4631-9f78-a64ffdba8150","roleDefinitionId":"b831a21d-db98-4760-89cb-bef871952df1","managedByRoleDefinitionId":"6256fb55-9e59-4018-a9e1-76b11c0a4c89"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services/projects","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationStatuses","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
+        US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataMigration","namespace":"Microsoft.DataMigration","authorization":{"applicationId":"a4bad4aa-bf02-4631-9f78-a64ffdba8150","roleDefinitionId":"b831a21d-db98-4760-89cb-bef871952df1","managedByRoleDefinitionId":"6256fb55-9e59-4018-a9e1-76b11c0a4c89"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services/projects","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationStatuses","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
-        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/recoverableServers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
@@ -1959,7 +1997,10 @@ http_interactions:
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
-        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/recoverableServers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
@@ -2015,12 +2056,7 @@ http_interactions:
         US 2","East US","West US","Central US","East US 2","West Central US","West
         Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
         US 2","East US","West US","Central US","East US 2","West Central US","West
-        Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","West
-        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
-        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
-        India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/consumergroups","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/disasterrecoveryconfigs","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
         US 2","South Central US","Central US","Australia Southeast","Central India","West
         Central US","West US 2","Canada East","Canada Central","Brazil South","UK
         South","UK West","East Asia","Australia East","Japan East","Japan West","North
@@ -2131,7 +2167,7 @@ http_interactions:
         West","Japan East","East Asia","Southeast Asia","West Europe","North Europe","East
         US","West US","Australia East","Australia Southeast","Central US","Brazil
         South","Central India","West India","South India","South Central US","Canada
-        Central","Canada East","West Central US","West US 2"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
+        Central","Canada East","West Central US","West US 2"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-05","2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
         Central US","East US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"operations","locations":["West
         Central US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
         Central US","East US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.PolicyInsights","namespace":"Microsoft.PolicyInsights","authorization":{"applicationId":"1d78a85d-813d-46f0-b496-dd72f50a3ec0","roleDefinitionId":"63d2b225-4c34-4641-8768-21a1f7c68ce8"},"resourceTypes":[{"resourceType":"policyEvents","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"policyStates","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
@@ -2163,12 +2199,12 @@ http_interactions:
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
         Central US","South Central US","North Europe","West Europe","East Asia","Southeast
         Asia","West US","East US","Japan West","Japan East","Brazil South","Central
         US","East US 2","Australia East","Australia Southeast","South India","Central
@@ -2208,52 +2244,62 @@ http_interactions:
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/clusterVersions","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"clusters/applications","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operations","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/clusterVersions","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/environments","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operations","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
         Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applianceDefinitions","locations":["West
         Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applications","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
-        Central US"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
+        Central US"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
-        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
-        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups","locations":["West
-        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
-        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups/cloudEndpoints","locations":["West
-        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
-        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups/serverEndpoints","locations":["West
-        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
-        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/registeredServers","locations":["West
-        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
-        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/workflows","locations":["West
-        US","West Europe","Southeast Asia","Australia East","East US","Canada Central","UK
-        South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
+        US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
+        US","Canada Central","Canada East","Central US","East US 2","UK South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups","locations":["West
+        US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
+        US","Canada Central","Canada East","Central US","East US 2","UK South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups/cloudEndpoints","locations":["West
+        US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
+        US","Canada Central","Canada East","Central US","East US 2","UK South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups/serverEndpoints","locations":["West
+        US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
+        US","Canada Central","Canada East","Central US","East US 2","UK South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/registeredServers","locations":["West
+        US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
+        US","Canada Central","Canada East","Central US","East US 2","UK South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/workflows","locations":["West
+        US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
+        US","Canada Central","Canada East","Central US","East US 2","UK South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-06-05-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorSimple","namespace":"Microsoft.StorSimple","resourceTypes":[{"resourceType":"managers","locations":["West
         US","East US","North Europe","West Europe","Brazil South","East Asia","Southeast
         Asia","West Central US","Japan East","Japan West","Australia East","Australia
         Southeast"],"apiVersions":["2017-06-01","2017-05-15","2017-01-01","2016-10-01","2016-06-01","2015-03-15","2014-09-01"]},{"resourceType":"operations","locations":["West
@@ -2332,7 +2378,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:17:17 GMT
+  recorded_at: Mon, 12 Mar 2018 10:26:52 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0?api-version=2017-12-01
@@ -2349,7 +2395,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1MzUsIm5iZiI6MTUyMDQ1MzUzNSwiZXhwIjoxNTIwNDU3NDM1LCJhaW8iOiJZMk5nWUhqUi9lQnphZnNXNW5XM1pSNXRZNHllQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVFd4TnhfUTBWRUdXYjJPcHlWVUFBQSIsInZlciI6IjEuMCJ9.e2i3GxEmeuslxOYYf0jlT3wxfYslqa2SqFf3GBB02OpL6V5R_rVg27O1b8Bub6Q1dsMaxtOpFunWINuSnFDkgoEOi9sT4WvEn8XAyd-t7-iUq73k2PSsCCUvawfaoI1eQlwp54csbi9pmPbEP14eB7MQlRe_1wSgpvjq-a8FBnt1kTNeXQMt6tseqBKp3SRJqf4HZPJ5_LUPoPdNKUriutw-0WyHJunOG7AG3mw4Z2BFZT5G2eyJslWG03SQ2i6nmnVsLZSvkmf3RrBTOCnVHvV31cZHBB6eiKf_B5pkM_adNl8xfPRg5KN-0CxyIBFkNY0y67kqnfh4KjQuA0kDyw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAxMDYsIm5iZiI6MTUyMDg1MDEwNiwiZXhwIjoxNTIwODU0MDA2LCJhaW8iOiJZMk5nWURqZHZsNHJValF5WExMUitlTVN4WHc3QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQU44emE0NnQ1VXFSSy1zQm50Z2pBQSIsInZlciI6IjEuMCJ9.F4V-68IPzBvISzR9WLBCZSRPedJ9RmecoD01csWdNVOsKDxjdoei_iYP8c6C_Bu7Vk-YGJ3BR5rARTuPNxwUfcsbeQL5nI6IJZa1pDvBcK0JRVDSiXRsw3_dp5NjquqwdWSzAUFfCGnclZf_Z9ohC_hLIdu3E0kfvvbVyEivA2NZ1jpF4BpeRwTUXp_vj2n0Y1S9y3d5ooDLsNY0lBjGC5hAhgxx-IAEPGyHN0HQIkUXi3WUE0CoDjXGjqbIlDCSbbXUyfM6qdXTV73GlNEVJM6ukiVN_hgWtxnJooKM7oNVLzQus7YCpIw7D8kU_Q3qBrSBjncBFoSvn4ocnhQU8A
   response:
     status:
       code: 200
@@ -2368,26 +2414,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/LowCostGet3Min;4736,Microsoft.Compute/LowCostGet30Min;37900
+      - Microsoft.Compute/LowCostGet3Min;4750,Microsoft.Compute/LowCostGet30Min;37784
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344652126238
       X-Ms-Request-Id:
-      - b095b7e7-e291-46bd-b77a-3e66ccbc2b7c
+      - 7e368bfd-f23d-46fa-867f-8d529baf84fc
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14979'
+      - '14985'
       X-Ms-Correlation-Request-Id:
-      - cf79893a-50dc-4144-a64e-7cb6415445a8
+      - 3f6076f3-7e50-452b-851a-76d64bdbf773
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201718Z:cf79893a-50dc-4144-a64e-7cb6415445a8
+      - WESTEUROPE:20180312T102649Z:3f6076f3-7e50-452b-851a-76d64bdbf773
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:17:18 GMT
+      - Mon, 12 Mar 2018 10:26:48 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"d7022008-f6b1-4f4c-8be8-e2d677ef3261\",\r\n
@@ -2412,7 +2458,7 @@ http_interactions:
         \ \"tags\": {\r\n    \"Shutdown\": \"true\"\r\n  },\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0\",\r\n
         \ \"name\": \"spec0deply1vm0\"\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:17:19 GMT
+  recorded_at: Mon, 12 Mar 2018 10:26:53 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0?api-version=2018-01-01
@@ -2429,7 +2475,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1MzUsIm5iZiI6MTUyMDQ1MzUzNSwiZXhwIjoxNTIwNDU3NDM1LCJhaW8iOiJZMk5nWUhqUi9lQnphZnNXNW5XM1pSNXRZNHllQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVFd4TnhfUTBWRUdXYjJPcHlWVUFBQSIsInZlciI6IjEuMCJ9.e2i3GxEmeuslxOYYf0jlT3wxfYslqa2SqFf3GBB02OpL6V5R_rVg27O1b8Bub6Q1dsMaxtOpFunWINuSnFDkgoEOi9sT4WvEn8XAyd-t7-iUq73k2PSsCCUvawfaoI1eQlwp54csbi9pmPbEP14eB7MQlRe_1wSgpvjq-a8FBnt1kTNeXQMt6tseqBKp3SRJqf4HZPJ5_LUPoPdNKUriutw-0WyHJunOG7AG3mw4Z2BFZT5G2eyJslWG03SQ2i6nmnVsLZSvkmf3RrBTOCnVHvV31cZHBB6eiKf_B5pkM_adNl8xfPRg5KN-0CxyIBFkNY0y67kqnfh4KjQuA0kDyw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAxMDYsIm5iZiI6MTUyMDg1MDEwNiwiZXhwIjoxNTIwODU0MDA2LCJhaW8iOiJZMk5nWURqZHZsNHJValF5WExMUitlTVN4WHc3QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQU44emE0NnQ1VXFSSy1zQm50Z2pBQSIsInZlciI6IjEuMCJ9.F4V-68IPzBvISzR9WLBCZSRPedJ9RmecoD01csWdNVOsKDxjdoei_iYP8c6C_Bu7Vk-YGJ3BR5rARTuPNxwUfcsbeQL5nI6IJZa1pDvBcK0JRVDSiXRsw3_dp5NjquqwdWSzAUFfCGnclZf_Z9ohC_hLIdu3E0kfvvbVyEivA2NZ1jpF4BpeRwTUXp_vj2n0Y1S9y3d5ooDLsNY0lBjGC5hAhgxx-IAEPGyHN0HQIkUXi3WUE0CoDjXGjqbIlDCSbbXUyfM6qdXTV73GlNEVJM6ukiVN_hgWtxnJooKM7oNVLzQus7YCpIw7D8kU_Q3qBrSBjncBFoSvn4ocnhQU8A
   response:
     status:
       code: 200
@@ -2450,22 +2496,22 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - c1c300e3-7ee8-4342-93ef-3931116da91a
+      - 833a2c4c-4740-4db1-b767-79db874b51fc
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14977'
+      - '14984'
       X-Ms-Correlation-Request-Id:
-      - 81a678d7-a535-4521-8aa7-697fc553bd25
+      - ea42934f-bf0a-4ae7-bb9a-ff7c51323472
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201719Z:81a678d7-a535-4521-8aa7-697fc553bd25
+      - WESTEUROPE:20180312T102649Z:ea42934f-bf0a-4ae7-bb9a-ff7c51323472
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:17:19 GMT
+      - Mon, 12 Mar 2018 10:26:49 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"spec0deply1nic0\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0\",\r\n
@@ -2490,10 +2536,10 @@ http_interactions:
         \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
         \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:17:20 GMT
+  recorded_at: Mon, 12 Mar 2018 10:26:54 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups/miq-azure-test1?api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0/instanceView?api-version=2017-12-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2507,60 +2553,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1MzUsIm5iZiI6MTUyMDQ1MzUzNSwiZXhwIjoxNTIwNDU3NDM1LCJhaW8iOiJZMk5nWUhqUi9lQnphZnNXNW5XM1pSNXRZNHllQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVFd4TnhfUTBWRUdXYjJPcHlWVUFBQSIsInZlciI6IjEuMCJ9.e2i3GxEmeuslxOYYf0jlT3wxfYslqa2SqFf3GBB02OpL6V5R_rVg27O1b8Bub6Q1dsMaxtOpFunWINuSnFDkgoEOi9sT4WvEn8XAyd-t7-iUq73k2PSsCCUvawfaoI1eQlwp54csbi9pmPbEP14eB7MQlRe_1wSgpvjq-a8FBnt1kTNeXQMt6tseqBKp3SRJqf4HZPJ5_LUPoPdNKUriutw-0WyHJunOG7AG3mw4Z2BFZT5G2eyJslWG03SQ2i6nmnVsLZSvkmf3RrBTOCnVHvV31cZHBB6eiKf_B5pkM_adNl8xfPRg5KN-0CxyIBFkNY0y67kqnfh4KjQuA0kDyw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14982'
-      X-Ms-Request-Id:
-      - 4230a707-1b7d-422a-821b-844aa1d210ed
-      X-Ms-Correlation-Request-Id:
-      - 4230a707-1b7d-422a-821b-844aa1d210ed
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201720Z:4230a707-1b7d-422a-821b-844aa1d210ed
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:17:19 GMT
-      Content-Length:
-      - '183'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1","name":"miq-azure-test1","location":"eastus","properties":{"provisioningState":"Succeeded"}}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:17:20 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute/locations/eastus/vmSizes?api-version=2017-12-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1MzUsIm5iZiI6MTUyMDQ1MzUzNSwiZXhwIjoxNTIwNDU3NDM1LCJhaW8iOiJZMk5nWUhqUi9lQnphZnNXNW5XM1pSNXRZNHllQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVFd4TnhfUTBWRUdXYjJPcHlWVUFBQSIsInZlciI6IjEuMCJ9.e2i3GxEmeuslxOYYf0jlT3wxfYslqa2SqFf3GBB02OpL6V5R_rVg27O1b8Bub6Q1dsMaxtOpFunWINuSnFDkgoEOi9sT4WvEn8XAyd-t7-iUq73k2PSsCCUvawfaoI1eQlwp54csbi9pmPbEP14eB7MQlRe_1wSgpvjq-a8FBnt1kTNeXQMt6tseqBKp3SRJqf4HZPJ5_LUPoPdNKUriutw-0WyHJunOG7AG3mw4Z2BFZT5G2eyJslWG03SQ2i6nmnVsLZSvkmf3RrBTOCnVHvV31cZHBB6eiKf_B5pkM_adNl8xfPRg5KN-0CxyIBFkNY0y67kqnfh4KjQuA0kDyw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAxMDYsIm5iZiI6MTUyMDg1MDEwNiwiZXhwIjoxNTIwODU0MDA2LCJhaW8iOiJZMk5nWURqZHZsNHJValF5WExMUitlTVN4WHc3QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQU44emE0NnQ1VXFSSy1zQm50Z2pBQSIsInZlciI6IjEuMCJ9.F4V-68IPzBvISzR9WLBCZSRPedJ9RmecoD01csWdNVOsKDxjdoei_iYP8c6C_Bu7Vk-YGJ3BR5rARTuPNxwUfcsbeQL5nI6IJZa1pDvBcK0JRVDSiXRsw3_dp5NjquqwdWSzAUFfCGnclZf_Z9ohC_hLIdu3E0kfvvbVyEivA2NZ1jpF4BpeRwTUXp_vj2n0Y1S9y3d5ooDLsNY0lBjGC5hAhgxx-IAEPGyHN0HQIkUXi3WUE0CoDjXGjqbIlDCSbbXUyfM6qdXTV73GlNEVJM6ukiVN_hgWtxnJooKM7oNVLzQus7YCpIw7D8kU_Q3qBrSBjncBFoSvn4ocnhQU8A
   response:
     status:
       code: 200
@@ -2579,26 +2572,155 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/LowCostGet3Min;4733,Microsoft.Compute/LowCostGet30Min;37897
+      - Microsoft.Compute/GetInstanceView3Min;4796,Microsoft.Compute/GetInstanceView30Min;23763
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344652126238
       X-Ms-Request-Id:
-      - e003d830-7ed2-49c7-96d1-98155613ed77
+      - e5576dcc-c1a9-40e4-9ff1-2540f64e1b27
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14978'
+      - '14985'
       X-Ms-Correlation-Request-Id:
-      - a883ce54-564d-468f-9039-0b72490412f0
+      - 2c46035b-4b56-459e-a6aa-cfda6be2f799
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201723Z:a883ce54-564d-468f-9039-0b72490412f0
+      - WESTEUROPE:20180312T102701Z:2c46035b-4b56-459e-a6aa-cfda6be2f799
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:17:23 GMT
+      - Mon, 12 Mar 2018 10:27:00 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"platformUpdateDomain\": 1,\r\n  \"platformFaultDomain\": 1,\r\n
+        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
+        [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
+        \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
+        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2018-03-12T10:26:50+00:00\"\r\n
+        \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"osdisk\",\r\n
+        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
+        succeeded\",\r\n          \"time\": \"2016-09-03T02:05:35.0977796+00:00\"\r\n
+        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
+        \"https://spec0deply1stor.blob.core.windows.net/bootdiagnostics-spec0depl-d7022008-f6b1-4f4c-8be8-e2d677ef3261/spec0deply1vm0.d7022008-f6b1-4f4c-8be8-e2d677ef3261.screenshot.bmp\",\r\n
+        \   \"serialConsoleLogBlobUri\": \"https://spec0deply1stor.blob.core.windows.net/bootdiagnostics-spec0depl-d7022008-f6b1-4f4c-8be8-e2d677ef3261/spec0deply1vm0.d7022008-f6b1-4f4c-8be8-e2d677ef3261.serialconsole.log\"\r\n
+        \ },\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n
+        \     \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n
+        \     \"time\": \"2016-09-03T02:05:35.1602741+00:00\"\r\n    },\r\n    {\r\n
+        \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
+        \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 10:27:05 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups/miq-azure-test1?api-version=2017-08-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAxMDYsIm5iZiI6MTUyMDg1MDEwNiwiZXhwIjoxNTIwODU0MDA2LCJhaW8iOiJZMk5nWURqZHZsNHJValF5WExMUitlTVN4WHc3QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQU44emE0NnQ1VXFSSy1zQm50Z2pBQSIsInZlciI6IjEuMCJ9.F4V-68IPzBvISzR9WLBCZSRPedJ9RmecoD01csWdNVOsKDxjdoei_iYP8c6C_Bu7Vk-YGJ3BR5rARTuPNxwUfcsbeQL5nI6IJZa1pDvBcK0JRVDSiXRsw3_dp5NjquqwdWSzAUFfCGnclZf_Z9ohC_hLIdu3E0kfvvbVyEivA2NZ1jpF4BpeRwTUXp_vj2n0Y1S9y3d5ooDLsNY0lBjGC5hAhgxx-IAEPGyHN0HQIkUXi3WUE0CoDjXGjqbIlDCSbbXUyfM6qdXTV73GlNEVJM6ukiVN_hgWtxnJooKM7oNVLzQus7YCpIw7D8kU_Q3qBrSBjncBFoSvn4ocnhQU8A
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14986'
+      X-Ms-Request-Id:
+      - acc886b8-43e6-46a8-8d07-fdd3874cad48
+      X-Ms-Correlation-Request-Id:
+      - acc886b8-43e6-46a8-8d07-fdd3874cad48
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T102701Z:acc886b8-43e6-46a8-8d07-fdd3874cad48
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 10:27:01 GMT
+      Content-Length:
+      - '183'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1","name":"miq-azure-test1","location":"eastus","properties":{"provisioningState":"Succeeded"}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 10:27:06 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute/locations/eastus/vmSizes?api-version=2017-12-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAxMDYsIm5iZiI6MTUyMDg1MDEwNiwiZXhwIjoxNTIwODU0MDA2LCJhaW8iOiJZMk5nWURqZHZsNHJValF5WExMUitlTVN4WHc3QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQU44emE0NnQ1VXFSSy1zQm50Z2pBQSIsInZlciI6IjEuMCJ9.F4V-68IPzBvISzR9WLBCZSRPedJ9RmecoD01csWdNVOsKDxjdoei_iYP8c6C_Bu7Vk-YGJ3BR5rARTuPNxwUfcsbeQL5nI6IJZa1pDvBcK0JRVDSiXRsw3_dp5NjquqwdWSzAUFfCGnclZf_Z9ohC_hLIdu3E0kfvvbVyEivA2NZ1jpF4BpeRwTUXp_vj2n0Y1S9y3d5ooDLsNY0lBjGC5hAhgxx-IAEPGyHN0HQIkUXi3WUE0CoDjXGjqbIlDCSbbXUyfM6qdXTV73GlNEVJM6ukiVN_hgWtxnJooKM7oNVLzQus7YCpIw7D8kU_Q3qBrSBjncBFoSvn4ocnhQU8A
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/LowCostGet3Min;4757,Microsoft.Compute/LowCostGet30Min;37780
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344652126238
+      X-Ms-Request-Id:
+      - b3842fae-f348-4f20-80ab-ec1e74972445
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14986'
+      X-Ms-Correlation-Request-Id:
+      - 11ac21c9-9580-426b-a00a-5f23f20b4eb0
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T102702Z:11ac21c9-9580-426b-a00a-5f23f20b4eb0
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 10:27:02 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"Standard_B1ms\",\r\n
@@ -3075,6 +3197,12 @@ http_interactions:
         \   },\r\n    {\r\n      \"name\": \"Standard_F72s_v2\",\r\n      \"numberOfCores\":
         72,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
         589824,\r\n      \"memoryInMB\": 147456,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_L8s_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1811981,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_L16s_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        3623962,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
         \   },\r\n    {\r\n      \"name\": \"Standard_ND6s\",\r\n      \"numberOfCores\":
         6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
         344064,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 12\r\n
@@ -3101,7 +3229,7 @@ http_interactions:
         391168,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
         \   }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:17:24 GMT
+  recorded_at: Mon, 12 Mar 2018 10:27:07 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete?api-version=2017-08-01
@@ -3118,7 +3246,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1MzUsIm5iZiI6MTUyMDQ1MzUzNSwiZXhwIjoxNTIwNDU3NDM1LCJhaW8iOiJZMk5nWUhqUi9lQnphZnNXNW5XM1pSNXRZNHllQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVFd4TnhfUTBWRUdXYjJPcHlWVUFBQSIsInZlciI6IjEuMCJ9.e2i3GxEmeuslxOYYf0jlT3wxfYslqa2SqFf3GBB02OpL6V5R_rVg27O1b8Bub6Q1dsMaxtOpFunWINuSnFDkgoEOi9sT4WvEn8XAyd-t7-iUq73k2PSsCCUvawfaoI1eQlwp54csbi9pmPbEP14eB7MQlRe_1wSgpvjq-a8FBnt1kTNeXQMt6tseqBKp3SRJqf4HZPJ5_LUPoPdNKUriutw-0WyHJunOG7AG3mw4Z2BFZT5G2eyJslWG03SQ2i6nmnVsLZSvkmf3RrBTOCnVHvV31cZHBB6eiKf_B5pkM_adNl8xfPRg5KN-0CxyIBFkNY0y67kqnfh4KjQuA0kDyw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAxMDYsIm5iZiI6MTUyMDg1MDEwNiwiZXhwIjoxNTIwODU0MDA2LCJhaW8iOiJZMk5nWURqZHZsNHJValF5WExMUitlTVN4WHc3QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQU44emE0NnQ1VXFSSy1zQm50Z2pBQSIsInZlciI6IjEuMCJ9.F4V-68IPzBvISzR9WLBCZSRPedJ9RmecoD01csWdNVOsKDxjdoei_iYP8c6C_Bu7Vk-YGJ3BR5rARTuPNxwUfcsbeQL5nI6IJZa1pDvBcK0JRVDSiXRsw3_dp5NjquqwdWSzAUFfCGnclZf_Z9ohC_hLIdu3E0kfvvbVyEivA2NZ1jpF4BpeRwTUXp_vj2n0Y1S9y3d5ooDLsNY0lBjGC5hAhgxx-IAEPGyHN0HQIkUXi3WUE0CoDjXGjqbIlDCSbbXUyfM6qdXTV73GlNEVJM6ukiVN_hgWtxnJooKM7oNVLzQus7YCpIw7D8kU_Q3qBrSBjncBFoSvn4ocnhQU8A
   response:
     status:
       code: 200
@@ -3135,26 +3263,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14978'
+      - '14987'
       X-Ms-Request-Id:
-      - 5790675e-7280-4b6b-aab2-4c4a20667d1d
+      - 893b8621-6514-4b8e-ae8f-647c736211c5
       X-Ms-Correlation-Request-Id:
-      - 5790675e-7280-4b6b-aab2-4c4a20667d1d
+      - 893b8621-6514-4b8e-ae8f-647c736211c5
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201724Z:5790675e-7280-4b6b-aab2-4c4a20667d1d
+      - WESTEUROPE:20180312T102703Z:893b8621-6514-4b8e-ae8f-647c736211c5
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:17:24 GMT
+      - Mon, 12 Mar 2018 10:27:03 GMT
       Content-Length:
       - '7230'
     body:
       encoding: ASCII-8BIT
       string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete","name":"spec-nested-deployment-dont-delete","properties":{"templateLink":{"uri":"https://gist.githubusercontent.com/bzwei/c09f906306399d238762bce711781200/raw/3558b735da03c1c030023d70b78ec3451dab5689/azure-loadbalancer.json","contentVersion":"1.0.0.0"},"parameters":{"storageAccountName":{"type":"String","value":"spec0deply1stor"},"availabilitySetName":{"type":"String","value":"spec0deply1as"},"adminUsername":{"type":"String","value":"deploy1admin"},"adminPassword":{"type":"SecureString"},"dnsNameforLBIP":{"type":"String","value":"spec0deply1dns"},"vmNamePrefix":{"type":"String","value":"spec0deply1vm"},"imagePublisher":{"type":"String","value":"MicrosoftWindowsServer"},"imageOffer":{"type":"String","value":"WindowsServer"},"imageSKU":{"type":"String","value":"2012-R2-Datacenter"},"lbName":{"type":"String","value":"spec0deply1lb"},"nicNamePrefix":{"type":"String","value":"spec0deply1nic"},"publicIPAddressName":{"type":"String","value":"spec0deply1ip"},"vnetName":{"type":"String","value":"spec0deply1vnet"},"vmSize":{"type":"String","value":"Standard_D1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-04-04T23:28:59.2682474Z","duration":"PT23M55.442141S","correlationId":"3a55e6b5-4a3b-431e-8144-53698bf6f1dc","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["eastus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"availabilitySets","locations":["eastus"]},{"resourceType":"virtualMachines","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"publicIPAddresses","locations":["eastus"]},{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"loadBalancers","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"spec0deply1ip"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic0"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic1"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"spec0deply1stor"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"spec0deply1as"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"spec0deply1vm0"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"spec0deply1stor"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"spec0deply1as"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"spec0deply1vm1"}],"outputResources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor"}]}}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:17:24 GMT
+  recorded_at: Mon, 12 Mar 2018 10:27:08 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-deployment-dont-delete?api-version=2017-08-01
@@ -3171,7 +3299,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1MzUsIm5iZiI6MTUyMDQ1MzUzNSwiZXhwIjoxNTIwNDU3NDM1LCJhaW8iOiJZMk5nWUhqUi9lQnphZnNXNW5XM1pSNXRZNHllQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVFd4TnhfUTBWRUdXYjJPcHlWVUFBQSIsInZlciI6IjEuMCJ9.e2i3GxEmeuslxOYYf0jlT3wxfYslqa2SqFf3GBB02OpL6V5R_rVg27O1b8Bub6Q1dsMaxtOpFunWINuSnFDkgoEOi9sT4WvEn8XAyd-t7-iUq73k2PSsCCUvawfaoI1eQlwp54csbi9pmPbEP14eB7MQlRe_1wSgpvjq-a8FBnt1kTNeXQMt6tseqBKp3SRJqf4HZPJ5_LUPoPdNKUriutw-0WyHJunOG7AG3mw4Z2BFZT5G2eyJslWG03SQ2i6nmnVsLZSvkmf3RrBTOCnVHvV31cZHBB6eiKf_B5pkM_adNl8xfPRg5KN-0CxyIBFkNY0y67kqnfh4KjQuA0kDyw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAxMDYsIm5iZiI6MTUyMDg1MDEwNiwiZXhwIjoxNTIwODU0MDA2LCJhaW8iOiJZMk5nWURqZHZsNHJValF5WExMUitlTVN4WHc3QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQU44emE0NnQ1VXFSSy1zQm50Z2pBQSIsInZlciI6IjEuMCJ9.F4V-68IPzBvISzR9WLBCZSRPedJ9RmecoD01csWdNVOsKDxjdoei_iYP8c6C_Bu7Vk-YGJ3BR5rARTuPNxwUfcsbeQL5nI6IJZa1pDvBcK0JRVDSiXRsw3_dp5NjquqwdWSzAUFfCGnclZf_Z9ohC_hLIdu3E0kfvvbVyEivA2NZ1jpF4BpeRwTUXp_vj2n0Y1S9y3d5ooDLsNY0lBjGC5hAhgxx-IAEPGyHN0HQIkUXi3WUE0CoDjXGjqbIlDCSbbXUyfM6qdXTV73GlNEVJM6ukiVN_hgWtxnJooKM7oNVLzQus7YCpIw7D8kU_Q3qBrSBjncBFoSvn4ocnhQU8A
   response:
     status:
       code: 200
@@ -3188,19 +3316,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14978'
+      - '14988'
       X-Ms-Request-Id:
-      - 183a99c1-649b-421e-ad24-0292168b7128
+      - 430c313e-f520-44bd-9de1-a7bde2f3f67c
       X-Ms-Correlation-Request-Id:
-      - 183a99c1-649b-421e-ad24-0292168b7128
+      - 430c313e-f520-44bd-9de1-a7bde2f3f67c
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201725Z:183a99c1-649b-421e-ad24-0292168b7128
+      - WESTEUROPE:20180312T102704Z:430c313e-f520-44bd-9de1-a7bde2f3f67c
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:17:24 GMT
+      - Mon, 12 Mar 2018 10:27:03 GMT
       Content-Length:
       - '3083'
     body:
@@ -3208,10 +3336,10 @@ http_interactions:
       string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-deployment-dont-delete","name":"spec-deployment-dont-delete","properties":{"templateLink":{"uri":"https://gist.githubusercontent.com/bzwei/e6ccc4d641d6afab8e26ef55c37c498e/raw/769505e37256e926a9b581a100c90bb657ff45ff/azure-parent-spec.json","contentVersion":"1.0.0.0"},"parameters":{"childDeployName":{"type":"String","value":"spec-nested-deployment-dont-delete"},"storageAccountName":{"type":"String","value":"spec0deply1stor"},"availabilitySetName":{"type":"String","value":"spec0deply1as"},"adminUsername":{"type":"String","value":"deploy1admin"},"adminPassword":{"type":"SecureString"},"dnsNameforLBIP":{"type":"String","value":"spec0deply1dns"},"vmNamePrefix":{"type":"String","value":"spec0deply1vm"},"imagePublisher":{"type":"String","value":"MicrosoftWindowsServer"},"imageOffer":{"type":"String","value":"WindowsServer"},"imageSKU":{"type":"String","value":"2012-R2-Datacenter"},"lbName":{"type":"String","value":"spec0deply1lb"},"nicNamePrefix":{"type":"String","value":"spec0deply1nic"},"publicIPAddressName":{"type":"String","value":"spec0deply1ip"},"vnetName":{"type":"String","value":"spec0deply1vnet"},"vmSize":{"type":"String","value":"Standard_D1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-04-04T23:29:05.0043846Z","duration":"PT24M6.1512983S","correlationId":"3a55e6b5-4a3b-431e-8144-53698bf6f1dc","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[],"outputs":{"siteUri":{"type":"String","value":"hard-coded
         output for test"}},"outputResources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor"}]}}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:17:25 GMT
+  recorded_at: Mon, 12 Mar 2018 10:27:08 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations?api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor?api-version=2017-10-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3225,222 +3353,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1MzUsIm5iZiI6MTUyMDQ1MzUzNSwiZXhwIjoxNTIwNDU3NDM1LCJhaW8iOiJZMk5nWUhqUi9lQnphZnNXNW5XM1pSNXRZNHllQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVFd4TnhfUTBWRUdXYjJPcHlWVUFBQSIsInZlciI6IjEuMCJ9.e2i3GxEmeuslxOYYf0jlT3wxfYslqa2SqFf3GBB02OpL6V5R_rVg27O1b8Bub6Q1dsMaxtOpFunWINuSnFDkgoEOi9sT4WvEn8XAyd-t7-iUq73k2PSsCCUvawfaoI1eQlwp54csbi9pmPbEP14eB7MQlRe_1wSgpvjq-a8FBnt1kTNeXQMt6tseqBKp3SRJqf4HZPJ5_LUPoPdNKUriutw-0WyHJunOG7AG3mw4Z2BFZT5G2eyJslWG03SQ2i6nmnVsLZSvkmf3RrBTOCnVHvV31cZHBB6eiKf_B5pkM_adNl8xfPRg5KN-0CxyIBFkNY0y67kqnfh4KjQuA0kDyw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14977'
-      X-Ms-Request-Id:
-      - 5f489eec-1ee5-40c0-a720-cf4c3b0a21f7
-      X-Ms-Correlation-Request-Id:
-      - 5f489eec-1ee5-40c0-a720-cf4c3b0a21f7
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201727Z:5f489eec-1ee5-40c0-a720-cf4c3b0a21f7
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:17:27 GMT
-      Content-Length:
-      - '6866'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/2A5D9DB48CB9B87D","operationId":"2A5D9DB48CB9B87D","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:28:58.871396Z","duration":"PT4M5.2351465S","trackingId":"413c1acd-4a86-42aa-8371-2f7fe7760fba","serviceRequestId":"520c4ff7-a725-4e8f-946e-d203617aa3f9","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"spec0deply1vm1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/F59DBCC8F57674DA","operationId":"F59DBCC8F57674DA","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:28:57.3638022Z","duration":"PT4M3.6342685S","trackingId":"a7e62d93-ed67-4f9f-93bc-d7ca4451f6f9","serviceRequestId":"5b58ce6a-8aa5-45a1-b7a3-9c82b6150bd7","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"spec0deply1vm0"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/727DE014666F097A","operationId":"727DE014666F097A","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:28.2942519Z","duration":"PT3.4353223S","trackingId":"dda58292-47ab-4139-8d67-8c99aae9c93c","serviceRequestId":"7b1ba585-6ce8-4e35-83cf-27d7a344ff40","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/8984B6C47B4DBB63","operationId":"8984B6C47B4DBB63","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:26.6945925Z","duration":"PT1.75149S","trackingId":"cf689996-82e8-4740-87f0-8f820b4d153a","serviceRequestId":"831312e5-eaf1-417d-9fdb-5723d493b396","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic0"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/5BB7F6FEF271DCC5","operationId":"5BB7F6FEF271DCC5","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:24.7522379Z","duration":"PT1.8393589S","trackingId":"f42ecee0-2ab0-44d0-9748-44249046b29e","serviceRequestId":"2c6c9788-7fc1-4e6b-928f-241a44e192ea","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/ACBE290D4E246F6C","operationId":"ACBE290D4E246F6C","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:22.8224458Z","duration":"PT16.8373612S","trackingId":"a7759f29-cf9e-4892-bb7b-3e08f64e4ff7","serviceRequestId":"25c16d1d-b611-4fc3-ad7c-eedb21574599","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"spec0deply1ip"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/CDA31B5D53DE7D18","operationId":"CDA31B5D53DE7D18","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:24:53.5717985Z","duration":"PT19M47.4658028S","trackingId":"1ce6f839-7da9-4e40-97d4-2693cfbbc796","serviceRequestId":"3a55e6b5-4a3b-431e-8144-53698bf6f1dc","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"spec0deply1stor"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/07A1436712650187","operationId":"07A1436712650187","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:22.0339723Z","duration":"PT16.0077667S","trackingId":"89200282-9510-4328-ac23-a73df06aea3e","serviceRequestId":"86d89b1a-900e-4719-8d9b-7f18bc963ec7","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"spec0deply1vnet"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/operations/C35E071B1E2FC92A","operationId":"C35E071B1E2FC92A","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:05:08.170721Z","duration":"PT2.1819157S","trackingId":"a2495990-63ae-4ea3-8904-866b7e01ec18","serviceRequestId":"97334c1c-6e32-4bc5-b96c-25314a5fef57","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"spec0deply1as"}}}]}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:17:28 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-deployment-dont-delete/operations?api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1MzUsIm5iZiI6MTUyMDQ1MzUzNSwiZXhwIjoxNTIwNDU3NDM1LCJhaW8iOiJZMk5nWUhqUi9lQnphZnNXNW5XM1pSNXRZNHllQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVFd4TnhfUTBWRUdXYjJPcHlWVUFBQSIsInZlciI6IjEuMCJ9.e2i3GxEmeuslxOYYf0jlT3wxfYslqa2SqFf3GBB02OpL6V5R_rVg27O1b8Bub6Q1dsMaxtOpFunWINuSnFDkgoEOi9sT4WvEn8XAyd-t7-iUq73k2PSsCCUvawfaoI1eQlwp54csbi9pmPbEP14eB7MQlRe_1wSgpvjq-a8FBnt1kTNeXQMt6tseqBKp3SRJqf4HZPJ5_LUPoPdNKUriutw-0WyHJunOG7AG3mw4Z2BFZT5G2eyJslWG03SQ2i6nmnVsLZSvkmf3RrBTOCnVHvV31cZHBB6eiKf_B5pkM_adNl8xfPRg5KN-0CxyIBFkNY0y67kqnfh4KjQuA0kDyw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14978'
-      X-Ms-Request-Id:
-      - aea6c3dd-d652-4731-b95a-c6791b9ae814
-      X-Ms-Correlation-Request-Id:
-      - aea6c3dd-d652-4731-b95a-c6791b9ae814
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201728Z:aea6c3dd-d652-4731-b95a-c6791b9ae814
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:17:28 GMT
-      Content-Length:
-      - '801'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-deployment-dont-delete/operations/6AF613CA61ABB553","operationId":"6AF613CA61ABB553","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-04-04T23:29:04.6934934Z","duration":"PT24M3.4746371S","trackingId":"a0997dbb-9578-4dd9-bad6-1286c02855c8","serviceRequestId":"08b8faec-0f0f-4cb2-8453-fabbd3448cb9","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete","resourceType":"Microsoft.Resources/deployments","resourceName":"spec-nested-deployment-dont-delete"}}}]}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:17:29 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete?api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1MzUsIm5iZiI6MTUyMDQ1MzUzNSwiZXhwIjoxNTIwNDU3NDM1LCJhaW8iOiJZMk5nWUhqUi9lQnphZnNXNW5XM1pSNXRZNHllQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVFd4TnhfUTBWRUdXYjJPcHlWVUFBQSIsInZlciI6IjEuMCJ9.e2i3GxEmeuslxOYYf0jlT3wxfYslqa2SqFf3GBB02OpL6V5R_rVg27O1b8Bub6Q1dsMaxtOpFunWINuSnFDkgoEOi9sT4WvEn8XAyd-t7-iUq73k2PSsCCUvawfaoI1eQlwp54csbi9pmPbEP14eB7MQlRe_1wSgpvjq-a8FBnt1kTNeXQMt6tseqBKp3SRJqf4HZPJ5_LUPoPdNKUriutw-0WyHJunOG7AG3mw4Z2BFZT5G2eyJslWG03SQ2i6nmnVsLZSvkmf3RrBTOCnVHvV31cZHBB6eiKf_B5pkM_adNl8xfPRg5KN-0CxyIBFkNY0y67kqnfh4KjQuA0kDyw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14977'
-      X-Ms-Request-Id:
-      - 867aae37-c809-45a8-84a0-4cd47c4434a3
-      X-Ms-Correlation-Request-Id:
-      - 867aae37-c809-45a8-84a0-4cd47c4434a3
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201729Z:867aae37-c809-45a8-84a0-4cd47c4434a3
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:17:29 GMT
-      Content-Length:
-      - '7230'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete","name":"spec-nested-deployment-dont-delete","properties":{"templateLink":{"uri":"https://gist.githubusercontent.com/bzwei/c09f906306399d238762bce711781200/raw/3558b735da03c1c030023d70b78ec3451dab5689/azure-loadbalancer.json","contentVersion":"1.0.0.0"},"parameters":{"storageAccountName":{"type":"String","value":"spec0deply1stor"},"availabilitySetName":{"type":"String","value":"spec0deply1as"},"adminUsername":{"type":"String","value":"deploy1admin"},"adminPassword":{"type":"SecureString"},"dnsNameforLBIP":{"type":"String","value":"spec0deply1dns"},"vmNamePrefix":{"type":"String","value":"spec0deply1vm"},"imagePublisher":{"type":"String","value":"MicrosoftWindowsServer"},"imageOffer":{"type":"String","value":"WindowsServer"},"imageSKU":{"type":"String","value":"2012-R2-Datacenter"},"lbName":{"type":"String","value":"spec0deply1lb"},"nicNamePrefix":{"type":"String","value":"spec0deply1nic"},"publicIPAddressName":{"type":"String","value":"spec0deply1ip"},"vnetName":{"type":"String","value":"spec0deply1vnet"},"vmSize":{"type":"String","value":"Standard_D1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-04-04T23:28:59.2682474Z","duration":"PT23M55.442141S","correlationId":"3a55e6b5-4a3b-431e-8144-53698bf6f1dc","providers":[{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["eastus"]}]},{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"availabilitySets","locations":["eastus"]},{"resourceType":"virtualMachines","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"publicIPAddresses","locations":["eastus"]},{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"loadBalancers","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip","resourceType":"Microsoft.Network/publicIPAddresses","resourceName":"spec0deply1ip"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic0"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb","resourceType":"Microsoft.Network/loadBalancers","resourceName":"spec0deply1lb"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic1"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"spec0deply1stor"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"spec0deply1as"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"spec0deply1vm0"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"spec0deply1stor"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"spec0deply1nic1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"spec0deply1as"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"spec0deply1vm1"}],"outputResources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor"}]}}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:17:29 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-deployment-dont-delete?api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1MzUsIm5iZiI6MTUyMDQ1MzUzNSwiZXhwIjoxNTIwNDU3NDM1LCJhaW8iOiJZMk5nWUhqUi9lQnphZnNXNW5XM1pSNXRZNHllQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVFd4TnhfUTBWRUdXYjJPcHlWVUFBQSIsInZlciI6IjEuMCJ9.e2i3GxEmeuslxOYYf0jlT3wxfYslqa2SqFf3GBB02OpL6V5R_rVg27O1b8Bub6Q1dsMaxtOpFunWINuSnFDkgoEOi9sT4WvEn8XAyd-t7-iUq73k2PSsCCUvawfaoI1eQlwp54csbi9pmPbEP14eB7MQlRe_1wSgpvjq-a8FBnt1kTNeXQMt6tseqBKp3SRJqf4HZPJ5_LUPoPdNKUriutw-0WyHJunOG7AG3mw4Z2BFZT5G2eyJslWG03SQ2i6nmnVsLZSvkmf3RrBTOCnVHvV31cZHBB6eiKf_B5pkM_adNl8xfPRg5KN-0CxyIBFkNY0y67kqnfh4KjQuA0kDyw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14972'
-      X-Ms-Request-Id:
-      - 847e8be3-d84b-4f44-b372-48c645e20502
-      X-Ms-Correlation-Request-Id:
-      - 847e8be3-d84b-4f44-b372-48c645e20502
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201730Z:847e8be3-d84b-4f44-b372-48c645e20502
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:17:30 GMT
-      Content-Length:
-      - '3083'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-deployment-dont-delete","name":"spec-deployment-dont-delete","properties":{"templateLink":{"uri":"https://gist.githubusercontent.com/bzwei/e6ccc4d641d6afab8e26ef55c37c498e/raw/769505e37256e926a9b581a100c90bb657ff45ff/azure-parent-spec.json","contentVersion":"1.0.0.0"},"parameters":{"childDeployName":{"type":"String","value":"spec-nested-deployment-dont-delete"},"storageAccountName":{"type":"String","value":"spec0deply1stor"},"availabilitySetName":{"type":"String","value":"spec0deply1as"},"adminUsername":{"type":"String","value":"deploy1admin"},"adminPassword":{"type":"SecureString"},"dnsNameforLBIP":{"type":"String","value":"spec0deply1dns"},"vmNamePrefix":{"type":"String","value":"spec0deply1vm"},"imagePublisher":{"type":"String","value":"MicrosoftWindowsServer"},"imageOffer":{"type":"String","value":"WindowsServer"},"imageSKU":{"type":"String","value":"2012-R2-Datacenter"},"lbName":{"type":"String","value":"spec0deply1lb"},"nicNamePrefix":{"type":"String","value":"spec0deply1nic"},"publicIPAddressName":{"type":"String","value":"spec0deply1ip"},"vnetName":{"type":"String","value":"spec0deply1vnet"},"vmSize":{"type":"String","value":"Standard_D1"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-04-04T23:29:05.0043846Z","duration":"PT24M6.1512983S","correlationId":"3a55e6b5-4a3b-431e-8144-53698bf6f1dc","providers":[{"namespace":"Microsoft.Resources","resourceTypes":[{"resourceType":"deployments","locations":[null]}]}],"dependencies":[],"outputs":{"siteUri":{"type":"String","value":"hard-coded
-        output for test"}},"outputResources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/spec0deply1as"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor"}]}}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:17:30 GMT
-- request:
-    method: post
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-nested-deployment-dont-delete/exportTemplate?api-version=2017-08-01
-    body:
-      encoding: ASCII-8BIT
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1MzUsIm5iZiI6MTUyMDQ1MzUzNSwiZXhwIjoxNTIwNDU3NDM1LCJhaW8iOiJZMk5nWUhqUi9lQnphZnNXNW5XM1pSNXRZNHllQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVFd4TnhfUTBWRUdXYjJPcHlWVUFBQSIsInZlciI6IjEuMCJ9.e2i3GxEmeuslxOYYf0jlT3wxfYslqa2SqFf3GBB02OpL6V5R_rVg27O1b8Bub6Q1dsMaxtOpFunWINuSnFDkgoEOi9sT4WvEn8XAyd-t7-iUq73k2PSsCCUvawfaoI1eQlwp54csbi9pmPbEP14eB7MQlRe_1wSgpvjq-a8FBnt1kTNeXQMt6tseqBKp3SRJqf4HZPJ5_LUPoPdNKUriutw-0WyHJunOG7AG3mw4Z2BFZT5G2eyJslWG03SQ2i6nmnVsLZSvkmf3RrBTOCnVHvV31cZHBB6eiKf_B5pkM_adNl8xfPRg5KN-0CxyIBFkNY0y67kqnfh4KjQuA0kDyw
-      Content-Length:
-      - '0'
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAxMDYsIm5iZiI6MTUyMDg1MDEwNiwiZXhwIjoxNTIwODU0MDA2LCJhaW8iOiJZMk5nWURqZHZsNHJValF5WExMUitlTVN4WHc3QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQU44emE0NnQ1VXFSSy1zQm50Z2pBQSIsInZlciI6IjEuMCJ9.F4V-68IPzBvISzR9WLBCZSRPedJ9RmecoD01csWdNVOsKDxjdoei_iYP8c6C_Bu7Vk-YGJ3BR5rARTuPNxwUfcsbeQL5nI6IJZa1pDvBcK0JRVDSiXRsw3_dp5NjquqwdWSzAUFfCGnclZf_Z9ohC_hLIdu3E0kfvvbVyEivA2NZ1jpF4BpeRwTUXp_vj2n0Y1S9y3d5ooDLsNY0lBjGC5hAhgxx-IAEPGyHN0HQIkUXi3WUE0CoDjXGjqbIlDCSbbXUyfM6qdXTV73GlNEVJM6ukiVN_hgWtxnJooKM7oNVLzQus7YCpIw7D8kU_Q3qBrSBjncBFoSvn4ocnhQU8A
   response:
     status:
       code: 200
@@ -3453,385 +3366,32 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Content-Type:
-      - application/json; charset=utf-8
+      - application/json
       Expires:
       - "-1"
       Vary:
       - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1197'
       X-Ms-Request-Id:
-      - c256c1b3-5128-42a8-8fec-a4c25f3596e0
-      X-Ms-Correlation-Request-Id:
-      - c256c1b3-5128-42a8-8fec-a4c25f3596e0
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201731Z:c256c1b3-5128-42a8-8fec-a4c25f3596e0
+      - aff031a4-c89a-4fbc-9870-661e8587c25c
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:17:31 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"template":{"$schema":"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json","contentVersion":"1.0.0.0","parameters":{"storageAccountName":{"type":"String","metadata":{"description":"Name
-        of storage account"}},"availabilitySetName":{"type":"String","metadata":{"description":"Name
-        of availability set"}},"adminUsername":{"type":"String","metadata":{"description":"Admin
-        username"}},"adminPassword":{"type":"SecureString","metadata":{"description":"Admin
-        password"}},"dnsNameforLBIP":{"type":"String","metadata":{"description":"DNS
-        for Load Balancer IP"}},"vmNamePrefix":{"defaultValue":"myVM","type":"String","metadata":{"description":"Prefix
-        to use for VM names"}},"imagePublisher":{"defaultValue":"MicrosoftWindowsServer","type":"String","metadata":{"description":"Image
-        Publisher"}},"imageOffer":{"defaultValue":"WindowsServer","type":"String","metadata":{"description":"Image
-        Offer"}},"imageSKU":{"defaultValue":"2012-R2-Datacenter","type":"String","metadata":{"description":"Image
-        SKU"}},"lbName":{"defaultValue":"myLB","type":"String","metadata":{"description":"Load
-        Balancer name"}},"nicNamePrefix":{"defaultValue":"nic","type":"String","metadata":{"description":"Network
-        Interface name prefix"}},"publicIPAddressName":{"defaultValue":"myPublicIP","type":"String","metadata":{"description":"Public
-        IP Name"}},"vnetName":{"defaultValue":"myVNET","type":"String","metadata":{"description":"VNET
-        name"}},"vmSize":{"defaultValue":"Standard_D1","type":"String","metadata":{"description":"Size
-        of the VM"}}},"variables":{"storageAccountType":"Standard_LRS","addressPrefix":"10.0.0.0/16","subnetName":"Subnet-1","subnetPrefix":"10.0.0.0/24","publicIPAddressType":"Dynamic","vnetID":"[resourceId(''Microsoft.Network/virtualNetworks'',parameters(''vnetName''))]","subnetRef":"[concat(variables(''vnetID''),''/subnets/'',variables
-        (''subnetName''))]","publicIPAddressID":"[resourceId(''Microsoft.Network/publicIPAddresses'',parameters(''publicIPAddressName''))]","numberOfInstances":2,"lbID":"[resourceId(''Microsoft.Network/loadBalancers'',parameters(''lbName''))]","frontEndIPConfigID":"[concat(variables(''lbID''),''/frontendIPConfigurations/LoadBalancerFrontEnd'')]","lbPoolID":"[concat(variables(''lbID''),''/backendAddressPools/BackendPool1'')]","lbProbeID":"[concat(variables(''lbID''),''/probes/tcpProbe'')]"},"resources":[{"type":"Microsoft.Storage/storageAccounts","name":"[parameters(''storageAccountName'')]","apiVersion":"2015-05-01-preview","location":"[resourceGroup().location]","properties":{"accountType":"[variables(''storageAccountType'')]"}},{"type":"Microsoft.Compute/availabilitySets","name":"[parameters(''availabilitySetName'')]","apiVersion":"2015-05-01-preview","location":"[resourceGroup().location]","properties":{}},{"type":"Microsoft.Network/publicIPAddresses","name":"[parameters(''publicIPAddressName'')]","apiVersion":"2015-05-01-preview","location":"[resourceGroup().location]","properties":{"publicIPAllocationMethod":"[variables(''publicIPAddressType'')]","dnsSettings":{"domainNameLabel":"[parameters(''dnsNameforLBIP'')]"}}},{"type":"Microsoft.Network/virtualNetworks","name":"[parameters(''vnetName'')]","apiVersion":"2015-05-01-preview","location":"[resourceGroup().location]","properties":{"addressSpace":{"addressPrefixes":["[variables(''addressPrefix'')]"]},"subnets":[{"name":"[variables(''subnetName'')]","properties":{"addressPrefix":"[variables(''subnetPrefix'')]"}}]}},{"type":"Microsoft.Network/networkInterfaces","name":"[concat(parameters(''nicNamePrefix''),
-        copyindex())]","apiVersion":"2015-05-01-preview","location":"[resourceGroup().location]","copy":{"name":"nicLoop","count":"[variables(''numberOfInstances'')]"},"properties":{"ipConfigurations":[{"name":"ipconfig1","properties":{"privateIPAllocationMethod":"Dynamic","subnet":{"id":"[variables(''subnetRef'')]"},"loadBalancerBackendAddressPools":[{"id":"[concat(variables(''lbID''),
-        ''/backendAddressPools/BackendPool1'')]"}],"loadBalancerInboundNatRules":[{"id":"[concat(variables(''lbID''),''/inboundNatRules/RDP-VM'',
-        copyindex())]"}]}}]},"dependsOn":["[concat(''Microsoft.Network/virtualNetworks/'',
-        parameters(''vnetName''))]","[concat(''Microsoft.Network/loadBalancers/'',
-        parameters(''lbName''))]"]},{"type":"Microsoft.Network/loadBalancers","name":"[parameters(''lbName'')]","apiVersion":"2015-05-01-preview","location":"[resourceGroup().location]","properties":{"frontendIPConfigurations":[{"name":"LoadBalancerFrontEnd","properties":{"publicIPAddress":{"id":"[variables(''publicIPAddressID'')]"}}}],"backendAddressPools":[{"name":"BackendPool1"}],"inboundNatRules":[{"name":"RDP-VM0","properties":{"frontendIPConfiguration":{"id":"[variables(''frontEndIPConfigID'')]"},"protocol":"tcp","frontendPort":50001,"backendPort":3389,"enableFloatingIP":false}},{"name":"RDP-VM1","properties":{"frontendIPConfiguration":{"id":"[variables(''frontEndIPConfigID'')]"},"protocol":"tcp","frontendPort":50002,"backendPort":3389,"enableFloatingIP":false}}],"loadBalancingRules":[{"name":"LBRule","properties":{"frontendIPConfiguration":{"id":"[variables(''frontEndIPConfigID'')]"},"backendAddressPool":{"id":"[variables(''lbPoolID'')]"},"protocol":"tcp","frontendPort":80,"backendPort":80,"enableFloatingIP":false,"idleTimeoutInMinutes":5,"probe":{"id":"[variables(''lbProbeID'')]"}}}],"probes":[{"name":"tcpProbe","properties":{"protocol":"tcp","port":80,"intervalInSeconds":5,"numberOfProbes":2}}]},"dependsOn":["[concat(''Microsoft.Network/publicIPAddresses/'',
-        parameters(''publicIPAddressName''))]"]},{"type":"Microsoft.Compute/virtualMachines","name":"[concat(parameters(''vmNamePrefix''),
-        copyindex())]","apiVersion":"2015-06-15","location":"[resourceGroup().location]","copy":{"name":"virtualMachineLoop","count":"[variables(''numberOfInstances'')]"},"properties":{"availabilitySet":{"id":"[resourceId(''Microsoft.Compute/availabilitySets'',parameters(''availabilitySetName''))]"},"hardwareProfile":{"vmSize":"[parameters(''vmSize'')]"},"osProfile":{"computerName":"[concat(parameters(''vmNamePrefix''),
-        copyIndex())]","adminUsername":"[parameters(''adminUsername'')]","adminPassword":"[parameters(''adminPassword'')]"},"storageProfile":{"imageReference":{"publisher":"[parameters(''imagePublisher'')]","offer":"[parameters(''imageOffer'')]","sku":"[parameters(''imageSKU'')]","version":"latest"},"osDisk":{"name":"osdisk","vhd":{"uri":"[concat(''http://'',parameters(''storageAccountName''),''.blob.core.windows.net/vhds/'',''osdisk'',
-        copyindex(), ''.vhd'')]"},"caching":"ReadWrite","createOption":"FromImage"}},"networkProfile":{"networkInterfaces":[{"id":"[resourceId(''Microsoft.Network/networkInterfaces'',concat(parameters(''nicNamePrefix''),copyindex()))]"}]},"diagnosticsProfile":{"bootDiagnostics":{"enabled":"true","storageUri":"[concat(''http://'',parameters(''storageAccountName''),''.blob.core.windows.net'')]"}}},"dependsOn":["[concat(''Microsoft.Storage/storageAccounts/'',
-        parameters(''storageAccountName''))]","[concat(''Microsoft.Network/networkInterfaces/'',
-        parameters(''nicNamePrefix''), copyindex())]","[concat(''Microsoft.Compute/availabilitySets/'',
-        parameters(''availabilitySetName''))]"]}]}}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:17:31 GMT
-- request:
-    method: post
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/spec-deployment-dont-delete/exportTemplate?api-version=2017-08-01
-    body:
-      encoding: ASCII-8BIT
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1MzUsIm5iZiI6MTUyMDQ1MzUzNSwiZXhwIjoxNTIwNDU3NDM1LCJhaW8iOiJZMk5nWUhqUi9lQnphZnNXNW5XM1pSNXRZNHllQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVFd4TnhfUTBWRUdXYjJPcHlWVUFBQSIsInZlciI6IjEuMCJ9.e2i3GxEmeuslxOYYf0jlT3wxfYslqa2SqFf3GBB02OpL6V5R_rVg27O1b8Bub6Q1dsMaxtOpFunWINuSnFDkgoEOi9sT4WvEn8XAyd-t7-iUq73k2PSsCCUvawfaoI1eQlwp54csbi9pmPbEP14eB7MQlRe_1wSgpvjq-a8FBnt1kTNeXQMt6tseqBKp3SRJqf4HZPJ5_LUPoPdNKUriutw-0WyHJunOG7AG3mw4Z2BFZT5G2eyJslWG03SQ2i6nmnVsLZSvkmf3RrBTOCnVHvV31cZHBB6eiKf_B5pkM_adNl8xfPRg5KN-0CxyIBFkNY0y67kqnfh4KjQuA0kDyw
-      Content-Length:
-      - '0'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1199'
-      X-Ms-Request-Id:
-      - 86704cbd-8430-4253-b5e5-bcf9a594abce
-      X-Ms-Correlation-Request-Id:
-      - 86704cbd-8430-4253-b5e5-bcf9a594abce
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201732Z:86704cbd-8430-4253-b5e5-bcf9a594abce
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:17:32 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"template":{"$schema":"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#","contentVersion":"1.0.0.0","parameters":{"childDeployName":{"type":"String"},"storageAccountName":{"type":"String","metadata":{"description":"Name
-        of storage account"}},"availabilitySetName":{"type":"String","metadata":{"description":"Name
-        of availability set"}},"adminUsername":{"type":"String","metadata":{"description":"Admin
-        username"}},"adminPassword":{"type":"SecureString","metadata":{"description":"Admin
-        password"}},"dnsNameforLBIP":{"type":"String","metadata":{"description":"DNS
-        for Load Balancer IP"}},"vmNamePrefix":{"defaultValue":"myVM","type":"String","metadata":{"description":"Prefix
-        to use for VM names"}},"imagePublisher":{"defaultValue":"MicrosoftWindowsServer","type":"String","metadata":{"description":"Image
-        Publisher"}},"imageOffer":{"defaultValue":"WindowsServer","type":"String","metadata":{"description":"Image
-        Offer"}},"imageSKU":{"defaultValue":"2012-R2-Datacenter","type":"String","metadata":{"description":"Image
-        SKU"}},"lbName":{"defaultValue":"myLB","type":"String","metadata":{"description":"Load
-        Balancer name"}},"nicNamePrefix":{"defaultValue":"nic","type":"String","metadata":{"description":"Network
-        Interface name prefix"}},"publicIPAddressName":{"defaultValue":"myPublicIP","type":"String","metadata":{"description":"Public
-        IP Name"}},"vnetName":{"defaultValue":"myVNET","type":"String","metadata":{"description":"VNET
-        name"}},"vmSize":{"defaultValue":"Standard_D1","type":"String","metadata":{"description":"Size
-        of the VM"}}},"resources":[{"type":"Microsoft.Resources/deployments","name":"[parameters(''childDeployName'')]","apiVersion":"2015-01-01","properties":{"mode":"Incremental","templateLink":{"uri":"https://gist.githubusercontent.com/bzwei/c09f906306399d238762bce711781200/raw/3558b735da03c1c030023d70b78ec3451dab5689/azure-loadbalancer.json","contentVersion":"1.0.0.0"},"parameters":{"storageAccountName":{"value":"[parameters(''storageAccountName'')]"},"availabilitySetName":{"value":"[parameters(''availabilitySetName'')]"},"adminUsername":{"value":"[parameters(''adminUsername'')]"},"adminPassword":{"value":"[parameters(''adminPassword'')]"},"dnsNameforLBIP":{"value":"[parameters(''dnsNameforLBIP'')]"},"vmNamePrefix":{"value":"[parameters(''vmNamePrefix'')]"},"imagePublisher":{"value":"[parameters(''imagePublisher'')]"},"imageOffer":{"value":"[parameters(''imageOffer'')]"},"imageSKU":{"value":"[parameters(''imageSKU'')]"},"lbName":{"value":"[parameters(''lbName'')]"},"nicNamePrefix":{"value":"[parameters(''nicNamePrefix'')]"},"publicIPAddressName":{"value":"[parameters(''publicIPAddressName'')]"},"vnetName":{"value":"[parameters(''vnetName'')]"},"vmSize":{"value":"[parameters(''vmSize'')]"}}}}],"outputs":{"siteUri":{"type":"String","value":"hard-coded
-        output for test"}}}}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:17:32 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0?api-version=2017-12-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1MzUsIm5iZiI6MTUyMDQ1MzUzNSwiZXhwIjoxNTIwNDU3NDM1LCJhaW8iOiJZMk5nWUhqUi9lQnphZnNXNW5XM1pSNXRZNHllQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVFd4TnhfUTBWRUdXYjJPcHlWVUFBQSIsInZlciI6IjEuMCJ9.e2i3GxEmeuslxOYYf0jlT3wxfYslqa2SqFf3GBB02OpL6V5R_rVg27O1b8Bub6Q1dsMaxtOpFunWINuSnFDkgoEOi9sT4WvEn8XAyd-t7-iUq73k2PSsCCUvawfaoI1eQlwp54csbi9pmPbEP14eB7MQlRe_1wSgpvjq-a8FBnt1kTNeXQMt6tseqBKp3SRJqf4HZPJ5_LUPoPdNKUriutw-0WyHJunOG7AG3mw4Z2BFZT5G2eyJslWG03SQ2i6nmnVsLZSvkmf3RrBTOCnVHvV31cZHBB6eiKf_B5pkM_adNl8xfPRg5KN-0CxyIBFkNY0y67kqnfh4KjQuA0kDyw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/LowCostGet3Min;4738,Microsoft.Compute/LowCostGet30Min;37891
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
-      X-Ms-Request-Id:
-      - '038dd444-18c8-459f-9ec8-5a9670518e4a'
       Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14874'
+      - '14982'
       X-Ms-Correlation-Request-Id:
-      - 37468164-bba7-41fe-968d-f30069b83030
+      - dc9d0094-5417-4b4d-a43d-6b6dfd441280
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201733Z:37468164-bba7-41fe-968d-f30069b83030
+      - WESTEUROPE:20180312T102704Z:dc9d0094-5417-4b4d-a43d-6b6dfd441280
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:17:32 GMT
+      - Mon, 12 Mar 2018 10:27:04 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"d7022008-f6b1-4f4c-8be8-e2d677ef3261\",\r\n
-        \   \"availabilitySet\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/SPEC0DEPLY1AS\"\r\n
-        \   },\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Standard_D1\"\r\n
-        \   },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
-        \"MicrosoftWindowsServer\",\r\n        \"offer\": \"WindowsServer\",\r\n        \"sku\":
-        \"2012-R2-Datacenter\",\r\n        \"version\": \"latest\"\r\n      },\r\n
-        \     \"osDisk\": {\r\n        \"osType\": \"Windows\",\r\n        \"name\":
-        \"osdisk\",\r\n        \"createOption\": \"FromImage\",\r\n        \"vhd\":
-        {\r\n          \"uri\": \"http://spec0deply1stor.blob.core.windows.net/vhds/osdisk0.vhd\"\r\n
-        \       },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n      \"dataDisks\":
-        []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"spec0deply1vm0\",\r\n
-        \     \"adminUsername\": \"deploy1admin\",\r\n      \"windowsConfiguration\":
-        {\r\n        \"provisionVMAgent\": true,\r\n        \"enableAutomaticUpdates\":
-        true\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\":
-        {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0\"}]},\r\n
-        \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
-        true,\r\n        \"storageUri\": \"http://spec0deply1stor.blob.core.windows.net\"\r\n
-        \     }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n
-        \ \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\": \"eastus\",\r\n
-        \ \"tags\": {\r\n    \"Shutdown\": \"true\"\r\n  },\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0\",\r\n
-        \ \"name\": \"spec0deply1vm0\"\r\n}"
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","name":"spec0deply1stor","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-04-04T23:05:07.8274794Z","primaryEndpoints":{"blob":"https://spec0deply1stor.blob.core.windows.net/","queue":"https://spec0deply1stor.queue.core.windows.net/","table":"https://spec0deply1stor.table.core.windows.net/","file":"https://spec0deply1stor.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:17:33 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0/instanceView?api-version=2017-12-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1MzUsIm5iZiI6MTUyMDQ1MzUzNSwiZXhwIjoxNTIwNDU3NDM1LCJhaW8iOiJZMk5nWUhqUi9lQnphZnNXNW5XM1pSNXRZNHllQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVFd4TnhfUTBWRUdXYjJPcHlWVUFBQSIsInZlciI6IjEuMCJ9.e2i3GxEmeuslxOYYf0jlT3wxfYslqa2SqFf3GBB02OpL6V5R_rVg27O1b8Bub6Q1dsMaxtOpFunWINuSnFDkgoEOi9sT4WvEn8XAyd-t7-iUq73k2PSsCCUvawfaoI1eQlwp54csbi9pmPbEP14eB7MQlRe_1wSgpvjq-a8FBnt1kTNeXQMt6tseqBKp3SRJqf4HZPJ5_LUPoPdNKUriutw-0WyHJunOG7AG3mw4Z2BFZT5G2eyJslWG03SQ2i6nmnVsLZSvkmf3RrBTOCnVHvV31cZHBB6eiKf_B5pkM_adNl8xfPRg5KN-0CxyIBFkNY0y67kqnfh4KjQuA0kDyw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/GetInstanceView3Min;4794,Microsoft.Compute/GetInstanceView30Min;23923
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
-      X-Ms-Request-Id:
-      - e88f6c4b-a9cf-4987-b6f4-e108e5a703be
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14974'
-      X-Ms-Correlation-Request-Id:
-      - 66a31423-af7f-4f3f-8478-e7ccb59903f0
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201745Z:66a31423-af7f-4f3f-8478-e7ccb59903f0
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:17:45 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"platformUpdateDomain\": 1,\r\n  \"platformFaultDomain\": 1,\r\n
-        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
-        [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
-        \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
-        \"VM Agent is unresponsive.\",\r\n        \"time\": \"2018-03-07T20:17:33+00:00\"\r\n
-        \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"osdisk\",\r\n
-        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
-        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"time\": \"2016-09-03T02:05:35.0977796+00:00\"\r\n
-        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
-        \"https://spec0deply1stor.blob.core.windows.net/bootdiagnostics-spec0depl-d7022008-f6b1-4f4c-8be8-e2d677ef3261/spec0deply1vm0.d7022008-f6b1-4f4c-8be8-e2d677ef3261.screenshot.bmp\",\r\n
-        \   \"serialConsoleLogBlobUri\": \"https://spec0deply1stor.blob.core.windows.net/bootdiagnostics-spec0depl-d7022008-f6b1-4f4c-8be8-e2d677ef3261/spec0deply1vm0.d7022008-f6b1-4f4c-8be8-e2d677ef3261.serialconsole.log\"\r\n
-        \ },\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n
-        \     \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n
-        \     \"time\": \"2016-09-03T02:05:35.1602741+00:00\"\r\n    },\r\n    {\r\n
-        \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
-        \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:17:46 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Network/networkInterfaces?api-version=2017-11-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1MzUsIm5iZiI6MTUyMDQ1MzUzNSwiZXhwIjoxNTIwNDU3NDM1LCJhaW8iOiJZMk5nWUhqUi9lQnphZnNXNW5XM1pSNXRZNHllQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVFd4TnhfUTBWRUdXYjJPcHlWVUFBQSIsInZlciI6IjEuMCJ9.e2i3GxEmeuslxOYYf0jlT3wxfYslqa2SqFf3GBB02OpL6V5R_rVg27O1b8Bub6Q1dsMaxtOpFunWINuSnFDkgoEOi9sT4WvEn8XAyd-t7-iUq73k2PSsCCUvawfaoI1eQlwp54csbi9pmPbEP14eB7MQlRe_1wSgpvjq-a8FBnt1kTNeXQMt6tseqBKp3SRJqf4HZPJ5_LUPoPdNKUriutw-0WyHJunOG7AG3mw4Z2BFZT5G2eyJslWG03SQ2i6nmnVsLZSvkmf3RrBTOCnVHvV31cZHBB6eiKf_B5pkM_adNl8xfPRg5KN-0CxyIBFkNY0y67kqnfh4KjQuA0kDyw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 57510b9a-ced9-42cd-a8fc-3f299b33ddd4
-      X-Ms-Correlation-Request-Id:
-      - 57510b9a-ced9-42cd-a8fc-3f299b33ddd4
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201748Z:57510b9a-ced9-42cd-a8fc-3f299b33ddd4
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:17:47 GMT
-      Content-Length:
-      - '31614'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[{"name":"miqazure-coreos1235","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235","etag":"W/\"4a6546ab-a4c0-4d27-bccd-f6ebf3c405a2\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"fb0a5e60-a6c2-4bb8-a2f5-0c16216a49b0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235/ipConfigurations/ipconfig1","etag":"W/\"4a6546ab-a4c0-4d27-bccd-f6ebf3c405a2\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.20.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/publicIPAddresses/miqazure-coreos1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/virtualNetworks/miq-azure-test3/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"rliadcyr3l1elbnsw4rabxqg1f.dx.internal.cloudapp.net"},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkSecurityGroups/miqazure-coreos1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Compute/virtualMachines/miqazure-coreos1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"dbergerprov1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/dbergerprov1","etag":"W/\"074dd836-918c-4e40-a118-94f0d366e175\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"ecdcd2f0-91bb-4c40-91cd-a3d76fc5e455","ipConfigurations":[{"name":"dbergerprov1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/dbergerprov1/ipConfigurations/dbergerprov1","etag":"W/\"074dd836-918c-4e40-a118-94f0d366e175\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.9","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/dbergerprov1-publicIp"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/virtualMachines/dbergerprov1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-rhel1390","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390","etag":"W/\"f006e6f9-0292-42cd-99fc-f72f194553c1\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"98853f48-2806-4065-be57-cf9159550440","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1","etag":"W/\"f006e6f9-0292-42cd-99fc-f72f194553c1\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"macAddress":"00-0D-3A-10-EB-AB","enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-ubuntu1989","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989","etag":"W/\"64e07488-15a2-4cec-b84a-6fd5ef04323c\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"134a6669-ac4a-4d08-a0db-387bc4c49537","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989/ipConfigurations/ipconfig1","etag":"W/\"64e07488-15a2-4cec-b84a-6fd5ef04323c\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.17.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-ubuntu1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest18687/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-win12610","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610","etag":"W/\"dd925ef5-33d1-402c-a0f4-18c78c2641f4\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"5c2eef2c-0b36-4277-a940-957ed4d13be0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610/ipConfigurations/ipconfig1","etag":"W/\"dd925ef5-33d1-402c-a0f4-18c78c2641f4\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.18.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-win12"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest19881/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-winimg241","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241","etag":"W/\"4a17a745-16a9-42d9-88c9-17a518959525\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"8ed2f3b0-4a4b-49ae-9f1d-ff7890dbd396","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241/ipConfigurations/ipconfig1","etag":"W/\"4a17a745-16a9-42d9-88c9-17a518959525\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.7","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqtestwinimg6202"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-centos1611","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611","etag":"W/\"26031ef6-bb55-4019-8185-2dd1edcb207c\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"f1760e49-9853-4fdc-acfc-4ea232b9ed76","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1","etag":"W/\"26031ef6-bb55-4019-8185-2dd1edcb207c\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.5","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqmismatch1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1","etag":"W/\"3a72d0c3-bfda-4da5-a61b-e8c33e43de79\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"23d804a8-b623-49e7-9c8d-1d64245bef1e","ipConfigurations":[{"name":"miqmismatch1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1/ipConfigurations/miqmismatch1","etag":"W/\"3a72d0c3-bfda-4da5-a61b-e8c33e43de79\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.8","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqmismatch1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqmismatch1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"rspec-lb-a670","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670","etag":"W/\"cf3a0b0d-d596-4f33-bc31-749f92ba4f00\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"46cb8216-786e-408e-9d86-c0855b357349","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1","etag":"W/\"cf3a0b0d-d596-4f33-bc31-749f92ba4f00\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.6","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-a-ip"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"rspec-lb-b843","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843","etag":"W/\"76aabe0c-8678-43f0-81a5-2f15784a4b99\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"3ef6fa01-ac34-43a1-8fd7-67c706b4d8ef","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1","etag":"W/\"76aabe0c-8678-43f0-81a5-2f15784a4b99\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.11","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-b-ip"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"spec0deply1nic0","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","etag":"W/\"b817491c-aab8-4aab-b41d-b07bfffa5639\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"80ad9866-071d-4e3f-91d0-d47954eccee0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1","etag":"W/\"b817491c-aab8-4aab-b41d-b07bfffa5639\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.4","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"spec0deply1nic1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","etag":"W/\"2ec58a0b-4c03-4d0a-b788-9daffd54e7b2\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"57bbf7aa-d6c4-4f56-8f6a-089d15334221","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1","etag":"W/\"2ec58a0b-4c03-4d0a-b788-9daffd54e7b2\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.5","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqmismatch2656","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqmismatch2656","etag":"W/\"fef6a836-2802-4897-90c3-b3d71f133384\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"969dde6c-73c0-4340-877d-2b5fe2060026","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqmismatch2656/ipConfigurations/ipconfig1","etag":"W/\"fef6a836-2802-4897-90c3-b3d71f133384\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"172.23.0.4","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/virtualNetworks/miqazuretest33606/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkSecurityGroups/miqmismatch2-nsg"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Compute/virtualMachines/miqmismatch2"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-linux-manag944","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944","etag":"W/\"b6339880-8ead-4c9e-b5c0-f38c4f8612d5\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"c5e8b90e-5a78-49b0-b224-b70ed3fb45e5","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944/ipConfigurations/ipconfig1","etag":"W/\"b6339880-8ead-4c9e-b5c0-f38c4f8612d5\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"172.25.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqazure-linux-managed-ip"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"jf-metrics-2751","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751","etag":"W/\"c5f6f02a-b17c-4f34-882b-11c7adef0b44\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"207a58d3-f18d-4dab-8168-919877297a52","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751/ipConfigurations/ipconfig1","etag":"W/\"c5f6f02a-b17c-4f34-882b-11c7adef0b44\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.7","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-2"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-2"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/jf-metrics-2"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"jf-metrics-3421","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421","etag":"W/\"0b6f160b-ad10-48f8-9d0c-657193bb823f\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"b8b345e8-a353-4700-992e-be48a717b4e2","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421/ipConfigurations/ipconfig1","etag":"W/\"0b6f160b-ad10-48f8-9d0c-657193bb823f\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.8","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-3"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-3"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/jf-metrics-3"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-oraclelinux310","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310","etag":"W/\"54cd4fe1-3ed5-4a8c-bc8d-527679c7a631\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"6a3fc1d7-4532-4ca0-b5c2-546cc8f7f313","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310/ipConfigurations/ipconfig1","etag":"W/\"54cd4fe1-3ed5-4a8c-bc8d-527679c7a631\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.5","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-oraclelinux993","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993","etag":"W/\"a9432274-7b40-4eb3-a64f-a04267a423ff\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"75d8ed14-e0ae-4d84-99f6-e3f43d073e76","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993/ipConfigurations/ipconfig1","etag":"W/\"a9432274-7b40-4eb3-a64f-a04267a423ff\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.6","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux2"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux2"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"}]}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:17:48 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Storage/storageAccounts?api-version=2017-10-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1MzUsIm5iZiI6MTUyMDQ1MzUzNSwiZXhwIjoxNTIwNDU3NDM1LCJhaW8iOiJZMk5nWUhqUi9lQnphZnNXNW5XM1pSNXRZNHllQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVFd4TnhfUTBWRUdXYjJPcHlWVUFBQSIsInZlciI6IjEuMCJ9.e2i3GxEmeuslxOYYf0jlT3wxfYslqa2SqFf3GBB02OpL6V5R_rVg27O1b8Bub6Q1dsMaxtOpFunWINuSnFDkgoEOi9sT4WvEn8XAyd-t7-iUq73k2PSsCCUvawfaoI1eQlwp54csbi9pmPbEP14eB7MQlRe_1wSgpvjq-a8FBnt1kTNeXQMt6tseqBKp3SRJqf4HZPJ5_LUPoPdNKUriutw-0WyHJunOG7AG3mw4Z2BFZT5G2eyJslWG03SQ2i6nmnVsLZSvkmf3RrBTOCnVHvV31cZHBB6eiKf_B5pkM_adNl8xfPRg5KN-0CxyIBFkNY0y67kqnfh4KjQuA0kDyw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 87ca5df4-1209-4171-b5ad-df96d0794ee4
-      X-Ms-Correlation-Request-Id:
-      - 87ca5df4-1209-4171-b5ad-df96d0794ee4
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201750Z:87ca5df4-1209-4171-b5ad-df96d0794ee4
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:17:50 GMT
-      Content-Length:
-      - '8649'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","name":"miqazuretest18686","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T17:22:54.7808677Z","primaryEndpoints":{"blob":"https://miqazuretest18686.blob.core.windows.net/","queue":"https://miqazuretest18686.queue.core.windows.net/","table":"https://miqazuretest18686.table.core.windows.net/","file":"https://miqazuretest18686.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","name":"miqazuretest14047","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T17:30:25.7028008Z","primaryEndpoints":{"blob":"https://miqazuretest14047.blob.core.windows.net/","queue":"https://miqazuretest14047.queue.core.windows.net/","table":"https://miqazuretest14047.table.core.windows.net/","file":"https://miqazuretest14047.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Premium_LRS","tier":"Premium"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb","name":"rspeclb","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-09-02T16:29:11.6823797Z","primaryEndpoints":{"blob":"https://rspeclb.blob.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","name":"spec0deply1stor","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-04-04T23:05:07.8274794Z","primaryEndpoints":{"blob":"https://spec0deply1stor.blob.core.windows.net/","queue":"https://spec0deply1stor.queue.core.windows.net/","table":"https://spec0deply1stor.table.core.windows.net/","file":"https://spec0deply1stor.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Storage/storageAccounts/miqazuretest26611","name":"miqazuretest26611","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2211656Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2211656Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-05-02T18:01:29.2743021Z","primaryEndpoints":{"blob":"https://miqazuretest26611.blob.core.windows.net/","queue":"https://miqazuretest26611.queue.core.windows.net/","table":"https://miqazuretest26611.table.core.windows.net/","file":"https://miqazuretest26611.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","name":"miqazuretest16487","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T17:26:55.3231669Z","primaryEndpoints":{"blob":"https://miqazuretest16487.blob.core.windows.net/","queue":"https://miqazuretest16487.queue.core.windows.net/","table":"https://miqazuretest16487.table.core.windows.net/","file":"https://miqazuretest16487.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Storage/storageAccounts/miqazuretest32946","name":"miqazuretest32946","type":"Microsoft.Storage/storageAccounts","location":"westus","tags":{"delete":"false"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.0404359Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.0404359Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T21:18:37.0793411Z","primaryEndpoints":{"blob":"https://miqazuretest32946.blob.core.windows.net/","queue":"https://miqazuretest32946.queue.core.windows.net/","table":"https://miqazuretest32946.table.core.windows.net/","file":"https://miqazuretest32946.file.core.windows.net/"},"primaryLocation":"westus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Storage/storageAccounts/miqazureshared1","name":"miqazureshared1","type":"Microsoft.Storage/storageAccounts","location":"centralus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.1935084Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.1935084Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T20:42:52.498085Z","primaryEndpoints":{"blob":"https://miqazureshared1.blob.core.windows.net/","queue":"https://miqazureshared1.queue.core.windows.net/","table":"https://miqazureshared1.table.core.windows.net/","file":"https://miqazureshared1.file.core.windows.net/"},"primaryLocation":"centralus","statusOfPrimary":"available","secondaryLocation":"eastus2","statusOfSecondary":"available","secondaryEndpoints":{"blob":"https://miqazureshared1-secondary.blob.core.windows.net/","queue":"https://miqazureshared1-secondary.queue.core.windows.net/","table":"https://miqazureshared1-secondary.table.core.windows.net/"}}}]}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:17:51 GMT
+  recorded_at: Mon, 12 Mar 2018 10:27:09 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor/listKeys?api-version=2017-10-01
@@ -3848,7 +3408,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1MzUsIm5iZiI6MTUyMDQ1MzUzNSwiZXhwIjoxNTIwNDU3NDM1LCJhaW8iOiJZMk5nWUhqUi9lQnphZnNXNW5XM1pSNXRZNHllQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVFd4TnhfUTBWRUdXYjJPcHlWVUFBQSIsInZlciI6IjEuMCJ9.e2i3GxEmeuslxOYYf0jlT3wxfYslqa2SqFf3GBB02OpL6V5R_rVg27O1b8Bub6Q1dsMaxtOpFunWINuSnFDkgoEOi9sT4WvEn8XAyd-t7-iUq73k2PSsCCUvawfaoI1eQlwp54csbi9pmPbEP14eB7MQlRe_1wSgpvjq-a8FBnt1kTNeXQMt6tseqBKp3SRJqf4HZPJ5_LUPoPdNKUriutw-0WyHJunOG7AG3mw4Z2BFZT5G2eyJslWG03SQ2i6nmnVsLZSvkmf3RrBTOCnVHvV31cZHBB6eiKf_B5pkM_adNl8xfPRg5KN-0CxyIBFkNY0y67kqnfh4KjQuA0kDyw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAxMDYsIm5iZiI6MTUyMDg1MDEwNiwiZXhwIjoxNTIwODU0MDA2LCJhaW8iOiJZMk5nWURqZHZsNHJValF5WExMUitlTVN4WHc3QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQU44emE0NnQ1VXFSSy1zQm50Z2pBQSIsInZlciI6IjEuMCJ9.F4V-68IPzBvISzR9WLBCZSRPedJ9RmecoD01csWdNVOsKDxjdoei_iYP8c6C_Bu7Vk-YGJ3BR5rARTuPNxwUfcsbeQL5nI6IJZa1pDvBcK0JRVDSiXRsw3_dp5NjquqwdWSzAUFfCGnclZf_Z9ohC_hLIdu3E0kfvvbVyEivA2NZ1jpF4BpeRwTUXp_vj2n0Y1S9y3d5ooDLsNY0lBjGC5hAhgxx-IAEPGyHN0HQIkUXi3WUE0CoDjXGjqbIlDCSbbXUyfM6qdXTV73GlNEVJM6ukiVN_hgWtxnJooKM7oNVLzQus7YCpIw7D8kU_Q3qBrSBjncBFoSvn4ocnhQU8A
       Content-Length:
       - '0'
   response:
@@ -3869,26 +3429,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 3ec9defe-8b89-44d3-9da7-250e93a2011b
+      - 502ff0d6-b112-4ed1-88d8-39638258407b
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1197'
+      - '1198'
       X-Ms-Correlation-Request-Id:
-      - 4baf5fe4-6811-41dc-b035-1ed379408d04
+      - c43c284e-f84f-437c-8314-9643e515a028
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201751Z:4baf5fe4-6811-41dc-b035-1ed379408d04
+      - WESTEUROPE:20180312T102705Z:c43c284e-f84f-437c-8314-9643e515a028
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:17:50 GMT
+      - Mon, 12 Mar 2018 10:27:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keys":[{"keyName":"key1","value":"68JHlwL/JgyPmvNCqop65JbepxzK0RGKJ4uD6EKszcgv1nRUJKkxO6u4OoyW/6YPT+FMJxvzEBrCGD/bduFGJQ==","permissions":"Full"},{"keyName":"key2","value":"NCT/sPC/+mrVRzXq/V5IwjN2SPaWRF4kY2coPHzJ8f+IkWMUIyfUgYTAN//h4KnxeWuX9OkY1CPyssDhDs91fw==","permissions":"Full"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:17:51 GMT
+  recorded_at: Mon, 12 Mar 2018 10:27:10 GMT
 - request:
     method: head
     uri: https://spec0deply1stor.blob.core.windows.net/vhds/osdisk0.vhd
@@ -3905,7 +3465,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:17:51 GMT
+      - Mon, 12 Mar 2018 10:27:10 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -3913,7 +3473,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey spec0deply1stor:saj3BoRTbx9aYmpMvd7gMyPPxp+mfjWH+7dvpOUfsAM=
+      - SharedKey spec0deply1stor:upHt73tUl1g0Gc92A1DhzVdCveBR9FD22VdQ4owrwRg=
   response:
     status:
       code: 200
@@ -3934,7 +3494,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 836edfb7-001e-013f-7551-b6d7f6000000
+      - dc5e2ee0-001e-008c-6bec-b96b24000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Microsoftazurecompute-Resourcegroupname:
@@ -3970,12 +3530,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:17:51 GMT
+      - Mon, 12 Mar 2018 10:27:06 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:17:52 GMT
+  recorded_at: Mon, 12 Mar 2018 10:27:11 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet?api-version=2018-01-01
@@ -3992,7 +3552,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1MzUsIm5iZiI6MTUyMDQ1MzUzNSwiZXhwIjoxNTIwNDU3NDM1LCJhaW8iOiJZMk5nWUhqUi9lQnphZnNXNW5XM1pSNXRZNHllQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVFd4TnhfUTBWRUdXYjJPcHlWVUFBQSIsInZlciI6IjEuMCJ9.e2i3GxEmeuslxOYYf0jlT3wxfYslqa2SqFf3GBB02OpL6V5R_rVg27O1b8Bub6Q1dsMaxtOpFunWINuSnFDkgoEOi9sT4WvEn8XAyd-t7-iUq73k2PSsCCUvawfaoI1eQlwp54csbi9pmPbEP14eB7MQlRe_1wSgpvjq-a8FBnt1kTNeXQMt6tseqBKp3SRJqf4HZPJ5_LUPoPdNKUriutw-0WyHJunOG7AG3mw4Z2BFZT5G2eyJslWG03SQ2i6nmnVsLZSvkmf3RrBTOCnVHvV31cZHBB6eiKf_B5pkM_adNl8xfPRg5KN-0CxyIBFkNY0y67kqnfh4KjQuA0kDyw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAxMDYsIm5iZiI6MTUyMDg1MDEwNiwiZXhwIjoxNTIwODU0MDA2LCJhaW8iOiJZMk5nWURqZHZsNHJValF5WExMUitlTVN4WHc3QUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQU44emE0NnQ1VXFSSy1zQm50Z2pBQSIsInZlciI6IjEuMCJ9.F4V-68IPzBvISzR9WLBCZSRPedJ9RmecoD01csWdNVOsKDxjdoei_iYP8c6C_Bu7Vk-YGJ3BR5rARTuPNxwUfcsbeQL5nI6IJZa1pDvBcK0JRVDSiXRsw3_dp5NjquqwdWSzAUFfCGnclZf_Z9ohC_hLIdu3E0kfvvbVyEivA2NZ1jpF4BpeRwTUXp_vj2n0Y1S9y3d5ooDLsNY0lBjGC5hAhgxx-IAEPGyHN0HQIkUXi3WUE0CoDjXGjqbIlDCSbbXUyfM6qdXTV73GlNEVJM6ukiVN_hgWtxnJooKM7oNVLzQus7YCpIw7D8kU_Q3qBrSBjncBFoSvn4ocnhQU8A
   response:
     status:
       code: 200
@@ -4013,22 +3573,22 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 15f81da2-e39f-4106-af5b-1ea49434e72e
+      - d02a5806-afe6-4977-87bb-a377c74ab96d
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14971'
+      - '14982'
       X-Ms-Correlation-Request-Id:
-      - b8d745ee-45db-46b8-8fe4-e46c621a7901
+      - 5ee2a6b9-3689-4d2d-91ea-3aa678116ba0
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201752Z:b8d745ee-45db-46b8-8fe4-e46c621a7901
+      - WESTEUROPE:20180312T102707Z:5ee2a6b9-3689-4d2d-91ea-3aa678116ba0
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:17:51 GMT
+      - Mon, 12 Mar 2018 10:27:07 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"spec0deply1vnet\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet\",\r\n
@@ -4047,83 +3607,5 @@ http_interactions:
         [],\r\n    \"enableDdosProtection\": false,\r\n    \"enableVmProtection\":
         false\r\n  }\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:17:52 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1MzUsIm5iZiI6MTUyMDQ1MzUzNSwiZXhwIjoxNTIwNDU3NDM1LCJhaW8iOiJZMk5nWUhqUi9lQnphZnNXNW5XM1pSNXRZNHllQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVFd4TnhfUTBWRUdXYjJPcHlWVUFBQSIsInZlciI6IjEuMCJ9.e2i3GxEmeuslxOYYf0jlT3wxfYslqa2SqFf3GBB02OpL6V5R_rVg27O1b8Bub6Q1dsMaxtOpFunWINuSnFDkgoEOi9sT4WvEn8XAyd-t7-iUq73k2PSsCCUvawfaoI1eQlwp54csbi9pmPbEP14eB7MQlRe_1wSgpvjq-a8FBnt1kTNeXQMt6tseqBKp3SRJqf4HZPJ5_LUPoPdNKUriutw-0WyHJunOG7AG3mw4Z2BFZT5G2eyJslWG03SQ2i6nmnVsLZSvkmf3RrBTOCnVHvV31cZHBB6eiKf_B5pkM_adNl8xfPRg5KN-0CxyIBFkNY0y67kqnfh4KjQuA0kDyw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"b817491c-aab8-4aab-b41d-b07bfffa5639"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 154b54c2-f8d9-4ab2-88b0-e954a92699a6
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14973'
-      X-Ms-Correlation-Request-Id:
-      - 1250a8ee-a963-4e3f-ab55-a73b6bb7461d
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201753Z:1250a8ee-a963-4e3f-ab55-a73b6bb7461d
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:17:52 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"spec0deply1nic0\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0\",\r\n
-        \ \"etag\": \"W/\\\"b817491c-aab8-4aab-b41d-b07bfffa5639\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"80ad9866-071d-4e3f-91d0-d47954eccee0\",\r\n    \"ipConfigurations\":
-        [\r\n      {\r\n        \"name\": \"ipconfig1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1\",\r\n
-        \       \"etag\": \"W/\\\"b817491c-aab8-4aab-b41d-b07bfffa5639\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAddress\": \"10.0.0.4\",\r\n          \"privateIPAllocationMethod\":
-        \"Dynamic\",\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1\"\r\n
-        \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
-        \"IPv4\",\r\n          \"loadBalancerBackendAddressPools\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1\"\r\n
-        \           }\r\n          ],\r\n          \"loadBalancerInboundNatRules\":
-        [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\":
-        {\r\n      \"dnsServers\": [],\r\n      \"appliedDnsServers\": []\r\n    },\r\n
-        \   \"enableAcceleratedNetworking\": false,\r\n    \"enableIPForwarding\":
-        false,\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0\"\r\n
-        \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
-        \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:17:53 GMT
+  recorded_at: Mon, 12 Mar 2018 10:27:11 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted_scope/powered_off_vm_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted_scope/powered_off_vm_refresh.yml
@@ -37,25 +37,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - ed498fcf-0bad-4a42-85c6-6139c85a0000
+      - 7e0db5ba-caef-466e-a564-b578c1d40000
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzqEra3y1vqHU60EbBEhuOV6D70RCOmWmEdlmRNNxsAgXoazCxafgt8kX2wuliScdDWIm0cxYUR1d5ObfB9yp-Cneo3Pmw1LnOT6ZsFx6_sEn0HicYnA0NENovXAWoDxB7BKBlKGd9SGqGKv8gRVU0NXw_q1NNCb3ysLr09-oAYbcgAA;
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzRJleUFD4xAkzMqNKhMIC9FeFuI7zgaCnnElJbXCdYGkSeMzXkSgtcSIw2QUDiB8BvKKIXaYhRqDLISV3cJnbtWqpU8obwQfviE-nfHd63e8PffGCsgMVWP3CxmaXTWhwbCANYZG0mA2FXNKjtRswbEWhgIDZQwZR6OpwkJxqC18gAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=007; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=006; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Wed, 07 Mar 2018 20:18:01 GMT
+      - Mon, 12 Mar 2018 10:25:07 GMT
       Content-Length:
       - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1520457481","not_before":"1520453581","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1ODEsIm5iZiI6MTUyMDQ1MzU4MSwiZXhwIjoxNTIwNDU3NDgxLCJhaW8iOiJZMk5nWURqdmVlYldiaDNsUkp1Sm9uZTFpN2ZQQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiejQ5SjdhMExRa3FGeG1FNXlGb0FBQSIsInZlciI6IjEuMCJ9.pBpmvta3GhE-q7jz0GPLGkXKVgiDCQmGLnwpg3-wQ0HBDJ79kKhZfOwiPFcXFZG8heoad_YWYcnVjQuMY9hsV3yTXGMgJlVBpYH5gUh9PiCSHPQTfdkX3Nxwv5vz8rLkwd_HH8UUMN96AkGpoSvbVxA3aDSC0sOYaHElhO6XOllD5CGuui1T3gpptUjj18PRQnCC_cZbqLJETdQT4S0IoEGz6-FNlt45pPg3rJUK1WFQa9rfWPsd3XCRQEvZjeaj4zeYRB8-bNe8dbrcitRhVocQWHmFKlQ1i7q2b840YCbG3udPoSJ0hPJqHcFexjzEMfn_vJeiNLETBncPUYfbPw"}'
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1520853908","not_before":"1520850008","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAwMDgsIm5iZiI6MTUyMDg1MDAwOCwiZXhwIjoxNTIwODUzOTA4LCJhaW8iOiJZMk5nWUpETSt4NVdsaFY1SWtqNTBsMHhMc1pwQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidXJVTmZ1X0tia2FsWkxWNHdkUUFBQSIsInZlciI6IjEuMCJ9.JZgL7n0qXHgKoO66Qr6QO-NQbdn-8kjLG3DkmcI-u8dGoFGPi7UW9xEJtKwYw5MqnpnItbSeHhmsDOQC8wPjV4dZ3gTEYehW8FpTsXkhOGy7EkeTmgpdegs96aOG7ttypkyxM9mQ3jk1x_NBm8c1jf4OssGN-WwXR7zIsmK0MHz0d2wCpu054SParX1ExHX-fgGDTMbC3h1RoXr28hJrVL5Z_7f2LbHWnkPtcUepfybilV7caVa3mgvWt3PO3cqwjE3p47pazCE-RoA9qqZqDhprJ7P3qHG6S9FBX9VvT1XReMG_k1U76MBJ-jwLUYucRgKrB5UDq1U83qgGrwiipg"}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:01 GMT
+  recorded_at: Mon, 12 Mar 2018 10:25:12 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -72,7 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1ODEsIm5iZiI6MTUyMDQ1MzU4MSwiZXhwIjoxNTIwNDU3NDgxLCJhaW8iOiJZMk5nWURqdmVlYldiaDNsUkp1Sm9uZTFpN2ZQQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiejQ5SjdhMExRa3FGeG1FNXlGb0FBQSIsInZlciI6IjEuMCJ9.pBpmvta3GhE-q7jz0GPLGkXKVgiDCQmGLnwpg3-wQ0HBDJ79kKhZfOwiPFcXFZG8heoad_YWYcnVjQuMY9hsV3yTXGMgJlVBpYH5gUh9PiCSHPQTfdkX3Nxwv5vz8rLkwd_HH8UUMN96AkGpoSvbVxA3aDSC0sOYaHElhO6XOllD5CGuui1T3gpptUjj18PRQnCC_cZbqLJETdQT4S0IoEGz6-FNlt45pPg3rJUK1WFQa9rfWPsd3XCRQEvZjeaj4zeYRB8-bNe8dbrcitRhVocQWHmFKlQ1i7q2b840YCbG3udPoSJ0hPJqHcFexjzEMfn_vJeiNLETBncPUYfbPw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAwMDgsIm5iZiI6MTUyMDg1MDAwOCwiZXhwIjoxNTIwODUzOTA4LCJhaW8iOiJZMk5nWUpETSt4NVdsaFY1SWtqNTBsMHhMc1pwQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidXJVTmZ1X0tia2FsWkxWNHdkUUFBQSIsInZlciI6IjEuMCJ9.JZgL7n0qXHgKoO66Qr6QO-NQbdn-8kjLG3DkmcI-u8dGoFGPi7UW9xEJtKwYw5MqnpnItbSeHhmsDOQC8wPjV4dZ3gTEYehW8FpTsXkhOGy7EkeTmgpdegs96aOG7ttypkyxM9mQ3jk1x_NBm8c1jf4OssGN-WwXR7zIsmK0MHz0d2wCpu054SParX1ExHX-fgGDTMbC3h1RoXr28hJrVL5Z_7f2LbHWnkPtcUepfybilV7caVa3mgvWt3PO3cqwjE3p47pazCE-RoA9qqZqDhprJ7P3qHG6S9FBX9VvT1XReMG_k1U76MBJ-jwLUYucRgKrB5UDq1U83qgGrwiipg
   response:
     status:
       code: 200
@@ -93,24 +93,24 @@ http_interactions:
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
       - '14998'
       X-Ms-Request-Id:
-      - fdc21e73-9cb7-4540-885f-513228fdcfbf
+      - a99ddf0f-3a15-4fc3-9652-8d3995680875
       X-Ms-Correlation-Request-Id:
-      - fdc21e73-9cb7-4540-885f-513228fdcfbf
+      - a99ddf0f-3a15-4fc3-9652-8d3995680875
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201802Z:fdc21e73-9cb7-4540-885f-513228fdcfbf
+      - WESTEUROPE:20180312T102509Z:a99ddf0f-3a15-4fc3-9652-8d3995680875
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:18:01 GMT
+      - Mon, 12 Mar 2018 10:25:09 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID","subscriptionId":"AZURE_SUBSCRIPTION_ID","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:02 GMT
+  recorded_at: Mon, 12 Mar 2018 10:25:14 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers?api-version=2015-01-01
@@ -127,7 +127,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1ODEsIm5iZiI6MTUyMDQ1MzU4MSwiZXhwIjoxNTIwNDU3NDgxLCJhaW8iOiJZMk5nWURqdmVlYldiaDNsUkp1Sm9uZTFpN2ZQQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiejQ5SjdhMExRa3FGeG1FNXlGb0FBQSIsInZlciI6IjEuMCJ9.pBpmvta3GhE-q7jz0GPLGkXKVgiDCQmGLnwpg3-wQ0HBDJ79kKhZfOwiPFcXFZG8heoad_YWYcnVjQuMY9hsV3yTXGMgJlVBpYH5gUh9PiCSHPQTfdkX3Nxwv5vz8rLkwd_HH8UUMN96AkGpoSvbVxA3aDSC0sOYaHElhO6XOllD5CGuui1T3gpptUjj18PRQnCC_cZbqLJETdQT4S0IoEGz6-FNlt45pPg3rJUK1WFQa9rfWPsd3XCRQEvZjeaj4zeYRB8-bNe8dbrcitRhVocQWHmFKlQ1i7q2b840YCbG3udPoSJ0hPJqHcFexjzEMfn_vJeiNLETBncPUYfbPw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAwMDgsIm5iZiI6MTUyMDg1MDAwOCwiZXhwIjoxNTIwODUzOTA4LCJhaW8iOiJZMk5nWUpETSt4NVdsaFY1SWtqNTBsMHhMc1pwQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidXJVTmZ1X0tia2FsWkxWNHdkUUFBQSIsInZlciI6IjEuMCJ9.JZgL7n0qXHgKoO66Qr6QO-NQbdn-8kjLG3DkmcI-u8dGoFGPi7UW9xEJtKwYw5MqnpnItbSeHhmsDOQC8wPjV4dZ3gTEYehW8FpTsXkhOGy7EkeTmgpdegs96aOG7ttypkyxM9mQ3jk1x_NBm8c1jf4OssGN-WwXR7zIsmK0MHz0d2wCpu054SParX1ExHX-fgGDTMbC3h1RoXr28hJrVL5Z_7f2LbHWnkPtcUepfybilV7caVa3mgvWt3PO3cqwjE3p47pazCE-RoA9qqZqDhprJ7P3qHG6S9FBX9VvT1XReMG_k1U76MBJ-jwLUYucRgKrB5UDq1U83qgGrwiipg
   response:
     status:
       code: 200
@@ -144,39 +144,37 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14972'
+      - '14985'
       X-Ms-Request-Id:
-      - 81f3ae5c-704c-4e75-a0f0-b9f8b29b5ec3
+      - a39986ae-1cbe-49d0-bb1b-7d7385b69f97
       X-Ms-Correlation-Request-Id:
-      - 81f3ae5c-704c-4e75-a0f0-b9f8b29b5ec3
+      - a39986ae-1cbe-49d0-bb1b-7d7385b69f97
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201803Z:81f3ae5c-704c-4e75-a0f0-b9f8b29b5ec3
+      - WESTEUROPE:20180312T102514Z:a39986ae-1cbe-49d0-bb1b-7d7385b69f97
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:18:02 GMT
+      - Mon, 12 Mar 2018 10:25:14 GMT
       Content-Length:
-      - '310901'
+      - '320853'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"},{"applicationId":"d87dcbc6-a371-462e-88e3-28ad15ec4e64","roleDefinitionId":"861776c5-e0df-4f95-be4f-ac1eec193323"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
+      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"},{"applicationId":"d87dcbc6-a371-462e-88e3-28ad15ec4e64","roleDefinitionId":"861776c5-e0df-4f95-be4f-ac1eec193323"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["East
+        Asia","Southeast Asia","Australia East","Australia Southeast","Japan East","Japan
+        West","Central India","South India","West India","West Europe","North Europe","Canada
+        Central","Canada East","Brazil South","West US","Central US","East US","South
+        Central US","East US 2","West Central US","North Central US","West US 2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
         US","Central US","East US","South Central US","West Europe","North Europe","East
         Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
         Central US","North Central US","Japan East","Japan West","Brazil South","Central
         India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"operations","locations":["West
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["East
+        Asia","Southeast Asia","Australia East","Australia Southeast","Japan East","Japan
+        West","Central India","South India","West India","West Europe","North Europe","Canada
+        Central","Canada East","Brazil South","West US","Central US","East US","South
+        Central US","East US 2","West Central US","North Central US","West US 2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"operations","locations":["West
         US","Central US","East US","South Central US","West Europe","North Europe","East
         Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
         Central US","North Central US","Japan East","Japan West","Brazil South","Central
@@ -232,177 +230,177 @@ http_interactions:
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/internalLoadBalancers","locations":[],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"domainNames/slots/roles/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"domainNames/slots/roles/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"domainNames/capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"domainNames/serviceCertificates","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
         US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
         Central","Canada East","UK South","UK West","West US","Central US","South
         Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
-        East","Australia Southeast","West US 2","West Central US","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        East","Australia Southeast","West US 2","West Central US","France Central","South
+        India","Central India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
         US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
         Central","Canada East","UK South","UK West","West US","Central US","South
         Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
-        East","Australia Southeast","West US 2","West Central US","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metrics","locations":["North
+        East","Australia Southeast","West US 2","West Central US","France Central","South
+        India","Central India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metrics","locations":["North
         Central US","South Central US","East US","East US 2","Canada Central","Canada
         East","West US","West US 2","West Central US","Central US","East Asia","Southeast
         Asia","North Europe","West Europe","UK South","UK West","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"resourceTypes","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"moveSubscriptionResources","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"validateSubscriptionMoveAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operationStatuses","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operatingSystems","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"operatingSystemFamilies","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicNetwork","namespace":"Microsoft.ClassicNetwork","resourceTypes":[{"resourceType":"virtualNetworks","locations":["East
+        India","West India","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"resourceTypes","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"moveSubscriptionResources","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"validateSubscriptionMoveAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operationStatuses","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operatingSystems","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"operatingSystemFamilies","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicNetwork","namespace":"Microsoft.ClassicNetwork","resourceTypes":[{"resourceType":"virtualNetworks","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"virtualNetworks/remoteVirtualNetworkPeeringProxies","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01"]},{"resourceType":"virtualNetworks/remoteVirtualNetworkPeeringProxies","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"reservedIps","locations":["East
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01"]},{"resourceType":"reservedIps","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"gatewaySupportedDevices","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"networkSecurityGroups","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"gatewaySupportedDevices","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"networkSecurityGroups","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicStorage","namespace":"Microsoft.ClassicStorage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"expressRouteCrossConnections","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"expressRouteCrossConnections/peerings","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicStorage","namespace":"Microsoft.ClassicStorage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkStorageAccountAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"storageAccounts/services","locations":["West
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkStorageAccountAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"storageAccounts/services","locations":["West
         US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
         Asia","Australia East","Australia Southeast","South India","Central India","West
         India","West US 2","West Central US","East US","East US 2","North Central
         US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
-        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/diagnosticSettings","locations":["West
+        South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/diagnosticSettings","locations":["West
         US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
         Asia","Australia East","Australia Southeast","South India","Central India","West
         India","West US 2","West Central US","East US","East US 2","North Central
         US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
-        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"disks","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"images","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"vmImages","locations":[],"apiVersions":["2016-11-01"]},{"resourceType":"publicImages","locations":[],"apiVersions":["2016-11-01","2016-04-01"]},{"resourceType":"osImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"osPlatformImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute","namespace":"Microsoft.Compute","authorizations":[{"applicationId":"60e6cd67-9c8c-4951-9b3c-23c25a2169af","roleDefinitionId":"e4770acb-272e-4dc8-87f3-12f44a612224"},{"applicationId":"a303894e-f1d8-4a37-bf10-67aa654a0596","roleDefinitionId":"903ac751-8ad5-4e5a-bfc2-5e49f450a241"},{"applicationId":"a8b6bf88-1d1a-4626-b040-9a729ea93c65","roleDefinitionId":"45c8267c-80ba-4b96-9a43-115b8f49fccd"}],"resourceTypes":[{"resourceType":"availabilitySets","locations":["East
+        South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"disks","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"images","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"vmImages","locations":[],"apiVersions":["2016-11-01"]},{"resourceType":"storageAccounts/vmImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"publicImages","locations":[],"apiVersions":["2016-11-01","2016-04-01"]},{"resourceType":"osImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"osPlatformImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute","namespace":"Microsoft.Compute","authorizations":[{"applicationId":"60e6cd67-9c8c-4951-9b3c-23c25a2169af","roleDefinitionId":"e4770acb-272e-4dc8-87f3-12f44a612224"},{"applicationId":"a303894e-f1d8-4a37-bf10-67aa654a0596","roleDefinitionId":"903ac751-8ad5-4e5a-bfc2-5e49f450a241"},{"applicationId":"a8b6bf88-1d1a-4626-b040-9a729ea93c65","roleDefinitionId":"45c8267c-80ba-4b96-9a43-115b8f49fccd"}],"resourceTypes":[{"resourceType":"availabilitySets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations/usages","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations/usages","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"sharedVMImages","locations":["West
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"sharedVMImages","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"sharedVMImages/versions","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"locations/capsoperations","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"disks","locations":["Southeast
@@ -410,27 +408,27 @@ http_interactions:
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"snapshots","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"snapshots","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"locations/diskoperations","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"locations/diskoperations","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"images","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"images","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"]},{"resourceType":"locations/logAnalytics","locations":["East
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"]},{"resourceType":"locations/logAnalytics","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
         US","East US","South Central US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
@@ -547,7 +545,12 @@ http_interactions:
         US","East Asia","East US","East US 2","Japan East","Japan West","North Central
         US","North Europe","South Central US","South India","Southeast Asia","West
         Central US","West Europe","West India","West US","West US 2","UK West","UK
-        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"},{"applicationId":"f5c26e74-f226-4ae8-85f0-b4af0080ac9e","roleDefinitionId":"529d7ae6-e892-4d43-809d-8547aeb90643"}],"resourceTypes":[{"resourceType":"components","locations":["East
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/consumergroups","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/disasterrecoveryconfigs","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"},{"applicationId":"f5c26e74-f226-4ae8-85f0-b4af0080ac9e","roleDefinitionId":"529d7ae6-e892-4d43-809d-8547aeb90643"}],"resourceTypes":[{"resourceType":"components","locations":["East
         US","South Central US","North Europe","West Europe","Southeast Asia","West
         US 2"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
         US","South Central US","North Europe","West Europe","Southeast Asia","West
@@ -614,32 +617,32 @@ http_interactions:
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/accessPolicies","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"vaults/accessPolicies","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-10-01","2015-06-01","2014-12-19-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"deletedVaults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01","2014-12-19-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"deletedVaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-10-01"]},{"resourceType":"locations/deletedVaults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations/deletedVaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
         Central US","West Europe","Southeast Asia","Japan East","West Central US"],"apiVersions":["2016-04-01"]},{"resourceType":"webServices","locations":["South
         Central US","West Europe","Southeast Asia","Japan East","East US 2","West
         Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"operations","locations":["South
@@ -665,97 +668,97 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"networkWatchers/lenses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"networkWatchers/lenses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","West
         US 2","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
@@ -846,7 +849,7 @@ http_interactions:
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
         West","Korea Central","Korea South"],"apiVersions":["2017-07-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ResourceHealth","namespace":"Microsoft.ResourceHealth","authorizations":[{"applicationId":"8bdebf23-c0fe-4187-a378-717ad86f6a53","roleDefinitionId":"cc026344-c8b1-4561-83ba-59eba84b27cc"}],"resourceTypes":[{"resourceType":"availabilityStatuses","locations":[],"apiVersions":["2017-07-01","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"notifications","locations":["Australia
-        Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Security","namespace":"Microsoft.Security","authorization":{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
+        Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Security","namespace":"Microsoft.Security","authorizations":[{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},{"applicationId":"fc780465-2017-40d4-a0c5-307022471b92"}],"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatuses","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/virtualMachines","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/endpoints","locations":["Central
@@ -898,565 +901,595 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Central India","South
         India"],"apiVersions":["2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Sql","namespace":"Microsoft.Sql","authorizations":[{"applicationId":"e4ab13ed-33cb-41b4-9140-6e264582cf85","roleDefinitionId":"ec3ddc95-44dc-47a2-9926-5e9f5ffd44ec"},{"applicationId":"0130cc9f-7ac5-4026-bd5f-80a08a54e6d9","roleDefinitionId":"45e8abf8-0ec4-44f3-9c37-cff4f7779302"},{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},{"applicationId":"76c7f279-7959-468f-8943-3954880e0d8c","roleDefinitionId":"7f7513a8-73f9-4c5f-97a2-c41f0ea783ef"}],"resourceTypes":[{"resourceType":"operations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/capabilities","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/databaseAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/databaseOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverKeyOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/keys","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/encryptionProtector","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/usages","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01","2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/communicationLinks","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administrators","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administratorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/restorableDroppedDatabases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recoverableDatabases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/geoBackupPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/importExportOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/operationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/backupLongTermRetentionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/automaticTuning","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/automaticTuning","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/databases/transparentDataEncryption","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recommendedElasticPools","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/auditingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/connectionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/connectionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies/rules","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/securityAlertPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/securityAlertPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/auditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/extendedAuditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/elasticpools","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-09-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/jobAgentOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/jobAgentAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/disasterRecoveryConfiguration","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/dnsAliases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/failoverGroups","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/virtualNetworkRules","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/virtualNetworkRulesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/virtualNetworkRulesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/databaseRestoreAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metricDefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/aggregatedDatabaseMetrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metricdefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries/queryText","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPools/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/extensions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPoolEstimates","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditRecords","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentScans","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/vulnerabilityAssessments","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessment","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/syncGroups","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups/syncMembers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/syncAgents","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"managedInstances/administrators","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/databases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metricDefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/administratorAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/administratorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncMemberOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncAgentOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncDatabaseIds","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorizations":[{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},{"applicationId":"e406a681-f3d4-42a8-90b6-c2b029497af1"}],"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/capabilities","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/databaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"locations/databaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverKeyOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/keys","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/encryptionProtector","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01","2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/communicationLinks","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/restorableDroppedDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recoverableDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/geoBackupPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/importExportOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/operationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/backupLongTermRetentionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/databases/transparentDataEncryption","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recommendedElasticPools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies/rules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/extendedAuditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/elasticPoolAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/elasticPoolOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/elasticpools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-09-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/jobAgentOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/jobAgentAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/disasterRecoveryConfiguration","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/dnsAliases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/failoverGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/virtualNetworkRules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/virtualNetworkRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/virtualNetworkRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/databaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/aggregatedDatabaseMetrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metricdefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries/queryText","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPools/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/extensions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPoolEstimates","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditRecords","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentScans","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/vulnerabilityAssessments","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessment","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/syncGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups/syncMembers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/syncAgents","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"managedInstances/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/administratorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncMemberOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncAgentOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncDatabaseIds","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/longTermRetentionPolicyOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionPolicyAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionBackupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionBackupAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorizations":[{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},{"applicationId":"e406a681-f3d4-42a8-90b6-c2b029497af1"}],"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
@@ -1795,12 +1828,12 @@ http_interactions:
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","Canada Central","Canada East","UK South","UK West","West US 2","West
-        Central US","South India","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","South India","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","South India","Canada Central","Canada East","UK South","UK West","West
-        US 2","West Central US","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Capacity","namespace":"Microsoft.Capacity","authorization":{"applicationId":"4d0ad6c7-f6c3-46d8-ab0d-1406d5e6c86b","roleDefinitionId":"FD9C0A9A-4DB9-4F41-8A61-98385DEB6E2D"},"resourceTypes":[{"resourceType":"resources","locations":["South
+        US 2","West Central US","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Capacity","namespace":"Microsoft.Capacity","authorization":{"applicationId":"4d0ad6c7-f6c3-46d8-ab0d-1406d5e6c86b","roleDefinitionId":"FD9C0A9A-4DB9-4F41-8A61-98385DEB6E2D"},"resourceTypes":[{"resourceType":"resources","locations":["South
         Central US"],"apiVersions":["2017-11-01"]},{"resourceType":"reservationOrders","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/reservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/reservations/revisions","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"catalogs","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"appliedReservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"checkOffers","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"checkScopes","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"calculatePrice","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/calculateRefund","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/return","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/split","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/merge","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"validateReservationOrder","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/availableScopes","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Cdn","namespace":"Microsoft.Cdn","resourceTypes":[{"resourceType":"profiles","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
@@ -1876,9 +1909,9 @@ http_interactions:
         2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/updateAccountsCreationSettings","locations":["West
         US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/accountsCreationSettings","locations":["West
         US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2016-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Commerce","namespace":"Microsoft.Commerce","resourceTypes":[{"resourceType":"UsageAggregates","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]},{"resourceType":"RateCard","locations":[],"apiVersions":["2016-08-31-preview","2015-06-01-preview","2015-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Consumption","namespace":"Microsoft.Consumption","resourceTypes":[{"resourceType":"ReservationSummaries","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationTransactions","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Balances","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Marketplaces","locations":[],"apiVersions":["2018-01-31"]},{"resourceType":"Pricesheets","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationDetails","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Budgets","locations":[],"apiVersions":["2018-01-31","2017-12-30-preview"]},{"resourceType":"Terms","locations":[],"apiVersions":["2018-01-31","2017-12-30-preview"]},{"resourceType":"UsageDetails","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview","2017-04-24-preview"]},{"resourceType":"Operations","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview","2017-04-24-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerInstance","namespace":"Microsoft.ContainerInstance","resourceTypes":[{"resourceType":"containerGroups","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/usages","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/operations","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/operations","locations":["West
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
         US"],"apiVersions":["2016-04-08"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.CustomerInsights","namespace":"Microsoft.CustomerInsights","authorization":{"applicationId":"38c77d00-5fcb-4cce-9d93-af4738258e3c","roleDefinitionId":"E006F9C7-F333-477C-8AD6-1F3A9FE87F55"},"resourceTypes":[{"resourceType":"hubs","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/profiles","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/interactions","locations":["East
@@ -1895,7 +1928,9 @@ http_interactions:
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"operations","locations":["East
         US 2"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Databricks","namespace":"Microsoft.Databricks","authorizations":[{"applicationId":"d9327919-6775-4843-9037-3fb0fb0473cb","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},{"applicationId":"2ff814a6-3304-4ab8-85cb-cd0e6f879c1d","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"}],"resourceTypes":[{"resourceType":"workspaces","locations":["West
         US","East US 2","West Europe","East US","North Europe","Southeast Asia","East
-        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]},{"resourceType":"locations","locations":["West
+        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2017-09-01-preview"]},{"resourceType":"workspaces/virtualNetworkPeerings","locations":["West
+        US","East US 2","West Europe","North Europe","East US","Southeast Asia","East
+        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01"]},{"resourceType":"locations","locations":["West
         US","East US 2","West Europe","North Europe","East US","Southeast Asia"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
         US","East US 2","West Europe","East US","North Europe","Southeast Asia","East
         Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataCatalog","namespace":"Microsoft.DataCatalog","resourceTypes":[{"resourceType":"catalogs","locations":["East
@@ -1919,23 +1954,26 @@ http_interactions:
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers/listSasTokens","locations":["East
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataLakeStore","namespace":"Microsoft.DataLakeStore","authorization":{"applicationId":"e9f49c6b-5ce5-44c8-925d-015017e9f7ad","roleDefinitionId":"17eb9cca-f08a-4499-b2d3-852d175f614f"},"resourceTypes":[{"resourceType":"accounts","locations":["East
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/firewallRules","locations":["East
-        US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataMigration","namespace":"Microsoft.DataMigration","authorization":{"applicationId":"a4bad4aa-bf02-4631-9f78-a64ffdba8150","roleDefinitionId":"b831a21d-db98-4760-89cb-bef871952df1","managedByRoleDefinitionId":"6256fb55-9e59-4018-a9e1-76b11c0a4c89"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services/projects","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationStatuses","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
+        US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataMigration","namespace":"Microsoft.DataMigration","authorization":{"applicationId":"a4bad4aa-bf02-4631-9f78-a64ffdba8150","roleDefinitionId":"b831a21d-db98-4760-89cb-bef871952df1","managedByRoleDefinitionId":"6256fb55-9e59-4018-a9e1-76b11c0a4c89"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services/projects","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationStatuses","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
-        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/recoverableServers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
@@ -1959,7 +1997,10 @@ http_interactions:
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
-        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/recoverableServers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
@@ -2015,12 +2056,7 @@ http_interactions:
         US 2","East US","West US","Central US","East US 2","West Central US","West
         Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
         US 2","East US","West US","Central US","East US 2","West Central US","West
-        Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","West
-        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
-        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
-        India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/consumergroups","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/disasterrecoveryconfigs","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
         US 2","South Central US","Central US","Australia Southeast","Central India","West
         Central US","West US 2","Canada East","Canada Central","Brazil South","UK
         South","UK West","East Asia","Australia East","Japan East","Japan West","North
@@ -2131,7 +2167,7 @@ http_interactions:
         West","Japan East","East Asia","Southeast Asia","West Europe","North Europe","East
         US","West US","Australia East","Australia Southeast","Central US","Brazil
         South","Central India","West India","South India","South Central US","Canada
-        Central","Canada East","West Central US","West US 2"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
+        Central","Canada East","West Central US","West US 2"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-05","2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
         Central US","East US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"operations","locations":["West
         Central US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
         Central US","East US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.PolicyInsights","namespace":"Microsoft.PolicyInsights","authorization":{"applicationId":"1d78a85d-813d-46f0-b496-dd72f50a3ec0","roleDefinitionId":"63d2b225-4c34-4641-8768-21a1f7c68ce8"},"resourceTypes":[{"resourceType":"policyEvents","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"policyStates","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
@@ -2163,12 +2199,12 @@ http_interactions:
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
         Central US","South Central US","North Europe","West Europe","East Asia","Southeast
         Asia","West US","East US","Japan West","Japan East","Brazil South","Central
         US","East US 2","Australia East","Australia Southeast","South India","Central
@@ -2208,40 +2244,50 @@ http_interactions:
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/clusterVersions","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"clusters/applications","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operations","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/clusterVersions","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/environments","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operations","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
         Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applianceDefinitions","locations":["West
         Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applications","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
-        Central US"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
+        Central US"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
         US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
         US","Canada Central","Canada East","Central US","East US 2","UK South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups","locations":["West
         US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
@@ -2332,7 +2378,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:03 GMT
+  recorded_at: Mon, 12 Mar 2018 10:25:19 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1?api-version=2017-12-01
@@ -2349,7 +2395,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1ODEsIm5iZiI6MTUyMDQ1MzU4MSwiZXhwIjoxNTIwNDU3NDgxLCJhaW8iOiJZMk5nWURqdmVlYldiaDNsUkp1Sm9uZTFpN2ZQQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiejQ5SjdhMExRa3FGeG1FNXlGb0FBQSIsInZlciI6IjEuMCJ9.pBpmvta3GhE-q7jz0GPLGkXKVgiDCQmGLnwpg3-wQ0HBDJ79kKhZfOwiPFcXFZG8heoad_YWYcnVjQuMY9hsV3yTXGMgJlVBpYH5gUh9PiCSHPQTfdkX3Nxwv5vz8rLkwd_HH8UUMN96AkGpoSvbVxA3aDSC0sOYaHElhO6XOllD5CGuui1T3gpptUjj18PRQnCC_cZbqLJETdQT4S0IoEGz6-FNlt45pPg3rJUK1WFQa9rfWPsd3XCRQEvZjeaj4zeYRB8-bNe8dbrcitRhVocQWHmFKlQ1i7q2b840YCbG3udPoSJ0hPJqHcFexjzEMfn_vJeiNLETBncPUYfbPw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAwMDgsIm5iZiI6MTUyMDg1MDAwOCwiZXhwIjoxNTIwODUzOTA4LCJhaW8iOiJZMk5nWUpETSt4NVdsaFY1SWtqNTBsMHhMc1pwQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidXJVTmZ1X0tia2FsWkxWNHdkUUFBQSIsInZlciI6IjEuMCJ9.JZgL7n0qXHgKoO66Qr6QO-NQbdn-8kjLG3DkmcI-u8dGoFGPi7UW9xEJtKwYw5MqnpnItbSeHhmsDOQC8wPjV4dZ3gTEYehW8FpTsXkhOGy7EkeTmgpdegs96aOG7ttypkyxM9mQ3jk1x_NBm8c1jf4OssGN-WwXR7zIsmK0MHz0d2wCpu054SParX1ExHX-fgGDTMbC3h1RoXr28hJrVL5Z_7f2LbHWnkPtcUepfybilV7caVa3mgvWt3PO3cqwjE3p47pazCE-RoA9qqZqDhprJ7P3qHG6S9FBX9VvT1XReMG_k1U76MBJ-jwLUYucRgKrB5UDq1U83qgGrwiipg
   response:
     status:
       code: 200
@@ -2368,26 +2414,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/LowCostGet3Min;4735,Microsoft.Compute/LowCostGet30Min;37881
+      - Microsoft.Compute/LowCostGet3Min;4745,Microsoft.Compute/LowCostGet30Min;37810
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344652126238
       X-Ms-Request-Id:
-      - b6060594-8221-4a19-956b-a6ca4037c64d
+      - 82e50c79-4765-4ed7-ad8d-9ba3a28da399
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14973'
+      - '14983'
       X-Ms-Correlation-Request-Id:
-      - 7de84c7e-9ab1-4e3d-b9e2-f5a50eb1a1ce
+      - 05daa20c-f68c-404d-a099-16a5a22fbd2d
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201804Z:7de84c7e-9ab1-4e3d-b9e2-f5a50eb1a1ce
+      - WESTEUROPE:20180312T102515Z:05daa20c-f68c-404d-a099-16a5a22fbd2d
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:18:03 GMT
+      - Mon, 12 Mar 2018 10:25:15 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"796c5bcc-338a-448d-b61c-165279a7fb3e\",\r\n
@@ -2419,7 +2465,7 @@ http_interactions:
         \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1\",\r\n
         \ \"name\": \"miqazure-centos1\"\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:04 GMT
+  recorded_at: Mon, 12 Mar 2018 10:25:20 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611?api-version=2018-01-01
@@ -2436,7 +2482,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1ODEsIm5iZiI6MTUyMDQ1MzU4MSwiZXhwIjoxNTIwNDU3NDgxLCJhaW8iOiJZMk5nWURqdmVlYldiaDNsUkp1Sm9uZTFpN2ZQQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiejQ5SjdhMExRa3FGeG1FNXlGb0FBQSIsInZlciI6IjEuMCJ9.pBpmvta3GhE-q7jz0GPLGkXKVgiDCQmGLnwpg3-wQ0HBDJ79kKhZfOwiPFcXFZG8heoad_YWYcnVjQuMY9hsV3yTXGMgJlVBpYH5gUh9PiCSHPQTfdkX3Nxwv5vz8rLkwd_HH8UUMN96AkGpoSvbVxA3aDSC0sOYaHElhO6XOllD5CGuui1T3gpptUjj18PRQnCC_cZbqLJETdQT4S0IoEGz6-FNlt45pPg3rJUK1WFQa9rfWPsd3XCRQEvZjeaj4zeYRB8-bNe8dbrcitRhVocQWHmFKlQ1i7q2b840YCbG3udPoSJ0hPJqHcFexjzEMfn_vJeiNLETBncPUYfbPw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAwMDgsIm5iZiI6MTUyMDg1MDAwOCwiZXhwIjoxNTIwODUzOTA4LCJhaW8iOiJZMk5nWUpETSt4NVdsaFY1SWtqNTBsMHhMc1pwQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidXJVTmZ1X0tia2FsWkxWNHdkUUFBQSIsInZlciI6IjEuMCJ9.JZgL7n0qXHgKoO66Qr6QO-NQbdn-8kjLG3DkmcI-u8dGoFGPi7UW9xEJtKwYw5MqnpnItbSeHhmsDOQC8wPjV4dZ3gTEYehW8FpTsXkhOGy7EkeTmgpdegs96aOG7ttypkyxM9mQ3jk1x_NBm8c1jf4OssGN-WwXR7zIsmK0MHz0d2wCpu054SParX1ExHX-fgGDTMbC3h1RoXr28hJrVL5Z_7f2LbHWnkPtcUepfybilV7caVa3mgvWt3PO3cqwjE3p47pazCE-RoA9qqZqDhprJ7P3qHG6S9FBX9VvT1XReMG_k1U76MBJ-jwLUYucRgKrB5UDq1U83qgGrwiipg
   response:
     status:
       code: 200
@@ -2457,22 +2503,22 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - dea4f723-5af5-43fb-b179-31bd18347bab
+      - 4dd9c11e-8bb3-49b9-8df9-e9ee1bdf7e89
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14984'
+      - '14988'
       X-Ms-Correlation-Request-Id:
-      - 5057e583-f5d1-4453-9b93-27a49cc727ce
+      - e0d9104d-db22-4aa1-b28b-06a3a918bdf8
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201804Z:5057e583-f5d1-4453-9b93-27a49cc727ce
+      - WESTEUROPE:20180312T102516Z:e0d9104d-db22-4aa1-b28b-06a3a918bdf8
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:18:04 GMT
+      - Mon, 12 Mar 2018 10:25:16 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"miqazure-centos1611\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611\",\r\n
@@ -2494,10 +2540,10 @@ http_interactions:
         \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
         \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:04 GMT
+  recorded_at: Mon, 12 Mar 2018 10:25:21 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups/miq-azure-test1?api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1/instanceView?api-version=2017-12-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2511,60 +2557,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1ODEsIm5iZiI6MTUyMDQ1MzU4MSwiZXhwIjoxNTIwNDU3NDgxLCJhaW8iOiJZMk5nWURqdmVlYldiaDNsUkp1Sm9uZTFpN2ZQQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiejQ5SjdhMExRa3FGeG1FNXlGb0FBQSIsInZlciI6IjEuMCJ9.pBpmvta3GhE-q7jz0GPLGkXKVgiDCQmGLnwpg3-wQ0HBDJ79kKhZfOwiPFcXFZG8heoad_YWYcnVjQuMY9hsV3yTXGMgJlVBpYH5gUh9PiCSHPQTfdkX3Nxwv5vz8rLkwd_HH8UUMN96AkGpoSvbVxA3aDSC0sOYaHElhO6XOllD5CGuui1T3gpptUjj18PRQnCC_cZbqLJETdQT4S0IoEGz6-FNlt45pPg3rJUK1WFQa9rfWPsd3XCRQEvZjeaj4zeYRB8-bNe8dbrcitRhVocQWHmFKlQ1i7q2b840YCbG3udPoSJ0hPJqHcFexjzEMfn_vJeiNLETBncPUYfbPw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14983'
-      X-Ms-Request-Id:
-      - e57abf1c-9261-4dea-9feb-f381aa84066c
-      X-Ms-Correlation-Request-Id:
-      - e57abf1c-9261-4dea-9feb-f381aa84066c
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201805Z:e57abf1c-9261-4dea-9feb-f381aa84066c
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:18:05 GMT
-      Content-Length:
-      - '183'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1","name":"miq-azure-test1","location":"eastus","properties":{"provisioningState":"Succeeded"}}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:05 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute/locations/eastus/vmSizes?api-version=2017-12-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1ODEsIm5iZiI6MTUyMDQ1MzU4MSwiZXhwIjoxNTIwNDU3NDgxLCJhaW8iOiJZMk5nWURqdmVlYldiaDNsUkp1Sm9uZTFpN2ZQQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiejQ5SjdhMExRa3FGeG1FNXlGb0FBQSIsInZlciI6IjEuMCJ9.pBpmvta3GhE-q7jz0GPLGkXKVgiDCQmGLnwpg3-wQ0HBDJ79kKhZfOwiPFcXFZG8heoad_YWYcnVjQuMY9hsV3yTXGMgJlVBpYH5gUh9PiCSHPQTfdkX3Nxwv5vz8rLkwd_HH8UUMN96AkGpoSvbVxA3aDSC0sOYaHElhO6XOllD5CGuui1T3gpptUjj18PRQnCC_cZbqLJETdQT4S0IoEGz6-FNlt45pPg3rJUK1WFQa9rfWPsd3XCRQEvZjeaj4zeYRB8-bNe8dbrcitRhVocQWHmFKlQ1i7q2b840YCbG3udPoSJ0hPJqHcFexjzEMfn_vJeiNLETBncPUYfbPw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAwMDgsIm5iZiI6MTUyMDg1MDAwOCwiZXhwIjoxNTIwODUzOTA4LCJhaW8iOiJZMk5nWUpETSt4NVdsaFY1SWtqNTBsMHhMc1pwQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidXJVTmZ1X0tia2FsWkxWNHdkUUFBQSIsInZlciI6IjEuMCJ9.JZgL7n0qXHgKoO66Qr6QO-NQbdn-8kjLG3DkmcI-u8dGoFGPi7UW9xEJtKwYw5MqnpnItbSeHhmsDOQC8wPjV4dZ3gTEYehW8FpTsXkhOGy7EkeTmgpdegs96aOG7ttypkyxM9mQ3jk1x_NBm8c1jf4OssGN-WwXR7zIsmK0MHz0d2wCpu054SParX1ExHX-fgGDTMbC3h1RoXr28hJrVL5Z_7f2LbHWnkPtcUepfybilV7caVa3mgvWt3PO3cqwjE3p47pazCE-RoA9qqZqDhprJ7P3qHG6S9FBX9VvT1XReMG_k1U76MBJ-jwLUYucRgKrB5UDq1U83qgGrwiipg
   response:
     status:
       code: 200
@@ -2583,26 +2576,156 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/LowCostGet3Min;4733,Microsoft.Compute/LowCostGet30Min;37879
+      - Microsoft.Compute/GetInstanceView3Min;4797,Microsoft.Compute/GetInstanceView30Min;23765
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344652126238
       X-Ms-Request-Id:
-      - e83bc32f-d8c8-4c68-83ad-f63570c7f9f8
+      - 254c436d-fca3-41ac-ae6e-a3e1b41bf143
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14973'
+      - '14985'
       X-Ms-Correlation-Request-Id:
-      - 38729ebe-7f40-4628-84be-c7db53551a5f
+      - d0b7f30b-7cc2-40cf-a485-fc4ffd50ad6f
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201805Z:38729ebe-7f40-4628-84be-c7db53551a5f
+      - WESTEUROPE:20180312T102528Z:d0b7f30b-7cc2-40cf-a485-fc4ffd50ad6f
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:18:04 GMT
+      - Mon, 12 Mar 2018 10:25:27 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"platformUpdateDomain\": 0,\r\n  \"platformFaultDomain\": 0,\r\n
+        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
+        [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
+        \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
+        \"Failed to fetch the VM status.\",\r\n        \"time\": \"2018-03-12T10:25:17+00:00\"\r\n
+        \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"miqazure-centos1\",\r\n
+        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
+        succeeded\",\r\n          \"time\": \"2016-06-22T21:18:47.2011229+00:00\"\r\n
+        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
+        \"https://miqazuretest14047.blob.core.windows.net/bootdiagnostics-miqazurec-796c5bcc-338a-448d-b61c-165279a7fb3e/miqazure-centos1.796c5bcc-338a-448d-b61c-165279a7fb3e.screenshot.bmp\",\r\n
+        \   \"serialConsoleLogBlobUri\": \"https://miqazuretest14047.blob.core.windows.net/bootdiagnostics-miqazurec-796c5bcc-338a-448d-b61c-165279a7fb3e/miqazure-centos1.796c5bcc-338a-448d-b61c-165279a7fb3e.serialconsole.log\"\r\n
+        \ },\r\n  \"extensions\": [\r\n    {\r\n      \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n
+        \   }\r\n  ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n
+        \     \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n
+        \     \"time\": \"2016-06-22T21:18:47.2636196+00:00\"\r\n    },\r\n    {\r\n
+        \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
+        \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 10:25:32 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups/miq-azure-test1?api-version=2017-08-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAwMDgsIm5iZiI6MTUyMDg1MDAwOCwiZXhwIjoxNTIwODUzOTA4LCJhaW8iOiJZMk5nWUpETSt4NVdsaFY1SWtqNTBsMHhMc1pwQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidXJVTmZ1X0tia2FsWkxWNHdkUUFBQSIsInZlciI6IjEuMCJ9.JZgL7n0qXHgKoO66Qr6QO-NQbdn-8kjLG3DkmcI-u8dGoFGPi7UW9xEJtKwYw5MqnpnItbSeHhmsDOQC8wPjV4dZ3gTEYehW8FpTsXkhOGy7EkeTmgpdegs96aOG7ttypkyxM9mQ3jk1x_NBm8c1jf4OssGN-WwXR7zIsmK0MHz0d2wCpu054SParX1ExHX-fgGDTMbC3h1RoXr28hJrVL5Z_7f2LbHWnkPtcUepfybilV7caVa3mgvWt3PO3cqwjE3p47pazCE-RoA9qqZqDhprJ7P3qHG6S9FBX9VvT1XReMG_k1U76MBJ-jwLUYucRgKrB5UDq1U83qgGrwiipg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14987'
+      X-Ms-Request-Id:
+      - 72769874-5307-4593-92d4-7d6e74d39ffc
+      X-Ms-Correlation-Request-Id:
+      - 72769874-5307-4593-92d4-7d6e74d39ffc
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T102528Z:72769874-5307-4593-92d4-7d6e74d39ffc
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 10:25:27 GMT
+      Content-Length:
+      - '183'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1","name":"miq-azure-test1","location":"eastus","properties":{"provisioningState":"Succeeded"}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 10:25:33 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute/locations/eastus/vmSizes?api-version=2017-12-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAwMDgsIm5iZiI6MTUyMDg1MDAwOCwiZXhwIjoxNTIwODUzOTA4LCJhaW8iOiJZMk5nWUpETSt4NVdsaFY1SWtqNTBsMHhMc1pwQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidXJVTmZ1X0tia2FsWkxWNHdkUUFBQSIsInZlciI6IjEuMCJ9.JZgL7n0qXHgKoO66Qr6QO-NQbdn-8kjLG3DkmcI-u8dGoFGPi7UW9xEJtKwYw5MqnpnItbSeHhmsDOQC8wPjV4dZ3gTEYehW8FpTsXkhOGy7EkeTmgpdegs96aOG7ttypkyxM9mQ3jk1x_NBm8c1jf4OssGN-WwXR7zIsmK0MHz0d2wCpu054SParX1ExHX-fgGDTMbC3h1RoXr28hJrVL5Z_7f2LbHWnkPtcUepfybilV7caVa3mgvWt3PO3cqwjE3p47pazCE-RoA9qqZqDhprJ7P3qHG6S9FBX9VvT1XReMG_k1U76MBJ-jwLUYucRgKrB5UDq1U83qgGrwiipg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/LowCostGet3Min;4741,Microsoft.Compute/LowCostGet30Min;37806
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344652126238
+      X-Ms-Request-Id:
+      - e504d13c-9366-4f50-b221-d7a002df42c8
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14985'
+      X-Ms-Correlation-Request-Id:
+      - 305ebea8-5b8d-462d-9f70-208e8f66aea5
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T102529Z:305ebea8-5b8d-462d-9f70-208e8f66aea5
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 10:25:28 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"Standard_B1ms\",\r\n
@@ -3079,6 +3202,12 @@ http_interactions:
         \   },\r\n    {\r\n      \"name\": \"Standard_F72s_v2\",\r\n      \"numberOfCores\":
         72,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
         589824,\r\n      \"memoryInMB\": 147456,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_L8s_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1811981,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_L16s_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        3623962,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
         \   },\r\n    {\r\n      \"name\": \"Standard_ND6s\",\r\n      \"numberOfCores\":
         6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
         344064,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 12\r\n
@@ -3105,7 +3234,7 @@ http_interactions:
         391168,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
         \   }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:05 GMT
+  recorded_at: Mon, 12 Mar 2018 10:25:34 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950?api-version=2017-08-01
@@ -3122,7 +3251,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1ODEsIm5iZiI6MTUyMDQ1MzU4MSwiZXhwIjoxNTIwNDU3NDgxLCJhaW8iOiJZMk5nWURqdmVlYldiaDNsUkp1Sm9uZTFpN2ZQQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiejQ5SjdhMExRa3FGeG1FNXlGb0FBQSIsInZlciI6IjEuMCJ9.pBpmvta3GhE-q7jz0GPLGkXKVgiDCQmGLnwpg3-wQ0HBDJ79kKhZfOwiPFcXFZG8heoad_YWYcnVjQuMY9hsV3yTXGMgJlVBpYH5gUh9PiCSHPQTfdkX3Nxwv5vz8rLkwd_HH8UUMN96AkGpoSvbVxA3aDSC0sOYaHElhO6XOllD5CGuui1T3gpptUjj18PRQnCC_cZbqLJETdQT4S0IoEGz6-FNlt45pPg3rJUK1WFQa9rfWPsd3XCRQEvZjeaj4zeYRB8-bNe8dbrcitRhVocQWHmFKlQ1i7q2b840YCbG3udPoSJ0hPJqHcFexjzEMfn_vJeiNLETBncPUYfbPw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAwMDgsIm5iZiI6MTUyMDg1MDAwOCwiZXhwIjoxNTIwODUzOTA4LCJhaW8iOiJZMk5nWUpETSt4NVdsaFY1SWtqNTBsMHhMc1pwQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidXJVTmZ1X0tia2FsWkxWNHdkUUFBQSIsInZlciI6IjEuMCJ9.JZgL7n0qXHgKoO66Qr6QO-NQbdn-8kjLG3DkmcI-u8dGoFGPi7UW9xEJtKwYw5MqnpnItbSeHhmsDOQC8wPjV4dZ3gTEYehW8FpTsXkhOGy7EkeTmgpdegs96aOG7ttypkyxM9mQ3jk1x_NBm8c1jf4OssGN-WwXR7zIsmK0MHz0d2wCpu054SParX1ExHX-fgGDTMbC3h1RoXr28hJrVL5Z_7f2LbHWnkPtcUepfybilV7caVa3mgvWt3PO3cqwjE3p47pazCE-RoA9qqZqDhprJ7P3qHG6S9FBX9VvT1XReMG_k1U76MBJ-jwLUYucRgKrB5UDq1U83qgGrwiipg
   response:
     status:
       code: 200
@@ -3139,26 +3268,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14975'
+      - '14984'
       X-Ms-Request-Id:
-      - 2a0d6442-e572-4151-af6d-3e698c814f19
+      - 402c703c-4eb5-4a10-8378-ecb4d72fdf07
       X-Ms-Correlation-Request-Id:
-      - 2a0d6442-e572-4151-af6d-3e698c814f19
+      - 402c703c-4eb5-4a10-8378-ecb4d72fdf07
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201806Z:2a0d6442-e572-4151-af6d-3e698c814f19
+      - WESTEUROPE:20180312T102534Z:402c703c-4eb5-4a10-8378-ecb4d72fdf07
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:18:05 GMT
+      - Mon, 12 Mar 2018 10:25:34 GMT
       Content-Length:
       - '5882'
     body:
       encoding: ASCII-8BIT
       string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950","name":"OpenLogic.CentOSbased71-20160221104950","properties":{"parameters":{"location":{"type":"String","value":"eastus"},"virtualMachineName":{"type":"String","value":"miqazure-centos1"},"virtualMachineSize":{"type":"String","value":"Basic_A0"},"adminUsername":{"type":"String","value":"dberger"},"storageAccountName":{"type":"String","value":"miqazuretest14047"},"virtualNetworkName":{"type":"String","value":"miq-azure-test1"},"networkInterfaceName":{"type":"String","value":"miqazure-centos1611"},"networkSecurityGroupName":{"type":"String","value":"miqazure-centos1"},"adminPassword":{"type":"SecureString"},"availabilitySetName":{"type":"String","value":"miqazure-availset-east"},"availabilitySetPlatformFaultDomainCount":{"type":"String","value":"3"},"availabilitySetPlatformUpdateDomainCount":{"type":"String","value":"5"},"diagnosticsStorageAccountName":{"type":"String","value":"miqazuretest14047"},"diagnosticsStorageAccountId":{"type":"String","value":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047"},"subnetName":{"type":"String","value":"default"},"publicIpAddressName":{"type":"String","value":"miqazure-centos1"},"publicIpAddressType":{"type":"String","value":"Dynamic"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-03-21T16:55:03.9867512Z","duration":"PT5M11.803863S","correlationId":"c3daf7bc-96ed-4987-89ba-ed85952a355c","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]},{"resourceType":"virtualMachines/extensions","locations":["eastus"]},{"resourceType":"availabilitySets","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkInterfaces","locations":["eastus"]},{"resourceType":"publicIpAddresses","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miqazure-centos1611"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/miqazure-availset-east","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"miqazure-availset-east"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miqazure-centos1"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miqazure-centos1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","actionName":"listKeys","apiVersion":"2015-05-01-preview"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miqazure-centos1/Microsoft.Insights.VMDiagnosticsSettings"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miqazure-centos1","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miqazure-centos1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miqazure-centos1"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miqazure-centos1611"}],"outputs":{"adminUsername":{"type":"String","value":"dberger"}},"outputResources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/miqazure-availset-east"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1/extensions/Microsoft.Insights.VMDiagnosticsSettings"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miqazure-centos1"}]}}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:06 GMT
+  recorded_at: Mon, 12 Mar 2018 10:25:39 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250?api-version=2017-08-01
@@ -3175,7 +3304,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1ODEsIm5iZiI6MTUyMDQ1MzU4MSwiZXhwIjoxNTIwNDU3NDgxLCJhaW8iOiJZMk5nWURqdmVlYldiaDNsUkp1Sm9uZTFpN2ZQQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiejQ5SjdhMExRa3FGeG1FNXlGb0FBQSIsInZlciI6IjEuMCJ9.pBpmvta3GhE-q7jz0GPLGkXKVgiDCQmGLnwpg3-wQ0HBDJ79kKhZfOwiPFcXFZG8heoad_YWYcnVjQuMY9hsV3yTXGMgJlVBpYH5gUh9PiCSHPQTfdkX3Nxwv5vz8rLkwd_HH8UUMN96AkGpoSvbVxA3aDSC0sOYaHElhO6XOllD5CGuui1T3gpptUjj18PRQnCC_cZbqLJETdQT4S0IoEGz6-FNlt45pPg3rJUK1WFQa9rfWPsd3XCRQEvZjeaj4zeYRB8-bNe8dbrcitRhVocQWHmFKlQ1i7q2b840YCbG3udPoSJ0hPJqHcFexjzEMfn_vJeiNLETBncPUYfbPw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAwMDgsIm5iZiI6MTUyMDg1MDAwOCwiZXhwIjoxNTIwODUzOTA4LCJhaW8iOiJZMk5nWUpETSt4NVdsaFY1SWtqNTBsMHhMc1pwQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidXJVTmZ1X0tia2FsWkxWNHdkUUFBQSIsInZlciI6IjEuMCJ9.JZgL7n0qXHgKoO66Qr6QO-NQbdn-8kjLG3DkmcI-u8dGoFGPi7UW9xEJtKwYw5MqnpnItbSeHhmsDOQC8wPjV4dZ3gTEYehW8FpTsXkhOGy7EkeTmgpdegs96aOG7ttypkyxM9mQ3jk1x_NBm8c1jf4OssGN-WwXR7zIsmK0MHz0d2wCpu054SParX1ExHX-fgGDTMbC3h1RoXr28hJrVL5Z_7f2LbHWnkPtcUepfybilV7caVa3mgvWt3PO3cqwjE3p47pazCE-RoA9qqZqDhprJ7P3qHG6S9FBX9VvT1XReMG_k1U76MBJ-jwLUYucRgKrB5UDq1U83qgGrwiipg
   response:
     status:
       code: 200
@@ -3192,29 +3321,29 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14981'
+      - '14986'
       X-Ms-Request-Id:
-      - 4de02c3b-2756-4fff-aca8-f53222fae28e
+      - 19399830-0a50-42b3-af99-8bf048887d67
       X-Ms-Correlation-Request-Id:
-      - 4de02c3b-2756-4fff-aca8-f53222fae28e
+      - 19399830-0a50-42b3-af99-8bf048887d67
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201806Z:4de02c3b-2756-4fff-aca8-f53222fae28e
+      - WESTEUROPE:20180312T102535Z:19399830-0a50-42b3-af99-8bf048887d67
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:18:06 GMT
+      - Mon, 12 Mar 2018 10:25:35 GMT
       Content-Length:
       - '6266'
     body:
       encoding: ASCII-8BIT
       string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250","name":"RedHat.RedHatEnterpriseLinux72-20160218112250","properties":{"parameters":{"location":{"type":"String","value":"eastus"},"virtualMachineName":{"type":"String","value":"miq-test-rhel1"},"virtualMachineSize":{"type":"String","value":"Basic_A0"},"adminUsername":{"type":"String","value":"dberger"},"storageAccountName":{"type":"String","value":"miqazuretest18686"},"virtualNetworkName":{"type":"String","value":"miq-azure-test1"},"networkInterfaceName":{"type":"String","value":"miq-test-rhel1390"},"networkSecurityGroupName":{"type":"String","value":"miq-test-rhel1"},"adminPassword":{"type":"SecureString"},"storageAccountType":{"type":"String","value":"Standard_LRS"},"diagnosticsStorageAccountName":{"type":"String","value":"miqazuretest18686"},"diagnosticsStorageAccountId":{"type":"String","value":"Microsoft.Storage/storageAccounts/miqazuretest18686"},"diagnosticsStorageAccountType":{"type":"String","value":"Standard_LRS"},"addressPrefix":{"type":"String","value":"10.16.0.0/16"},"subnetName":{"type":"String","value":"default"},"subnetPrefix":{"type":"String","value":"10.16.0.0/24"},"publicIpAddressName":{"type":"String","value":"miq-test-rhel1"},"publicIpAddressType":{"type":"String","value":"Dynamic"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-03-18T17:28:57.6212521Z","duration":"PT6M6.1062402S","correlationId":"3222315f-f31e-4ee7-b405-4d40dfd500a3","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]},{"resourceType":"virtualMachines/extensions","locations":["eastus"]}]},{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]},{"resourceType":"publicIpAddresses","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-rhel1390"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-rhel1"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-rhel1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686","actionName":"listKeys","apiVersion":"2015-05-01-preview"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-rhel1/Microsoft.Insights.VMDiagnosticsSettings"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"miq-azure-test1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-rhel1","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-rhel1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-rhel1"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-rhel1390"}],"outputs":{"adminUsername":{"type":"String","value":"dberger"}},"outputResources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/extensions/Microsoft.Insights.VMDiagnosticsSettings"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-rhel1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686"}]}}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:07 GMT
+  recorded_at: Mon, 12 Mar 2018 10:25:40 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/operations?api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1?api-version=2018-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3228,221 +3357,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1ODEsIm5iZiI6MTUyMDQ1MzU4MSwiZXhwIjoxNTIwNDU3NDgxLCJhaW8iOiJZMk5nWURqdmVlYldiaDNsUkp1Sm9uZTFpN2ZQQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiejQ5SjdhMExRa3FGeG1FNXlGb0FBQSIsInZlciI6IjEuMCJ9.pBpmvta3GhE-q7jz0GPLGkXKVgiDCQmGLnwpg3-wQ0HBDJ79kKhZfOwiPFcXFZG8heoad_YWYcnVjQuMY9hsV3yTXGMgJlVBpYH5gUh9PiCSHPQTfdkX3Nxwv5vz8rLkwd_HH8UUMN96AkGpoSvbVxA3aDSC0sOYaHElhO6XOllD5CGuui1T3gpptUjj18PRQnCC_cZbqLJETdQT4S0IoEGz6-FNlt45pPg3rJUK1WFQa9rfWPsd3XCRQEvZjeaj4zeYRB8-bNe8dbrcitRhVocQWHmFKlQ1i7q2b840YCbG3udPoSJ0hPJqHcFexjzEMfn_vJeiNLETBncPUYfbPw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14969'
-      X-Ms-Request-Id:
-      - 8fc342dc-4b34-4c17-9548-cb3256727a4d
-      X-Ms-Correlation-Request-Id:
-      - 8fc342dc-4b34-4c17-9548-cb3256727a4d
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201807Z:8fc342dc-4b34-4c17-9548-cb3256727a4d
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:18:06 GMT
-      Content-Length:
-      - '6818'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/operations/6F3CDD195F5AA64D","operationId":"6F3CDD195F5AA64D","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-21T16:55:03.1868654Z","duration":"PT2M40.8951551S","trackingId":"34ebfefe-500f-4081-a0f6-27e83b3497c0","serviceRequestId":"57d6085f-2656-460f-9fdc-391f3813ba9b","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miqazure-centos1/Microsoft.Insights.VMDiagnosticsSettings"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/operations/A4399909BA133C0D","operationId":"A4399909BA133C0D","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-21T16:52:22.2353497Z","duration":"PT2M10.5072242S","trackingId":"3eeac2e5-7321-48c4-a621-6b89d4a02d69","serviceRequestId":"9e20cfcf-cf82-4053-8a96-ba1a60126341","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miqazure-centos1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/operations/8905B6E136664A5B","operationId":"8905B6E136664A5B","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-21T16:50:11.6254839Z","duration":"PT2.7585091S","trackingId":"b41c1179-a579-4ef2-8f9f-0d7651db12d1","serviceRequestId":"fac0cc26-0839-4302-9536-69cff4273fb9","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miqazure-centos1611"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/operations/C2DCF4B8AD34B069","operationId":"C2DCF4B8AD34B069","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-21T16:49:56.9428379Z","duration":"PT2.0956285S","trackingId":"902fb4c8-003f-4fd0-bd4c-3d7dc20fd503","serviceRequestId":"82cddf5c-1792-4498-9ed5-ccdfaf52d93c","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/miqazure-availset-east","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"miqazure-availset-east"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/operations/9990AFF176EBE6D6","operationId":"9990AFF176EBE6D6","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-21T16:50:08.2533087Z","duration":"PT13.3722364S","trackingId":"9b48f8bd-0d5a-480f-b9c0-5a2dd47d69ef","serviceRequestId":"f082fd2f-3170-4f36-b9ff-a635e33f5fcf","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miqazure-centos1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/operations/CDF7EC27C23131A3","operationId":"CDF7EC27C23131A3","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-21T16:50:08.77339Z","duration":"PT13.92517S","trackingId":"f52480f9-3fba-4714-b5f6-88a1beef299a","serviceRequestId":"7df6e0cb-b78b-47ff-b479-90a1aee5a885","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miqazure-centos1","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miqazure-centos1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/operations/47603DE16848EC46","operationId":"47603DE16848EC46","properties":{"provisioningOperation":"Action","provisioningState":"Succeeded","timestamp":"2016-03-21T16:49:55.6348253Z","duration":"PT0.794081S","trackingId":"7b8561f2-66f7-4982-9bc8-98531e92c8b1","serviceRequestId":"c3daf7bc-96ed-4987-89ba-ed85952a355c","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","actionName":"listKeys","apiVersion":"2015-05-01-preview"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/operations/1885C71933AB322C","operationId":"1885C71933AB322C","properties":{"provisioningOperation":"Read","provisioningState":"Succeeded","timestamp":"2016-03-21T16:49:55.6318086Z","duration":"PT0.795157S","trackingId":"78813777-c251-4997-a559-fa2bb83e2bba","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","apiVersion":"2015-06-15"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/operations/08587430278932948168","operationId":"08587430278932948168","properties":{"provisioningOperation":"EvaluateDeploymentOutput","provisioningState":"Succeeded","timestamp":"2016-03-21T16:55:03.9460544Z","duration":"PT0.4693921S","trackingId":"68a8a1f0-e69d-4d2e-9ee1-1fc98c0e122f","statusCode":"OK","statusMessage":null}}]}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:08 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations?api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1ODEsIm5iZiI6MTUyMDQ1MzU4MSwiZXhwIjoxNTIwNDU3NDgxLCJhaW8iOiJZMk5nWURqdmVlYldiaDNsUkp1Sm9uZTFpN2ZQQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiejQ5SjdhMExRa3FGeG1FNXlGb0FBQSIsInZlciI6IjEuMCJ9.pBpmvta3GhE-q7jz0GPLGkXKVgiDCQmGLnwpg3-wQ0HBDJ79kKhZfOwiPFcXFZG8heoad_YWYcnVjQuMY9hsV3yTXGMgJlVBpYH5gUh9PiCSHPQTfdkX3Nxwv5vz8rLkwd_HH8UUMN96AkGpoSvbVxA3aDSC0sOYaHElhO6XOllD5CGuui1T3gpptUjj18PRQnCC_cZbqLJETdQT4S0IoEGz6-FNlt45pPg3rJUK1WFQa9rfWPsd3XCRQEvZjeaj4zeYRB8-bNe8dbrcitRhVocQWHmFKlQ1i7q2b840YCbG3udPoSJ0hPJqHcFexjzEMfn_vJeiNLETBncPUYfbPw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14979'
-      X-Ms-Request-Id:
-      - 72de3fc0-2043-4199-ba6c-c35adbee5866
-      X-Ms-Correlation-Request-Id:
-      - 72de3fc0-2043-4199-ba6c-c35adbee5866
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201808Z:72de3fc0-2043-4199-ba6c-c35adbee5866
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:18:08 GMT
-      Content-Length:
-      - '7624'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/B42FCDF4A2A39FE2","operationId":"B42FCDF4A2A39FE2","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:28:56.9829484Z","duration":"PT3M1.9672591S","trackingId":"14feeb1c-b462-4bdc-98e0-07e3c051bc4a","serviceRequestId":"929da49c-b732-4413-8fe7-6a94ebf1b7df","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-rhel1/Microsoft.Insights.VMDiagnosticsSettings"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/90897F1FE623927D","operationId":"90897F1FE623927D","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:25:54.9100087Z","duration":"PT2M28.9316677S","trackingId":"677bf860-1814-46bf-81b8-2f40e478702f","serviceRequestId":"0d568f4d-db1a-414b-82af-8a476f4ee398","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-rhel1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/465DEB7D7737AAEB","operationId":"465DEB7D7737AAEB","properties":{"provisioningOperation":"Read","provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:25.8536981Z","duration":"PT2.5042804S","trackingId":"39bb6568-d7b8-42e4-97ed-3b32cb629561","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686","apiVersion":"2015-06-15"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/2972B36A0CF48AB3","operationId":"2972B36A0CF48AB3","properties":{"provisioningOperation":"Action","provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:23.6072605Z","duration":"PT0.2582045S","trackingId":"c5a9e298-ec4e-439b-ba11-f531388139de","serviceRequestId":"3222315f-f31e-4ee7-b405-4d40dfd500a3","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686","actionName":"listKeys","apiVersion":"2015-05-01-preview"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/E74E878C29CB66B6","operationId":"E74E878C29CB66B6","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:10.196193Z","duration":"PT1.6122458S","trackingId":"2341df4a-20e3-4fb4-b417-2f2263e009d3","serviceRequestId":"ad2b548c-e848-42f3-8834-a07996ead051","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-rhel1390"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/159B68AE177CBFD9","operationId":"159B68AE177CBFD9","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:23.2936909Z","duration":"PT30.2333245S","trackingId":"3d2daef3-03af-4017-9b52-2202b98e54c0","serviceRequestId":"3222315f-f31e-4ee7-b405-4d40dfd500a3","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/601C5CBE140F5FC4","operationId":"601C5CBE140F5FC4","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:08.4807196Z","duration":"PT15.4177267S","trackingId":"5280cb26-eed9-43e1-aff7-2c60ba0a4e32","serviceRequestId":"18d0a142-7dcb-4e5d-86ea-b8cd95ab1ff4","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-rhel1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/DDFCB6138638C2AE","operationId":"DDFCB6138638C2AE","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:06.4145604Z","duration":"PT13.2922738S","trackingId":"18bf2d19-1ef3-4026-b6c2-650bcd5a6da9","serviceRequestId":"8f6af50d-004e-4653-b263-3e2a8e85ebeb","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-rhel1","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-rhel1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/6E56D08B1E39DCCA","operationId":"6E56D08B1E39DCCA","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:05.836911Z","duration":"PT12.771463S","trackingId":"33412052-f3be-4e84-bd79-0a00abef61f4","serviceRequestId":"2252541d-7285-41d8-87d1-3a0a1d1b330a","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"miq-azure-test1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/08587432851139626716","operationId":"08587432851139626716","properties":{"provisioningOperation":"EvaluateDeploymentOutput","provisioningState":"Succeeded","timestamp":"2016-03-18T17:28:57.5892101Z","duration":"PT0.2087634S","trackingId":"85e2cf8a-3929-4515-8a51-97dbc778352e","statusCode":"OK","statusMessage":null}}]}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:08 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950?api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1ODEsIm5iZiI6MTUyMDQ1MzU4MSwiZXhwIjoxNTIwNDU3NDgxLCJhaW8iOiJZMk5nWURqdmVlYldiaDNsUkp1Sm9uZTFpN2ZQQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiejQ5SjdhMExRa3FGeG1FNXlGb0FBQSIsInZlciI6IjEuMCJ9.pBpmvta3GhE-q7jz0GPLGkXKVgiDCQmGLnwpg3-wQ0HBDJ79kKhZfOwiPFcXFZG8heoad_YWYcnVjQuMY9hsV3yTXGMgJlVBpYH5gUh9PiCSHPQTfdkX3Nxwv5vz8rLkwd_HH8UUMN96AkGpoSvbVxA3aDSC0sOYaHElhO6XOllD5CGuui1T3gpptUjj18PRQnCC_cZbqLJETdQT4S0IoEGz6-FNlt45pPg3rJUK1WFQa9rfWPsd3XCRQEvZjeaj4zeYRB8-bNe8dbrcitRhVocQWHmFKlQ1i7q2b840YCbG3udPoSJ0hPJqHcFexjzEMfn_vJeiNLETBncPUYfbPw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14871'
-      X-Ms-Request-Id:
-      - 11700475-dbd2-4731-8f0f-fd34695d9cf1
-      X-Ms-Correlation-Request-Id:
-      - 11700475-dbd2-4731-8f0f-fd34695d9cf1
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201809Z:11700475-dbd2-4731-8f0f-fd34695d9cf1
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:18:09 GMT
-      Content-Length:
-      - '5882'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950","name":"OpenLogic.CentOSbased71-20160221104950","properties":{"parameters":{"location":{"type":"String","value":"eastus"},"virtualMachineName":{"type":"String","value":"miqazure-centos1"},"virtualMachineSize":{"type":"String","value":"Basic_A0"},"adminUsername":{"type":"String","value":"dberger"},"storageAccountName":{"type":"String","value":"miqazuretest14047"},"virtualNetworkName":{"type":"String","value":"miq-azure-test1"},"networkInterfaceName":{"type":"String","value":"miqazure-centos1611"},"networkSecurityGroupName":{"type":"String","value":"miqazure-centos1"},"adminPassword":{"type":"SecureString"},"availabilitySetName":{"type":"String","value":"miqazure-availset-east"},"availabilitySetPlatformFaultDomainCount":{"type":"String","value":"3"},"availabilitySetPlatformUpdateDomainCount":{"type":"String","value":"5"},"diagnosticsStorageAccountName":{"type":"String","value":"miqazuretest14047"},"diagnosticsStorageAccountId":{"type":"String","value":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047"},"subnetName":{"type":"String","value":"default"},"publicIpAddressName":{"type":"String","value":"miqazure-centos1"},"publicIpAddressType":{"type":"String","value":"Dynamic"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-03-21T16:55:03.9867512Z","duration":"PT5M11.803863S","correlationId":"c3daf7bc-96ed-4987-89ba-ed85952a355c","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]},{"resourceType":"virtualMachines/extensions","locations":["eastus"]},{"resourceType":"availabilitySets","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkInterfaces","locations":["eastus"]},{"resourceType":"publicIpAddresses","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miqazure-centos1611"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/miqazure-availset-east","resourceType":"Microsoft.Compute/availabilitySets","resourceName":"miqazure-availset-east"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miqazure-centos1"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miqazure-centos1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest14047","actionName":"listKeys","apiVersion":"2015-05-01-preview"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miqazure-centos1/Microsoft.Insights.VMDiagnosticsSettings"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miqazure-centos1","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miqazure-centos1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miqazure-centos1"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miqazure-centos1611"}],"outputs":{"adminUsername":{"type":"String","value":"dberger"}},"outputResources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/miqazure-availset-east"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1/extensions/Microsoft.Insights.VMDiagnosticsSettings"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miqazure-centos1"}]}}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:10 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250?api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1ODEsIm5iZiI6MTUyMDQ1MzU4MSwiZXhwIjoxNTIwNDU3NDgxLCJhaW8iOiJZMk5nWURqdmVlYldiaDNsUkp1Sm9uZTFpN2ZQQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiejQ5SjdhMExRa3FGeG1FNXlGb0FBQSIsInZlciI6IjEuMCJ9.pBpmvta3GhE-q7jz0GPLGkXKVgiDCQmGLnwpg3-wQ0HBDJ79kKhZfOwiPFcXFZG8heoad_YWYcnVjQuMY9hsV3yTXGMgJlVBpYH5gUh9PiCSHPQTfdkX3Nxwv5vz8rLkwd_HH8UUMN96AkGpoSvbVxA3aDSC0sOYaHElhO6XOllD5CGuui1T3gpptUjj18PRQnCC_cZbqLJETdQT4S0IoEGz6-FNlt45pPg3rJUK1WFQa9rfWPsd3XCRQEvZjeaj4zeYRB8-bNe8dbrcitRhVocQWHmFKlQ1i7q2b840YCbG3udPoSJ0hPJqHcFexjzEMfn_vJeiNLETBncPUYfbPw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14972'
-      X-Ms-Request-Id:
-      - 3569b7b9-164d-42d4-89c9-e5c8ac34f994
-      X-Ms-Correlation-Request-Id:
-      - 3569b7b9-164d-42d4-89c9-e5c8ac34f994
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201810Z:3569b7b9-164d-42d4-89c9-e5c8ac34f994
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:18:10 GMT
-      Content-Length:
-      - '6266'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250","name":"RedHat.RedHatEnterpriseLinux72-20160218112250","properties":{"parameters":{"location":{"type":"String","value":"eastus"},"virtualMachineName":{"type":"String","value":"miq-test-rhel1"},"virtualMachineSize":{"type":"String","value":"Basic_A0"},"adminUsername":{"type":"String","value":"dberger"},"storageAccountName":{"type":"String","value":"miqazuretest18686"},"virtualNetworkName":{"type":"String","value":"miq-azure-test1"},"networkInterfaceName":{"type":"String","value":"miq-test-rhel1390"},"networkSecurityGroupName":{"type":"String","value":"miq-test-rhel1"},"adminPassword":{"type":"SecureString"},"storageAccountType":{"type":"String","value":"Standard_LRS"},"diagnosticsStorageAccountName":{"type":"String","value":"miqazuretest18686"},"diagnosticsStorageAccountId":{"type":"String","value":"Microsoft.Storage/storageAccounts/miqazuretest18686"},"diagnosticsStorageAccountType":{"type":"String","value":"Standard_LRS"},"addressPrefix":{"type":"String","value":"10.16.0.0/16"},"subnetName":{"type":"String","value":"default"},"subnetPrefix":{"type":"String","value":"10.16.0.0/24"},"publicIpAddressName":{"type":"String","value":"miq-test-rhel1"},"publicIpAddressType":{"type":"String","value":"Dynamic"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-03-18T17:28:57.6212521Z","duration":"PT6M6.1062402S","correlationId":"3222315f-f31e-4ee7-b405-4d40dfd500a3","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]},{"resourceType":"virtualMachines/extensions","locations":["eastus"]}]},{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]},{"resourceType":"publicIpAddresses","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-rhel1390"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-rhel1"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-rhel1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686","actionName":"listKeys","apiVersion":"2015-05-01-preview"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-rhel1/Microsoft.Insights.VMDiagnosticsSettings"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"miq-azure-test1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-rhel1","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-rhel1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-rhel1"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-rhel1390"}],"outputs":{"adminUsername":{"type":"String","value":"dberger"}},"outputResources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/extensions/Microsoft.Insights.VMDiagnosticsSettings"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-rhel1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686"}]}}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:10 GMT
-- request:
-    method: post
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/OpenLogic.CentOSbased71-20160221104950/exportTemplate?api-version=2017-08-01
-    body:
-      encoding: ASCII-8BIT
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1ODEsIm5iZiI6MTUyMDQ1MzU4MSwiZXhwIjoxNTIwNDU3NDgxLCJhaW8iOiJZMk5nWURqdmVlYldiaDNsUkp1Sm9uZTFpN2ZQQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiejQ5SjdhMExRa3FGeG1FNXlGb0FBQSIsInZlciI6IjEuMCJ9.pBpmvta3GhE-q7jz0GPLGkXKVgiDCQmGLnwpg3-wQ0HBDJ79kKhZfOwiPFcXFZG8heoad_YWYcnVjQuMY9hsV3yTXGMgJlVBpYH5gUh9PiCSHPQTfdkX3Nxwv5vz8rLkwd_HH8UUMN96AkGpoSvbVxA3aDSC0sOYaHElhO6XOllD5CGuui1T3gpptUjj18PRQnCC_cZbqLJETdQT4S0IoEGz6-FNlt45pPg3rJUK1WFQa9rfWPsd3XCRQEvZjeaj4zeYRB8-bNe8dbrcitRhVocQWHmFKlQ1i7q2b840YCbG3udPoSJ0hPJqHcFexjzEMfn_vJeiNLETBncPUYfbPw
-      Content-Length:
-      - '0'
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAwMDgsIm5iZiI6MTUyMDg1MDAwOCwiZXhwIjoxNTIwODUzOTA4LCJhaW8iOiJZMk5nWUpETSt4NVdsaFY1SWtqNTBsMHhMc1pwQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidXJVTmZ1X0tia2FsWkxWNHdkUUFBQSIsInZlciI6IjEuMCJ9.JZgL7n0qXHgKoO66Qr6QO-NQbdn-8kjLG3DkmcI-u8dGoFGPi7UW9xEJtKwYw5MqnpnItbSeHhmsDOQC8wPjV4dZ3gTEYehW8FpTsXkhOGy7EkeTmgpdegs96aOG7ttypkyxM9mQ3jk1x_NBm8c1jf4OssGN-WwXR7zIsmK0MHz0d2wCpu054SParX1ExHX-fgGDTMbC3h1RoXr28hJrVL5Z_7f2LbHWnkPtcUepfybilV7caVa3mgvWt3PO3cqwjE3p47pazCE-RoA9qqZqDhprJ7P3qHG6S9FBX9VvT1XReMG_k1U76MBJ-jwLUYucRgKrB5UDq1U83qgGrwiipg
   response:
     status:
       code: 200
@@ -3458,372 +3373,42 @@ http_interactions:
       - application/json; charset=utf-8
       Expires:
       - "-1"
+      Etag:
+      - W/"734a3944-a880-444c-8c92-cace6e28e303"
       Vary:
       - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1198'
       X-Ms-Request-Id:
-      - 67976214-7c55-43fe-9ef8-a1b39138ca7a
-      X-Ms-Correlation-Request-Id:
-      - 67976214-7c55-43fe-9ef8-a1b39138ca7a
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201811Z:67976214-7c55-43fe-9ef8-a1b39138ca7a
+      - c2df32be-3ad2-4b28-bfe9-5083a16f431a
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:18:10 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"template":{"$schema":"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#","contentVersion":"1.0.0.0","parameters":{"location":{"type":"String"},"virtualMachineName":{"type":"String"},"virtualMachineSize":{"type":"String"},"adminUsername":{"type":"String"},"storageAccountName":{"type":"String"},"virtualNetworkName":{"type":"String"},"networkInterfaceName":{"type":"String"},"networkSecurityGroupName":{"type":"String"},"adminPassword":{"type":"SecureString"},"availabilitySetName":{"type":"String"},"availabilitySetPlatformFaultDomainCount":{"type":"String"},"availabilitySetPlatformUpdateDomainCount":{"type":"String"},"diagnosticsStorageAccountName":{"type":"String"},"diagnosticsStorageAccountId":{"type":"String"},"subnetName":{"type":"String"},"publicIpAddressName":{"type":"String"},"publicIpAddressType":{"type":"String"}},"variables":{"vnetId":"[resourceId(''miq-azure-test1'',''Microsoft.Network/virtualNetworks'',
-        parameters(''virtualNetworkName''))]","subnetRef":"[concat(variables(''vnetId''),
-        ''/subnets/'', parameters(''subnetName''))]","metricsresourceid":"[concat(''/subscriptions/'',
-        subscription().subscriptionId, ''/resourceGroups/'', resourceGroup().name,
-        ''/providers/'', ''Microsoft.Compute/virtualMachines/'', parameters(''virtualMachineName''))]","metricsclosing":"[concat(''<Metrics
-        resourceId=\"'', variables(''metricsresourceid''), ''\"><MetricAggregation
-        scheduledTransferPeriod=\"PT1H\"/><MetricAggregation scheduledTransferPeriod=\"PT1M\"/></Metrics></DiagnosticMonitorConfiguration></WadCfg>'')]","metricscounters":"<PerformanceCounters
-        scheduledTransferPeriod=\"PT1M\"><PerformanceCounterConfiguration counterSpecifier=\"\\Memory\\AvailableMemory\"
-        sampleRate=\"PT15S\" unit=\"Bytes\"><annotation displayName=\"Memory available\"
-        locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PercentAvailableMemory\" sampleRate=\"PT15S\"
-        unit=\"Percent\"><annotation displayName=\"Mem. percent available\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\UsedMemory\" sampleRate=\"PT15S\" unit=\"Bytes\"><annotation
-        displayName=\"Memory used\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PercentUsedMemory\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"Memory percentage\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PercentUsedByCache\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"Mem. used by cache\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PagesPerSec\" sampleRate=\"PT15S\" unit=\"CountPerSecond\"><annotation
-        displayName=\"Pages\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PagesReadPerSec\" sampleRate=\"PT15S\" unit=\"CountPerSecond\"><annotation
-        displayName=\"Page reads\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PagesWrittenPerSec\" sampleRate=\"PT15S\" unit=\"CountPerSecond\"><annotation
-        displayName=\"Page writes\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\AvailableSwap\" sampleRate=\"PT15S\" unit=\"Bytes\"><annotation
-        displayName=\"Swap available\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PercentAvailableSwap\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"Swap percent available\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\UsedSwap\" sampleRate=\"PT15S\" unit=\"Bytes\"><annotation
-        displayName=\"Swap used\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PercentUsedSwap\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"Swap percent used\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentIdleTime\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"CPU idle time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentUserTime\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"CPU user time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentNiceTime\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"CPU nice time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentPrivilegedTime\" sampleRate=\"PT15S\"
-        unit=\"Percent\"><annotation displayName=\"CPU privileged time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentInterruptTime\" sampleRate=\"PT15S\"
-        unit=\"Percent\"><annotation displayName=\"CPU interrupt time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentDPCTime\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"CPU DPC time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentProcessorTime\" sampleRate=\"PT15S\"
-        unit=\"Percent\"><annotation displayName=\"CPU percentage guest OS\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentIOWaitTime\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"CPU IO wait time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\BytesPerSecond\" sampleRate=\"PT15S\" unit=\"BytesPerSecond\"><annotation
-        displayName=\"Disk total bytes\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\ReadBytesPerSecond\" sampleRate=\"PT15S\"
-        unit=\"BytesPerSecond\"><annotation displayName=\"Disk read guest OS\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\WriteBytesPerSecond\" sampleRate=\"PT15S\"
-        unit=\"BytesPerSecond\"><annotation displayName=\"Disk write guest OS\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\TransfersPerSecond\" sampleRate=\"PT15S\"
-        unit=\"CountPerSecond\"><annotation displayName=\"Disk transfers\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\ReadsPerSecond\" sampleRate=\"PT15S\" unit=\"CountPerSecond\"><annotation
-        displayName=\"Disk reads\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\WritesPerSecond\" sampleRate=\"PT15S\"
-        unit=\"CountPerSecond\"><annotation displayName=\"Disk writes\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\AverageReadTime\" sampleRate=\"PT15S\"
-        unit=\"Seconds\"><annotation displayName=\"Disk read time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\AverageWriteTime\" sampleRate=\"PT15S\"
-        unit=\"Seconds\"><annotation displayName=\"Disk write time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\AverageTransferTime\" sampleRate=\"PT15S\"
-        unit=\"Seconds\"><annotation displayName=\"Disk transfer time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\AverageDiskQueueLength\" sampleRate=\"PT15S\"
-        unit=\"Count\"><annotation displayName=\"Disk queue length\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\BytesTransmitted\" sampleRate=\"PT15S\"
-        unit=\"Bytes\"><annotation displayName=\"Network out guest OS\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\BytesReceived\" sampleRate=\"PT15S\"
-        unit=\"Bytes\"><annotation displayName=\"Network in guest OS\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\PacketsTransmitted\" sampleRate=\"PT15S\"
-        unit=\"Count\"><annotation displayName=\"Packets sent\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\PacketsReceived\" sampleRate=\"PT15S\"
-        unit=\"Count\"><annotation displayName=\"Packets received\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\BytesTotal\" sampleRate=\"PT15S\" unit=\"Bytes\"><annotation
-        displayName=\"Network total bytes\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\TotalRxErrors\" sampleRate=\"PT15S\"
-        unit=\"Count\"><annotation displayName=\"Packets received errors\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\TotalTxErrors\" sampleRate=\"PT15S\"
-        unit=\"Count\"><annotation displayName=\"Packets sent errors\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\TotalCollisions\" sampleRate=\"PT15S\"
-        unit=\"Count\"><annotation displayName=\"Network collisions\" locale=\"en-us\"/></PerformanceCounterConfiguration></PerformanceCounters>","metricsstart":"<WadCfg><DiagnosticMonitorConfiguration
-        overallQuotaInMB=\"4096\"><DiagnosticInfrastructureLogs scheduledTransferPeriod=\"PT1M\"
-        scheduledTransferLogLevelFilter=\"Warning\"/>","wadcfgx":"[concat(variables(''metricsstart''),
-        variables(''metricscounters''), variables(''metricsclosing''))]"},"resources":[{"type":"Microsoft.Compute/virtualMachines","name":"[parameters(''virtualMachineName'')]","apiVersion":"2015-06-15","location":"[parameters(''location'')]","properties":{"osProfile":{"computerName":"[parameters(''virtualMachineName'')]","adminUsername":"[parameters(''adminUsername'')]","adminPassword":"[parameters(''adminPassword'')]"},"hardwareProfile":{"vmSize":"[parameters(''virtualMachineSize'')]"},"storageProfile":{"imageReference":{"publisher":"OpenLogic","offer":"CentOS","sku":"7.1","version":"latest"},"osDisk":{"name":"[parameters(''virtualMachineName'')]","vhd":{"uri":"[concat(concat(reference(resourceId(''miq-azure-test1'',
-        ''Microsoft.Storage/storageAccounts'', parameters(''storageAccountName'')),
-        ''2015-06-15'').primaryEndpoints[''blob''], ''vhds/''), parameters(''virtualMachineName''),
-        ''2016221104946.vhd'')]"},"createOption":"fromImage"},"dataDisks":[]},"networkProfile":{"networkInterfaces":[{"id":"[resourceId(''Microsoft.Network/networkInterfaces'',
-        parameters(''networkInterfaceName''))]"}]},"diagnosticsProfile":{"bootDiagnostics":{"enabled":true,"storageUri":"[reference(resourceId(''miq-azure-test1'',
-        ''Microsoft.Storage/storageAccounts'', parameters(''diagnosticsStorageAccountName'')),
-        ''2015-06-15'').primaryEndpoints[''blob'']]"}},"availabilitySet":{"id":"[resourceId(''Microsoft.Compute/availabilitySets'',
-        parameters(''availabilitySetName''))]"}},"resources":[{"type":"extensions","name":"Microsoft.Insights.VMDiagnosticsSettings","apiVersion":"2015-05-01-preview","location":"[parameters(''location'')]","properties":{"publisher":"Microsoft.OSTCExtensions","type":"LinuxDiagnostic","typeHandlerVersion":"2.0","autoUpgradeMinorVersion":true,"settings":{"xmlCfg":"[base64(variables(''wadcfgx''))]","StorageAccount":"[parameters(''diagnosticsStorageAccountName'')]"},"protectedSettings":{"storageAccountName":"[parameters(''diagnosticsStorageAccountName'')]","storageAccountKey":"[listKeys(parameters(''diagnosticsStorageAccountId''),''2015-05-01-preview'').key1]","storageAccountEndPoint":"https://core.windows.net/"}},"dependsOn":["[concat(''Microsoft.Compute/virtualMachines/'',
-        parameters(''virtualMachineName''))]"]}],"dependsOn":["[concat(''Microsoft.Network/networkInterfaces/'',
-        parameters(''networkInterfaceName''))]","[concat(''Microsoft.Compute/availabilitySets/'',
-        parameters(''availabilitySetName''))]"]},{"type":"Microsoft.Compute/availabilitySets","name":"[parameters(''availabilitySetName'')]","apiVersion":"2015-05-01-preview","location":"[parameters(''location'')]","properties":{"platformFaultDomainCount":"[parameters(''availabilitySetPlatformFaultDomainCount'')]","platformUpdateDomainCount":"[parameters(''availabilitySetPlatformUpdateDomainCount'')]"}},{"type":"Microsoft.Network/networkInterfaces","name":"[parameters(''networkInterfaceName'')]","apiVersion":"2015-05-01-preview","location":"[parameters(''location'')]","properties":{"ipConfigurations":[{"name":"ipconfig1","properties":{"subnet":{"id":"[variables(''subnetRef'')]"},"privateIPAllocationMethod":"Dynamic","publicIpAddress":{"id":"[resourceId(''miq-azure-test1'',''Microsoft.Network/publicIpAddresses'',
-        parameters(''publicIpAddressName''))]"}}}],"networkSecurityGroup":{"id":"[resourceId(''miq-azure-test1'',
-        ''Microsoft.Network/networkSecurityGroups'', parameters(''networkSecurityGroupName''))]"}},"dependsOn":["[concat(''Microsoft.Network/publicIpAddresses/'',
-        parameters(''publicIpAddressName''))]","[concat(''Microsoft.Network/networkSecurityGroups/'',
-        parameters(''networkSecurityGroupName''))]"]},{"type":"Microsoft.Network/publicIpAddresses","name":"[parameters(''publicIpAddressName'')]","apiVersion":"2015-05-01-preview","location":"[parameters(''location'')]","properties":{"publicIpAllocationMethod":"[parameters(''publicIpAddressType'')]"}},{"type":"Microsoft.Network/networkSecurityGroups","name":"[parameters(''networkSecurityGroupName'')]","apiVersion":"2015-05-01-preview","location":"[parameters(''location'')]","properties":{"securityRules":[{"name":"default-allow-ssh","properties":{"priority":1000,"sourceAddressPrefix":"*","protocol":"Tcp","destinationPortRange":"22","access":"Allow","direction":"inbound","sourcePortRange":"*","destinationAddressPrefix":"*"}}]}}],"outputs":{"adminUsername":{"type":"String","value":"[parameters(''adminUsername'')]"}}}}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:11 GMT
-- request:
-    method: post
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/exportTemplate?api-version=2017-08-01
-    body:
-      encoding: ASCII-8BIT
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1ODEsIm5iZiI6MTUyMDQ1MzU4MSwiZXhwIjoxNTIwNDU3NDgxLCJhaW8iOiJZMk5nWURqdmVlYldiaDNsUkp1Sm9uZTFpN2ZQQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiejQ5SjdhMExRa3FGeG1FNXlGb0FBQSIsInZlciI6IjEuMCJ9.pBpmvta3GhE-q7jz0GPLGkXKVgiDCQmGLnwpg3-wQ0HBDJ79kKhZfOwiPFcXFZG8heoad_YWYcnVjQuMY9hsV3yTXGMgJlVBpYH5gUh9PiCSHPQTfdkX3Nxwv5vz8rLkwd_HH8UUMN96AkGpoSvbVxA3aDSC0sOYaHElhO6XOllD5CGuui1T3gpptUjj18PRQnCC_cZbqLJETdQT4S0IoEGz6-FNlt45pPg3rJUK1WFQa9rfWPsd3XCRQEvZjeaj4zeYRB8-bNe8dbrcitRhVocQWHmFKlQ1i7q2b840YCbG3udPoSJ0hPJqHcFexjzEMfn_vJeiNLETBncPUYfbPw
-      Content-Length:
-      - '0'
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1197'
-      X-Ms-Request-Id:
-      - fd5ca559-9624-4286-be9c-7b69682cb992
-      X-Ms-Correlation-Request-Id:
-      - fd5ca559-9624-4286-be9c-7b69682cb992
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201812Z:fd5ca559-9624-4286-be9c-7b69682cb992
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:18:12 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"template":{"$schema":"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#","contentVersion":"1.0.0.0","parameters":{"location":{"type":"String"},"virtualMachineName":{"type":"String"},"virtualMachineSize":{"type":"String"},"adminUsername":{"type":"String"},"storageAccountName":{"type":"String"},"virtualNetworkName":{"type":"String"},"networkInterfaceName":{"type":"String"},"networkSecurityGroupName":{"type":"String"},"adminPassword":{"type":"SecureString"},"storageAccountType":{"type":"String"},"diagnosticsStorageAccountName":{"type":"String"},"diagnosticsStorageAccountId":{"type":"String"},"diagnosticsStorageAccountType":{"type":"String"},"addressPrefix":{"type":"String"},"subnetName":{"type":"String"},"subnetPrefix":{"type":"String"},"publicIpAddressName":{"type":"String"},"publicIpAddressType":{"type":"String"}},"variables":{"vnetId":"[resourceId(''miq-azure-test1'',''Microsoft.Network/virtualNetworks'',
-        parameters(''virtualNetworkName''))]","subnetRef":"[concat(variables(''vnetId''),
-        ''/subnets/'', parameters(''subnetName''))]","metricsresourceid":"[concat(''/subscriptions/'',
-        subscription().subscriptionId, ''/resourceGroups/'', resourceGroup().name,
-        ''/providers/'', ''Microsoft.Compute/virtualMachines/'', parameters(''virtualMachineName''))]","metricsclosing":"[concat(''<Metrics
-        resourceId=\"'', variables(''metricsresourceid''), ''\"><MetricAggregation
-        scheduledTransferPeriod=\"PT1H\"/><MetricAggregation scheduledTransferPeriod=\"PT1M\"/></Metrics></DiagnosticMonitorConfiguration></WadCfg>'')]","metricscounters":"<PerformanceCounters
-        scheduledTransferPeriod=\"PT1M\"><PerformanceCounterConfiguration counterSpecifier=\"\\Memory\\AvailableMemory\"
-        sampleRate=\"PT15S\" unit=\"Bytes\"><annotation displayName=\"Memory available\"
-        locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PercentAvailableMemory\" sampleRate=\"PT15S\"
-        unit=\"Percent\"><annotation displayName=\"Mem. percent available\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\UsedMemory\" sampleRate=\"PT15S\" unit=\"Bytes\"><annotation
-        displayName=\"Memory used\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PercentUsedMemory\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"Memory percentage\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PercentUsedByCache\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"Mem. used by cache\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PagesPerSec\" sampleRate=\"PT15S\" unit=\"CountPerSecond\"><annotation
-        displayName=\"Pages\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PagesReadPerSec\" sampleRate=\"PT15S\" unit=\"CountPerSecond\"><annotation
-        displayName=\"Page reads\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PagesWrittenPerSec\" sampleRate=\"PT15S\" unit=\"CountPerSecond\"><annotation
-        displayName=\"Page writes\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\AvailableSwap\" sampleRate=\"PT15S\" unit=\"Bytes\"><annotation
-        displayName=\"Swap available\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PercentAvailableSwap\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"Swap percent available\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\UsedSwap\" sampleRate=\"PT15S\" unit=\"Bytes\"><annotation
-        displayName=\"Swap used\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PercentUsedSwap\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"Swap percent used\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentIdleTime\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"CPU idle time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentUserTime\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"CPU user time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentNiceTime\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"CPU nice time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentPrivilegedTime\" sampleRate=\"PT15S\"
-        unit=\"Percent\"><annotation displayName=\"CPU privileged time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentInterruptTime\" sampleRate=\"PT15S\"
-        unit=\"Percent\"><annotation displayName=\"CPU interrupt time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentDPCTime\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"CPU DPC time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentProcessorTime\" sampleRate=\"PT15S\"
-        unit=\"Percent\"><annotation displayName=\"CPU percentage guest OS\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentIOWaitTime\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"CPU IO wait time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\BytesPerSecond\" sampleRate=\"PT15S\" unit=\"BytesPerSecond\"><annotation
-        displayName=\"Disk total bytes\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\ReadBytesPerSecond\" sampleRate=\"PT15S\"
-        unit=\"BytesPerSecond\"><annotation displayName=\"Disk read guest OS\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\WriteBytesPerSecond\" sampleRate=\"PT15S\"
-        unit=\"BytesPerSecond\"><annotation displayName=\"Disk write guest OS\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\TransfersPerSecond\" sampleRate=\"PT15S\"
-        unit=\"CountPerSecond\"><annotation displayName=\"Disk transfers\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\ReadsPerSecond\" sampleRate=\"PT15S\" unit=\"CountPerSecond\"><annotation
-        displayName=\"Disk reads\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\WritesPerSecond\" sampleRate=\"PT15S\"
-        unit=\"CountPerSecond\"><annotation displayName=\"Disk writes\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\AverageReadTime\" sampleRate=\"PT15S\"
-        unit=\"Seconds\"><annotation displayName=\"Disk read time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\AverageWriteTime\" sampleRate=\"PT15S\"
-        unit=\"Seconds\"><annotation displayName=\"Disk write time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\AverageTransferTime\" sampleRate=\"PT15S\"
-        unit=\"Seconds\"><annotation displayName=\"Disk transfer time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\AverageDiskQueueLength\" sampleRate=\"PT15S\"
-        unit=\"Count\"><annotation displayName=\"Disk queue length\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\BytesTransmitted\" sampleRate=\"PT15S\"
-        unit=\"Bytes\"><annotation displayName=\"Network out guest OS\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\BytesReceived\" sampleRate=\"PT15S\"
-        unit=\"Bytes\"><annotation displayName=\"Network in guest OS\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\PacketsTransmitted\" sampleRate=\"PT15S\"
-        unit=\"Count\"><annotation displayName=\"Packets sent\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\PacketsReceived\" sampleRate=\"PT15S\"
-        unit=\"Count\"><annotation displayName=\"Packets received\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\BytesTotal\" sampleRate=\"PT15S\" unit=\"Bytes\"><annotation
-        displayName=\"Network total bytes\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\TotalRxErrors\" sampleRate=\"PT15S\"
-        unit=\"Count\"><annotation displayName=\"Packets received errors\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\TotalTxErrors\" sampleRate=\"PT15S\"
-        unit=\"Count\"><annotation displayName=\"Packets sent errors\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\TotalCollisions\" sampleRate=\"PT15S\"
-        unit=\"Count\"><annotation displayName=\"Network collisions\" locale=\"en-us\"/></PerformanceCounterConfiguration></PerformanceCounters>","metricsstart":"<WadCfg><DiagnosticMonitorConfiguration
-        overallQuotaInMB=\"4096\"><DiagnosticInfrastructureLogs scheduledTransferPeriod=\"PT1M\"
-        scheduledTransferLogLevelFilter=\"Warning\"/>","wadcfgx":"[concat(variables(''metricsstart''),
-        variables(''metricscounters''), variables(''metricsclosing''))]"},"resources":[{"type":"Microsoft.Compute/virtualMachines","name":"[parameters(''virtualMachineName'')]","apiVersion":"2015-06-15","location":"[parameters(''location'')]","properties":{"osProfile":{"computerName":"[parameters(''virtualMachineName'')]","adminUsername":"[parameters(''adminUsername'')]","adminPassword":"[parameters(''adminPassword'')]"},"hardwareProfile":{"vmSize":"[parameters(''virtualMachineSize'')]"},"storageProfile":{"imageReference":{"publisher":"RedHat","offer":"RHEL","sku":"7.2","version":"latest"},"osDisk":{"name":"[parameters(''virtualMachineName'')]","vhd":{"uri":"[concat(concat(reference(resourceId(''miq-azure-test1'',
-        ''Microsoft.Storage/storageAccounts'', parameters(''storageAccountName'')),
-        ''2015-06-15'').primaryEndpoints[''blob''], ''vhds/''), parameters(''virtualMachineName''),
-        ''2016218112243.vhd'')]"},"createOption":"fromImage"},"dataDisks":[]},"networkProfile":{"networkInterfaces":[{"id":"[resourceId(''Microsoft.Network/networkInterfaces'',
-        parameters(''networkInterfaceName''))]"}]},"diagnosticsProfile":{"bootDiagnostics":{"enabled":true,"storageUri":"[reference(resourceId(''miq-azure-test1'',
-        ''Microsoft.Storage/storageAccounts'', parameters(''diagnosticsStorageAccountName'')),
-        ''2015-06-15'').primaryEndpoints[''blob'']]"}}},"resources":[{"type":"extensions","name":"Microsoft.Insights.VMDiagnosticsSettings","apiVersion":"2015-05-01-preview","location":"[parameters(''location'')]","properties":{"publisher":"Microsoft.OSTCExtensions","type":"LinuxDiagnostic","typeHandlerVersion":"2.0","autoUpgradeMinorVersion":true,"settings":{"xmlCfg":"[base64(variables(''wadcfgx''))]","StorageAccount":"[parameters(''diagnosticsStorageAccountName'')]"},"protectedSettings":{"storageAccountName":"[parameters(''diagnosticsStorageAccountName'')]","storageAccountKey":"[listKeys(parameters(''diagnosticsStorageAccountId''),''2015-05-01-preview'').key1]","storageAccountEndPoint":"https://core.windows.net/"}},"dependsOn":["[concat(''Microsoft.Compute/virtualMachines/'',
-        parameters(''virtualMachineName''))]"]}],"dependsOn":["[concat(''Microsoft.Network/networkInterfaces/'',
-        parameters(''networkInterfaceName''))]","[concat(''Microsoft.Storage/storageAccounts/'',
-        parameters(''storageAccountName''))]"]},{"type":"Microsoft.Storage/storageAccounts","name":"[parameters(''storageAccountName'')]","apiVersion":"2015-05-01-preview","location":"[parameters(''location'')]","properties":{"accountType":"[parameters(''storageAccountType'')]"}},{"type":"Microsoft.Network/virtualNetworks","name":"[parameters(''virtualNetworkName'')]","apiVersion":"2015-05-01-preview","location":"[parameters(''location'')]","properties":{"addressSpace":{"addressPrefixes":["[parameters(''addressPrefix'')]"]},"subnets":[{"name":"[parameters(''subnetName'')]","properties":{"addressPrefix":"[parameters(''subnetPrefix'')]"}}]}},{"type":"Microsoft.Network/networkInterfaces","name":"[parameters(''networkInterfaceName'')]","apiVersion":"2015-05-01-preview","location":"[parameters(''location'')]","properties":{"ipConfigurations":[{"name":"ipconfig1","properties":{"subnet":{"id":"[variables(''subnetRef'')]"},"privateIPAllocationMethod":"Dynamic","publicIpAddress":{"id":"[resourceId(''miq-azure-test1'',''Microsoft.Network/publicIpAddresses'',
-        parameters(''publicIpAddressName''))]"}}}],"networkSecurityGroup":{"id":"[resourceId(''miq-azure-test1'',
-        ''Microsoft.Network/networkSecurityGroups'', parameters(''networkSecurityGroupName''))]"}},"dependsOn":["[concat(''Microsoft.Network/virtualNetworks/'',
-        parameters(''virtualNetworkName''))]","[concat(''Microsoft.Network/publicIpAddresses/'',
-        parameters(''publicIpAddressName''))]","[concat(''Microsoft.Network/networkSecurityGroups/'',
-        parameters(''networkSecurityGroupName''))]"]},{"type":"Microsoft.Network/publicIpAddresses","name":"[parameters(''publicIpAddressName'')]","apiVersion":"2015-05-01-preview","location":"[parameters(''location'')]","properties":{"publicIpAllocationMethod":"[parameters(''publicIpAddressType'')]"}},{"type":"Microsoft.Network/networkSecurityGroups","name":"[parameters(''networkSecurityGroupName'')]","apiVersion":"2015-05-01-preview","location":"[parameters(''location'')]","properties":{"securityRules":[{"name":"default-allow-ssh","properties":{"priority":1000,"sourceAddressPrefix":"*","protocol":"Tcp","destinationPortRange":"22","access":"Allow","direction":"inbound","sourcePortRange":"*","destinationAddressPrefix":"*"}}]}}],"outputs":{"adminUsername":{"type":"String","value":"[parameters(''adminUsername'')]"}}}}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:12 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1?api-version=2017-12-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1ODEsIm5iZiI6MTUyMDQ1MzU4MSwiZXhwIjoxNTIwNDU3NDgxLCJhaW8iOiJZMk5nWURqdmVlYldiaDNsUkp1Sm9uZTFpN2ZQQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiejQ5SjdhMExRa3FGeG1FNXlGb0FBQSIsInZlciI6IjEuMCJ9.pBpmvta3GhE-q7jz0GPLGkXKVgiDCQmGLnwpg3-wQ0HBDJ79kKhZfOwiPFcXFZG8heoad_YWYcnVjQuMY9hsV3yTXGMgJlVBpYH5gUh9PiCSHPQTfdkX3Nxwv5vz8rLkwd_HH8UUMN96AkGpoSvbVxA3aDSC0sOYaHElhO6XOllD5CGuui1T3gpptUjj18PRQnCC_cZbqLJETdQT4S0IoEGz6-FNlt45pPg3rJUK1WFQa9rfWPsd3XCRQEvZjeaj4zeYRB8-bNe8dbrcitRhVocQWHmFKlQ1i7q2b840YCbG3udPoSJ0hPJqHcFexjzEMfn_vJeiNLETBncPUYfbPw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/LowCostGet3Min;4730,Microsoft.Compute/LowCostGet30Min;37876
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
-      X-Ms-Request-Id:
-      - 9e12ba2f-b90f-4ddf-9aae-9fca6c5f291e
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14980'
+      - '14986'
       X-Ms-Correlation-Request-Id:
-      - 96951c07-0b73-42b9-a578-049b1c7bec43
+      - 3404c77f-2055-4b35-b334-6bb93e016871
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201816Z:96951c07-0b73-42b9-a578-049b1c7bec43
+      - WESTEUROPE:20180312T102536Z:3404c77f-2055-4b35-b334-6bb93e016871
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:18:15 GMT
+      - Mon, 12 Mar 2018 10:25:36 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"796c5bcc-338a-448d-b61c-165279a7fb3e\",\r\n
-        \   \"availabilitySet\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/availabilitySets/MIQAZURE-AVAILSET-EAST\"\r\n
-        \   },\r\n    \"hardwareProfile\": {\r\n      \"vmSize\": \"Basic_A0\"\r\n
-        \   },\r\n    \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
-        \"OpenLogic\",\r\n        \"offer\": \"CentOS\",\r\n        \"sku\": \"7.1\",\r\n
-        \       \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
-        \"Linux\",\r\n        \"name\": \"miqazure-centos1\",\r\n        \"createOption\":
-        \"FromImage\",\r\n        \"vhd\": {\r\n          \"uri\": \"https://miqazuretest14047.blob.core.windows.net/vhds/miqazure-centos12016221104946.vhd\"\r\n
-        \       },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n      \"dataDisks\":
-        []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"miqazure-centos1\",\r\n
-        \     \"adminUsername\": \"dberger\",\r\n      \"linuxConfiguration\": {\r\n
-        \       \"disablePasswordAuthentication\": false\r\n      },\r\n      \"secrets\":
-        []\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611\"}]},\r\n
-        \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
-        true,\r\n        \"storageUri\": \"https://miqazuretest14047.blob.core.windows.net/\"\r\n
-        \     }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n
-        \ \"resources\": [\r\n    {\r\n      \"properties\": {\r\n        \"publisher\":
-        \"Microsoft.OSTCExtensions\",\r\n        \"type\": \"LinuxDiagnostic\",\r\n
-        \       \"typeHandlerVersion\": \"2.0\",\r\n        \"autoUpgradeMinorVersion\":
-        true,\r\n        \"settings\": {\"xmlCfg\":\"PFdhZENmZz48RGlhZ25vc3RpY01vbml0b3JDb25maWd1cmF0aW9uIG92ZXJhbGxRdW90YUluTUI9IjQwOTYiPjxEaWFnbm9zdGljSW5mcmFzdHJ1Y3R1cmVMb2dzIHNjaGVkdWxlZFRyYW5zZmVyUGVyaW9kPSJQVDFNIiBzY2hlZHVsZWRUcmFuc2ZlckxvZ0xldmVsRmlsdGVyPSJXYXJuaW5nIi8+PFBlcmZvcm1hbmNlQ291bnRlcnMgc2NoZWR1bGVkVHJhbnNmZXJQZXJpb2Q9IlBUMU0iPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlTWVtb3J5IiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQnl0ZXMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcUGVyY2VudEF2YWlsYWJsZU1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iTWVtb3J5IHVzZWQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50VXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgcGVyY2VudGFnZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkQnlDYWNoZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHVzZWQgYnkgY2FjaGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1BlclNlYyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50UGVyU2Vjb25kIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFnZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1JlYWRQZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2UgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1dyaXR0ZW5QZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2Ugd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iU3dhcCBhdmFpbGFibGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50QXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZFN3YXAiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlN3YXAgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRJZGxlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgaWRsZSB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFVzZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iUGVyY2VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkNQVSB1c2VyIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50TmljZVRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIG5pY2UgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRQcml2aWxlZ2VkVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgcHJpdmlsZWdlZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudEludGVycnVwdFRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIGludGVycnVwdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudERQQ1RpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIERQQyB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFByb2Nlc3NvclRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIHBlcmNlbnRhZ2UgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50SU9XYWl0VGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgSU8gd2FpdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xSZWFkQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCBndWVzdCBPUyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXFdyaXRlQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGUgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xUcmFuc2ZlcnNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXJzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcUmVhZHNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xXcml0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVJlYWRUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVdyaXRlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlNlY29uZHMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJEaXNrIHdyaXRlIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xBdmVyYWdlVHJhbnNmZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXIgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXEF2ZXJhZ2VEaXNrUXVldWVMZW5ndGgiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcXVldWUgbGVuZ3RoIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVHJhbnNtaXR0ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgb3V0IGd1ZXN0IE9TIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzUmVjZWl2ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgaW4gZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1RyYW5zbWl0dGVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHNlbnQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1JlY2VpdmVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHJlY2VpdmVkIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVG90YWwiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxSeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyByZWNlaXZlZCBlcnJvcnMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxUeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyBzZW50IGVycm9ycyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTmV0d29ya0ludGVyZmFjZVxUb3RhbENvbGxpc2lvbnMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgY29sbGlzaW9ucyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48L1BlcmZvcm1hbmNlQ291bnRlcnM+PE1ldHJpY3MgcmVzb3VyY2VJZD0iL3N1YnNjcmlwdGlvbnMvMjU4NmM2NGItMzhiNC00NTI3LWExNDAtMDEyZDQ5ZGZjMDJjL3Jlc291cmNlR3JvdXBzL21pcS1henVyZS10ZXN0MS9wcm92aWRlcnMvTWljcm9zb2Z0LkNvbXB1dGUvdmlydHVhbE1hY2hpbmVzL21pcWF6dXJlLWNlbnRvczEiPjxNZXRyaWNBZ2dyZWdhdGlvbiBzY2hlZHVsZWRUcmFuc2ZlclBlcmlvZD0iUFQxSCIvPjxNZXRyaWNBZ2dyZWdhdGlvbiBzY2hlZHVsZWRUcmFuc2ZlclBlcmlvZD0iUFQxTSIvPjwvTWV0cmljcz48L0RpYWdub3N0aWNNb25pdG9yQ29uZmlndXJhdGlvbj48L1dhZENmZz4=\",\"StorageAccount\":\"miqazuretest14047\"},\r\n
-        \       \"provisioningState\": \"Succeeded\"\r\n      },\r\n      \"type\":
-        \"Microsoft.Compute/virtualMachines/extensions\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1/extensions/Microsoft.Insights.VMDiagnosticsSettings\",\r\n
-        \     \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n    }\r\n
-        \ ],\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\":
-        \"eastus\",\r\n  \"tags\": {\r\n    \"Shutdown\": \"true\"\r\n  },\r\n  \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1\",\r\n
-        \ \"name\": \"miqazure-centos1\"\r\n}"
+      string: "{\r\n  \"name\": \"miqazure-centos1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1\",\r\n
+        \ \"etag\": \"W/\\\"734a3944-a880-444c-8c92-cace6e28e303\\\"\",\r\n  \"location\":
+        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"475a66f0-9e89-4226-a9f0-9baaaf31d619\",\r\n    \"publicIPAddressVersion\":
+        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
+        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1\"\r\n
+        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
+        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:16 GMT
+  recorded_at: Mon, 12 Mar 2018 10:25:40 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1/instanceView?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047?api-version=2017-10-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3837,7 +3422,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1ODEsIm5iZiI6MTUyMDQ1MzU4MSwiZXhwIjoxNTIwNDU3NDgxLCJhaW8iOiJZMk5nWURqdmVlYldiaDNsUkp1Sm9uZTFpN2ZQQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiejQ5SjdhMExRa3FGeG1FNXlGb0FBQSIsInZlciI6IjEuMCJ9.pBpmvta3GhE-q7jz0GPLGkXKVgiDCQmGLnwpg3-wQ0HBDJ79kKhZfOwiPFcXFZG8heoad_YWYcnVjQuMY9hsV3yTXGMgJlVBpYH5gUh9PiCSHPQTfdkX3Nxwv5vz8rLkwd_HH8UUMN96AkGpoSvbVxA3aDSC0sOYaHElhO6XOllD5CGuui1T3gpptUjj18PRQnCC_cZbqLJETdQT4S0IoEGz6-FNlt45pPg3rJUK1WFQa9rfWPsd3XCRQEvZjeaj4zeYRB8-bNe8dbrcitRhVocQWHmFKlQ1i7q2b840YCbG3udPoSJ0hPJqHcFexjzEMfn_vJeiNLETBncPUYfbPw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAwMDgsIm5iZiI6MTUyMDg1MDAwOCwiZXhwIjoxNTIwODUzOTA4LCJhaW8iOiJZMk5nWUpETSt4NVdsaFY1SWtqNTBsMHhMc1pwQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidXJVTmZ1X0tia2FsWkxWNHdkUUFBQSIsInZlciI6IjEuMCJ9.JZgL7n0qXHgKoO66Qr6QO-NQbdn-8kjLG3DkmcI-u8dGoFGPi7UW9xEJtKwYw5MqnpnItbSeHhmsDOQC8wPjV4dZ3gTEYehW8FpTsXkhOGy7EkeTmgpdegs96aOG7ttypkyxM9mQ3jk1x_NBm8c1jf4OssGN-WwXR7zIsmK0MHz0d2wCpu054SParX1ExHX-fgGDTMbC3h1RoXr28hJrVL5Z_7f2LbHWnkPtcUepfybilV7caVa3mgvWt3PO3cqwjE3p47pazCE-RoA9qqZqDhprJ7P3qHG6S9FBX9VvT1XReMG_k1U76MBJ-jwLUYucRgKrB5UDq1U83qgGrwiipg
   response:
     status:
       code: 200
@@ -3850,207 +3435,32 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Content-Type:
-      - application/json; charset=utf-8
+      - application/json
       Expires:
       - "-1"
       Vary:
       - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/GetInstanceView3Min;4791,Microsoft.Compute/GetInstanceView30Min;23920
+      X-Ms-Request-Id:
+      - 483bd335-8296-483a-a5b3-113016690046
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
-      X-Ms-Request-Id:
-      - 1b2252ff-9c89-447e-99fc-6036071618f6
       Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14769'
+      - '14983'
       X-Ms-Correlation-Request-Id:
-      - 9c60ed28-04ea-4e42-8274-9e8dd53e25e5
+      - f9ddc3da-6e85-4b04-a5b6-4f8b45acf167
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201828Z:9c60ed28-04ea-4e42-8274-9e8dd53e25e5
+      - WESTEUROPE:20180312T102537Z:f9ddc3da-6e85-4b04-a5b6-4f8b45acf167
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:18:27 GMT
+      - Mon, 12 Mar 2018 10:25:36 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"platformUpdateDomain\": 0,\r\n  \"platformFaultDomain\": 0,\r\n
-        \ \"vmAgent\": {\r\n    \"vmAgentVersion\": \"Unknown\",\r\n    \"statuses\":
-        [\r\n      {\r\n        \"code\": \"ProvisioningState/Unavailable\",\r\n        \"level\":
-        \"Warning\",\r\n        \"displayStatus\": \"Not Ready\",\r\n        \"message\":
-        \"Failed to fetch the VM status.\",\r\n        \"time\": \"2018-03-07T20:18:16+00:00\"\r\n
-        \     }\r\n    ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"miqazure-centos1\",\r\n
-        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
-        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"time\": \"2016-06-22T21:18:47.2011229+00:00\"\r\n
-        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
-        \"https://miqazuretest14047.blob.core.windows.net/bootdiagnostics-miqazurec-796c5bcc-338a-448d-b61c-165279a7fb3e/miqazure-centos1.796c5bcc-338a-448d-b61c-165279a7fb3e.screenshot.bmp\",\r\n
-        \   \"serialConsoleLogBlobUri\": \"https://miqazuretest14047.blob.core.windows.net/bootdiagnostics-miqazurec-796c5bcc-338a-448d-b61c-165279a7fb3e/miqazure-centos1.796c5bcc-338a-448d-b61c-165279a7fb3e.serialconsole.log\"\r\n
-        \ },\r\n  \"extensions\": [\r\n    {\r\n      \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n
-        \   }\r\n  ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\": \"ProvisioningState/succeeded\",\r\n
-        \     \"level\": \"Info\",\r\n      \"displayStatus\": \"Provisioning succeeded\",\r\n
-        \     \"time\": \"2016-06-22T21:18:47.2636196+00:00\"\r\n    },\r\n    {\r\n
-        \     \"code\": \"PowerState/deallocated\",\r\n      \"level\": \"Info\",\r\n
-        \     \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","name":"miqazuretest14047","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T17:30:25.7028008Z","primaryEndpoints":{"blob":"https://miqazuretest14047.blob.core.windows.net/","queue":"https://miqazuretest14047.queue.core.windows.net/","table":"https://miqazuretest14047.table.core.windows.net/","file":"https://miqazuretest14047.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:28 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Network/networkInterfaces?api-version=2017-11-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1ODEsIm5iZiI6MTUyMDQ1MzU4MSwiZXhwIjoxNTIwNDU3NDgxLCJhaW8iOiJZMk5nWURqdmVlYldiaDNsUkp1Sm9uZTFpN2ZQQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiejQ5SjdhMExRa3FGeG1FNXlGb0FBQSIsInZlciI6IjEuMCJ9.pBpmvta3GhE-q7jz0GPLGkXKVgiDCQmGLnwpg3-wQ0HBDJ79kKhZfOwiPFcXFZG8heoad_YWYcnVjQuMY9hsV3yTXGMgJlVBpYH5gUh9PiCSHPQTfdkX3Nxwv5vz8rLkwd_HH8UUMN96AkGpoSvbVxA3aDSC0sOYaHElhO6XOllD5CGuui1T3gpptUjj18PRQnCC_cZbqLJETdQT4S0IoEGz6-FNlt45pPg3rJUK1WFQa9rfWPsd3XCRQEvZjeaj4zeYRB8-bNe8dbrcitRhVocQWHmFKlQ1i7q2b840YCbG3udPoSJ0hPJqHcFexjzEMfn_vJeiNLETBncPUYfbPw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 4dd6d42e-60a1-43a4-8145-7b8f6231dbaa
-      X-Ms-Correlation-Request-Id:
-      - 4dd6d42e-60a1-43a4-8145-7b8f6231dbaa
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201831Z:4dd6d42e-60a1-43a4-8145-7b8f6231dbaa
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:18:30 GMT
-      Content-Length:
-      - '31614'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[{"name":"miqazure-coreos1235","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235","etag":"W/\"4a6546ab-a4c0-4d27-bccd-f6ebf3c405a2\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"fb0a5e60-a6c2-4bb8-a2f5-0c16216a49b0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235/ipConfigurations/ipconfig1","etag":"W/\"4a6546ab-a4c0-4d27-bccd-f6ebf3c405a2\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.20.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/publicIPAddresses/miqazure-coreos1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/virtualNetworks/miq-azure-test3/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"rliadcyr3l1elbnsw4rabxqg1f.dx.internal.cloudapp.net"},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkSecurityGroups/miqazure-coreos1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Compute/virtualMachines/miqazure-coreos1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"dbergerprov1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/dbergerprov1","etag":"W/\"074dd836-918c-4e40-a118-94f0d366e175\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"ecdcd2f0-91bb-4c40-91cd-a3d76fc5e455","ipConfigurations":[{"name":"dbergerprov1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/dbergerprov1/ipConfigurations/dbergerprov1","etag":"W/\"074dd836-918c-4e40-a118-94f0d366e175\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.9","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/dbergerprov1-publicIp"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/virtualMachines/dbergerprov1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-rhel1390","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390","etag":"W/\"f006e6f9-0292-42cd-99fc-f72f194553c1\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"98853f48-2806-4065-be57-cf9159550440","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1","etag":"W/\"f006e6f9-0292-42cd-99fc-f72f194553c1\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"macAddress":"00-0D-3A-10-EB-AB","enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-ubuntu1989","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989","etag":"W/\"64e07488-15a2-4cec-b84a-6fd5ef04323c\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"134a6669-ac4a-4d08-a0db-387bc4c49537","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989/ipConfigurations/ipconfig1","etag":"W/\"64e07488-15a2-4cec-b84a-6fd5ef04323c\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.17.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-ubuntu1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest18687/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-win12610","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610","etag":"W/\"dd925ef5-33d1-402c-a0f4-18c78c2641f4\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"5c2eef2c-0b36-4277-a940-957ed4d13be0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610/ipConfigurations/ipconfig1","etag":"W/\"dd925ef5-33d1-402c-a0f4-18c78c2641f4\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.18.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-win12"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest19881/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-winimg241","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241","etag":"W/\"4a17a745-16a9-42d9-88c9-17a518959525\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"8ed2f3b0-4a4b-49ae-9f1d-ff7890dbd396","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241/ipConfigurations/ipconfig1","etag":"W/\"4a17a745-16a9-42d9-88c9-17a518959525\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.7","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqtestwinimg6202"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-centos1611","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611","etag":"W/\"26031ef6-bb55-4019-8185-2dd1edcb207c\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"f1760e49-9853-4fdc-acfc-4ea232b9ed76","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1","etag":"W/\"26031ef6-bb55-4019-8185-2dd1edcb207c\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.5","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqmismatch1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1","etag":"W/\"3a72d0c3-bfda-4da5-a61b-e8c33e43de79\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"23d804a8-b623-49e7-9c8d-1d64245bef1e","ipConfigurations":[{"name":"miqmismatch1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1/ipConfigurations/miqmismatch1","etag":"W/\"3a72d0c3-bfda-4da5-a61b-e8c33e43de79\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.8","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqmismatch1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqmismatch1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"rspec-lb-a670","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670","etag":"W/\"cf3a0b0d-d596-4f33-bc31-749f92ba4f00\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"46cb8216-786e-408e-9d86-c0855b357349","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1","etag":"W/\"cf3a0b0d-d596-4f33-bc31-749f92ba4f00\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.6","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-a-ip"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"rspec-lb-b843","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843","etag":"W/\"76aabe0c-8678-43f0-81a5-2f15784a4b99\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"3ef6fa01-ac34-43a1-8fd7-67c706b4d8ef","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1","etag":"W/\"76aabe0c-8678-43f0-81a5-2f15784a4b99\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.11","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-b-ip"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"spec0deply1nic0","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","etag":"W/\"b817491c-aab8-4aab-b41d-b07bfffa5639\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"80ad9866-071d-4e3f-91d0-d47954eccee0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1","etag":"W/\"b817491c-aab8-4aab-b41d-b07bfffa5639\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.4","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"spec0deply1nic1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","etag":"W/\"2ec58a0b-4c03-4d0a-b788-9daffd54e7b2\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"57bbf7aa-d6c4-4f56-8f6a-089d15334221","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1","etag":"W/\"2ec58a0b-4c03-4d0a-b788-9daffd54e7b2\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.5","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqmismatch2656","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqmismatch2656","etag":"W/\"fef6a836-2802-4897-90c3-b3d71f133384\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"969dde6c-73c0-4340-877d-2b5fe2060026","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqmismatch2656/ipConfigurations/ipconfig1","etag":"W/\"fef6a836-2802-4897-90c3-b3d71f133384\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"172.23.0.4","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/virtualNetworks/miqazuretest33606/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkSecurityGroups/miqmismatch2-nsg"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Compute/virtualMachines/miqmismatch2"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-linux-manag944","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944","etag":"W/\"b6339880-8ead-4c9e-b5c0-f38c4f8612d5\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"c5e8b90e-5a78-49b0-b224-b70ed3fb45e5","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944/ipConfigurations/ipconfig1","etag":"W/\"b6339880-8ead-4c9e-b5c0-f38c4f8612d5\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"172.25.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqazure-linux-managed-ip"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"jf-metrics-2751","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751","etag":"W/\"c5f6f02a-b17c-4f34-882b-11c7adef0b44\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"207a58d3-f18d-4dab-8168-919877297a52","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751/ipConfigurations/ipconfig1","etag":"W/\"c5f6f02a-b17c-4f34-882b-11c7adef0b44\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.7","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-2"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-2"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/jf-metrics-2"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"jf-metrics-3421","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421","etag":"W/\"0b6f160b-ad10-48f8-9d0c-657193bb823f\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"b8b345e8-a353-4700-992e-be48a717b4e2","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421/ipConfigurations/ipconfig1","etag":"W/\"0b6f160b-ad10-48f8-9d0c-657193bb823f\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.8","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-3"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-3"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/jf-metrics-3"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-oraclelinux310","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310","etag":"W/\"54cd4fe1-3ed5-4a8c-bc8d-527679c7a631\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"6a3fc1d7-4532-4ca0-b5c2-546cc8f7f313","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310/ipConfigurations/ipconfig1","etag":"W/\"54cd4fe1-3ed5-4a8c-bc8d-527679c7a631\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.5","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-oraclelinux993","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993","etag":"W/\"a9432274-7b40-4eb3-a64f-a04267a423ff\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"75d8ed14-e0ae-4d84-99f6-e3f43d073e76","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993/ipConfigurations/ipconfig1","etag":"W/\"a9432274-7b40-4eb3-a64f-a04267a423ff\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.6","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux2"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux2"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"}]}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:31 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Network/publicIPAddresses?api-version=2017-11-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1ODEsIm5iZiI6MTUyMDQ1MzU4MSwiZXhwIjoxNTIwNDU3NDgxLCJhaW8iOiJZMk5nWURqdmVlYldiaDNsUkp1Sm9uZTFpN2ZQQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiejQ5SjdhMExRa3FGeG1FNXlGb0FBQSIsInZlciI6IjEuMCJ9.pBpmvta3GhE-q7jz0GPLGkXKVgiDCQmGLnwpg3-wQ0HBDJ79kKhZfOwiPFcXFZG8heoad_YWYcnVjQuMY9hsV3yTXGMgJlVBpYH5gUh9PiCSHPQTfdkX3Nxwv5vz8rLkwd_HH8UUMN96AkGpoSvbVxA3aDSC0sOYaHElhO6XOllD5CGuui1T3gpptUjj18PRQnCC_cZbqLJETdQT4S0IoEGz6-FNlt45pPg3rJUK1WFQa9rfWPsd3XCRQEvZjeaj4zeYRB8-bNe8dbrcitRhVocQWHmFKlQ1i7q2b840YCbG3udPoSJ0hPJqHcFexjzEMfn_vJeiNLETBncPUYfbPw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 3ce45609-30ac-4a0b-981b-9182e2d8e84c
-      X-Ms-Correlation-Request-Id:
-      - 3ce45609-30ac-4a0b-981b-9182e2d8e84c
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201833Z:3ce45609-30ac-4a0b-981b-9182e2d8e84c
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:18:32 GMT
-      Content-Length:
-      - '13978'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[{"name":"miqazure-coreos1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/publicIPAddresses/miqazure-coreos1","etag":"W/\"da64b64b-a755-4389-a2f3-5cba32f18c06\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"28617ed1-0270-4b39-873a-c3b48b3deef1","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"dbergerprov1-publicIp","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/dbergerprov1-publicIp","etag":"W/\"3d984c69-3f35-41ce-bdfc-8d207053a6a9\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"eb0e8804-e169-44ac-bb47-0929370977d2","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/dbergerprov1/ipConfigurations/dbergerprov1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"ladas_test","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/ladas_test","etag":"W/\"32e21623-9a1b-4c40-80f4-6a350aa237a7\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"3daa5f66-5a01-4242-b95b-c4e0ee8f0c36","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[]},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miq-test-rhel1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1","etag":"W/\"054052bb-11ff-4f6e-ac1a-3427c2fd17aa\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"f6cfc635-411e-48ce-a627-39a2fc0d3168","ipAddress":"52.224.165.15","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miq-test-ubuntu1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-ubuntu1","etag":"W/\"bcae50c5-146f-4fcb-a461-7c1030ba7b74\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"e272bd74-f661-484f-b223-88dd128a4049","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miq-test-win12","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-win12","etag":"W/\"56ce00f4-50d7-4682-9ee8-6836bf5c0ea6\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"b9200977-8147-40a5-83c2-d5892d5ddedc","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miqazure-centos1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1","etag":"W/\"734a3944-a880-444c-8c92-cace6e28e303\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"475a66f0-9e89-4226-a9f0-9baaaf31d619","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miqtestwinimg6202","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqtestwinimg6202","etag":"W/\"b656279a-26ff-4021-94bb-263420cf494e\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"fb942169-855b-44f8-b12f-fd63e961b140","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"rspec-lb-a-ip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-a-ip","etag":"W/\"3ba30997-7d2f-470c-96f6-301158e93b7c\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"3c605f75-23c0-46ab-ba2b-6fd4430140fd","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"rspec-lb-b-ip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-b-ip","etag":"W/\"cf6012c7-3d47-438f-84d7-332ad1ef4500\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"5d1a2425-a351-4c0f-bc87-37e6500bff22","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"rspec-lb1-LoadBalancerFrontEnd","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd","etag":"W/\"a38434c8-7b23-4092-b7c6-402238eac0dc\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"f28e0f25-b372-4edf-97d9-13a9e3b4ba2d","ipAddress":"40.71.82.83","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"rspec-lb2-publicip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip","etag":"W/\"cddd97d1-6111-4477-8a00-3dc885237a1d\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"83e7257d-ab94-4229-8eb5-4798f37ef28d","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"spec0deply1ip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip","etag":"W/\"2080997a-38a6-420d-ba86-e9582e1331c7\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"a08b891e-e45a-4970-aefc-f6c996989490","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"spec0deply1dns","fqdn":"spec0deply1dns.eastus.cloudapp.azure.com"},"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miqazure-linux-managed-ip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqazure-linux-managed-ip","etag":"W/\"0efc9684-fb7d-4fb7-b9b9-f33dbac04a28\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"6a2a9142-26e8-45cd-93bf-7318192f3528","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miqmismatch1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqmismatch1","etag":"W/\"9b8b1729-21c4-4c53-94f2-15715315ad73\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"a97c71d0-6b78-4ffe-8e5c-0be1ee653f8c","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"miqmismatch1","fqdn":"miqmismatch1.eastus.cloudapp.azure.com"},"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1/ipConfigurations/miqmismatch1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"jf-metrics-2","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-2","etag":"W/\"b43ebe01-574c-4454-87eb-3401fbcf36f2\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"e446f3e4-9410-4d7f-bb04-2652096359de","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"jf-metrics-3","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-3","etag":"W/\"a6ee7100-6202-4ae2-a2db-f828abec8af9\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"de5995a4-15c1-40ba-ad78-67e70a92654b","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miqazure-oraclelinux1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux1","etag":"W/\"98bee7b4-2fcc-471d-b5ce-92850e6c3d6b\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"f2ac7c18-520b-4b42-94e7-da264a842f41","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miqazure-oraclelinux2","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux2","etag":"W/\"0865cebc-95b9-49d2-9f10-21dbafb23cac\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"2f4e1091-46f0-474c-a697-8dbcea6ba2a6","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}}]}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:33 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Storage/storageAccounts?api-version=2017-10-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1ODEsIm5iZiI6MTUyMDQ1MzU4MSwiZXhwIjoxNTIwNDU3NDgxLCJhaW8iOiJZMk5nWURqdmVlYldiaDNsUkp1Sm9uZTFpN2ZQQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiejQ5SjdhMExRa3FGeG1FNXlGb0FBQSIsInZlciI6IjEuMCJ9.pBpmvta3GhE-q7jz0GPLGkXKVgiDCQmGLnwpg3-wQ0HBDJ79kKhZfOwiPFcXFZG8heoad_YWYcnVjQuMY9hsV3yTXGMgJlVBpYH5gUh9PiCSHPQTfdkX3Nxwv5vz8rLkwd_HH8UUMN96AkGpoSvbVxA3aDSC0sOYaHElhO6XOllD5CGuui1T3gpptUjj18PRQnCC_cZbqLJETdQT4S0IoEGz6-FNlt45pPg3rJUK1WFQa9rfWPsd3XCRQEvZjeaj4zeYRB8-bNe8dbrcitRhVocQWHmFKlQ1i7q2b840YCbG3udPoSJ0hPJqHcFexjzEMfn_vJeiNLETBncPUYfbPw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 430913ca-b878-4712-bc5f-08b0d0619fb7
-      X-Ms-Correlation-Request-Id:
-      - 430913ca-b878-4712-bc5f-08b0d0619fb7
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201835Z:430913ca-b878-4712-bc5f-08b0d0619fb7
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:18:34 GMT
-      Content-Length:
-      - '8649'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","name":"miqazuretest18686","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T17:22:54.7808677Z","primaryEndpoints":{"blob":"https://miqazuretest18686.blob.core.windows.net/","queue":"https://miqazuretest18686.queue.core.windows.net/","table":"https://miqazuretest18686.table.core.windows.net/","file":"https://miqazuretest18686.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","name":"miqazuretest14047","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T17:30:25.7028008Z","primaryEndpoints":{"blob":"https://miqazuretest14047.blob.core.windows.net/","queue":"https://miqazuretest14047.queue.core.windows.net/","table":"https://miqazuretest14047.table.core.windows.net/","file":"https://miqazuretest14047.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Premium_LRS","tier":"Premium"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb","name":"rspeclb","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-09-02T16:29:11.6823797Z","primaryEndpoints":{"blob":"https://rspeclb.blob.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","name":"spec0deply1stor","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-04-04T23:05:07.8274794Z","primaryEndpoints":{"blob":"https://spec0deply1stor.blob.core.windows.net/","queue":"https://spec0deply1stor.queue.core.windows.net/","table":"https://spec0deply1stor.table.core.windows.net/","file":"https://spec0deply1stor.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Storage/storageAccounts/miqazuretest26611","name":"miqazuretest26611","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2211656Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2211656Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-05-02T18:01:29.2743021Z","primaryEndpoints":{"blob":"https://miqazuretest26611.blob.core.windows.net/","queue":"https://miqazuretest26611.queue.core.windows.net/","table":"https://miqazuretest26611.table.core.windows.net/","file":"https://miqazuretest26611.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","name":"miqazuretest16487","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T17:26:55.3231669Z","primaryEndpoints":{"blob":"https://miqazuretest16487.blob.core.windows.net/","queue":"https://miqazuretest16487.queue.core.windows.net/","table":"https://miqazuretest16487.table.core.windows.net/","file":"https://miqazuretest16487.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Storage/storageAccounts/miqazuretest32946","name":"miqazuretest32946","type":"Microsoft.Storage/storageAccounts","location":"westus","tags":{"delete":"false"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.0404359Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.0404359Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T21:18:37.0793411Z","primaryEndpoints":{"blob":"https://miqazuretest32946.blob.core.windows.net/","queue":"https://miqazuretest32946.queue.core.windows.net/","table":"https://miqazuretest32946.table.core.windows.net/","file":"https://miqazuretest32946.file.core.windows.net/"},"primaryLocation":"westus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Storage/storageAccounts/miqazureshared1","name":"miqazureshared1","type":"Microsoft.Storage/storageAccounts","location":"centralus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.1935084Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.1935084Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T20:42:52.498085Z","primaryEndpoints":{"blob":"https://miqazureshared1.blob.core.windows.net/","queue":"https://miqazureshared1.queue.core.windows.net/","table":"https://miqazureshared1.table.core.windows.net/","file":"https://miqazureshared1.file.core.windows.net/"},"primaryLocation":"centralus","statusOfPrimary":"available","secondaryLocation":"eastus2","statusOfSecondary":"available","secondaryEndpoints":{"blob":"https://miqazureshared1-secondary.blob.core.windows.net/","queue":"https://miqazureshared1-secondary.queue.core.windows.net/","table":"https://miqazureshared1-secondary.table.core.windows.net/"}}}]}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:35 GMT
+  recorded_at: Mon, 12 Mar 2018 10:25:41 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047/listKeys?api-version=2017-10-01
@@ -4067,7 +3477,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1ODEsIm5iZiI6MTUyMDQ1MzU4MSwiZXhwIjoxNTIwNDU3NDgxLCJhaW8iOiJZMk5nWURqdmVlYldiaDNsUkp1Sm9uZTFpN2ZQQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiejQ5SjdhMExRa3FGeG1FNXlGb0FBQSIsInZlciI6IjEuMCJ9.pBpmvta3GhE-q7jz0GPLGkXKVgiDCQmGLnwpg3-wQ0HBDJ79kKhZfOwiPFcXFZG8heoad_YWYcnVjQuMY9hsV3yTXGMgJlVBpYH5gUh9PiCSHPQTfdkX3Nxwv5vz8rLkwd_HH8UUMN96AkGpoSvbVxA3aDSC0sOYaHElhO6XOllD5CGuui1T3gpptUjj18PRQnCC_cZbqLJETdQT4S0IoEGz6-FNlt45pPg3rJUK1WFQa9rfWPsd3XCRQEvZjeaj4zeYRB8-bNe8dbrcitRhVocQWHmFKlQ1i7q2b840YCbG3udPoSJ0hPJqHcFexjzEMfn_vJeiNLETBncPUYfbPw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAwMDgsIm5iZiI6MTUyMDg1MDAwOCwiZXhwIjoxNTIwODUzOTA4LCJhaW8iOiJZMk5nWUpETSt4NVdsaFY1SWtqNTBsMHhMc1pwQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidXJVTmZ1X0tia2FsWkxWNHdkUUFBQSIsInZlciI6IjEuMCJ9.JZgL7n0qXHgKoO66Qr6QO-NQbdn-8kjLG3DkmcI-u8dGoFGPi7UW9xEJtKwYw5MqnpnItbSeHhmsDOQC8wPjV4dZ3gTEYehW8FpTsXkhOGy7EkeTmgpdegs96aOG7ttypkyxM9mQ3jk1x_NBm8c1jf4OssGN-WwXR7zIsmK0MHz0d2wCpu054SParX1ExHX-fgGDTMbC3h1RoXr28hJrVL5Z_7f2LbHWnkPtcUepfybilV7caVa3mgvWt3PO3cqwjE3p47pazCE-RoA9qqZqDhprJ7P3qHG6S9FBX9VvT1XReMG_k1U76MBJ-jwLUYucRgKrB5UDq1U83qgGrwiipg
       Content-Length:
       - '0'
   response:
@@ -4088,26 +3498,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - bdc14cbc-90d6-49fe-8be5-d58d04ed003d
+      - '0799b8a2-7768-43e8-ab57-84367e020a79'
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1196'
+      - '1198'
       X-Ms-Correlation-Request-Id:
-      - 510061fc-8591-4fa6-a693-475edddb6e62
+      - a2215cbf-a052-4f1a-8c38-0f8ef77bd092
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201835Z:510061fc-8591-4fa6-a693-475edddb6e62
+      - WESTEUROPE:20180312T102538Z:a2215cbf-a052-4f1a-8c38-0f8ef77bd092
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:18:35 GMT
+      - Mon, 12 Mar 2018 10:25:37 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keys":[{"keyName":"key1","value":"9hGLwV9mjvAc1ARzeGwpsS9oZPLqOBzHCCHjeixyt1wpPYVn32cXmm3Gs9ogFPXZhDH61PAXxud0Dg/qwOnJ1w==","permissions":"Full"},{"keyName":"key2","value":"FfW8btVjJE2LkKHvN8Prr3FDX71BrS4SnMkONq2fLVPPm6x7vqqjeDSWDh17aI4CBLYf3Y1pc6njkbz53HdMYg==","permissions":"Full"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:35 GMT
+  recorded_at: Mon, 12 Mar 2018 10:25:42 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/vhds/miqazure-centos12016221104946.vhd
@@ -4124,7 +3534,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:18:35 GMT
+      - Mon, 12 Mar 2018 10:25:42 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -4132,7 +3542,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:veQYy11nfWUKhl1c/9G48XeASSreN5e5TslQJKWh3UQ=
+      - SharedKey miqazuretest14047:5unKI9SjP1qWw+XuVomTqbuT8hHNvq8/8iOtjtAWt4o=
   response:
     status:
       code: 200
@@ -4153,7 +3563,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 3e4bf7a1-001e-005a-3851-b620fe000000
+      - e98d3073-001e-0094-17ec-b946b1000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Microsoftazurecompute-Resourcegroupname:
@@ -4189,12 +3599,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:18:35 GMT
+      - Mon, 12 Mar 2018 10:25:38 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:36 GMT
+  recorded_at: Mon, 12 Mar 2018 10:25:43 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1?api-version=2018-01-01
@@ -4211,7 +3621,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1ODEsIm5iZiI6MTUyMDQ1MzU4MSwiZXhwIjoxNTIwNDU3NDgxLCJhaW8iOiJZMk5nWURqdmVlYldiaDNsUkp1Sm9uZTFpN2ZQQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiejQ5SjdhMExRa3FGeG1FNXlGb0FBQSIsInZlciI6IjEuMCJ9.pBpmvta3GhE-q7jz0GPLGkXKVgiDCQmGLnwpg3-wQ0HBDJ79kKhZfOwiPFcXFZG8heoad_YWYcnVjQuMY9hsV3yTXGMgJlVBpYH5gUh9PiCSHPQTfdkX3Nxwv5vz8rLkwd_HH8UUMN96AkGpoSvbVxA3aDSC0sOYaHElhO6XOllD5CGuui1T3gpptUjj18PRQnCC_cZbqLJETdQT4S0IoEGz6-FNlt45pPg3rJUK1WFQa9rfWPsd3XCRQEvZjeaj4zeYRB8-bNe8dbrcitRhVocQWHmFKlQ1i7q2b840YCbG3udPoSJ0hPJqHcFexjzEMfn_vJeiNLETBncPUYfbPw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAwMDgsIm5iZiI6MTUyMDg1MDAwOCwiZXhwIjoxNTIwODUzOTA4LCJhaW8iOiJZMk5nWUpETSt4NVdsaFY1SWtqNTBsMHhMc1pwQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidXJVTmZ1X0tia2FsWkxWNHdkUUFBQSIsInZlciI6IjEuMCJ9.JZgL7n0qXHgKoO66Qr6QO-NQbdn-8kjLG3DkmcI-u8dGoFGPi7UW9xEJtKwYw5MqnpnItbSeHhmsDOQC8wPjV4dZ3gTEYehW8FpTsXkhOGy7EkeTmgpdegs96aOG7ttypkyxM9mQ3jk1x_NBm8c1jf4OssGN-WwXR7zIsmK0MHz0d2wCpu054SParX1ExHX-fgGDTMbC3h1RoXr28hJrVL5Z_7f2LbHWnkPtcUepfybilV7caVa3mgvWt3PO3cqwjE3p47pazCE-RoA9qqZqDhprJ7P3qHG6S9FBX9VvT1XReMG_k1U76MBJ-jwLUYucRgKrB5UDq1U83qgGrwiipg
   response:
     status:
       code: 200
@@ -4232,22 +3642,22 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - c0d6b10e-a88b-4e6c-aeae-0af18bbaaa90
+      - 81eee16f-1dcb-46fb-a6ad-594902775bc3
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14985'
+      - '14984'
       X-Ms-Correlation-Request-Id:
-      - 224c90c5-cd02-4eb5-90fb-fd2dbcdad109
+      - 5a772296-8d34-4c81-8074-35bef07e20bb
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201836Z:224c90c5-cd02-4eb5-90fb-fd2dbcdad109
+      - WESTEUROPE:20180312T102542Z:5a772296-8d34-4c81-8074-35bef07e20bb
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:18:36 GMT
+      - Mon, 12 Mar 2018 10:25:42 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"miqazure-centos1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1\",\r\n
@@ -4332,7 +3742,7 @@ http_interactions:
         \   ],\r\n    \"networkInterfaces\": [\r\n      {\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611\"\r\n
         \     }\r\n    ]\r\n  }\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:36 GMT
+  recorded_at: Mon, 12 Mar 2018 10:25:47 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1?api-version=2018-01-01
@@ -4349,7 +3759,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1ODEsIm5iZiI6MTUyMDQ1MzU4MSwiZXhwIjoxNTIwNDU3NDgxLCJhaW8iOiJZMk5nWURqdmVlYldiaDNsUkp1Sm9uZTFpN2ZQQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiejQ5SjdhMExRa3FGeG1FNXlGb0FBQSIsInZlciI6IjEuMCJ9.pBpmvta3GhE-q7jz0GPLGkXKVgiDCQmGLnwpg3-wQ0HBDJ79kKhZfOwiPFcXFZG8heoad_YWYcnVjQuMY9hsV3yTXGMgJlVBpYH5gUh9PiCSHPQTfdkX3Nxwv5vz8rLkwd_HH8UUMN96AkGpoSvbVxA3aDSC0sOYaHElhO6XOllD5CGuui1T3gpptUjj18PRQnCC_cZbqLJETdQT4S0IoEGz6-FNlt45pPg3rJUK1WFQa9rfWPsd3XCRQEvZjeaj4zeYRB8-bNe8dbrcitRhVocQWHmFKlQ1i7q2b840YCbG3udPoSJ0hPJqHcFexjzEMfn_vJeiNLETBncPUYfbPw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAwMDgsIm5iZiI6MTUyMDg1MDAwOCwiZXhwIjoxNTIwODUzOTA4LCJhaW8iOiJZMk5nWUpETSt4NVdsaFY1SWtqNTBsMHhMc1pwQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoidXJVTmZ1X0tia2FsWkxWNHdkUUFBQSIsInZlciI6IjEuMCJ9.JZgL7n0qXHgKoO66Qr6QO-NQbdn-8kjLG3DkmcI-u8dGoFGPi7UW9xEJtKwYw5MqnpnItbSeHhmsDOQC8wPjV4dZ3gTEYehW8FpTsXkhOGy7EkeTmgpdegs96aOG7ttypkyxM9mQ3jk1x_NBm8c1jf4OssGN-WwXR7zIsmK0MHz0d2wCpu054SParX1ExHX-fgGDTMbC3h1RoXr28hJrVL5Z_7f2LbHWnkPtcUepfybilV7caVa3mgvWt3PO3cqwjE3p47pazCE-RoA9qqZqDhprJ7P3qHG6S9FBX9VvT1XReMG_k1U76MBJ-jwLUYucRgKrB5UDq1U83qgGrwiipg
   response:
     status:
       code: 200
@@ -4366,36 +3776,36 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"fceae1ac-4620-482a-bc6d-79c867179ae5"
+      - W/"a8b09238-30fc-4b36-a58d-e3cc69e267c5"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 5c2b1454-3774-4240-a348-8542377f2f14
+      - 19d12d1c-1740-4dee-ae9c-ad03453f721d
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14966'
+      - '14986'
       X-Ms-Correlation-Request-Id:
-      - ddc48ab8-3962-4700-8a3c-0ecd4c68b954
+      - 7159943e-2d6b-4d7c-bfc3-94a78d7499be
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201836Z:ddc48ab8-3962-4700-8a3c-0ecd4c68b954
+      - WESTEUROPE:20180312T102543Z:7159943e-2d6b-4d7c-bfc3-94a78d7499be
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:18:36 GMT
+      - Mon, 12 Mar 2018 10:25:43 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"miq-azure-test1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1\",\r\n
-        \ \"etag\": \"W/\\\"fceae1ac-4620-482a-bc6d-79c867179ae5\\\"\",\r\n  \"type\":
+        \ \"etag\": \"W/\\\"a8b09238-30fc-4b36-a58d-e3cc69e267c5\\\"\",\r\n  \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
         \"d74c1e5f-50e4-4c8a-a7fe-78eaddc6b915\",\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\":
         [\r\n        \"10.16.0.0/16\"\r\n      ]\r\n    },\r\n    \"subnets\": [\r\n
         \     {\r\n        \"name\": \"default\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\",\r\n
-        \       \"etag\": \"W/\\\"fceae1ac-4620-482a-bc6d-79c867179ae5\\\"\",\r\n
+        \       \"etag\": \"W/\\\"a8b09238-30fc-4b36-a58d-e3cc69e267c5\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"addressPrefix\": \"10.16.0.0/24\",\r\n          \"ipConfigurations\":
         [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1\"\r\n
@@ -4405,149 +3815,10 @@ http_interactions:
         \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/dbergerprov1/ipConfigurations/dbergerprov1\"\r\n
         \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
         \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/ladas_test_1/ipConfigurations/ladas_test_1\"\r\n
         \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"virtualNetworkPeerings\":
         [],\r\n    \"enableDdosProtection\": false,\r\n    \"enableVmProtection\":
         false\r\n  }\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:37 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1ODEsIm5iZiI6MTUyMDQ1MzU4MSwiZXhwIjoxNTIwNDU3NDgxLCJhaW8iOiJZMk5nWURqdmVlYldiaDNsUkp1Sm9uZTFpN2ZQQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiejQ5SjdhMExRa3FGeG1FNXlGb0FBQSIsInZlciI6IjEuMCJ9.pBpmvta3GhE-q7jz0GPLGkXKVgiDCQmGLnwpg3-wQ0HBDJ79kKhZfOwiPFcXFZG8heoad_YWYcnVjQuMY9hsV3yTXGMgJlVBpYH5gUh9PiCSHPQTfdkX3Nxwv5vz8rLkwd_HH8UUMN96AkGpoSvbVxA3aDSC0sOYaHElhO6XOllD5CGuui1T3gpptUjj18PRQnCC_cZbqLJETdQT4S0IoEGz6-FNlt45pPg3rJUK1WFQa9rfWPsd3XCRQEvZjeaj4zeYRB8-bNe8dbrcitRhVocQWHmFKlQ1i7q2b840YCbG3udPoSJ0hPJqHcFexjzEMfn_vJeiNLETBncPUYfbPw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"26031ef6-bb55-4019-8185-2dd1edcb207c"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 969a7284-15fa-46e4-949e-853af23b465e
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14968'
-      X-Ms-Correlation-Request-Id:
-      - 3bde35eb-c513-4d5c-bdb9-a52eb6707d0b
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201837Z:3bde35eb-c513-4d5c-bdb9-a52eb6707d0b
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:18:37 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"miqazure-centos1611\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611\",\r\n
-        \ \"etag\": \"W/\\\"26031ef6-bb55-4019-8185-2dd1edcb207c\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"f1760e49-9853-4fdc-acfc-4ea232b9ed76\",\r\n    \"ipConfigurations\":
-        [\r\n      {\r\n        \"name\": \"ipconfig1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1\",\r\n
-        \       \"etag\": \"W/\\\"26031ef6-bb55-4019-8185-2dd1edcb207c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAddress\": \"10.16.0.5\",\r\n          \"privateIPAllocationMethod\":
-        \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1\"\r\n
-        \         },\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\"\r\n
-        \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
-        \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\":
-        [],\r\n      \"appliedDnsServers\": []\r\n    },\r\n    \"enableAcceleratedNetworking\":
-        false,\r\n    \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\":
-        {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1\"\r\n
-        \   },\r\n    \"virtualMachine\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1\"\r\n
-        \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
-        \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:37 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1ODEsIm5iZiI6MTUyMDQ1MzU4MSwiZXhwIjoxNTIwNDU3NDgxLCJhaW8iOiJZMk5nWURqdmVlYldiaDNsUkp1Sm9uZTFpN2ZQQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiejQ5SjdhMExRa3FGeG1FNXlGb0FBQSIsInZlciI6IjEuMCJ9.pBpmvta3GhE-q7jz0GPLGkXKVgiDCQmGLnwpg3-wQ0HBDJ79kKhZfOwiPFcXFZG8heoad_YWYcnVjQuMY9hsV3yTXGMgJlVBpYH5gUh9PiCSHPQTfdkX3Nxwv5vz8rLkwd_HH8UUMN96AkGpoSvbVxA3aDSC0sOYaHElhO6XOllD5CGuui1T3gpptUjj18PRQnCC_cZbqLJETdQT4S0IoEGz6-FNlt45pPg3rJUK1WFQa9rfWPsd3XCRQEvZjeaj4zeYRB8-bNe8dbrcitRhVocQWHmFKlQ1i7q2b840YCbG3udPoSJ0hPJqHcFexjzEMfn_vJeiNLETBncPUYfbPw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"734a3944-a880-444c-8c92-cace6e28e303"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 33b813aa-8b09-4fef-b23d-59032073bd98
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14976'
-      X-Ms-Correlation-Request-Id:
-      - 7ace61d4-f4d1-4004-b1b0-7ec3534336f3
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201837Z:7ace61d4-f4d1-4004-b1b0-7ec3534336f3
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:18:37 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"miqazure-centos1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1\",\r\n
-        \ \"etag\": \"W/\\\"734a3944-a880-444c-8c92-cace6e28e303\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"475a66f0-9e89-4226-a9f0-9baaaf31d619\",\r\n    \"publicIPAddressVersion\":
-        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
-        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1\"\r\n
-        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
-        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:38 GMT
+  recorded_at: Mon, 12 Mar 2018 10:25:48 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted_scope/powered_on_vm_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted_scope/powered_on_vm_refresh.yml
@@ -37,25 +37,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - d32ec8c7-5de7-4285-ada9-ab2c88750000
+      - 7c17f596-aeed-4f73-8f7c-933fa9832300
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzEOzWrMGuZhmQDvVQIcYadgSPfUwWq4-IFgC7J0PwHd_KeLv44YRGCMUCFbocOJgmqy2kS5z5h4iKq-t-amWjCkyO327NCl7JWovGHcZG9f5OEalBc191LGbTJVbdtpZdxOt2DdY-bvNdR5G1Lu7nxcrBTLu8zu37a5UwO1afy2cgAA;
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzhFj-vxiwgmuEUX7EasUT4yTRdCk4Rtx-fDJ4gI0cwaiCYXuo-2sCtYn0hKl3ZbMt6bK-VPWd0aTn4jt-uPjrJBH4R42vZVrHlPfsiRdo578YUmQvneutVOtj-5c5IlQAsjB-5BBV0qfIS7VR7U_5tspPbI5VAx3jML1bQ-Y6vNMgAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=004; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=006; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Wed, 07 Mar 2018 20:19:19 GMT
+      - Mon, 12 Mar 2018 10:26:04 GMT
       Content-Length:
       - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1520457560","not_before":"1520453660","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2NjAsIm5iZiI6MTUyMDQ1MzY2MCwiZXhwIjoxNTIwNDU3NTYwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieDhndTAtZGRoVUt0cWFzc2lIVUFBQSIsInZlciI6IjEuMCJ9.otktnWJntN5Ex1m7B5cYjtAq_50geAaUdyQL0oOsiREDXuiRlPCYHBD9qLNkbn04dkTg0udUaXIYYVQx6vRBxKM7dxBnWfIQPTI5JaYw23DzThSUby_ELy4B6mmUi4xKbCYyMZISCnGEfjBjwNT53TL3aromQYvsPVAQ0_LNepqAL5it4b6jQU1nxQ6pSyBZCsA5oeNLRrL6aUtER3Xkm5_bNTjQtancjiNV2aMLUrb5OE2hyolWNuAHHkMmyFCxHHJZOVaw3ZgNPD5w4W8DCE8zcY9ztkuXrO_IxUmL897cNkxyFEmB1I4Kd_x7JvKqrDDPrOmHHA5-v6z-Q4B7qw"}'
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1520853964","not_before":"1520850064","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAwNjQsIm5iZiI6MTUyMDg1MDA2NCwiZXhwIjoxNTIwODUzOTY0LCJhaW8iOiJZMk5nWU9CK3RLbGJkbDJjVzZqMEYxbW5xSVgvQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibHZVWGZPMnVjMC1QZkpNX3FZTWpBQSIsInZlciI6IjEuMCJ9.HuwcHNI5Ym8-9Q8VQU_4_9VjHjXX0742q3FJy2FcwT5elihMisL2t9diXcW-1EmhDws298qnqMfhZB2vY9knNNtqRyeZKFuVQXzgjvAWEujllH2w2qRl2Erh324uCFeadskjhqwjyt1jD1NAGfwhAZdxpwaLAGXl-6LQ4PZIWwGW6YDn9eZr6nHZcPXVEBPhYYw2ErNcHljU93hMRfZjHYMWXf3UUgmjS23bRpQydXKsFMLe1f38Xdfpb6OUyHltk7S6K7mzwNe8npW1se0u51KQg54pYhD-ET1h7hkOe27Q1SeL8rSOZTzLP3gJo_F_WhvEp-5-7iCNQN4I1hWiFg"}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:19:20 GMT
+  recorded_at: Mon, 12 Mar 2018 10:26:09 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -72,7 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2NjAsIm5iZiI6MTUyMDQ1MzY2MCwiZXhwIjoxNTIwNDU3NTYwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieDhndTAtZGRoVUt0cWFzc2lIVUFBQSIsInZlciI6IjEuMCJ9.otktnWJntN5Ex1m7B5cYjtAq_50geAaUdyQL0oOsiREDXuiRlPCYHBD9qLNkbn04dkTg0udUaXIYYVQx6vRBxKM7dxBnWfIQPTI5JaYw23DzThSUby_ELy4B6mmUi4xKbCYyMZISCnGEfjBjwNT53TL3aromQYvsPVAQ0_LNepqAL5it4b6jQU1nxQ6pSyBZCsA5oeNLRrL6aUtER3Xkm5_bNTjQtancjiNV2aMLUrb5OE2hyolWNuAHHkMmyFCxHHJZOVaw3ZgNPD5w4W8DCE8zcY9ztkuXrO_IxUmL897cNkxyFEmB1I4Kd_x7JvKqrDDPrOmHHA5-v6z-Q4B7qw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAwNjQsIm5iZiI6MTUyMDg1MDA2NCwiZXhwIjoxNTIwODUzOTY0LCJhaW8iOiJZMk5nWU9CK3RLbGJkbDJjVzZqMEYxbW5xSVgvQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibHZVWGZPMnVjMC1QZkpNX3FZTWpBQSIsInZlciI6IjEuMCJ9.HuwcHNI5Ym8-9Q8VQU_4_9VjHjXX0742q3FJy2FcwT5elihMisL2t9diXcW-1EmhDws298qnqMfhZB2vY9knNNtqRyeZKFuVQXzgjvAWEujllH2w2qRl2Erh324uCFeadskjhqwjyt1jD1NAGfwhAZdxpwaLAGXl-6LQ4PZIWwGW6YDn9eZr6nHZcPXVEBPhYYw2ErNcHljU93hMRfZjHYMWXf3UUgmjS23bRpQydXKsFMLe1f38Xdfpb6OUyHltk7S6K7mzwNe8npW1se0u51KQg54pYhD-ET1h7hkOe27Q1SeL8rSOZTzLP3gJo_F_WhvEp-5-7iCNQN4I1hWiFg
   response:
     status:
       code: 200
@@ -91,26 +91,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14999'
+      - '14997'
       X-Ms-Request-Id:
-      - eeaecf99-b7da-44c0-aaf8-21cb3d7d361f
+      - 94e14d2d-b625-40f5-acd9-95d8b5690024
       X-Ms-Correlation-Request-Id:
-      - eeaecf99-b7da-44c0-aaf8-21cb3d7d361f
+      - 94e14d2d-b625-40f5-acd9-95d8b5690024
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201921Z:eeaecf99-b7da-44c0-aaf8-21cb3d7d361f
+      - WESTEUROPE:20180312T102605Z:94e14d2d-b625-40f5-acd9-95d8b5690024
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:19:20 GMT
+      - Mon, 12 Mar 2018 10:26:05 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID","subscriptionId":"AZURE_SUBSCRIPTION_ID","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:19:21 GMT
+  recorded_at: Mon, 12 Mar 2018 10:26:09 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers?api-version=2015-01-01
@@ -127,7 +127,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2NjAsIm5iZiI6MTUyMDQ1MzY2MCwiZXhwIjoxNTIwNDU3NTYwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieDhndTAtZGRoVUt0cWFzc2lIVUFBQSIsInZlciI6IjEuMCJ9.otktnWJntN5Ex1m7B5cYjtAq_50geAaUdyQL0oOsiREDXuiRlPCYHBD9qLNkbn04dkTg0udUaXIYYVQx6vRBxKM7dxBnWfIQPTI5JaYw23DzThSUby_ELy4B6mmUi4xKbCYyMZISCnGEfjBjwNT53TL3aromQYvsPVAQ0_LNepqAL5it4b6jQU1nxQ6pSyBZCsA5oeNLRrL6aUtER3Xkm5_bNTjQtancjiNV2aMLUrb5OE2hyolWNuAHHkMmyFCxHHJZOVaw3ZgNPD5w4W8DCE8zcY9ztkuXrO_IxUmL897cNkxyFEmB1I4Kd_x7JvKqrDDPrOmHHA5-v6z-Q4B7qw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAwNjQsIm5iZiI6MTUyMDg1MDA2NCwiZXhwIjoxNTIwODUzOTY0LCJhaW8iOiJZMk5nWU9CK3RLbGJkbDJjVzZqMEYxbW5xSVgvQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibHZVWGZPMnVjMC1QZkpNX3FZTWpBQSIsInZlciI6IjEuMCJ9.HuwcHNI5Ym8-9Q8VQU_4_9VjHjXX0742q3FJy2FcwT5elihMisL2t9diXcW-1EmhDws298qnqMfhZB2vY9knNNtqRyeZKFuVQXzgjvAWEujllH2w2qRl2Erh324uCFeadskjhqwjyt1jD1NAGfwhAZdxpwaLAGXl-6LQ4PZIWwGW6YDn9eZr6nHZcPXVEBPhYYw2ErNcHljU93hMRfZjHYMWXf3UUgmjS23bRpQydXKsFMLe1f38Xdfpb6OUyHltk7S6K7mzwNe8npW1se0u51KQg54pYhD-ET1h7hkOe27Q1SeL8rSOZTzLP3gJo_F_WhvEp-5-7iCNQN4I1hWiFg
   response:
     status:
       code: 200
@@ -144,39 +144,37 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14974'
+      - '14985'
       X-Ms-Request-Id:
-      - d4d9b296-46d1-4ba8-b667-3b29fac9806e
+      - 5cc38601-e9f6-40a9-b5f9-d0f296715087
       X-Ms-Correlation-Request-Id:
-      - d4d9b296-46d1-4ba8-b667-3b29fac9806e
+      - 5cc38601-e9f6-40a9-b5f9-d0f296715087
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201922Z:d4d9b296-46d1-4ba8-b667-3b29fac9806e
+      - WESTEUROPE:20180312T102609Z:5cc38601-e9f6-40a9-b5f9-d0f296715087
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:19:22 GMT
+      - Mon, 12 Mar 2018 10:26:08 GMT
       Content-Length:
-      - '310901'
+      - '320853'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"},{"applicationId":"d87dcbc6-a371-462e-88e3-28ad15ec4e64","roleDefinitionId":"861776c5-e0df-4f95-be4f-ac1eec193323"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
+      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"},{"applicationId":"d87dcbc6-a371-462e-88e3-28ad15ec4e64","roleDefinitionId":"861776c5-e0df-4f95-be4f-ac1eec193323"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["East
+        Asia","Southeast Asia","Australia East","Australia Southeast","Japan East","Japan
+        West","Central India","South India","West India","West Europe","North Europe","Canada
+        Central","Canada East","Brazil South","West US","Central US","East US","South
+        Central US","East US 2","West Central US","North Central US","West US 2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
         US","Central US","East US","South Central US","West Europe","North Europe","East
         Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
         Central US","North Central US","Japan East","Japan West","Brazil South","Central
         India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"operations","locations":["West
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["East
+        Asia","Southeast Asia","Australia East","Australia Southeast","Japan East","Japan
+        West","Central India","South India","West India","West Europe","North Europe","Canada
+        Central","Canada East","Brazil South","West US","Central US","East US","South
+        Central US","East US 2","West Central US","North Central US","West US 2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"operations","locations":["West
         US","Central US","East US","South Central US","West Europe","North Europe","East
         Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
         Central US","North Central US","Japan East","Japan West","Brazil South","Central
@@ -232,177 +230,177 @@ http_interactions:
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/internalLoadBalancers","locations":[],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"domainNames/slots/roles/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"domainNames/slots/roles/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"domainNames/capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"domainNames/serviceCertificates","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
         US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
         Central","Canada East","UK South","UK West","West US","Central US","South
         Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
-        East","Australia Southeast","West US 2","West Central US","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        East","Australia Southeast","West US 2","West Central US","France Central","South
+        India","Central India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
         US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
         Central","Canada East","UK South","UK West","West US","Central US","South
         Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
-        East","Australia Southeast","West US 2","West Central US","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metrics","locations":["North
+        East","Australia Southeast","West US 2","West Central US","France Central","South
+        India","Central India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metrics","locations":["North
         Central US","South Central US","East US","East US 2","Canada Central","Canada
         East","West US","West US 2","West Central US","Central US","East Asia","Southeast
         Asia","North Europe","West Europe","UK South","UK West","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"resourceTypes","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"moveSubscriptionResources","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"validateSubscriptionMoveAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operationStatuses","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operatingSystems","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"operatingSystemFamilies","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicNetwork","namespace":"Microsoft.ClassicNetwork","resourceTypes":[{"resourceType":"virtualNetworks","locations":["East
+        India","West India","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"resourceTypes","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"moveSubscriptionResources","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"validateSubscriptionMoveAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operationStatuses","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operatingSystems","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"operatingSystemFamilies","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicNetwork","namespace":"Microsoft.ClassicNetwork","resourceTypes":[{"resourceType":"virtualNetworks","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"virtualNetworks/remoteVirtualNetworkPeeringProxies","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01"]},{"resourceType":"virtualNetworks/remoteVirtualNetworkPeeringProxies","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"reservedIps","locations":["East
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01"]},{"resourceType":"reservedIps","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"gatewaySupportedDevices","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"networkSecurityGroups","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"gatewaySupportedDevices","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"networkSecurityGroups","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicStorage","namespace":"Microsoft.ClassicStorage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"expressRouteCrossConnections","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"expressRouteCrossConnections/peerings","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicStorage","namespace":"Microsoft.ClassicStorage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkStorageAccountAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"storageAccounts/services","locations":["West
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkStorageAccountAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"storageAccounts/services","locations":["West
         US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
         Asia","Australia East","Australia Southeast","South India","Central India","West
         India","West US 2","West Central US","East US","East US 2","North Central
         US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
-        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/diagnosticSettings","locations":["West
+        South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/diagnosticSettings","locations":["West
         US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
         Asia","Australia East","Australia Southeast","South India","Central India","West
         India","West US 2","West Central US","East US","East US 2","North Central
         US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
-        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"disks","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"images","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"vmImages","locations":[],"apiVersions":["2016-11-01"]},{"resourceType":"publicImages","locations":[],"apiVersions":["2016-11-01","2016-04-01"]},{"resourceType":"osImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"osPlatformImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute","namespace":"Microsoft.Compute","authorizations":[{"applicationId":"60e6cd67-9c8c-4951-9b3c-23c25a2169af","roleDefinitionId":"e4770acb-272e-4dc8-87f3-12f44a612224"},{"applicationId":"a303894e-f1d8-4a37-bf10-67aa654a0596","roleDefinitionId":"903ac751-8ad5-4e5a-bfc2-5e49f450a241"},{"applicationId":"a8b6bf88-1d1a-4626-b040-9a729ea93c65","roleDefinitionId":"45c8267c-80ba-4b96-9a43-115b8f49fccd"}],"resourceTypes":[{"resourceType":"availabilitySets","locations":["East
+        South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"disks","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"images","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"vmImages","locations":[],"apiVersions":["2016-11-01"]},{"resourceType":"storageAccounts/vmImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"publicImages","locations":[],"apiVersions":["2016-11-01","2016-04-01"]},{"resourceType":"osImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"osPlatformImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute","namespace":"Microsoft.Compute","authorizations":[{"applicationId":"60e6cd67-9c8c-4951-9b3c-23c25a2169af","roleDefinitionId":"e4770acb-272e-4dc8-87f3-12f44a612224"},{"applicationId":"a303894e-f1d8-4a37-bf10-67aa654a0596","roleDefinitionId":"903ac751-8ad5-4e5a-bfc2-5e49f450a241"},{"applicationId":"a8b6bf88-1d1a-4626-b040-9a729ea93c65","roleDefinitionId":"45c8267c-80ba-4b96-9a43-115b8f49fccd"}],"resourceTypes":[{"resourceType":"availabilitySets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations/usages","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations/usages","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"sharedVMImages","locations":["West
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"sharedVMImages","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"sharedVMImages/versions","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"locations/capsoperations","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"disks","locations":["Southeast
@@ -410,27 +408,27 @@ http_interactions:
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"snapshots","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"snapshots","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"locations/diskoperations","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"locations/diskoperations","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"images","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"images","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"]},{"resourceType":"locations/logAnalytics","locations":["East
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"]},{"resourceType":"locations/logAnalytics","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
         US","East US","South Central US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
@@ -547,7 +545,12 @@ http_interactions:
         US","East Asia","East US","East US 2","Japan East","Japan West","North Central
         US","North Europe","South Central US","South India","Southeast Asia","West
         Central US","West Europe","West India","West US","West US 2","UK West","UK
-        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"},{"applicationId":"f5c26e74-f226-4ae8-85f0-b4af0080ac9e","roleDefinitionId":"529d7ae6-e892-4d43-809d-8547aeb90643"}],"resourceTypes":[{"resourceType":"components","locations":["East
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/consumergroups","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/disasterrecoveryconfigs","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"},{"applicationId":"f5c26e74-f226-4ae8-85f0-b4af0080ac9e","roleDefinitionId":"529d7ae6-e892-4d43-809d-8547aeb90643"}],"resourceTypes":[{"resourceType":"components","locations":["East
         US","South Central US","North Europe","West Europe","Southeast Asia","West
         US 2"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
         US","South Central US","North Europe","West Europe","Southeast Asia","West
@@ -614,32 +617,32 @@ http_interactions:
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/accessPolicies","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"vaults/accessPolicies","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-10-01","2015-06-01","2014-12-19-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"deletedVaults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01","2014-12-19-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"deletedVaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-10-01"]},{"resourceType":"locations/deletedVaults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations/deletedVaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
         Central US","West Europe","Southeast Asia","Japan East","West Central US"],"apiVersions":["2016-04-01"]},{"resourceType":"webServices","locations":["South
         Central US","West Europe","Southeast Asia","Japan East","East US 2","West
         Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"operations","locations":["South
@@ -665,97 +668,97 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"networkWatchers/lenses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"networkWatchers/lenses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","West
         US 2","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
@@ -846,7 +849,7 @@ http_interactions:
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
         West","Korea Central","Korea South"],"apiVersions":["2017-07-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ResourceHealth","namespace":"Microsoft.ResourceHealth","authorizations":[{"applicationId":"8bdebf23-c0fe-4187-a378-717ad86f6a53","roleDefinitionId":"cc026344-c8b1-4561-83ba-59eba84b27cc"}],"resourceTypes":[{"resourceType":"availabilityStatuses","locations":[],"apiVersions":["2017-07-01","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"notifications","locations":["Australia
-        Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Security","namespace":"Microsoft.Security","authorization":{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
+        Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Security","namespace":"Microsoft.Security","authorizations":[{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},{"applicationId":"fc780465-2017-40d4-a0c5-307022471b92"}],"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatuses","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/virtualMachines","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/endpoints","locations":["Central
@@ -898,565 +901,595 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Central India","South
         India"],"apiVersions":["2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Sql","namespace":"Microsoft.Sql","authorizations":[{"applicationId":"e4ab13ed-33cb-41b4-9140-6e264582cf85","roleDefinitionId":"ec3ddc95-44dc-47a2-9926-5e9f5ffd44ec"},{"applicationId":"0130cc9f-7ac5-4026-bd5f-80a08a54e6d9","roleDefinitionId":"45e8abf8-0ec4-44f3-9c37-cff4f7779302"},{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},{"applicationId":"76c7f279-7959-468f-8943-3954880e0d8c","roleDefinitionId":"7f7513a8-73f9-4c5f-97a2-c41f0ea783ef"}],"resourceTypes":[{"resourceType":"operations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/capabilities","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/databaseAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/databaseOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverKeyOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/keys","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/encryptionProtector","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/usages","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01","2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/communicationLinks","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administrators","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administratorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/restorableDroppedDatabases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recoverableDatabases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/geoBackupPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/importExportOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/operationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/backupLongTermRetentionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/automaticTuning","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/automaticTuning","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/databases/transparentDataEncryption","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recommendedElasticPools","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/auditingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/connectionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/connectionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies/rules","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/securityAlertPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/securityAlertPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/auditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/extendedAuditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/elasticpools","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-09-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/jobAgentOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/jobAgentAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/disasterRecoveryConfiguration","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/dnsAliases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/failoverGroups","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/virtualNetworkRules","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/virtualNetworkRulesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/virtualNetworkRulesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/databaseRestoreAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metricDefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/aggregatedDatabaseMetrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metricdefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries/queryText","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPools/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/extensions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPoolEstimates","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditRecords","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentScans","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/vulnerabilityAssessments","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessment","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/syncGroups","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups/syncMembers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/syncAgents","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"managedInstances/administrators","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/databases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metricDefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/administratorAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/administratorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncMemberOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncAgentOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncDatabaseIds","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorizations":[{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},{"applicationId":"e406a681-f3d4-42a8-90b6-c2b029497af1"}],"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/capabilities","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/databaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"locations/databaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverKeyOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/keys","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/encryptionProtector","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01","2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/communicationLinks","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/restorableDroppedDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recoverableDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/geoBackupPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/importExportOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/operationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/backupLongTermRetentionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/databases/transparentDataEncryption","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recommendedElasticPools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies/rules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/extendedAuditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/elasticPoolAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/elasticPoolOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/elasticpools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-09-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/jobAgentOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/jobAgentAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/disasterRecoveryConfiguration","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/dnsAliases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/failoverGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/virtualNetworkRules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/virtualNetworkRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/virtualNetworkRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/databaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/aggregatedDatabaseMetrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metricdefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries/queryText","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPools/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/extensions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPoolEstimates","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditRecords","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentScans","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/vulnerabilityAssessments","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessment","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/syncGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups/syncMembers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/syncAgents","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"managedInstances/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/administratorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncMemberOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncAgentOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncDatabaseIds","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/longTermRetentionPolicyOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionPolicyAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionBackupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionBackupAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorizations":[{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},{"applicationId":"e406a681-f3d4-42a8-90b6-c2b029497af1"}],"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
@@ -1795,12 +1828,12 @@ http_interactions:
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","Canada Central","Canada East","UK South","UK West","West US 2","West
-        Central US","South India","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","South India","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","South India","Canada Central","Canada East","UK South","UK West","West
-        US 2","West Central US","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Capacity","namespace":"Microsoft.Capacity","authorization":{"applicationId":"4d0ad6c7-f6c3-46d8-ab0d-1406d5e6c86b","roleDefinitionId":"FD9C0A9A-4DB9-4F41-8A61-98385DEB6E2D"},"resourceTypes":[{"resourceType":"resources","locations":["South
+        US 2","West Central US","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Capacity","namespace":"Microsoft.Capacity","authorization":{"applicationId":"4d0ad6c7-f6c3-46d8-ab0d-1406d5e6c86b","roleDefinitionId":"FD9C0A9A-4DB9-4F41-8A61-98385DEB6E2D"},"resourceTypes":[{"resourceType":"resources","locations":["South
         Central US"],"apiVersions":["2017-11-01"]},{"resourceType":"reservationOrders","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/reservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/reservations/revisions","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"catalogs","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"appliedReservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"checkOffers","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"checkScopes","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"calculatePrice","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/calculateRefund","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/return","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/split","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/merge","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"validateReservationOrder","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/availableScopes","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Cdn","namespace":"Microsoft.Cdn","resourceTypes":[{"resourceType":"profiles","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
@@ -1876,9 +1909,9 @@ http_interactions:
         2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/updateAccountsCreationSettings","locations":["West
         US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/accountsCreationSettings","locations":["West
         US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2016-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Commerce","namespace":"Microsoft.Commerce","resourceTypes":[{"resourceType":"UsageAggregates","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]},{"resourceType":"RateCard","locations":[],"apiVersions":["2016-08-31-preview","2015-06-01-preview","2015-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Consumption","namespace":"Microsoft.Consumption","resourceTypes":[{"resourceType":"ReservationSummaries","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationTransactions","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Balances","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Marketplaces","locations":[],"apiVersions":["2018-01-31"]},{"resourceType":"Pricesheets","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationDetails","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Budgets","locations":[],"apiVersions":["2018-01-31","2017-12-30-preview"]},{"resourceType":"Terms","locations":[],"apiVersions":["2018-01-31","2017-12-30-preview"]},{"resourceType":"UsageDetails","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview","2017-04-24-preview"]},{"resourceType":"Operations","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview","2017-04-24-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerInstance","namespace":"Microsoft.ContainerInstance","resourceTypes":[{"resourceType":"containerGroups","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/usages","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/operations","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/operations","locations":["West
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
         US"],"apiVersions":["2016-04-08"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.CustomerInsights","namespace":"Microsoft.CustomerInsights","authorization":{"applicationId":"38c77d00-5fcb-4cce-9d93-af4738258e3c","roleDefinitionId":"E006F9C7-F333-477C-8AD6-1F3A9FE87F55"},"resourceTypes":[{"resourceType":"hubs","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/profiles","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/interactions","locations":["East
@@ -1895,7 +1928,9 @@ http_interactions:
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"operations","locations":["East
         US 2"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Databricks","namespace":"Microsoft.Databricks","authorizations":[{"applicationId":"d9327919-6775-4843-9037-3fb0fb0473cb","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},{"applicationId":"2ff814a6-3304-4ab8-85cb-cd0e6f879c1d","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"}],"resourceTypes":[{"resourceType":"workspaces","locations":["West
         US","East US 2","West Europe","East US","North Europe","Southeast Asia","East
-        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]},{"resourceType":"locations","locations":["West
+        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2017-09-01-preview"]},{"resourceType":"workspaces/virtualNetworkPeerings","locations":["West
+        US","East US 2","West Europe","North Europe","East US","Southeast Asia","East
+        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01"]},{"resourceType":"locations","locations":["West
         US","East US 2","West Europe","North Europe","East US","Southeast Asia"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
         US","East US 2","West Europe","East US","North Europe","Southeast Asia","East
         Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataCatalog","namespace":"Microsoft.DataCatalog","resourceTypes":[{"resourceType":"catalogs","locations":["East
@@ -1919,23 +1954,26 @@ http_interactions:
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers/listSasTokens","locations":["East
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataLakeStore","namespace":"Microsoft.DataLakeStore","authorization":{"applicationId":"e9f49c6b-5ce5-44c8-925d-015017e9f7ad","roleDefinitionId":"17eb9cca-f08a-4499-b2d3-852d175f614f"},"resourceTypes":[{"resourceType":"accounts","locations":["East
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/firewallRules","locations":["East
-        US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataMigration","namespace":"Microsoft.DataMigration","authorization":{"applicationId":"a4bad4aa-bf02-4631-9f78-a64ffdba8150","roleDefinitionId":"b831a21d-db98-4760-89cb-bef871952df1","managedByRoleDefinitionId":"6256fb55-9e59-4018-a9e1-76b11c0a4c89"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services/projects","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationStatuses","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
+        US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataMigration","namespace":"Microsoft.DataMigration","authorization":{"applicationId":"a4bad4aa-bf02-4631-9f78-a64ffdba8150","roleDefinitionId":"b831a21d-db98-4760-89cb-bef871952df1","managedByRoleDefinitionId":"6256fb55-9e59-4018-a9e1-76b11c0a4c89"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services/projects","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationStatuses","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
-        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/recoverableServers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
@@ -1959,7 +1997,10 @@ http_interactions:
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
-        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/recoverableServers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
@@ -2015,12 +2056,7 @@ http_interactions:
         US 2","East US","West US","Central US","East US 2","West Central US","West
         Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
         US 2","East US","West US","Central US","East US 2","West Central US","West
-        Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","West
-        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
-        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
-        India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/consumergroups","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/disasterrecoveryconfigs","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
         US 2","South Central US","Central US","Australia Southeast","Central India","West
         Central US","West US 2","Canada East","Canada Central","Brazil South","UK
         South","UK West","East Asia","Australia East","Japan East","Japan West","North
@@ -2131,7 +2167,7 @@ http_interactions:
         West","Japan East","East Asia","Southeast Asia","West Europe","North Europe","East
         US","West US","Australia East","Australia Southeast","Central US","Brazil
         South","Central India","West India","South India","South Central US","Canada
-        Central","Canada East","West Central US","West US 2"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
+        Central","Canada East","West Central US","West US 2"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-05","2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
         Central US","East US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"operations","locations":["West
         Central US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
         Central US","East US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.PolicyInsights","namespace":"Microsoft.PolicyInsights","authorization":{"applicationId":"1d78a85d-813d-46f0-b496-dd72f50a3ec0","roleDefinitionId":"63d2b225-4c34-4641-8768-21a1f7c68ce8"},"resourceTypes":[{"resourceType":"policyEvents","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"policyStates","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
@@ -2163,12 +2199,12 @@ http_interactions:
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
         Central US","South Central US","North Europe","West Europe","East Asia","Southeast
         Asia","West US","East US","Japan West","Japan East","Brazil South","Central
         US","East US 2","Australia East","Australia Southeast","South India","Central
@@ -2208,40 +2244,50 @@ http_interactions:
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/clusterVersions","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"clusters/applications","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operations","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/clusterVersions","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/environments","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operations","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
         Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applianceDefinitions","locations":["West
         Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applications","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
-        Central US"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
+        Central US"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
         US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
         US","Canada Central","Canada East","Central US","East US 2","UK South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups","locations":["West
         US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
@@ -2332,7 +2378,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:19:23 GMT
+  recorded_at: Mon, 12 Mar 2018 10:26:14 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1?api-version=2017-12-01
@@ -2349,7 +2395,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2NjAsIm5iZiI6MTUyMDQ1MzY2MCwiZXhwIjoxNTIwNDU3NTYwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieDhndTAtZGRoVUt0cWFzc2lIVUFBQSIsInZlciI6IjEuMCJ9.otktnWJntN5Ex1m7B5cYjtAq_50geAaUdyQL0oOsiREDXuiRlPCYHBD9qLNkbn04dkTg0udUaXIYYVQx6vRBxKM7dxBnWfIQPTI5JaYw23DzThSUby_ELy4B6mmUi4xKbCYyMZISCnGEfjBjwNT53TL3aromQYvsPVAQ0_LNepqAL5it4b6jQU1nxQ6pSyBZCsA5oeNLRrL6aUtER3Xkm5_bNTjQtancjiNV2aMLUrb5OE2hyolWNuAHHkMmyFCxHHJZOVaw3ZgNPD5w4W8DCE8zcY9ztkuXrO_IxUmL897cNkxyFEmB1I4Kd_x7JvKqrDDPrOmHHA5-v6z-Q4B7qw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAwNjQsIm5iZiI6MTUyMDg1MDA2NCwiZXhwIjoxNTIwODUzOTY0LCJhaW8iOiJZMk5nWU9CK3RLbGJkbDJjVzZqMEYxbW5xSVgvQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibHZVWGZPMnVjMC1QZkpNX3FZTWpBQSIsInZlciI6IjEuMCJ9.HuwcHNI5Ym8-9Q8VQU_4_9VjHjXX0742q3FJy2FcwT5elihMisL2t9diXcW-1EmhDws298qnqMfhZB2vY9knNNtqRyeZKFuVQXzgjvAWEujllH2w2qRl2Erh324uCFeadskjhqwjyt1jD1NAGfwhAZdxpwaLAGXl-6LQ4PZIWwGW6YDn9eZr6nHZcPXVEBPhYYw2ErNcHljU93hMRfZjHYMWXf3UUgmjS23bRpQydXKsFMLe1f38Xdfpb6OUyHltk7S6K7mzwNe8npW1se0u51KQg54pYhD-ET1h7hkOe27Q1SeL8rSOZTzLP3gJo_F_WhvEp-5-7iCNQN4I1hWiFg
   response:
     status:
       code: 200
@@ -2368,26 +2414,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/LowCostGet3Min;4726,Microsoft.Compute/LowCostGet30Min;37848
+      - Microsoft.Compute/LowCostGet3Min;4749,Microsoft.Compute/LowCostGet30Min;37796
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344652126238
       X-Ms-Request-Id:
-      - 5232e80f-6e71-4ffa-a64c-ec4b6dc2ba94
+      - 230fa84e-6599-407a-963e-94b1f0943712
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14762'
+      - '14987'
       X-Ms-Correlation-Request-Id:
-      - 4f5692c7-0b75-42de-87e6-77a7f3b91970
+      - 6fa86022-9078-4cbf-8699-271cf79b66e3
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201923Z:4f5692c7-0b75-42de-87e6-77a7f3b91970
+      - WESTEUROPE:20180312T102610Z:6fa86022-9078-4cbf-8699-271cf79b66e3
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:19:23 GMT
+      - Mon, 12 Mar 2018 10:26:10 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"03e8467b-baab-4867-9cc4-157336b7e2e4\",\r\n
@@ -2418,7 +2464,7 @@ http_interactions:
         \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1\",\r\n
         \ \"name\": \"miq-test-rhel1\"\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:19:23 GMT
+  recorded_at: Mon, 12 Mar 2018 10:26:15 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390?api-version=2018-01-01
@@ -2435,7 +2481,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2NjAsIm5iZiI6MTUyMDQ1MzY2MCwiZXhwIjoxNTIwNDU3NTYwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieDhndTAtZGRoVUt0cWFzc2lIVUFBQSIsInZlciI6IjEuMCJ9.otktnWJntN5Ex1m7B5cYjtAq_50geAaUdyQL0oOsiREDXuiRlPCYHBD9qLNkbn04dkTg0udUaXIYYVQx6vRBxKM7dxBnWfIQPTI5JaYw23DzThSUby_ELy4B6mmUi4xKbCYyMZISCnGEfjBjwNT53TL3aromQYvsPVAQ0_LNepqAL5it4b6jQU1nxQ6pSyBZCsA5oeNLRrL6aUtER3Xkm5_bNTjQtancjiNV2aMLUrb5OE2hyolWNuAHHkMmyFCxHHJZOVaw3ZgNPD5w4W8DCE8zcY9ztkuXrO_IxUmL897cNkxyFEmB1I4Kd_x7JvKqrDDPrOmHHA5-v6z-Q4B7qw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAwNjQsIm5iZiI6MTUyMDg1MDA2NCwiZXhwIjoxNTIwODUzOTY0LCJhaW8iOiJZMk5nWU9CK3RLbGJkbDJjVzZqMEYxbW5xSVgvQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibHZVWGZPMnVjMC1QZkpNX3FZTWpBQSIsInZlciI6IjEuMCJ9.HuwcHNI5Ym8-9Q8VQU_4_9VjHjXX0742q3FJy2FcwT5elihMisL2t9diXcW-1EmhDws298qnqMfhZB2vY9knNNtqRyeZKFuVQXzgjvAWEujllH2w2qRl2Erh324uCFeadskjhqwjyt1jD1NAGfwhAZdxpwaLAGXl-6LQ4PZIWwGW6YDn9eZr6nHZcPXVEBPhYYw2ErNcHljU93hMRfZjHYMWXf3UUgmjS23bRpQydXKsFMLe1f38Xdfpb6OUyHltk7S6K7mzwNe8npW1se0u51KQg54pYhD-ET1h7hkOe27Q1SeL8rSOZTzLP3gJo_F_WhvEp-5-7iCNQN4I1hWiFg
   response:
     status:
       code: 200
@@ -2456,22 +2502,22 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 799a8afd-57a6-46a5-ae9f-95c14405488d
+      - 462bb9b3-1382-447c-b202-264f7fef5842
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14865'
+      - '14987'
       X-Ms-Correlation-Request-Id:
-      - dde314df-78f3-48f9-b952-a76289b68c09
+      - f6fac3d6-92c2-4908-882f-aabbcf25b2db
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201924Z:dde314df-78f3-48f9-b952-a76289b68c09
+      - WESTEUROPE:20180312T102611Z:f6fac3d6-92c2-4908-882f-aabbcf25b2db
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:19:24 GMT
+      - Mon, 12 Mar 2018 10:26:11 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"miq-test-rhel1390\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390\",\r\n
@@ -2496,10 +2542,10 @@ http_interactions:
         \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
         \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:19:24 GMT
+  recorded_at: Mon, 12 Mar 2018 10:26:16 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups/miq-azure-test1?api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/instanceView?api-version=2017-12-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2513,60 +2559,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2NjAsIm5iZiI6MTUyMDQ1MzY2MCwiZXhwIjoxNTIwNDU3NTYwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieDhndTAtZGRoVUt0cWFzc2lIVUFBQSIsInZlciI6IjEuMCJ9.otktnWJntN5Ex1m7B5cYjtAq_50geAaUdyQL0oOsiREDXuiRlPCYHBD9qLNkbn04dkTg0udUaXIYYVQx6vRBxKM7dxBnWfIQPTI5JaYw23DzThSUby_ELy4B6mmUi4xKbCYyMZISCnGEfjBjwNT53TL3aromQYvsPVAQ0_LNepqAL5it4b6jQU1nxQ6pSyBZCsA5oeNLRrL6aUtER3Xkm5_bNTjQtancjiNV2aMLUrb5OE2hyolWNuAHHkMmyFCxHHJZOVaw3ZgNPD5w4W8DCE8zcY9ztkuXrO_IxUmL897cNkxyFEmB1I4Kd_x7JvKqrDDPrOmHHA5-v6z-Q4B7qw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14968'
-      X-Ms-Request-Id:
-      - 1deffb23-ef9e-4c9c-af3f-068d8cbc75bc
-      X-Ms-Correlation-Request-Id:
-      - 1deffb23-ef9e-4c9c-af3f-068d8cbc75bc
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201924Z:1deffb23-ef9e-4c9c-af3f-068d8cbc75bc
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:19:23 GMT
-      Content-Length:
-      - '183'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1","name":"miq-azure-test1","location":"eastus","properties":{"provisioningState":"Succeeded"}}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:19:24 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute/locations/eastus/vmSizes?api-version=2017-12-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2NjAsIm5iZiI6MTUyMDQ1MzY2MCwiZXhwIjoxNTIwNDU3NTYwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieDhndTAtZGRoVUt0cWFzc2lIVUFBQSIsInZlciI6IjEuMCJ9.otktnWJntN5Ex1m7B5cYjtAq_50geAaUdyQL0oOsiREDXuiRlPCYHBD9qLNkbn04dkTg0udUaXIYYVQx6vRBxKM7dxBnWfIQPTI5JaYw23DzThSUby_ELy4B6mmUi4xKbCYyMZISCnGEfjBjwNT53TL3aromQYvsPVAQ0_LNepqAL5it4b6jQU1nxQ6pSyBZCsA5oeNLRrL6aUtER3Xkm5_bNTjQtancjiNV2aMLUrb5OE2hyolWNuAHHkMmyFCxHHJZOVaw3ZgNPD5w4W8DCE8zcY9ztkuXrO_IxUmL897cNkxyFEmB1I4Kd_x7JvKqrDDPrOmHHA5-v6z-Q4B7qw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAwNjQsIm5iZiI6MTUyMDg1MDA2NCwiZXhwIjoxNTIwODUzOTY0LCJhaW8iOiJZMk5nWU9CK3RLbGJkbDJjVzZqMEYxbW5xSVgvQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibHZVWGZPMnVjMC1QZkpNX3FZTWpBQSIsInZlciI6IjEuMCJ9.HuwcHNI5Ym8-9Q8VQU_4_9VjHjXX0742q3FJy2FcwT5elihMisL2t9diXcW-1EmhDws298qnqMfhZB2vY9knNNtqRyeZKFuVQXzgjvAWEujllH2w2qRl2Erh324uCFeadskjhqwjyt1jD1NAGfwhAZdxpwaLAGXl-6LQ4PZIWwGW6YDn9eZr6nHZcPXVEBPhYYw2ErNcHljU93hMRfZjHYMWXf3UUgmjS23bRpQydXKsFMLe1f38Xdfpb6OUyHltk7S6K7mzwNe8npW1se0u51KQg54pYhD-ET1h7hkOe27Q1SeL8rSOZTzLP3gJo_F_WhvEp-5-7iCNQN4I1hWiFg
   response:
     status:
       code: 200
@@ -2585,26 +2578,164 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/LowCostGet3Min;4725,Microsoft.Compute/LowCostGet30Min;37847
+      - Microsoft.Compute/GetInstanceView3Min;4796,Microsoft.Compute/GetInstanceView30Min;23764
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344652126238
       X-Ms-Request-Id:
-      - cf399660-edf6-45c9-8053-da3e12866ba2
+      - 1a7fbdf5-690c-47a7-a9bf-a3131e0011fa
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14978'
+      - '14988'
       X-Ms-Correlation-Request-Id:
-      - be8ec8ff-7cc8-4153-9436-d87c8533ee1e
+      - 4f18fe27-e048-452b-8f75-e67ffa9d5dc0
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201925Z:be8ec8ff-7cc8-4153-9436-d87c8533ee1e
+      - WESTEUROPE:20180312T102622Z:4f18fe27-e048-452b-8f75-e67ffa9d5dc0
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:19:24 GMT
+      - Mon, 12 Mar 2018 10:26:22 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"vmAgent\": {\r\n    \"vmAgentVersion\": \"WALinuxAgent-2.0.16\",\r\n
+        \   \"statuses\": [\r\n      {\r\n        \"code\": \"ProvisioningState/succeeded\",\r\n
+        \       \"level\": \"Info\",\r\n        \"displayStatus\": \"Ready\",\r\n
+        \       \"message\": \"GuestAgent is running and accepting new configurations.\",\r\n
+        \       \"time\": \"2018-03-12T10:25:57+00:00\"\r\n      }\r\n    ],\r\n    \"extensionHandlers\":
+        [\r\n      {\r\n        \"type\": \"Microsoft.OSTCExtensions.LinuxDiagnostic\",\r\n
+        \       \"typeHandlerVersion\": \"2.3.9027\",\r\n        \"status\": {\r\n
+        \         \"code\": \"ProvisioningState/succeeded\",\r\n          \"level\":
+        \"Info\",\r\n          \"displayStatus\": \"Ready\"\r\n        }\r\n      }\r\n
+        \   ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"miq-test-rhel1\",\r\n
+        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
+        succeeded\",\r\n          \"time\": \"2018-01-17T18:00:29.9011002+00:00\"\r\n
+        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
+        \"https://miqazuretest18686.blob.core.windows.net/bootdiagnostics-miqtestrh-03e8467b-baab-4867-9cc4-157336b7e2e4/miq-test-rhel1.03e8467b-baab-4867-9cc4-157336b7e2e4.screenshot.bmp\",\r\n
+        \   \"serialConsoleLogBlobUri\": \"https://miqazuretest18686.blob.core.windows.net/bootdiagnostics-miqtestrh-03e8467b-baab-4867-9cc4-157336b7e2e4/miq-test-rhel1.03e8467b-baab-4867-9cc4-157336b7e2e4.serialconsole.log\"\r\n
+        \ },\r\n  \"extensions\": [\r\n    {\r\n      \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\",\r\n
+        \     \"type\": \"Microsoft.OSTCExtensions.LinuxDiagnostic\",\r\n      \"typeHandlerVersion\":
+        \"2.3.9027\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\":
+        \"ProvisioningState/succeeded\",\r\n          \"level\": \"Info\",\r\n          \"displayStatus\":
+        \"Provisioning succeeded\",\r\n          \"message\": \"Enable succeeded\"\r\n
+        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\":
+        \"ProvisioningState/succeeded\",\r\n      \"level\": \"Info\",\r\n      \"displayStatus\":
+        \"Provisioning succeeded\",\r\n      \"time\": \"2018-01-17T18:02:26.9167163+00:00\"\r\n
+        \   },\r\n    {\r\n      \"code\": \"PowerState/running\",\r\n      \"level\":
+        \"Info\",\r\n      \"displayStatus\": \"VM running\"\r\n    }\r\n  ]\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 10:26:27 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups/miq-azure-test1?api-version=2017-08-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAwNjQsIm5iZiI6MTUyMDg1MDA2NCwiZXhwIjoxNTIwODUzOTY0LCJhaW8iOiJZMk5nWU9CK3RLbGJkbDJjVzZqMEYxbW5xSVgvQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibHZVWGZPMnVjMC1QZkpNX3FZTWpBQSIsInZlciI6IjEuMCJ9.HuwcHNI5Ym8-9Q8VQU_4_9VjHjXX0742q3FJy2FcwT5elihMisL2t9diXcW-1EmhDws298qnqMfhZB2vY9knNNtqRyeZKFuVQXzgjvAWEujllH2w2qRl2Erh324uCFeadskjhqwjyt1jD1NAGfwhAZdxpwaLAGXl-6LQ4PZIWwGW6YDn9eZr6nHZcPXVEBPhYYw2ErNcHljU93hMRfZjHYMWXf3UUgmjS23bRpQydXKsFMLe1f38Xdfpb6OUyHltk7S6K7mzwNe8npW1se0u51KQg54pYhD-ET1h7hkOe27Q1SeL8rSOZTzLP3gJo_F_WhvEp-5-7iCNQN4I1hWiFg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14984'
+      X-Ms-Request-Id:
+      - abf9091f-0b91-4250-b981-5790678a33b7
+      X-Ms-Correlation-Request-Id:
+      - abf9091f-0b91-4250-b981-5790678a33b7
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T102623Z:abf9091f-0b91-4250-b981-5790678a33b7
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 10:26:22 GMT
+      Content-Length:
+      - '183'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1","name":"miq-azure-test1","location":"eastus","properties":{"provisioningState":"Succeeded"}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 10:26:28 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute/locations/eastus/vmSizes?api-version=2017-12-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAwNjQsIm5iZiI6MTUyMDg1MDA2NCwiZXhwIjoxNTIwODUzOTY0LCJhaW8iOiJZMk5nWU9CK3RLbGJkbDJjVzZqMEYxbW5xSVgvQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibHZVWGZPMnVjMC1QZkpNX3FZTWpBQSIsInZlciI6IjEuMCJ9.HuwcHNI5Ym8-9Q8VQU_4_9VjHjXX0742q3FJy2FcwT5elihMisL2t9diXcW-1EmhDws298qnqMfhZB2vY9knNNtqRyeZKFuVQXzgjvAWEujllH2w2qRl2Erh324uCFeadskjhqwjyt1jD1NAGfwhAZdxpwaLAGXl-6LQ4PZIWwGW6YDn9eZr6nHZcPXVEBPhYYw2ErNcHljU93hMRfZjHYMWXf3UUgmjS23bRpQydXKsFMLe1f38Xdfpb6OUyHltk7S6K7mzwNe8npW1se0u51KQg54pYhD-ET1h7hkOe27Q1SeL8rSOZTzLP3gJo_F_WhvEp-5-7iCNQN4I1hWiFg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/LowCostGet3Min;4744,Microsoft.Compute/LowCostGet30Min;37791
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344652126238
+      X-Ms-Request-Id:
+      - cceda113-f452-4f9f-ba3c-e0d0922ae83b
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14986'
+      X-Ms-Correlation-Request-Id:
+      - f58a3649-3f0b-4d38-8ea5-44ac9b4548f0
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T102624Z:f58a3649-3f0b-4d38-8ea5-44ac9b4548f0
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 10:26:23 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"Standard_B1ms\",\r\n
@@ -3081,6 +3212,12 @@ http_interactions:
         \   },\r\n    {\r\n      \"name\": \"Standard_F72s_v2\",\r\n      \"numberOfCores\":
         72,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
         589824,\r\n      \"memoryInMB\": 147456,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_L8s_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1811981,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_L16s_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        3623962,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
         \   },\r\n    {\r\n      \"name\": \"Standard_ND6s\",\r\n      \"numberOfCores\":
         6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
         344064,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 12\r\n
@@ -3107,7 +3244,7 @@ http_interactions:
         391168,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
         \   }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:19:25 GMT
+  recorded_at: Mon, 12 Mar 2018 10:26:29 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250?api-version=2017-08-01
@@ -3124,7 +3261,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2NjAsIm5iZiI6MTUyMDQ1MzY2MCwiZXhwIjoxNTIwNDU3NTYwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieDhndTAtZGRoVUt0cWFzc2lIVUFBQSIsInZlciI6IjEuMCJ9.otktnWJntN5Ex1m7B5cYjtAq_50geAaUdyQL0oOsiREDXuiRlPCYHBD9qLNkbn04dkTg0udUaXIYYVQx6vRBxKM7dxBnWfIQPTI5JaYw23DzThSUby_ELy4B6mmUi4xKbCYyMZISCnGEfjBjwNT53TL3aromQYvsPVAQ0_LNepqAL5it4b6jQU1nxQ6pSyBZCsA5oeNLRrL6aUtER3Xkm5_bNTjQtancjiNV2aMLUrb5OE2hyolWNuAHHkMmyFCxHHJZOVaw3ZgNPD5w4W8DCE8zcY9ztkuXrO_IxUmL897cNkxyFEmB1I4Kd_x7JvKqrDDPrOmHHA5-v6z-Q4B7qw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAwNjQsIm5iZiI6MTUyMDg1MDA2NCwiZXhwIjoxNTIwODUzOTY0LCJhaW8iOiJZMk5nWU9CK3RLbGJkbDJjVzZqMEYxbW5xSVgvQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibHZVWGZPMnVjMC1QZkpNX3FZTWpBQSIsInZlciI6IjEuMCJ9.HuwcHNI5Ym8-9Q8VQU_4_9VjHjXX0742q3FJy2FcwT5elihMisL2t9diXcW-1EmhDws298qnqMfhZB2vY9knNNtqRyeZKFuVQXzgjvAWEujllH2w2qRl2Erh324uCFeadskjhqwjyt1jD1NAGfwhAZdxpwaLAGXl-6LQ4PZIWwGW6YDn9eZr6nHZcPXVEBPhYYw2ErNcHljU93hMRfZjHYMWXf3UUgmjS23bRpQydXKsFMLe1f38Xdfpb6OUyHltk7S6K7mzwNe8npW1se0u51KQg54pYhD-ET1h7hkOe27Q1SeL8rSOZTzLP3gJo_F_WhvEp-5-7iCNQN4I1hWiFg
   response:
     status:
       code: 200
@@ -3141,29 +3278,29 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14978'
+      - '14985'
       X-Ms-Request-Id:
-      - e536c5d7-a8f7-46b9-b238-cc1bbc6fd04e
+      - 11a8b6d2-635b-4b1d-9c3d-4d3b005484ea
       X-Ms-Correlation-Request-Id:
-      - e536c5d7-a8f7-46b9-b238-cc1bbc6fd04e
+      - 11a8b6d2-635b-4b1d-9c3d-4d3b005484ea
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201925Z:e536c5d7-a8f7-46b9-b238-cc1bbc6fd04e
+      - WESTEUROPE:20180312T102626Z:11a8b6d2-635b-4b1d-9c3d-4d3b005484ea
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:19:24 GMT
+      - Mon, 12 Mar 2018 10:26:26 GMT
       Content-Length:
       - '6266'
     body:
       encoding: ASCII-8BIT
       string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250","name":"RedHat.RedHatEnterpriseLinux72-20160218112250","properties":{"parameters":{"location":{"type":"String","value":"eastus"},"virtualMachineName":{"type":"String","value":"miq-test-rhel1"},"virtualMachineSize":{"type":"String","value":"Basic_A0"},"adminUsername":{"type":"String","value":"dberger"},"storageAccountName":{"type":"String","value":"miqazuretest18686"},"virtualNetworkName":{"type":"String","value":"miq-azure-test1"},"networkInterfaceName":{"type":"String","value":"miq-test-rhel1390"},"networkSecurityGroupName":{"type":"String","value":"miq-test-rhel1"},"adminPassword":{"type":"SecureString"},"storageAccountType":{"type":"String","value":"Standard_LRS"},"diagnosticsStorageAccountName":{"type":"String","value":"miqazuretest18686"},"diagnosticsStorageAccountId":{"type":"String","value":"Microsoft.Storage/storageAccounts/miqazuretest18686"},"diagnosticsStorageAccountType":{"type":"String","value":"Standard_LRS"},"addressPrefix":{"type":"String","value":"10.16.0.0/16"},"subnetName":{"type":"String","value":"default"},"subnetPrefix":{"type":"String","value":"10.16.0.0/24"},"publicIpAddressName":{"type":"String","value":"miq-test-rhel1"},"publicIpAddressType":{"type":"String","value":"Dynamic"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-03-18T17:28:57.6212521Z","duration":"PT6M6.1062402S","correlationId":"3222315f-f31e-4ee7-b405-4d40dfd500a3","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]},{"resourceType":"virtualMachines/extensions","locations":["eastus"]}]},{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]},{"resourceType":"publicIpAddresses","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-rhel1390"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-rhel1"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-rhel1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686","actionName":"listKeys","apiVersion":"2015-05-01-preview"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-rhel1/Microsoft.Insights.VMDiagnosticsSettings"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"miq-azure-test1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-rhel1","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-rhel1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-rhel1"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-rhel1390"}],"outputs":{"adminUsername":{"type":"String","value":"dberger"}},"outputResources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/extensions/Microsoft.Insights.VMDiagnosticsSettings"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-rhel1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686"}]}}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:19:25 GMT
+  recorded_at: Mon, 12 Mar 2018 10:26:31 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations?api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1?api-version=2018-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3177,115 +3314,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2NjAsIm5iZiI6MTUyMDQ1MzY2MCwiZXhwIjoxNTIwNDU3NTYwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieDhndTAtZGRoVUt0cWFzc2lIVUFBQSIsInZlciI6IjEuMCJ9.otktnWJntN5Ex1m7B5cYjtAq_50geAaUdyQL0oOsiREDXuiRlPCYHBD9qLNkbn04dkTg0udUaXIYYVQx6vRBxKM7dxBnWfIQPTI5JaYw23DzThSUby_ELy4B6mmUi4xKbCYyMZISCnGEfjBjwNT53TL3aromQYvsPVAQ0_LNepqAL5it4b6jQU1nxQ6pSyBZCsA5oeNLRrL6aUtER3Xkm5_bNTjQtancjiNV2aMLUrb5OE2hyolWNuAHHkMmyFCxHHJZOVaw3ZgNPD5w4W8DCE8zcY9ztkuXrO_IxUmL897cNkxyFEmB1I4Kd_x7JvKqrDDPrOmHHA5-v6z-Q4B7qw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14967'
-      X-Ms-Request-Id:
-      - 90107780-f26a-499c-bf88-804afd23c8e4
-      X-Ms-Correlation-Request-Id:
-      - 90107780-f26a-499c-bf88-804afd23c8e4
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201926Z:90107780-f26a-499c-bf88-804afd23c8e4
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:19:25 GMT
-      Content-Length:
-      - '7624'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/B42FCDF4A2A39FE2","operationId":"B42FCDF4A2A39FE2","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:28:56.9829484Z","duration":"PT3M1.9672591S","trackingId":"14feeb1c-b462-4bdc-98e0-07e3c051bc4a","serviceRequestId":"929da49c-b732-4413-8fe7-6a94ebf1b7df","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-rhel1/Microsoft.Insights.VMDiagnosticsSettings"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/90897F1FE623927D","operationId":"90897F1FE623927D","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:25:54.9100087Z","duration":"PT2M28.9316677S","trackingId":"677bf860-1814-46bf-81b8-2f40e478702f","serviceRequestId":"0d568f4d-db1a-414b-82af-8a476f4ee398","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-rhel1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/465DEB7D7737AAEB","operationId":"465DEB7D7737AAEB","properties":{"provisioningOperation":"Read","provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:25.8536981Z","duration":"PT2.5042804S","trackingId":"39bb6568-d7b8-42e4-97ed-3b32cb629561","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686","apiVersion":"2015-06-15"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/2972B36A0CF48AB3","operationId":"2972B36A0CF48AB3","properties":{"provisioningOperation":"Action","provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:23.6072605Z","duration":"PT0.2582045S","trackingId":"c5a9e298-ec4e-439b-ba11-f531388139de","serviceRequestId":"3222315f-f31e-4ee7-b405-4d40dfd500a3","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686","actionName":"listKeys","apiVersion":"2015-05-01-preview"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/E74E878C29CB66B6","operationId":"E74E878C29CB66B6","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:10.196193Z","duration":"PT1.6122458S","trackingId":"2341df4a-20e3-4fb4-b417-2f2263e009d3","serviceRequestId":"ad2b548c-e848-42f3-8834-a07996ead051","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-rhel1390"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/159B68AE177CBFD9","operationId":"159B68AE177CBFD9","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:23.2936909Z","duration":"PT30.2333245S","trackingId":"3d2daef3-03af-4017-9b52-2202b98e54c0","serviceRequestId":"3222315f-f31e-4ee7-b405-4d40dfd500a3","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/601C5CBE140F5FC4","operationId":"601C5CBE140F5FC4","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:08.4807196Z","duration":"PT15.4177267S","trackingId":"5280cb26-eed9-43e1-aff7-2c60ba0a4e32","serviceRequestId":"18d0a142-7dcb-4e5d-86ea-b8cd95ab1ff4","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-rhel1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/DDFCB6138638C2AE","operationId":"DDFCB6138638C2AE","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:06.4145604Z","duration":"PT13.2922738S","trackingId":"18bf2d19-1ef3-4026-b6c2-650bcd5a6da9","serviceRequestId":"8f6af50d-004e-4653-b263-3e2a8e85ebeb","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-rhel1","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-rhel1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/6E56D08B1E39DCCA","operationId":"6E56D08B1E39DCCA","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2016-03-18T17:23:05.836911Z","duration":"PT12.771463S","trackingId":"33412052-f3be-4e84-bd79-0a00abef61f4","serviceRequestId":"2252541d-7285-41d8-87d1-3a0a1d1b330a","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"miq-azure-test1"}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/operations/08587432851139626716","operationId":"08587432851139626716","properties":{"provisioningOperation":"EvaluateDeploymentOutput","provisioningState":"Succeeded","timestamp":"2016-03-18T17:28:57.5892101Z","duration":"PT0.2087634S","trackingId":"85e2cf8a-3929-4515-8a51-97dbc778352e","statusCode":"OK","statusMessage":null}}]}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:19:26 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250?api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2NjAsIm5iZiI6MTUyMDQ1MzY2MCwiZXhwIjoxNTIwNDU3NTYwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieDhndTAtZGRoVUt0cWFzc2lIVUFBQSIsInZlciI6IjEuMCJ9.otktnWJntN5Ex1m7B5cYjtAq_50geAaUdyQL0oOsiREDXuiRlPCYHBD9qLNkbn04dkTg0udUaXIYYVQx6vRBxKM7dxBnWfIQPTI5JaYw23DzThSUby_ELy4B6mmUi4xKbCYyMZISCnGEfjBjwNT53TL3aromQYvsPVAQ0_LNepqAL5it4b6jQU1nxQ6pSyBZCsA5oeNLRrL6aUtER3Xkm5_bNTjQtancjiNV2aMLUrb5OE2hyolWNuAHHkMmyFCxHHJZOVaw3ZgNPD5w4W8DCE8zcY9ztkuXrO_IxUmL897cNkxyFEmB1I4Kd_x7JvKqrDDPrOmHHA5-v6z-Q4B7qw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14970'
-      X-Ms-Request-Id:
-      - a8f030ae-baa3-45af-afa4-7a7432221118
-      X-Ms-Correlation-Request-Id:
-      - a8f030ae-baa3-45af-afa4-7a7432221118
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201927Z:a8f030ae-baa3-45af-afa4-7a7432221118
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:19:26 GMT
-      Content-Length:
-      - '6266'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250","name":"RedHat.RedHatEnterpriseLinux72-20160218112250","properties":{"parameters":{"location":{"type":"String","value":"eastus"},"virtualMachineName":{"type":"String","value":"miq-test-rhel1"},"virtualMachineSize":{"type":"String","value":"Basic_A0"},"adminUsername":{"type":"String","value":"dberger"},"storageAccountName":{"type":"String","value":"miqazuretest18686"},"virtualNetworkName":{"type":"String","value":"miq-azure-test1"},"networkInterfaceName":{"type":"String","value":"miq-test-rhel1390"},"networkSecurityGroupName":{"type":"String","value":"miq-test-rhel1"},"adminPassword":{"type":"SecureString"},"storageAccountType":{"type":"String","value":"Standard_LRS"},"diagnosticsStorageAccountName":{"type":"String","value":"miqazuretest18686"},"diagnosticsStorageAccountId":{"type":"String","value":"Microsoft.Storage/storageAccounts/miqazuretest18686"},"diagnosticsStorageAccountType":{"type":"String","value":"Standard_LRS"},"addressPrefix":{"type":"String","value":"10.16.0.0/16"},"subnetName":{"type":"String","value":"default"},"subnetPrefix":{"type":"String","value":"10.16.0.0/24"},"publicIpAddressName":{"type":"String","value":"miq-test-rhel1"},"publicIpAddressType":{"type":"String","value":"Dynamic"}},"mode":"Incremental","provisioningState":"Succeeded","timestamp":"2016-03-18T17:28:57.6212521Z","duration":"PT6M6.1062402S","correlationId":"3222315f-f31e-4ee7-b405-4d40dfd500a3","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]},{"resourceType":"virtualMachines/extensions","locations":["eastus"]}]},{"namespace":"Microsoft.Storage","resourceTypes":[{"resourceType":"storageAccounts","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"virtualNetworks","locations":["eastus"]},{"resourceType":"networkInterfaces","locations":["eastus"]},{"resourceType":"publicIpAddresses","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-rhel1390"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686","apiVersion":"2015-06-15"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-rhel1"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miq-test-rhel1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","resourceType":"Microsoft.Storage/storageAccounts","resourceName":"miqazuretest18686","actionName":"listKeys","apiVersion":"2015-05-01-preview"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/extensions/Microsoft.Insights.VMDiagnosticsSettings","resourceType":"Microsoft.Compute/virtualMachines/extensions","resourceName":"miq-test-rhel1/Microsoft.Insights.VMDiagnosticsSettings"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1","resourceType":"Microsoft.Network/virtualNetworks","resourceName":"miq-azure-test1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-rhel1","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miq-test-rhel1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miq-test-rhel1"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miq-test-rhel1390"}],"outputs":{"adminUsername":{"type":"String","value":"dberger"}},"outputResources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/extensions/Microsoft.Insights.VMDiagnosticsSettings"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIpAddresses/miq-test-rhel1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686"}]}}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:19:27 GMT
-- request:
-    method: post
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux72-20160218112250/exportTemplate?api-version=2017-08-01
-    body:
-      encoding: ASCII-8BIT
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2NjAsIm5iZiI6MTUyMDQ1MzY2MCwiZXhwIjoxNTIwNDU3NTYwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieDhndTAtZGRoVUt0cWFzc2lIVUFBQSIsInZlciI6IjEuMCJ9.otktnWJntN5Ex1m7B5cYjtAq_50geAaUdyQL0oOsiREDXuiRlPCYHBD9qLNkbn04dkTg0udUaXIYYVQx6vRBxKM7dxBnWfIQPTI5JaYw23DzThSUby_ELy4B6mmUi4xKbCYyMZISCnGEfjBjwNT53TL3aromQYvsPVAQ0_LNepqAL5it4b6jQU1nxQ6pSyBZCsA5oeNLRrL6aUtER3Xkm5_bNTjQtancjiNV2aMLUrb5OE2hyolWNuAHHkMmyFCxHHJZOVaw3ZgNPD5w4W8DCE8zcY9ztkuXrO_IxUmL897cNkxyFEmB1I4Kd_x7JvKqrDDPrOmHHA5-v6z-Q4B7qw
-      Content-Length:
-      - '0'
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAwNjQsIm5iZiI6MTUyMDg1MDA2NCwiZXhwIjoxNTIwODUzOTY0LCJhaW8iOiJZMk5nWU9CK3RLbGJkbDJjVzZqMEYxbW5xSVgvQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibHZVWGZPMnVjMC1QZkpNX3FZTWpBQSIsInZlciI6IjEuMCJ9.HuwcHNI5Ym8-9Q8VQU_4_9VjHjXX0742q3FJy2FcwT5elihMisL2t9diXcW-1EmhDws298qnqMfhZB2vY9knNNtqRyeZKFuVQXzgjvAWEujllH2w2qRl2Erh324uCFeadskjhqwjyt1jD1NAGfwhAZdxpwaLAGXl-6LQ4PZIWwGW6YDn9eZr6nHZcPXVEBPhYYw2ErNcHljU93hMRfZjHYMWXf3UUgmjS23bRpQydXKsFMLe1f38Xdfpb6OUyHltk7S6K7mzwNe8npW1se0u51KQg54pYhD-ET1h7hkOe27Q1SeL8rSOZTzLP3gJo_F_WhvEp-5-7iCNQN4I1hWiFg
   response:
     status:
       code: 200
@@ -3301,216 +3330,43 @@ http_interactions:
       - application/json; charset=utf-8
       Expires:
       - "-1"
+      Etag:
+      - W/"054052bb-11ff-4f6e-ac1a-3427c2fd17aa"
       Vary:
       - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1198'
       X-Ms-Request-Id:
-      - 17d3b59d-0362-4b2a-81ce-80a136b8e354
-      X-Ms-Correlation-Request-Id:
-      - 17d3b59d-0362-4b2a-81ce-80a136b8e354
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201928Z:17d3b59d-0362-4b2a-81ce-80a136b8e354
+      - 75de0e9e-703a-430f-b6c1-97dd6b109f42
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:19:27 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: '{"template":{"$schema":"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#","contentVersion":"1.0.0.0","parameters":{"location":{"type":"String"},"virtualMachineName":{"type":"String"},"virtualMachineSize":{"type":"String"},"adminUsername":{"type":"String"},"storageAccountName":{"type":"String"},"virtualNetworkName":{"type":"String"},"networkInterfaceName":{"type":"String"},"networkSecurityGroupName":{"type":"String"},"adminPassword":{"type":"SecureString"},"storageAccountType":{"type":"String"},"diagnosticsStorageAccountName":{"type":"String"},"diagnosticsStorageAccountId":{"type":"String"},"diagnosticsStorageAccountType":{"type":"String"},"addressPrefix":{"type":"String"},"subnetName":{"type":"String"},"subnetPrefix":{"type":"String"},"publicIpAddressName":{"type":"String"},"publicIpAddressType":{"type":"String"}},"variables":{"vnetId":"[resourceId(''miq-azure-test1'',''Microsoft.Network/virtualNetworks'',
-        parameters(''virtualNetworkName''))]","subnetRef":"[concat(variables(''vnetId''),
-        ''/subnets/'', parameters(''subnetName''))]","metricsresourceid":"[concat(''/subscriptions/'',
-        subscription().subscriptionId, ''/resourceGroups/'', resourceGroup().name,
-        ''/providers/'', ''Microsoft.Compute/virtualMachines/'', parameters(''virtualMachineName''))]","metricsclosing":"[concat(''<Metrics
-        resourceId=\"'', variables(''metricsresourceid''), ''\"><MetricAggregation
-        scheduledTransferPeriod=\"PT1H\"/><MetricAggregation scheduledTransferPeriod=\"PT1M\"/></Metrics></DiagnosticMonitorConfiguration></WadCfg>'')]","metricscounters":"<PerformanceCounters
-        scheduledTransferPeriod=\"PT1M\"><PerformanceCounterConfiguration counterSpecifier=\"\\Memory\\AvailableMemory\"
-        sampleRate=\"PT15S\" unit=\"Bytes\"><annotation displayName=\"Memory available\"
-        locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PercentAvailableMemory\" sampleRate=\"PT15S\"
-        unit=\"Percent\"><annotation displayName=\"Mem. percent available\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\UsedMemory\" sampleRate=\"PT15S\" unit=\"Bytes\"><annotation
-        displayName=\"Memory used\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PercentUsedMemory\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"Memory percentage\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PercentUsedByCache\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"Mem. used by cache\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PagesPerSec\" sampleRate=\"PT15S\" unit=\"CountPerSecond\"><annotation
-        displayName=\"Pages\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PagesReadPerSec\" sampleRate=\"PT15S\" unit=\"CountPerSecond\"><annotation
-        displayName=\"Page reads\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PagesWrittenPerSec\" sampleRate=\"PT15S\" unit=\"CountPerSecond\"><annotation
-        displayName=\"Page writes\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\AvailableSwap\" sampleRate=\"PT15S\" unit=\"Bytes\"><annotation
-        displayName=\"Swap available\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PercentAvailableSwap\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"Swap percent available\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\UsedSwap\" sampleRate=\"PT15S\" unit=\"Bytes\"><annotation
-        displayName=\"Swap used\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Memory\\PercentUsedSwap\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"Swap percent used\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentIdleTime\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"CPU idle time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentUserTime\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"CPU user time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentNiceTime\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"CPU nice time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentPrivilegedTime\" sampleRate=\"PT15S\"
-        unit=\"Percent\"><annotation displayName=\"CPU privileged time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentInterruptTime\" sampleRate=\"PT15S\"
-        unit=\"Percent\"><annotation displayName=\"CPU interrupt time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentDPCTime\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"CPU DPC time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentProcessorTime\" sampleRate=\"PT15S\"
-        unit=\"Percent\"><annotation displayName=\"CPU percentage guest OS\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\Processor\\PercentIOWaitTime\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation
-        displayName=\"CPU IO wait time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\BytesPerSecond\" sampleRate=\"PT15S\" unit=\"BytesPerSecond\"><annotation
-        displayName=\"Disk total bytes\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\ReadBytesPerSecond\" sampleRate=\"PT15S\"
-        unit=\"BytesPerSecond\"><annotation displayName=\"Disk read guest OS\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\WriteBytesPerSecond\" sampleRate=\"PT15S\"
-        unit=\"BytesPerSecond\"><annotation displayName=\"Disk write guest OS\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\TransfersPerSecond\" sampleRate=\"PT15S\"
-        unit=\"CountPerSecond\"><annotation displayName=\"Disk transfers\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\ReadsPerSecond\" sampleRate=\"PT15S\" unit=\"CountPerSecond\"><annotation
-        displayName=\"Disk reads\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\WritesPerSecond\" sampleRate=\"PT15S\"
-        unit=\"CountPerSecond\"><annotation displayName=\"Disk writes\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\AverageReadTime\" sampleRate=\"PT15S\"
-        unit=\"Seconds\"><annotation displayName=\"Disk read time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\AverageWriteTime\" sampleRate=\"PT15S\"
-        unit=\"Seconds\"><annotation displayName=\"Disk write time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\AverageTransferTime\" sampleRate=\"PT15S\"
-        unit=\"Seconds\"><annotation displayName=\"Disk transfer time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\PhysicalDisk\\AverageDiskQueueLength\" sampleRate=\"PT15S\"
-        unit=\"Count\"><annotation displayName=\"Disk queue length\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\BytesTransmitted\" sampleRate=\"PT15S\"
-        unit=\"Bytes\"><annotation displayName=\"Network out guest OS\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\BytesReceived\" sampleRate=\"PT15S\"
-        unit=\"Bytes\"><annotation displayName=\"Network in guest OS\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\PacketsTransmitted\" sampleRate=\"PT15S\"
-        unit=\"Count\"><annotation displayName=\"Packets sent\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\PacketsReceived\" sampleRate=\"PT15S\"
-        unit=\"Count\"><annotation displayName=\"Packets received\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\BytesTotal\" sampleRate=\"PT15S\" unit=\"Bytes\"><annotation
-        displayName=\"Network total bytes\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\TotalRxErrors\" sampleRate=\"PT15S\"
-        unit=\"Count\"><annotation displayName=\"Packets received errors\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\TotalTxErrors\" sampleRate=\"PT15S\"
-        unit=\"Count\"><annotation displayName=\"Packets sent errors\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration
-        counterSpecifier=\"\\NetworkInterface\\TotalCollisions\" sampleRate=\"PT15S\"
-        unit=\"Count\"><annotation displayName=\"Network collisions\" locale=\"en-us\"/></PerformanceCounterConfiguration></PerformanceCounters>","metricsstart":"<WadCfg><DiagnosticMonitorConfiguration
-        overallQuotaInMB=\"4096\"><DiagnosticInfrastructureLogs scheduledTransferPeriod=\"PT1M\"
-        scheduledTransferLogLevelFilter=\"Warning\"/>","wadcfgx":"[concat(variables(''metricsstart''),
-        variables(''metricscounters''), variables(''metricsclosing''))]"},"resources":[{"type":"Microsoft.Compute/virtualMachines","name":"[parameters(''virtualMachineName'')]","apiVersion":"2015-06-15","location":"[parameters(''location'')]","properties":{"osProfile":{"computerName":"[parameters(''virtualMachineName'')]","adminUsername":"[parameters(''adminUsername'')]","adminPassword":"[parameters(''adminPassword'')]"},"hardwareProfile":{"vmSize":"[parameters(''virtualMachineSize'')]"},"storageProfile":{"imageReference":{"publisher":"RedHat","offer":"RHEL","sku":"7.2","version":"latest"},"osDisk":{"name":"[parameters(''virtualMachineName'')]","vhd":{"uri":"[concat(concat(reference(resourceId(''miq-azure-test1'',
-        ''Microsoft.Storage/storageAccounts'', parameters(''storageAccountName'')),
-        ''2015-06-15'').primaryEndpoints[''blob''], ''vhds/''), parameters(''virtualMachineName''),
-        ''2016218112243.vhd'')]"},"createOption":"fromImage"},"dataDisks":[]},"networkProfile":{"networkInterfaces":[{"id":"[resourceId(''Microsoft.Network/networkInterfaces'',
-        parameters(''networkInterfaceName''))]"}]},"diagnosticsProfile":{"bootDiagnostics":{"enabled":true,"storageUri":"[reference(resourceId(''miq-azure-test1'',
-        ''Microsoft.Storage/storageAccounts'', parameters(''diagnosticsStorageAccountName'')),
-        ''2015-06-15'').primaryEndpoints[''blob'']]"}}},"resources":[{"type":"extensions","name":"Microsoft.Insights.VMDiagnosticsSettings","apiVersion":"2015-05-01-preview","location":"[parameters(''location'')]","properties":{"publisher":"Microsoft.OSTCExtensions","type":"LinuxDiagnostic","typeHandlerVersion":"2.0","autoUpgradeMinorVersion":true,"settings":{"xmlCfg":"[base64(variables(''wadcfgx''))]","StorageAccount":"[parameters(''diagnosticsStorageAccountName'')]"},"protectedSettings":{"storageAccountName":"[parameters(''diagnosticsStorageAccountName'')]","storageAccountKey":"[listKeys(parameters(''diagnosticsStorageAccountId''),''2015-05-01-preview'').key1]","storageAccountEndPoint":"https://core.windows.net/"}},"dependsOn":["[concat(''Microsoft.Compute/virtualMachines/'',
-        parameters(''virtualMachineName''))]"]}],"dependsOn":["[concat(''Microsoft.Network/networkInterfaces/'',
-        parameters(''networkInterfaceName''))]","[concat(''Microsoft.Storage/storageAccounts/'',
-        parameters(''storageAccountName''))]"]},{"type":"Microsoft.Storage/storageAccounts","name":"[parameters(''storageAccountName'')]","apiVersion":"2015-05-01-preview","location":"[parameters(''location'')]","properties":{"accountType":"[parameters(''storageAccountType'')]"}},{"type":"Microsoft.Network/virtualNetworks","name":"[parameters(''virtualNetworkName'')]","apiVersion":"2015-05-01-preview","location":"[parameters(''location'')]","properties":{"addressSpace":{"addressPrefixes":["[parameters(''addressPrefix'')]"]},"subnets":[{"name":"[parameters(''subnetName'')]","properties":{"addressPrefix":"[parameters(''subnetPrefix'')]"}}]}},{"type":"Microsoft.Network/networkInterfaces","name":"[parameters(''networkInterfaceName'')]","apiVersion":"2015-05-01-preview","location":"[parameters(''location'')]","properties":{"ipConfigurations":[{"name":"ipconfig1","properties":{"subnet":{"id":"[variables(''subnetRef'')]"},"privateIPAllocationMethod":"Dynamic","publicIpAddress":{"id":"[resourceId(''miq-azure-test1'',''Microsoft.Network/publicIpAddresses'',
-        parameters(''publicIpAddressName''))]"}}}],"networkSecurityGroup":{"id":"[resourceId(''miq-azure-test1'',
-        ''Microsoft.Network/networkSecurityGroups'', parameters(''networkSecurityGroupName''))]"}},"dependsOn":["[concat(''Microsoft.Network/virtualNetworks/'',
-        parameters(''virtualNetworkName''))]","[concat(''Microsoft.Network/publicIpAddresses/'',
-        parameters(''publicIpAddressName''))]","[concat(''Microsoft.Network/networkSecurityGroups/'',
-        parameters(''networkSecurityGroupName''))]"]},{"type":"Microsoft.Network/publicIpAddresses","name":"[parameters(''publicIpAddressName'')]","apiVersion":"2015-05-01-preview","location":"[parameters(''location'')]","properties":{"publicIpAllocationMethod":"[parameters(''publicIpAddressType'')]"}},{"type":"Microsoft.Network/networkSecurityGroups","name":"[parameters(''networkSecurityGroupName'')]","apiVersion":"2015-05-01-preview","location":"[parameters(''location'')]","properties":{"securityRules":[{"name":"default-allow-ssh","properties":{"priority":1000,"sourceAddressPrefix":"*","protocol":"Tcp","destinationPortRange":"22","access":"Allow","direction":"inbound","sourcePortRange":"*","destinationAddressPrefix":"*"}}]}}],"outputs":{"adminUsername":{"type":"String","value":"[parameters(''adminUsername'')]"}}}}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:19:28 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1?api-version=2017-12-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2NjAsIm5iZiI6MTUyMDQ1MzY2MCwiZXhwIjoxNTIwNDU3NTYwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieDhndTAtZGRoVUt0cWFzc2lIVUFBQSIsInZlciI6IjEuMCJ9.otktnWJntN5Ex1m7B5cYjtAq_50geAaUdyQL0oOsiREDXuiRlPCYHBD9qLNkbn04dkTg0udUaXIYYVQx6vRBxKM7dxBnWfIQPTI5JaYw23DzThSUby_ELy4B6mmUi4xKbCYyMZISCnGEfjBjwNT53TL3aromQYvsPVAQ0_LNepqAL5it4b6jQU1nxQ6pSyBZCsA5oeNLRrL6aUtER3Xkm5_bNTjQtancjiNV2aMLUrb5OE2hyolWNuAHHkMmyFCxHHJZOVaw3ZgNPD5w4W8DCE8zcY9ztkuXrO_IxUmL897cNkxyFEmB1I4Kd_x7JvKqrDDPrOmHHA5-v6z-Q4B7qw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/LowCostGet3Min;4723,Microsoft.Compute/LowCostGet30Min;37845
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
-      X-Ms-Request-Id:
-      - fa333b57-6c29-4db3-a01d-b576baa85914
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14983'
+      - '14986'
       X-Ms-Correlation-Request-Id:
-      - 0a986842-f3dd-455a-b071-80ae85267abd
+      - d60b67a9-4fd4-4358-8740-25b9ae1e71e2
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201935Z:0a986842-f3dd-455a-b071-80ae85267abd
+      - WESTEUROPE:20180312T102627Z:d60b67a9-4fd4-4358-8740-25b9ae1e71e2
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:19:35 GMT
+      - Mon, 12 Mar 2018 10:26:27 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"03e8467b-baab-4867-9cc4-157336b7e2e4\",\r\n
-        \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Basic_A0\"\r\n    },\r\n
-        \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
-        \"RedHat\",\r\n        \"offer\": \"RHEL\",\r\n        \"sku\": \"7.2\",\r\n
-        \       \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
-        \"Linux\",\r\n        \"name\": \"miq-test-rhel1\",\r\n        \"createOption\":
-        \"FromImage\",\r\n        \"vhd\": {\r\n          \"uri\": \"https://miqazuretest18686.blob.core.windows.net/vhds/miq-test-rhel12016218112243.vhd\"\r\n
-        \       },\r\n        \"caching\": \"ReadWrite\"\r\n      },\r\n      \"dataDisks\":
-        []\r\n    },\r\n    \"osProfile\": {\r\n      \"computerName\": \"miq-test-rhel1\",\r\n
-        \     \"adminUsername\": \"dberger\",\r\n      \"linuxConfiguration\": {\r\n
-        \       \"disablePasswordAuthentication\": false\r\n      },\r\n      \"secrets\":
-        []\r\n    },\r\n    \"networkProfile\": {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390\"}]},\r\n
-        \   \"diagnosticsProfile\": {\r\n      \"bootDiagnostics\": {\r\n        \"enabled\":
-        true,\r\n        \"storageUri\": \"https://miqazuretest18686.blob.core.windows.net/\"\r\n
-        \     }\r\n    },\r\n    \"provisioningState\": \"Succeeded\"\r\n  },\r\n
-        \ \"resources\": [\r\n    {\r\n      \"properties\": {\r\n        \"publisher\":
-        \"Microsoft.OSTCExtensions\",\r\n        \"type\": \"LinuxDiagnostic\",\r\n
-        \       \"typeHandlerVersion\": \"2.0\",\r\n        \"autoUpgradeMinorVersion\":
-        true,\r\n        \"settings\": {\"xmlCfg\":\"PFdhZENmZz48RGlhZ25vc3RpY01vbml0b3JDb25maWd1cmF0aW9uIG92ZXJhbGxRdW90YUluTUI9IjQwOTYiPjxEaWFnbm9zdGljSW5mcmFzdHJ1Y3R1cmVMb2dzIHNjaGVkdWxlZFRyYW5zZmVyUGVyaW9kPSJQVDFNIiBzY2hlZHVsZWRUcmFuc2ZlckxvZ0xldmVsRmlsdGVyPSJXYXJuaW5nIi8+PFBlcmZvcm1hbmNlQ291bnRlcnMgc2NoZWR1bGVkVHJhbnNmZXJQZXJpb2Q9IlBUMU0iPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlTWVtb3J5IiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQnl0ZXMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcUGVyY2VudEF2YWlsYWJsZU1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iTWVtb3J5IHVzZWQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50VXNlZE1lbW9yeSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW1vcnkgcGVyY2VudGFnZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkQnlDYWNoZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJNZW0uIHVzZWQgYnkgY2FjaGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1BlclNlYyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50UGVyU2Vjb25kIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFnZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1JlYWRQZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2UgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQYWdlc1dyaXR0ZW5QZXJTZWMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlBhZ2Ugd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcQXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkJ5dGVzIj48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iU3dhcCBhdmFpbGFibGUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE1lbW9yeVxQZXJjZW50QXZhaWxhYmxlU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgYXZhaWxhYmxlIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxNZW1vcnlcVXNlZFN3YXAiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IlN3YXAgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTWVtb3J5XFBlcmNlbnRVc2VkU3dhcCIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJTd2FwIHBlcmNlbnQgdXNlZCIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRJZGxlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgaWRsZSB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFVzZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iUGVyY2VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkNQVSB1c2VyIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50TmljZVRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIG5pY2UgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUHJvY2Vzc29yXFBlcmNlbnRQcml2aWxlZ2VkVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgcHJpdmlsZWdlZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudEludGVycnVwdFRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIGludGVycnVwdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudERQQ1RpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIERQQyB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQcm9jZXNzb3JcUGVyY2VudFByb2Nlc3NvclRpbWUiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJQZXJjZW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iQ1BVIHBlcmNlbnRhZ2UgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFByb2Nlc3NvclxQZXJjZW50SU9XYWl0VGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlBlcmNlbnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJDUFUgSU8gd2FpdCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xSZWFkQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCBndWVzdCBPUyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXFdyaXRlQnl0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlc1BlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGUgZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xUcmFuc2ZlcnNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXJzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcUmVhZHNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZHMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xXcml0ZXNQZXJTZWNvbmQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudFBlclNlY29uZCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgd3JpdGVzIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVJlYWRUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcmVhZCB0aW1lIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxQaHlzaWNhbERpc2tcQXZlcmFnZVdyaXRlVGltZSIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IlNlY29uZHMiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJEaXNrIHdyaXRlIHRpbWUiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXFBoeXNpY2FsRGlza1xBdmVyYWdlVHJhbnNmZXJUaW1lIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iU2Vjb25kcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgdHJhbnNmZXIgdGltZSIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcUGh5c2ljYWxEaXNrXEF2ZXJhZ2VEaXNrUXVldWVMZW5ndGgiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9IkRpc2sgcXVldWUgbGVuZ3RoIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVHJhbnNtaXR0ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgb3V0IGd1ZXN0IE9TIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzUmVjZWl2ZWQiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgaW4gZ3Vlc3QgT1MiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1RyYW5zbWl0dGVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHNlbnQiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcUGFja2V0c1JlY2VpdmVkIiBzYW1wbGVSYXRlPSJQVDE1UyIgdW5pdD0iQ291bnQiPjxhbm5vdGF0aW9uIGRpc3BsYXlOYW1lPSJQYWNrZXRzIHJlY2VpdmVkIiBsb2NhbGU9ImVuLXVzIi8+PC9QZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uPjxQZXJmb3JtYW5jZUNvdW50ZXJDb25maWd1cmF0aW9uIGNvdW50ZXJTcGVjaWZpZXI9IlxOZXR3b3JrSW50ZXJmYWNlXEJ5dGVzVG90YWwiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJCeXRlcyI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgdG90YWwgYnl0ZXMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxSeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyByZWNlaXZlZCBlcnJvcnMiIGxvY2FsZT0iZW4tdXMiLz48L1BlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24+PFBlcmZvcm1hbmNlQ291bnRlckNvbmZpZ3VyYXRpb24gY291bnRlclNwZWNpZmllcj0iXE5ldHdvcmtJbnRlcmZhY2VcVG90YWxUeEVycm9ycyIgc2FtcGxlUmF0ZT0iUFQxNVMiIHVuaXQ9IkNvdW50Ij48YW5ub3RhdGlvbiBkaXNwbGF5TmFtZT0iUGFja2V0cyBzZW50IGVycm9ycyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48UGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbiBjb3VudGVyU3BlY2lmaWVyPSJcTmV0d29ya0ludGVyZmFjZVxUb3RhbENvbGxpc2lvbnMiIHNhbXBsZVJhdGU9IlBUMTVTIiB1bml0PSJDb3VudCI+PGFubm90YXRpb24gZGlzcGxheU5hbWU9Ik5ldHdvcmsgY29sbGlzaW9ucyIgbG9jYWxlPSJlbi11cyIvPjwvUGVyZm9ybWFuY2VDb3VudGVyQ29uZmlndXJhdGlvbj48L1BlcmZvcm1hbmNlQ291bnRlcnM+PE1ldHJpY3MgcmVzb3VyY2VJZD0iL3N1YnNjcmlwdGlvbnMvMjU4NmM2NGItMzhiNC00NTI3LWExNDAtMDEyZDQ5ZGZjMDJjL3Jlc291cmNlR3JvdXBzL21pcS1henVyZS10ZXN0MS9wcm92aWRlcnMvTWljcm9zb2Z0LkNvbXB1dGUvdmlydHVhbE1hY2hpbmVzL21pcS10ZXN0LXJoZWwxIj48TWV0cmljQWdncmVnYXRpb24gc2NoZWR1bGVkVHJhbnNmZXJQZXJpb2Q9IlBUMUgiLz48TWV0cmljQWdncmVnYXRpb24gc2NoZWR1bGVkVHJhbnNmZXJQZXJpb2Q9IlBUMU0iLz48L01ldHJpY3M+PC9EaWFnbm9zdGljTW9uaXRvckNvbmZpZ3VyYXRpb24+PC9XYWRDZmc+\",\"StorageAccount\":\"miqazuretest18686\"},\r\n
-        \       \"provisioningState\": \"Succeeded\"\r\n      },\r\n      \"type\":
-        \"Microsoft.Compute/virtualMachines/extensions\",\r\n      \"location\": \"eastus\",\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/extensions/Microsoft.Insights.VMDiagnosticsSettings\",\r\n
-        \     \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\"\r\n    }\r\n
-        \ ],\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n  \"location\":
-        \"eastus\",\r\n  \"tags\": {\r\n    \"Shutdown\": \"true\"\r\n  },\r\n  \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1\",\r\n
-        \ \"name\": \"miq-test-rhel1\"\r\n}"
+      string: "{\r\n  \"name\": \"miq-test-rhel1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1\",\r\n
+        \ \"etag\": \"W/\\\"054052bb-11ff-4f6e-ac1a-3427c2fd17aa\\\"\",\r\n  \"location\":
+        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"f6cfc635-411e-48ce-a627-39a2fc0d3168\",\r\n    \"ipAddress\":
+        \"52.224.165.15\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\":
+        \"Dynamic\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipTags\": [],\r\n
+        \   \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1\"\r\n
+        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
+        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:19:35 GMT
+  recorded_at: Mon, 12 Mar 2018 10:26:32 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1/instanceView?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686?api-version=2017-10-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3524,7 +3380,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2NjAsIm5iZiI6MTUyMDQ1MzY2MCwiZXhwIjoxNTIwNDU3NTYwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieDhndTAtZGRoVUt0cWFzc2lIVUFBQSIsInZlciI6IjEuMCJ9.otktnWJntN5Ex1m7B5cYjtAq_50geAaUdyQL0oOsiREDXuiRlPCYHBD9qLNkbn04dkTg0udUaXIYYVQx6vRBxKM7dxBnWfIQPTI5JaYw23DzThSUby_ELy4B6mmUi4xKbCYyMZISCnGEfjBjwNT53TL3aromQYvsPVAQ0_LNepqAL5it4b6jQU1nxQ6pSyBZCsA5oeNLRrL6aUtER3Xkm5_bNTjQtancjiNV2aMLUrb5OE2hyolWNuAHHkMmyFCxHHJZOVaw3ZgNPD5w4W8DCE8zcY9ztkuXrO_IxUmL897cNkxyFEmB1I4Kd_x7JvKqrDDPrOmHHA5-v6z-Q4B7qw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAwNjQsIm5iZiI6MTUyMDg1MDA2NCwiZXhwIjoxNTIwODUzOTY0LCJhaW8iOiJZMk5nWU9CK3RLbGJkbDJjVzZqMEYxbW5xSVgvQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibHZVWGZPMnVjMC1QZkpNX3FZTWpBQSIsInZlciI6IjEuMCJ9.HuwcHNI5Ym8-9Q8VQU_4_9VjHjXX0742q3FJy2FcwT5elihMisL2t9diXcW-1EmhDws298qnqMfhZB2vY9knNNtqRyeZKFuVQXzgjvAWEujllH2w2qRl2Erh324uCFeadskjhqwjyt1jD1NAGfwhAZdxpwaLAGXl-6LQ4PZIWwGW6YDn9eZr6nHZcPXVEBPhYYw2ErNcHljU93hMRfZjHYMWXf3UUgmjS23bRpQydXKsFMLe1f38Xdfpb6OUyHltk7S6K7mzwNe8npW1se0u51KQg54pYhD-ET1h7hkOe27Q1SeL8rSOZTzLP3gJo_F_WhvEp-5-7iCNQN4I1hWiFg
   response:
     status:
       code: 200
@@ -3537,215 +3393,32 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Content-Type:
-      - application/json; charset=utf-8
+      - application/json
       Expires:
       - "-1"
       Vary:
       - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/GetInstanceView3Min;4793,Microsoft.Compute/GetInstanceView30Min;23917
+      X-Ms-Request-Id:
+      - bcd19d22-6cd6-4c34-aeb3-ac5291ee5fef
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
-      X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
-      X-Ms-Request-Id:
-      - 1d2c73d6-0e32-4197-976b-e5dc553015be
       Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
+      - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14977'
+      - '14982'
       X-Ms-Correlation-Request-Id:
-      - 2a94510f-ec8f-4c3c-bd49-3916c91944f2
+      - aacece03-f07d-409b-ab8b-426d462ffc49
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201947Z:2a94510f-ec8f-4c3c-bd49-3916c91944f2
+      - WESTEUROPE:20180312T102628Z:aacece03-f07d-409b-ab8b-426d462ffc49
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:19:47 GMT
+      - Mon, 12 Mar 2018 10:26:28 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"vmAgent\": {\r\n    \"vmAgentVersion\": \"WALinuxAgent-2.0.16\",\r\n
-        \   \"statuses\": [\r\n      {\r\n        \"code\": \"ProvisioningState/succeeded\",\r\n
-        \       \"level\": \"Info\",\r\n        \"displayStatus\": \"Ready\",\r\n
-        \       \"message\": \"GuestAgent is running and accepting new configurations.\",\r\n
-        \       \"time\": \"2018-03-07T20:19:33+00:00\"\r\n      }\r\n    ],\r\n    \"extensionHandlers\":
-        [\r\n      {\r\n        \"type\": \"Microsoft.OSTCExtensions.LinuxDiagnostic\",\r\n
-        \       \"typeHandlerVersion\": \"2.3.9027\",\r\n        \"status\": {\r\n
-        \         \"code\": \"ProvisioningState/succeeded\",\r\n          \"level\":
-        \"Info\",\r\n          \"displayStatus\": \"Ready\"\r\n        }\r\n      }\r\n
-        \   ]\r\n  },\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"miq-test-rhel1\",\r\n
-        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
-        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"time\": \"2018-01-17T18:00:29.9011002+00:00\"\r\n
-        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"bootDiagnostics\": {\r\n    \"consoleScreenshotBlobUri\":
-        \"https://miqazuretest18686.blob.core.windows.net/bootdiagnostics-miqtestrh-03e8467b-baab-4867-9cc4-157336b7e2e4/miq-test-rhel1.03e8467b-baab-4867-9cc4-157336b7e2e4.screenshot.bmp\",\r\n
-        \   \"serialConsoleLogBlobUri\": \"https://miqazuretest18686.blob.core.windows.net/bootdiagnostics-miqtestrh-03e8467b-baab-4867-9cc4-157336b7e2e4/miq-test-rhel1.03e8467b-baab-4867-9cc4-157336b7e2e4.serialconsole.log\"\r\n
-        \ },\r\n  \"extensions\": [\r\n    {\r\n      \"name\": \"Microsoft.Insights.VMDiagnosticsSettings\",\r\n
-        \     \"type\": \"Microsoft.OSTCExtensions.LinuxDiagnostic\",\r\n      \"typeHandlerVersion\":
-        \"2.3.9027\",\r\n      \"statuses\": [\r\n        {\r\n          \"code\":
-        \"ProvisioningState/succeeded\",\r\n          \"level\": \"Info\",\r\n          \"displayStatus\":
-        \"Provisioning succeeded\",\r\n          \"message\": \"Enable succeeded\"\r\n
-        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\":
-        \"ProvisioningState/succeeded\",\r\n      \"level\": \"Info\",\r\n      \"displayStatus\":
-        \"Provisioning succeeded\",\r\n      \"time\": \"2018-01-17T18:02:26.9167163+00:00\"\r\n
-        \   },\r\n    {\r\n      \"code\": \"PowerState/running\",\r\n      \"level\":
-        \"Info\",\r\n      \"displayStatus\": \"VM running\"\r\n    }\r\n  ]\r\n}"
+      string: '{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","name":"miqazuretest18686","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T17:22:54.7808677Z","primaryEndpoints":{"blob":"https://miqazuretest18686.blob.core.windows.net/","queue":"https://miqazuretest18686.queue.core.windows.net/","table":"https://miqazuretest18686.table.core.windows.net/","file":"https://miqazuretest18686.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:19:47 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Network/networkInterfaces?api-version=2017-11-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2NjAsIm5iZiI6MTUyMDQ1MzY2MCwiZXhwIjoxNTIwNDU3NTYwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieDhndTAtZGRoVUt0cWFzc2lIVUFBQSIsInZlciI6IjEuMCJ9.otktnWJntN5Ex1m7B5cYjtAq_50geAaUdyQL0oOsiREDXuiRlPCYHBD9qLNkbn04dkTg0udUaXIYYVQx6vRBxKM7dxBnWfIQPTI5JaYw23DzThSUby_ELy4B6mmUi4xKbCYyMZISCnGEfjBjwNT53TL3aromQYvsPVAQ0_LNepqAL5it4b6jQU1nxQ6pSyBZCsA5oeNLRrL6aUtER3Xkm5_bNTjQtancjiNV2aMLUrb5OE2hyolWNuAHHkMmyFCxHHJZOVaw3ZgNPD5w4W8DCE8zcY9ztkuXrO_IxUmL897cNkxyFEmB1I4Kd_x7JvKqrDDPrOmHHA5-v6z-Q4B7qw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 75afe20f-4a19-49c7-a3a5-dd1e08d9fc1a
-      X-Ms-Correlation-Request-Id:
-      - 75afe20f-4a19-49c7-a3a5-dd1e08d9fc1a
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201950Z:75afe20f-4a19-49c7-a3a5-dd1e08d9fc1a
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:19:50 GMT
-      Content-Length:
-      - '31614'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[{"name":"miqazure-coreos1235","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235","etag":"W/\"4a6546ab-a4c0-4d27-bccd-f6ebf3c405a2\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"fb0a5e60-a6c2-4bb8-a2f5-0c16216a49b0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235/ipConfigurations/ipconfig1","etag":"W/\"4a6546ab-a4c0-4d27-bccd-f6ebf3c405a2\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.20.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/publicIPAddresses/miqazure-coreos1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/virtualNetworks/miq-azure-test3/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"rliadcyr3l1elbnsw4rabxqg1f.dx.internal.cloudapp.net"},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkSecurityGroups/miqazure-coreos1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Compute/virtualMachines/miqazure-coreos1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"dbergerprov1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/dbergerprov1","etag":"W/\"074dd836-918c-4e40-a118-94f0d366e175\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"ecdcd2f0-91bb-4c40-91cd-a3d76fc5e455","ipConfigurations":[{"name":"dbergerprov1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/dbergerprov1/ipConfigurations/dbergerprov1","etag":"W/\"074dd836-918c-4e40-a118-94f0d366e175\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.9","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/dbergerprov1-publicIp"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/virtualMachines/dbergerprov1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-rhel1390","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390","etag":"W/\"f006e6f9-0292-42cd-99fc-f72f194553c1\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"98853f48-2806-4065-be57-cf9159550440","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1","etag":"W/\"f006e6f9-0292-42cd-99fc-f72f194553c1\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"macAddress":"00-0D-3A-10-EB-AB","enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-ubuntu1989","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989","etag":"W/\"64e07488-15a2-4cec-b84a-6fd5ef04323c\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"134a6669-ac4a-4d08-a0db-387bc4c49537","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989/ipConfigurations/ipconfig1","etag":"W/\"64e07488-15a2-4cec-b84a-6fd5ef04323c\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.17.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-ubuntu1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest18687/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-win12610","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610","etag":"W/\"dd925ef5-33d1-402c-a0f4-18c78c2641f4\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"5c2eef2c-0b36-4277-a940-957ed4d13be0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610/ipConfigurations/ipconfig1","etag":"W/\"dd925ef5-33d1-402c-a0f4-18c78c2641f4\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.18.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-win12"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest19881/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-winimg241","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241","etag":"W/\"4a17a745-16a9-42d9-88c9-17a518959525\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"8ed2f3b0-4a4b-49ae-9f1d-ff7890dbd396","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241/ipConfigurations/ipconfig1","etag":"W/\"4a17a745-16a9-42d9-88c9-17a518959525\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.7","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqtestwinimg6202"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-centos1611","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611","etag":"W/\"26031ef6-bb55-4019-8185-2dd1edcb207c\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"f1760e49-9853-4fdc-acfc-4ea232b9ed76","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1","etag":"W/\"26031ef6-bb55-4019-8185-2dd1edcb207c\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.5","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqmismatch1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1","etag":"W/\"3a72d0c3-bfda-4da5-a61b-e8c33e43de79\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"23d804a8-b623-49e7-9c8d-1d64245bef1e","ipConfigurations":[{"name":"miqmismatch1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1/ipConfigurations/miqmismatch1","etag":"W/\"3a72d0c3-bfda-4da5-a61b-e8c33e43de79\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.8","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqmismatch1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqmismatch1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"rspec-lb-a670","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670","etag":"W/\"cf3a0b0d-d596-4f33-bc31-749f92ba4f00\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"46cb8216-786e-408e-9d86-c0855b357349","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1","etag":"W/\"cf3a0b0d-d596-4f33-bc31-749f92ba4f00\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.6","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-a-ip"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"rspec-lb-b843","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843","etag":"W/\"76aabe0c-8678-43f0-81a5-2f15784a4b99\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"3ef6fa01-ac34-43a1-8fd7-67c706b4d8ef","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1","etag":"W/\"76aabe0c-8678-43f0-81a5-2f15784a4b99\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.11","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-b-ip"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"spec0deply1nic0","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","etag":"W/\"b817491c-aab8-4aab-b41d-b07bfffa5639\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"80ad9866-071d-4e3f-91d0-d47954eccee0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1","etag":"W/\"b817491c-aab8-4aab-b41d-b07bfffa5639\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.4","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"spec0deply1nic1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","etag":"W/\"2ec58a0b-4c03-4d0a-b788-9daffd54e7b2\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"57bbf7aa-d6c4-4f56-8f6a-089d15334221","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1","etag":"W/\"2ec58a0b-4c03-4d0a-b788-9daffd54e7b2\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.5","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqmismatch2656","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqmismatch2656","etag":"W/\"fef6a836-2802-4897-90c3-b3d71f133384\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"969dde6c-73c0-4340-877d-2b5fe2060026","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqmismatch2656/ipConfigurations/ipconfig1","etag":"W/\"fef6a836-2802-4897-90c3-b3d71f133384\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"172.23.0.4","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/virtualNetworks/miqazuretest33606/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkSecurityGroups/miqmismatch2-nsg"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Compute/virtualMachines/miqmismatch2"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-linux-manag944","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944","etag":"W/\"b6339880-8ead-4c9e-b5c0-f38c4f8612d5\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"c5e8b90e-5a78-49b0-b224-b70ed3fb45e5","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944/ipConfigurations/ipconfig1","etag":"W/\"b6339880-8ead-4c9e-b5c0-f38c4f8612d5\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"172.25.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqazure-linux-managed-ip"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"jf-metrics-2751","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751","etag":"W/\"c5f6f02a-b17c-4f34-882b-11c7adef0b44\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"207a58d3-f18d-4dab-8168-919877297a52","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751/ipConfigurations/ipconfig1","etag":"W/\"c5f6f02a-b17c-4f34-882b-11c7adef0b44\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.7","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-2"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-2"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/jf-metrics-2"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"jf-metrics-3421","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421","etag":"W/\"0b6f160b-ad10-48f8-9d0c-657193bb823f\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"b8b345e8-a353-4700-992e-be48a717b4e2","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421/ipConfigurations/ipconfig1","etag":"W/\"0b6f160b-ad10-48f8-9d0c-657193bb823f\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.8","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-3"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-3"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/jf-metrics-3"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-oraclelinux310","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310","etag":"W/\"54cd4fe1-3ed5-4a8c-bc8d-527679c7a631\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"6a3fc1d7-4532-4ca0-b5c2-546cc8f7f313","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310/ipConfigurations/ipconfig1","etag":"W/\"54cd4fe1-3ed5-4a8c-bc8d-527679c7a631\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.5","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-oraclelinux993","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993","etag":"W/\"a9432274-7b40-4eb3-a64f-a04267a423ff\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"75d8ed14-e0ae-4d84-99f6-e3f43d073e76","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993/ipConfigurations/ipconfig1","etag":"W/\"a9432274-7b40-4eb3-a64f-a04267a423ff\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.6","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux2"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux2"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"}]}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:19:50 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Network/publicIPAddresses?api-version=2017-11-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2NjAsIm5iZiI6MTUyMDQ1MzY2MCwiZXhwIjoxNTIwNDU3NTYwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieDhndTAtZGRoVUt0cWFzc2lIVUFBQSIsInZlciI6IjEuMCJ9.otktnWJntN5Ex1m7B5cYjtAq_50geAaUdyQL0oOsiREDXuiRlPCYHBD9qLNkbn04dkTg0udUaXIYYVQx6vRBxKM7dxBnWfIQPTI5JaYw23DzThSUby_ELy4B6mmUi4xKbCYyMZISCnGEfjBjwNT53TL3aromQYvsPVAQ0_LNepqAL5it4b6jQU1nxQ6pSyBZCsA5oeNLRrL6aUtER3Xkm5_bNTjQtancjiNV2aMLUrb5OE2hyolWNuAHHkMmyFCxHHJZOVaw3ZgNPD5w4W8DCE8zcY9ztkuXrO_IxUmL897cNkxyFEmB1I4Kd_x7JvKqrDDPrOmHHA5-v6z-Q4B7qw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - fdc772be-0406-4232-ba80-510e173f9cce
-      X-Ms-Correlation-Request-Id:
-      - fdc772be-0406-4232-ba80-510e173f9cce
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201952Z:fdc772be-0406-4232-ba80-510e173f9cce
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:19:52 GMT
-      Content-Length:
-      - '13978'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[{"name":"miqazure-coreos1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/publicIPAddresses/miqazure-coreos1","etag":"W/\"da64b64b-a755-4389-a2f3-5cba32f18c06\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"28617ed1-0270-4b39-873a-c3b48b3deef1","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"dbergerprov1-publicIp","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/dbergerprov1-publicIp","etag":"W/\"3d984c69-3f35-41ce-bdfc-8d207053a6a9\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"eb0e8804-e169-44ac-bb47-0929370977d2","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/dbergerprov1/ipConfigurations/dbergerprov1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"ladas_test","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/ladas_test","etag":"W/\"32e21623-9a1b-4c40-80f4-6a350aa237a7\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"3daa5f66-5a01-4242-b95b-c4e0ee8f0c36","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[]},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miq-test-rhel1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1","etag":"W/\"054052bb-11ff-4f6e-ac1a-3427c2fd17aa\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"f6cfc635-411e-48ce-a627-39a2fc0d3168","ipAddress":"52.224.165.15","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miq-test-ubuntu1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-ubuntu1","etag":"W/\"bcae50c5-146f-4fcb-a461-7c1030ba7b74\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"e272bd74-f661-484f-b223-88dd128a4049","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miq-test-win12","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-win12","etag":"W/\"56ce00f4-50d7-4682-9ee8-6836bf5c0ea6\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"b9200977-8147-40a5-83c2-d5892d5ddedc","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miqazure-centos1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1","etag":"W/\"734a3944-a880-444c-8c92-cace6e28e303\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"475a66f0-9e89-4226-a9f0-9baaaf31d619","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miqtestwinimg6202","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqtestwinimg6202","etag":"W/\"b656279a-26ff-4021-94bb-263420cf494e\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"fb942169-855b-44f8-b12f-fd63e961b140","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"rspec-lb-a-ip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-a-ip","etag":"W/\"3ba30997-7d2f-470c-96f6-301158e93b7c\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"3c605f75-23c0-46ab-ba2b-6fd4430140fd","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"rspec-lb-b-ip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-b-ip","etag":"W/\"cf6012c7-3d47-438f-84d7-332ad1ef4500\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"5d1a2425-a351-4c0f-bc87-37e6500bff22","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"rspec-lb1-LoadBalancerFrontEnd","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd","etag":"W/\"a38434c8-7b23-4092-b7c6-402238eac0dc\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"f28e0f25-b372-4edf-97d9-13a9e3b4ba2d","ipAddress":"40.71.82.83","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"rspec-lb2-publicip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip","etag":"W/\"cddd97d1-6111-4477-8a00-3dc885237a1d\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"83e7257d-ab94-4229-8eb5-4798f37ef28d","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"spec0deply1ip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip","etag":"W/\"2080997a-38a6-420d-ba86-e9582e1331c7\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"a08b891e-e45a-4970-aefc-f6c996989490","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"spec0deply1dns","fqdn":"spec0deply1dns.eastus.cloudapp.azure.com"},"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miqazure-linux-managed-ip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqazure-linux-managed-ip","etag":"W/\"0efc9684-fb7d-4fb7-b9b9-f33dbac04a28\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"6a2a9142-26e8-45cd-93bf-7318192f3528","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miqmismatch1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqmismatch1","etag":"W/\"9b8b1729-21c4-4c53-94f2-15715315ad73\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"a97c71d0-6b78-4ffe-8e5c-0be1ee653f8c","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"miqmismatch1","fqdn":"miqmismatch1.eastus.cloudapp.azure.com"},"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1/ipConfigurations/miqmismatch1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"jf-metrics-2","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-2","etag":"W/\"b43ebe01-574c-4454-87eb-3401fbcf36f2\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"e446f3e4-9410-4d7f-bb04-2652096359de","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"jf-metrics-3","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-3","etag":"W/\"a6ee7100-6202-4ae2-a2db-f828abec8af9\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"de5995a4-15c1-40ba-ad78-67e70a92654b","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miqazure-oraclelinux1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux1","etag":"W/\"98bee7b4-2fcc-471d-b5ce-92850e6c3d6b\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"f2ac7c18-520b-4b42-94e7-da264a842f41","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miqazure-oraclelinux2","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux2","etag":"W/\"0865cebc-95b9-49d2-9f10-21dbafb23cac\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"2f4e1091-46f0-474c-a697-8dbcea6ba2a6","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}}]}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:19:52 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Storage/storageAccounts?api-version=2017-10-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2NjAsIm5iZiI6MTUyMDQ1MzY2MCwiZXhwIjoxNTIwNDU3NTYwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieDhndTAtZGRoVUt0cWFzc2lIVUFBQSIsInZlciI6IjEuMCJ9.otktnWJntN5Ex1m7B5cYjtAq_50geAaUdyQL0oOsiREDXuiRlPCYHBD9qLNkbn04dkTg0udUaXIYYVQx6vRBxKM7dxBnWfIQPTI5JaYw23DzThSUby_ELy4B6mmUi4xKbCYyMZISCnGEfjBjwNT53TL3aromQYvsPVAQ0_LNepqAL5it4b6jQU1nxQ6pSyBZCsA5oeNLRrL6aUtER3Xkm5_bNTjQtancjiNV2aMLUrb5OE2hyolWNuAHHkMmyFCxHHJZOVaw3ZgNPD5w4W8DCE8zcY9ztkuXrO_IxUmL897cNkxyFEmB1I4Kd_x7JvKqrDDPrOmHHA5-v6z-Q4B7qw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - b32e410d-33e4-4598-b28a-002a3decb4b9
-      X-Ms-Correlation-Request-Id:
-      - b32e410d-33e4-4598-b28a-002a3decb4b9
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201954Z:b32e410d-33e4-4598-b28a-002a3decb4b9
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:19:54 GMT
-      Content-Length:
-      - '8649'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","name":"miqazuretest18686","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T17:22:54.7808677Z","primaryEndpoints":{"blob":"https://miqazuretest18686.blob.core.windows.net/","queue":"https://miqazuretest18686.queue.core.windows.net/","table":"https://miqazuretest18686.table.core.windows.net/","file":"https://miqazuretest18686.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","name":"miqazuretest14047","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T17:30:25.7028008Z","primaryEndpoints":{"blob":"https://miqazuretest14047.blob.core.windows.net/","queue":"https://miqazuretest14047.queue.core.windows.net/","table":"https://miqazuretest14047.table.core.windows.net/","file":"https://miqazuretest14047.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Premium_LRS","tier":"Premium"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb","name":"rspeclb","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-09-02T16:29:11.6823797Z","primaryEndpoints":{"blob":"https://rspeclb.blob.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","name":"spec0deply1stor","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-04-04T23:05:07.8274794Z","primaryEndpoints":{"blob":"https://spec0deply1stor.blob.core.windows.net/","queue":"https://spec0deply1stor.queue.core.windows.net/","table":"https://spec0deply1stor.table.core.windows.net/","file":"https://spec0deply1stor.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Storage/storageAccounts/miqazuretest26611","name":"miqazuretest26611","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2211656Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2211656Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-05-02T18:01:29.2743021Z","primaryEndpoints":{"blob":"https://miqazuretest26611.blob.core.windows.net/","queue":"https://miqazuretest26611.queue.core.windows.net/","table":"https://miqazuretest26611.table.core.windows.net/","file":"https://miqazuretest26611.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","name":"miqazuretest16487","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T17:26:55.3231669Z","primaryEndpoints":{"blob":"https://miqazuretest16487.blob.core.windows.net/","queue":"https://miqazuretest16487.queue.core.windows.net/","table":"https://miqazuretest16487.table.core.windows.net/","file":"https://miqazuretest16487.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Storage/storageAccounts/miqazuretest32946","name":"miqazuretest32946","type":"Microsoft.Storage/storageAccounts","location":"westus","tags":{"delete":"false"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.0404359Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.0404359Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T21:18:37.0793411Z","primaryEndpoints":{"blob":"https://miqazuretest32946.blob.core.windows.net/","queue":"https://miqazuretest32946.queue.core.windows.net/","table":"https://miqazuretest32946.table.core.windows.net/","file":"https://miqazuretest32946.file.core.windows.net/"},"primaryLocation":"westus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Storage/storageAccounts/miqazureshared1","name":"miqazureshared1","type":"Microsoft.Storage/storageAccounts","location":"centralus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.1935084Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.1935084Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T20:42:52.498085Z","primaryEndpoints":{"blob":"https://miqazureshared1.blob.core.windows.net/","queue":"https://miqazureshared1.queue.core.windows.net/","table":"https://miqazureshared1.table.core.windows.net/","file":"https://miqazureshared1.file.core.windows.net/"},"primaryLocation":"centralus","statusOfPrimary":"available","secondaryLocation":"eastus2","statusOfSecondary":"available","secondaryEndpoints":{"blob":"https://miqazureshared1-secondary.blob.core.windows.net/","queue":"https://miqazureshared1-secondary.queue.core.windows.net/","table":"https://miqazureshared1-secondary.table.core.windows.net/"}}}]}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:19:54 GMT
+  recorded_at: Mon, 12 Mar 2018 10:26:33 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686/listKeys?api-version=2017-10-01
@@ -3762,7 +3435,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2NjAsIm5iZiI6MTUyMDQ1MzY2MCwiZXhwIjoxNTIwNDU3NTYwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieDhndTAtZGRoVUt0cWFzc2lIVUFBQSIsInZlciI6IjEuMCJ9.otktnWJntN5Ex1m7B5cYjtAq_50geAaUdyQL0oOsiREDXuiRlPCYHBD9qLNkbn04dkTg0udUaXIYYVQx6vRBxKM7dxBnWfIQPTI5JaYw23DzThSUby_ELy4B6mmUi4xKbCYyMZISCnGEfjBjwNT53TL3aromQYvsPVAQ0_LNepqAL5it4b6jQU1nxQ6pSyBZCsA5oeNLRrL6aUtER3Xkm5_bNTjQtancjiNV2aMLUrb5OE2hyolWNuAHHkMmyFCxHHJZOVaw3ZgNPD5w4W8DCE8zcY9ztkuXrO_IxUmL897cNkxyFEmB1I4Kd_x7JvKqrDDPrOmHHA5-v6z-Q4B7qw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAwNjQsIm5iZiI6MTUyMDg1MDA2NCwiZXhwIjoxNTIwODUzOTY0LCJhaW8iOiJZMk5nWU9CK3RLbGJkbDJjVzZqMEYxbW5xSVgvQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibHZVWGZPMnVjMC1QZkpNX3FZTWpBQSIsInZlciI6IjEuMCJ9.HuwcHNI5Ym8-9Q8VQU_4_9VjHjXX0742q3FJy2FcwT5elihMisL2t9diXcW-1EmhDws298qnqMfhZB2vY9knNNtqRyeZKFuVQXzgjvAWEujllH2w2qRl2Erh324uCFeadskjhqwjyt1jD1NAGfwhAZdxpwaLAGXl-6LQ4PZIWwGW6YDn9eZr6nHZcPXVEBPhYYw2ErNcHljU93hMRfZjHYMWXf3UUgmjS23bRpQydXKsFMLe1f38Xdfpb6OUyHltk7S6K7mzwNe8npW1se0u51KQg54pYhD-ET1h7hkOe27Q1SeL8rSOZTzLP3gJo_F_WhvEp-5-7iCNQN4I1hWiFg
       Content-Length:
       - '0'
   response:
@@ -3783,26 +3456,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 253326f4-b16b-473a-a415-6e890d1702ec
+      - 46bb1f68-f54d-4e23-885f-f1d353921c56
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1198'
+      - '1195'
       X-Ms-Correlation-Request-Id:
-      - e5ea7a74-2437-47a9-8378-7c51f2d2f770
+      - 7e37d5fa-54ce-4638-9075-dc5ebab27fc5
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201955Z:e5ea7a74-2437-47a9-8378-7c51f2d2f770
+      - WESTEUROPE:20180312T102631Z:7e37d5fa-54ce-4638-9075-dc5ebab27fc5
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:19:54 GMT
+      - Mon, 12 Mar 2018 10:26:30 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keys":[{"keyName":"key1","value":"32PV5jeBt8nw1XvFbZokY26SXchbD6H2tw/YrteEYVE0kpMLKrZ74VrwaIjDyucdi/RxDaAlf7dJIilLS7muNw==","permissions":"Full"},{"keyName":"key2","value":"Eo5x9CQJL1/wl6Tkj5N7M5eEdw6Hym6AeyTt3xjcDl30sV8Iadro6ywZzOHQwNDlmrDaBF6x2a9ZFL7zswxQ7w==","permissions":"Full"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:19:55 GMT
+  recorded_at: Mon, 12 Mar 2018 10:26:35 GMT
 - request:
     method: head
     uri: https://miqazuretest18686.blob.core.windows.net/vhds/miq-test-rhel12016218112243.vhd
@@ -3819,7 +3492,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:19:55 GMT
+      - Mon, 12 Mar 2018 10:26:35 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -3827,7 +3500,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest18686:znthuwYAz52vLjzP5Xm1AHFvriVM+9tRdtUyfT/S1kM=
+      - SharedKey miqazuretest18686:ORrShM8IWt6rnXWTIrLBMD+Jv6Xlj06hu6e2V4vGbqQ=
   response:
     status:
       code: 200
@@ -3840,15 +3513,15 @@ http_interactions:
       Content-Md5:
       - dQL+XHjFNPdoMEweI63fwQ==
       Last-Modified:
-      - Wed, 07 Mar 2018 20:19:55 GMT
+      - Mon, 12 Mar 2018 10:26:31 GMT
       Accept-Ranges:
       - bytes
       Etag:
-      - '"0x8D58468CAC69141"'
+      - '"0x8D58803B91ECABB"'
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 68f6beff-001e-00fd-2151-b6191d000000
+      - aff705c4-001e-013a-70ec-b92389000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Microsoftazurecompute-Resourcegroupname:
@@ -3870,7 +3543,7 @@ http_interactions:
       X-Ms-Blob-Type:
       - PageBlob
       X-Ms-Blob-Sequence-Number:
-      - '371'
+      - '372'
       X-Ms-Copy-Id:
       - b967ea05-82a2-405a-8df9-4615d59df4eb
       X-Ms-Copy-Source:
@@ -3884,12 +3557,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:19:55 GMT
+      - Mon, 12 Mar 2018 10:26:31 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:19:56 GMT
+  recorded_at: Mon, 12 Mar 2018 10:26:36 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1?api-version=2018-01-01
@@ -3906,7 +3579,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2NjAsIm5iZiI6MTUyMDQ1MzY2MCwiZXhwIjoxNTIwNDU3NTYwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieDhndTAtZGRoVUt0cWFzc2lIVUFBQSIsInZlciI6IjEuMCJ9.otktnWJntN5Ex1m7B5cYjtAq_50geAaUdyQL0oOsiREDXuiRlPCYHBD9qLNkbn04dkTg0udUaXIYYVQx6vRBxKM7dxBnWfIQPTI5JaYw23DzThSUby_ELy4B6mmUi4xKbCYyMZISCnGEfjBjwNT53TL3aromQYvsPVAQ0_LNepqAL5it4b6jQU1nxQ6pSyBZCsA5oeNLRrL6aUtER3Xkm5_bNTjQtancjiNV2aMLUrb5OE2hyolWNuAHHkMmyFCxHHJZOVaw3ZgNPD5w4W8DCE8zcY9ztkuXrO_IxUmL897cNkxyFEmB1I4Kd_x7JvKqrDDPrOmHHA5-v6z-Q4B7qw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAwNjQsIm5iZiI6MTUyMDg1MDA2NCwiZXhwIjoxNTIwODUzOTY0LCJhaW8iOiJZMk5nWU9CK3RLbGJkbDJjVzZqMEYxbW5xSVgvQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibHZVWGZPMnVjMC1QZkpNX3FZTWpBQSIsInZlciI6IjEuMCJ9.HuwcHNI5Ym8-9Q8VQU_4_9VjHjXX0742q3FJy2FcwT5elihMisL2t9diXcW-1EmhDws298qnqMfhZB2vY9knNNtqRyeZKFuVQXzgjvAWEujllH2w2qRl2Erh324uCFeadskjhqwjyt1jD1NAGfwhAZdxpwaLAGXl-6LQ4PZIWwGW6YDn9eZr6nHZcPXVEBPhYYw2ErNcHljU93hMRfZjHYMWXf3UUgmjS23bRpQydXKsFMLe1f38Xdfpb6OUyHltk7S6K7mzwNe8npW1se0u51KQg54pYhD-ET1h7hkOe27Q1SeL8rSOZTzLP3gJo_F_WhvEp-5-7iCNQN4I1hWiFg
   response:
     status:
       code: 200
@@ -3927,22 +3600,22 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 293da33e-fe29-4b55-ac87-769b4ea1c7be
+      - c19f3770-fa87-4b6c-a1f0-a071bba13bce
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14974'
+      - '14989'
       X-Ms-Correlation-Request-Id:
-      - b3c7ab47-6e21-4982-95c5-4d2e49422b02
+      - 52388c4f-c830-4930-bf7d-3c9f8459dc97
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201956Z:b3c7ab47-6e21-4982-95c5-4d2e49422b02
+      - WESTEUROPE:20180312T102635Z:52388c4f-c830-4930-bf7d-3c9f8459dc97
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:19:55 GMT
+      - Mon, 12 Mar 2018 10:26:34 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"miq-test-rhel1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1\",\r\n
@@ -4048,7 +3721,7 @@ http_interactions:
         \   ],\r\n    \"networkInterfaces\": [\r\n      {\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390\"\r\n
         \     }\r\n    ]\r\n  }\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:19:56 GMT
+  recorded_at: Mon, 12 Mar 2018 10:26:39 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1?api-version=2018-01-01
@@ -4065,7 +3738,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2NjAsIm5iZiI6MTUyMDQ1MzY2MCwiZXhwIjoxNTIwNDU3NTYwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieDhndTAtZGRoVUt0cWFzc2lIVUFBQSIsInZlciI6IjEuMCJ9.otktnWJntN5Ex1m7B5cYjtAq_50geAaUdyQL0oOsiREDXuiRlPCYHBD9qLNkbn04dkTg0udUaXIYYVQx6vRBxKM7dxBnWfIQPTI5JaYw23DzThSUby_ELy4B6mmUi4xKbCYyMZISCnGEfjBjwNT53TL3aromQYvsPVAQ0_LNepqAL5it4b6jQU1nxQ6pSyBZCsA5oeNLRrL6aUtER3Xkm5_bNTjQtancjiNV2aMLUrb5OE2hyolWNuAHHkMmyFCxHHJZOVaw3ZgNPD5w4W8DCE8zcY9ztkuXrO_IxUmL897cNkxyFEmB1I4Kd_x7JvKqrDDPrOmHHA5-v6z-Q4B7qw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NTAwNjQsIm5iZiI6MTUyMDg1MDA2NCwiZXhwIjoxNTIwODUzOTY0LCJhaW8iOiJZMk5nWU9CK3RLbGJkbDJjVzZqMEYxbW5xSVgvQVE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibHZVWGZPMnVjMC1QZkpNX3FZTWpBQSIsInZlciI6IjEuMCJ9.HuwcHNI5Ym8-9Q8VQU_4_9VjHjXX0742q3FJy2FcwT5elihMisL2t9diXcW-1EmhDws298qnqMfhZB2vY9knNNtqRyeZKFuVQXzgjvAWEujllH2w2qRl2Erh324uCFeadskjhqwjyt1jD1NAGfwhAZdxpwaLAGXl-6LQ4PZIWwGW6YDn9eZr6nHZcPXVEBPhYYw2ErNcHljU93hMRfZjHYMWXf3UUgmjS23bRpQydXKsFMLe1f38Xdfpb6OUyHltk7S6K7mzwNe8npW1se0u51KQg54pYhD-ET1h7hkOe27Q1SeL8rSOZTzLP3gJo_F_WhvEp-5-7iCNQN4I1hWiFg
   response:
     status:
       code: 200
@@ -4082,36 +3755,36 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"fceae1ac-4620-482a-bc6d-79c867179ae5"
+      - W/"a8b09238-30fc-4b36-a58d-e3cc69e267c5"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 75d25831-f580-46d5-9757-a4156ebe7fbf
+      - 804f0246-a9fe-4857-b940-36bc2f1322e8
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14979'
+      - '14983'
       X-Ms-Correlation-Request-Id:
-      - 5f45fa41-1f59-42bd-8c86-8720539048d6
+      - 569829a7-b896-461f-8b0f-ba1d5f707379
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201956Z:5f45fa41-1f59-42bd-8c86-8720539048d6
+      - WESTEUROPE:20180312T102636Z:569829a7-b896-461f-8b0f-ba1d5f707379
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:19:56 GMT
+      - Mon, 12 Mar 2018 10:26:35 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"miq-azure-test1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1\",\r\n
-        \ \"etag\": \"W/\\\"fceae1ac-4620-482a-bc6d-79c867179ae5\\\"\",\r\n  \"type\":
+        \ \"etag\": \"W/\\\"a8b09238-30fc-4b36-a58d-e3cc69e267c5\\\"\",\r\n  \"type\":
         \"Microsoft.Network/virtualNetworks\",\r\n  \"location\": \"eastus\",\r\n
         \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
         \"d74c1e5f-50e4-4c8a-a7fe-78eaddc6b915\",\r\n    \"addressSpace\": {\r\n      \"addressPrefixes\":
         [\r\n        \"10.16.0.0/16\"\r\n      ]\r\n    },\r\n    \"subnets\": [\r\n
         \     {\r\n        \"name\": \"default\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\",\r\n
-        \       \"etag\": \"W/\\\"fceae1ac-4620-482a-bc6d-79c867179ae5\\\"\",\r\n
+        \       \"etag\": \"W/\\\"a8b09238-30fc-4b36-a58d-e3cc69e267c5\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
         \         \"addressPrefix\": \"10.16.0.0/24\",\r\n          \"ipConfigurations\":
         [\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1\"\r\n
@@ -4121,153 +3794,10 @@ http_interactions:
         \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/dbergerprov1/ipConfigurations/dbergerprov1\"\r\n
         \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
         \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\"\r\n
+        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/ladas_test_1/ipConfigurations/ladas_test_1\"\r\n
         \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"virtualNetworkPeerings\":
         [],\r\n    \"enableDdosProtection\": false,\r\n    \"enableVmProtection\":
         false\r\n  }\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:19:56 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2NjAsIm5iZiI6MTUyMDQ1MzY2MCwiZXhwIjoxNTIwNDU3NTYwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieDhndTAtZGRoVUt0cWFzc2lIVUFBQSIsInZlciI6IjEuMCJ9.otktnWJntN5Ex1m7B5cYjtAq_50geAaUdyQL0oOsiREDXuiRlPCYHBD9qLNkbn04dkTg0udUaXIYYVQx6vRBxKM7dxBnWfIQPTI5JaYw23DzThSUby_ELy4B6mmUi4xKbCYyMZISCnGEfjBjwNT53TL3aromQYvsPVAQ0_LNepqAL5it4b6jQU1nxQ6pSyBZCsA5oeNLRrL6aUtER3Xkm5_bNTjQtancjiNV2aMLUrb5OE2hyolWNuAHHkMmyFCxHHJZOVaw3ZgNPD5w4W8DCE8zcY9ztkuXrO_IxUmL897cNkxyFEmB1I4Kd_x7JvKqrDDPrOmHHA5-v6z-Q4B7qw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"f006e6f9-0292-42cd-99fc-f72f194553c1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - ada6abdb-4c87-4770-8e5c-8e0ff5abed1b
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14980'
-      X-Ms-Correlation-Request-Id:
-      - ec27f355-91f0-4f40-bc31-7de2fe520d59
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201957Z:ec27f355-91f0-4f40-bc31-7de2fe520d59
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:19:56 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"miq-test-rhel1390\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390\",\r\n
-        \ \"etag\": \"W/\\\"f006e6f9-0292-42cd-99fc-f72f194553c1\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"98853f48-2806-4065-be57-cf9159550440\",\r\n    \"ipConfigurations\":
-        [\r\n      {\r\n        \"name\": \"ipconfig1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1\",\r\n
-        \       \"etag\": \"W/\\\"f006e6f9-0292-42cd-99fc-f72f194553c1\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAddress\": \"10.16.0.4\",\r\n          \"privateIPAllocationMethod\":
-        \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1\"\r\n
-        \         },\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default\"\r\n
-        \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
-        \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\":
-        [],\r\n      \"appliedDnsServers\": [],\r\n      \"internalDomainNameSuffix\":
-        \"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net\"\r\n    },\r\n    \"macAddress\":
-        \"00-0D-3A-10-EB-AB\",\r\n    \"enableAcceleratedNetworking\": false,\r\n
-        \   \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\": {\r\n
-        \     \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1\"\r\n
-        \   },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1\"\r\n
-        \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
-        \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:19:57 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM2NjAsIm5iZiI6MTUyMDQ1MzY2MCwiZXhwIjoxNTIwNDU3NTYwLCJhaW8iOiJZMk5nWUNpZHBDZjdkdS9ONHpjMkNmYXYzeEc5R2dBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoieDhndTAtZGRoVUt0cWFzc2lIVUFBQSIsInZlciI6IjEuMCJ9.otktnWJntN5Ex1m7B5cYjtAq_50geAaUdyQL0oOsiREDXuiRlPCYHBD9qLNkbn04dkTg0udUaXIYYVQx6vRBxKM7dxBnWfIQPTI5JaYw23DzThSUby_ELy4B6mmUi4xKbCYyMZISCnGEfjBjwNT53TL3aromQYvsPVAQ0_LNepqAL5it4b6jQU1nxQ6pSyBZCsA5oeNLRrL6aUtER3Xkm5_bNTjQtancjiNV2aMLUrb5OE2hyolWNuAHHkMmyFCxHHJZOVaw3ZgNPD5w4W8DCE8zcY9ztkuXrO_IxUmL897cNkxyFEmB1I4Kd_x7JvKqrDDPrOmHHA5-v6z-Q4B7qw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"054052bb-11ff-4f6e-ac1a-3427c2fd17aa"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 54ba611d-6905-4fca-b57c-263af76b1989
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14974'
-      X-Ms-Correlation-Request-Id:
-      - 6e47ac65-bbc8-4e12-bc38-886fcf8e8d11
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201957Z:6e47ac65-bbc8-4e12-bc38-886fcf8e8d11
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:19:56 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"miq-test-rhel1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1\",\r\n
-        \ \"etag\": \"W/\\\"054052bb-11ff-4f6e-ac1a-3427c2fd17aa\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"f6cfc635-411e-48ce-a627-39a2fc0d3168\",\r\n    \"ipAddress\":
-        \"52.224.165.15\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\":
-        \"Dynamic\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipTags\": [],\r\n
-        \   \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1\"\r\n
-        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
-        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:19:57 GMT
+  recorded_at: Mon, 12 Mar 2018 10:26:40 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted_scope/resource_group_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted_scope/resource_group_refresh.yml
@@ -1,6 +1,62 @@
 ---
 http_interactions:
 - request:
+    method: post
+    uri: https://login.microsoftonline.com/AZURE_TENANT_ID/oauth2/token
+    body:
+      encoding: UTF-8
+      string: grant_type=client_credentials&client_id=AZURE_CLIENT_ID&client_secret=AZURE_CLIENT_SECRET&resource=https%3A%2F%2Fmanagement.azure.com%2F
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Server:
+      - Microsoft-IIS/10.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Request-Id:
+      - bf63ce4c-c093-4500-b391-7362a00a3000
+      P3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Set-Cookie:
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzmaRU-zPeQqYgfpKJPIesUYDs9HfIoPrSZAUME-xPTYYbyNsSlKsU64v1S6Uj-DHfJsGC-6H77GZ4EDYRMryOcZb0JYSFdW_zm_fQ4UZQZWk9we8UzEENhF6cYsAuHHAcNOTifaz2Qt_cEqTzW7-zZ9k7idfN3YX3FzvC9G4a3RwgAA;
+        domain=.login.microsoftonline.com; path=/; secure; HttpOnly
+      - stsservicecookie=ests; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=006; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Tue, 13 Mar 2018 09:04:19 GMT
+      Content-Length:
+      - '1505'
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1520935460","not_before":"1520931560","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA5MzE1NjAsIm5iZiI6MTUyMDkzMTU2MCwiZXhwIjoxNTIwOTM1NDYwLCJhaW8iOiJZMk5nWUxqUDVXV21iYmI2MkdUWHZCUENKZXQvQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVE01anY1UEFBRVd6a1hOaW9Bb3dBQSIsInZlciI6IjEuMCJ9.FYylCkPbMHu1fddTDYKDcVuM0tK_R8TmGMHu8pUp8vhoBNXx237D9LFxn7_Ef3qa95SLDvHD9hTxBX9m6ObWBtkuuwv5xc6V_70wRGfa2JX4vZDkz6lcW_QbH8pvWHQc9lXeWvF-MXvcrEB02ue4PAOgcbRw378dO3AoA5Frkefg8dDrgcp56bVOw23Ekem7Tdud_rf1Dm1Mfsqyu9sIxGBBsCcOBq33fuHaWsVoq3cb-XW8_lCLngCt3ppjMg4IBxnmTad3egCk9DPFQSnJgKua2PSAqYMTRsW-DRJSj9AOCCcExyhXjeYfkB740uLDcwgsumM2S5JcjFUH5v7iZQ"}'
+    http_version: 
+  recorded_at: Tue, 13 Mar 2018 09:04:20 GMT
+- request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
     body:
@@ -16,7 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1NDMsIm5iZiI6MTUyMDQ1MzU0MywiZXhwIjoxNTIwNDU3NDQzLCJhaW8iOiJZMk5nWUtnVTcxZFYzaEY3dGlIOFI4YzcyODZyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQXVkZnZJVlNIRVN2R3lpN0gySUFBQSIsInZlciI6IjEuMCJ9.DIpJSVBILdjgWTsPUuSjfYAwOg3J39WtKpji-H2_QiIDtP9TwVbFGnsY0qCNBvHBZJiEuXbpkNkRR_y2XGl6TT7BJe6jR9wqMEM3514u4JpwBgWH2aCbnLTjOo8JdqbphalN38iEWVwiUH2p4k7G3zDvZM6LsO9UGllA4K_AfRYfBosdPxqJjWgH3ZfgbBMMIvY5Z-Lr8-Z_AE_erdyYmIRc2mzUpWbQWdgzmm-PjH1-TaP4yzKckX5lnY34x5NHv8Hw55wiWxTPrWliHDnXNg-PAubyLnXwHQqDJqOUyNjgaa26Ru8nhB5XSlpRR19x4NVnosl2DIOgtF63sHTbnw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA5MzE1NjAsIm5iZiI6MTUyMDkzMTU2MCwiZXhwIjoxNTIwOTM1NDYwLCJhaW8iOiJZMk5nWUxqUDVXV21iYmI2MkdUWHZCUENKZXQvQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVE01anY1UEFBRVd6a1hOaW9Bb3dBQSIsInZlciI6IjEuMCJ9.FYylCkPbMHu1fddTDYKDcVuM0tK_R8TmGMHu8pUp8vhoBNXx237D9LFxn7_Ef3qa95SLDvHD9hTxBX9m6ObWBtkuuwv5xc6V_70wRGfa2JX4vZDkz6lcW_QbH8pvWHQc9lXeWvF-MXvcrEB02ue4PAOgcbRw378dO3AoA5Frkefg8dDrgcp56bVOw23Ekem7Tdud_rf1Dm1Mfsqyu9sIxGBBsCcOBq33fuHaWsVoq3cb-XW8_lCLngCt3ppjMg4IBxnmTad3egCk9DPFQSnJgKua2PSAqYMTRsW-DRJSj9AOCCcExyhXjeYfkB740uLDcwgsumM2S5JcjFUH5v7iZQ
   response:
     status:
       code: 200
@@ -35,26 +91,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14997'
+      - '14999'
       X-Ms-Request-Id:
-      - 8475c6b0-5886-4c7c-8de8-c76c88a61ad7
+      - 33377294-7114-47c3-9463-4848f7df3a05
       X-Ms-Correlation-Request-Id:
-      - 8475c6b0-5886-4c7c-8de8-c76c88a61ad7
+      - 33377294-7114-47c3-9463-4848f7df3a05
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201807Z:8475c6b0-5886-4c7c-8de8-c76c88a61ad7
+      - WESTEUROPE:20180313T090420Z:33377294-7114-47c3-9463-4848f7df3a05
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:18:06 GMT
+      - Tue, 13 Mar 2018 09:04:20 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID","subscriptionId":"AZURE_SUBSCRIPTION_ID","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:07 GMT
+  recorded_at: Tue, 13 Mar 2018 09:04:20 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers?api-version=2015-01-01
@@ -71,7 +127,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1NDMsIm5iZiI6MTUyMDQ1MzU0MywiZXhwIjoxNTIwNDU3NDQzLCJhaW8iOiJZMk5nWUtnVTcxZFYzaEY3dGlIOFI4YzcyODZyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQXVkZnZJVlNIRVN2R3lpN0gySUFBQSIsInZlciI6IjEuMCJ9.DIpJSVBILdjgWTsPUuSjfYAwOg3J39WtKpji-H2_QiIDtP9TwVbFGnsY0qCNBvHBZJiEuXbpkNkRR_y2XGl6TT7BJe6jR9wqMEM3514u4JpwBgWH2aCbnLTjOo8JdqbphalN38iEWVwiUH2p4k7G3zDvZM6LsO9UGllA4K_AfRYfBosdPxqJjWgH3ZfgbBMMIvY5Z-Lr8-Z_AE_erdyYmIRc2mzUpWbQWdgzmm-PjH1-TaP4yzKckX5lnY34x5NHv8Hw55wiWxTPrWliHDnXNg-PAubyLnXwHQqDJqOUyNjgaa26Ru8nhB5XSlpRR19x4NVnosl2DIOgtF63sHTbnw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA5MzE1NjAsIm5iZiI6MTUyMDkzMTU2MCwiZXhwIjoxNTIwOTM1NDYwLCJhaW8iOiJZMk5nWUxqUDVXV21iYmI2MkdUWHZCUENKZXQvQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVE01anY1UEFBRVd6a1hOaW9Bb3dBQSIsInZlciI6IjEuMCJ9.FYylCkPbMHu1fddTDYKDcVuM0tK_R8TmGMHu8pUp8vhoBNXx237D9LFxn7_Ef3qa95SLDvHD9hTxBX9m6ObWBtkuuwv5xc6V_70wRGfa2JX4vZDkz6lcW_QbH8pvWHQc9lXeWvF-MXvcrEB02ue4PAOgcbRw378dO3AoA5Frkefg8dDrgcp56bVOw23Ekem7Tdud_rf1Dm1Mfsqyu9sIxGBBsCcOBq33fuHaWsVoq3cb-XW8_lCLngCt3ppjMg4IBxnmTad3egCk9DPFQSnJgKua2PSAqYMTRsW-DRJSj9AOCCcExyhXjeYfkB740uLDcwgsumM2S5JcjFUH5v7iZQ
   response:
     status:
       code: 200
@@ -88,39 +144,37 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14971'
+      - '14924'
       X-Ms-Request-Id:
-      - d5b353a6-6e86-438b-9afd-36c29f8dcc24
+      - '08cb9125-1d07-4ef1-9c7e-fc90a584cb34'
       X-Ms-Correlation-Request-Id:
-      - d5b353a6-6e86-438b-9afd-36c29f8dcc24
+      - '08cb9125-1d07-4ef1-9c7e-fc90a584cb34'
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201807Z:d5b353a6-6e86-438b-9afd-36c29f8dcc24
+      - WESTEUROPE:20180313T090422Z:08cb9125-1d07-4ef1-9c7e-fc90a584cb34
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:18:07 GMT
+      - Tue, 13 Mar 2018 09:04:21 GMT
       Content-Length:
-      - '310901'
+      - '322992'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"},{"applicationId":"d87dcbc6-a371-462e-88e3-28ad15ec4e64","roleDefinitionId":"861776c5-e0df-4f95-be4f-ac1eec193323"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
+      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"},{"applicationId":"d87dcbc6-a371-462e-88e3-28ad15ec4e64","roleDefinitionId":"861776c5-e0df-4f95-be4f-ac1eec193323"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["East
+        Asia","Southeast Asia","Australia East","Australia Southeast","Japan East","Japan
+        West","Central India","South India","West India","West Europe","North Europe","Canada
+        Central","Canada East","Brazil South","West US","Central US","East US","South
+        Central US","East US 2","West Central US","North Central US","West US 2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
         US","Central US","East US","South Central US","West Europe","North Europe","East
         Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
         Central US","North Central US","Japan East","Japan West","Brazil South","Central
         India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"operations","locations":["West
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["East
+        Asia","Southeast Asia","Australia East","Australia Southeast","Japan East","Japan
+        West","Central India","South India","West India","West Europe","North Europe","Canada
+        Central","Canada East","Brazil South","West US","Central US","East US","South
+        Central US","East US 2","West Central US","North Central US","West US 2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"operations","locations":["West
         US","Central US","East US","South Central US","West Europe","North Europe","East
         Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
         Central US","North Central US","Japan East","Japan West","Brazil South","Central
@@ -176,177 +230,177 @@ http_interactions:
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/internalLoadBalancers","locations":[],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"domainNames/slots/roles/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"domainNames/slots/roles/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"domainNames/capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"domainNames/serviceCertificates","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
         US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
         Central","Canada East","UK South","UK West","West US","Central US","South
         Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
-        East","Australia Southeast","West US 2","West Central US","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        East","Australia Southeast","West US 2","West Central US","France Central","South
+        India","Central India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
         US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
         Central","Canada East","UK South","UK West","West US","Central US","South
         Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
-        East","Australia Southeast","West US 2","West Central US","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metrics","locations":["North
+        East","Australia Southeast","West US 2","West Central US","France Central","South
+        India","Central India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metrics","locations":["North
         Central US","South Central US","East US","East US 2","Canada Central","Canada
         East","West US","West US 2","West Central US","Central US","East Asia","Southeast
         Asia","North Europe","West Europe","UK South","UK West","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"resourceTypes","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"moveSubscriptionResources","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"validateSubscriptionMoveAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operationStatuses","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operatingSystems","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"operatingSystemFamilies","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicNetwork","namespace":"Microsoft.ClassicNetwork","resourceTypes":[{"resourceType":"virtualNetworks","locations":["East
+        India","West India","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"resourceTypes","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"moveSubscriptionResources","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"validateSubscriptionMoveAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operationStatuses","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operatingSystems","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"operatingSystemFamilies","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicNetwork","namespace":"Microsoft.ClassicNetwork","resourceTypes":[{"resourceType":"virtualNetworks","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"virtualNetworks/remoteVirtualNetworkPeeringProxies","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01"]},{"resourceType":"virtualNetworks/remoteVirtualNetworkPeeringProxies","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"reservedIps","locations":["East
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01"]},{"resourceType":"reservedIps","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"gatewaySupportedDevices","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"networkSecurityGroups","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"gatewaySupportedDevices","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"networkSecurityGroups","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicStorage","namespace":"Microsoft.ClassicStorage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"expressRouteCrossConnections","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"expressRouteCrossConnections/peerings","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicStorage","namespace":"Microsoft.ClassicStorage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkStorageAccountAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"storageAccounts/services","locations":["West
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkStorageAccountAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"storageAccounts/services","locations":["West
         US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
         Asia","Australia East","Australia Southeast","South India","Central India","West
         India","West US 2","West Central US","East US","East US 2","North Central
         US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
-        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/diagnosticSettings","locations":["West
+        South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/diagnosticSettings","locations":["West
         US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
         Asia","Australia East","Australia Southeast","South India","Central India","West
         India","West US 2","West Central US","East US","East US 2","North Central
         US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
-        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"disks","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"images","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"vmImages","locations":[],"apiVersions":["2016-11-01"]},{"resourceType":"publicImages","locations":[],"apiVersions":["2016-11-01","2016-04-01"]},{"resourceType":"osImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"osPlatformImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute","namespace":"Microsoft.Compute","authorizations":[{"applicationId":"60e6cd67-9c8c-4951-9b3c-23c25a2169af","roleDefinitionId":"e4770acb-272e-4dc8-87f3-12f44a612224"},{"applicationId":"a303894e-f1d8-4a37-bf10-67aa654a0596","roleDefinitionId":"903ac751-8ad5-4e5a-bfc2-5e49f450a241"},{"applicationId":"a8b6bf88-1d1a-4626-b040-9a729ea93c65","roleDefinitionId":"45c8267c-80ba-4b96-9a43-115b8f49fccd"}],"resourceTypes":[{"resourceType":"availabilitySets","locations":["East
+        South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"disks","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"images","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"vmImages","locations":[],"apiVersions":["2016-11-01"]},{"resourceType":"storageAccounts/vmImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"publicImages","locations":[],"apiVersions":["2016-11-01","2016-04-01"]},{"resourceType":"osImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"osPlatformImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute","namespace":"Microsoft.Compute","authorizations":[{"applicationId":"60e6cd67-9c8c-4951-9b3c-23c25a2169af","roleDefinitionId":"e4770acb-272e-4dc8-87f3-12f44a612224"},{"applicationId":"a303894e-f1d8-4a37-bf10-67aa654a0596","roleDefinitionId":"903ac751-8ad5-4e5a-bfc2-5e49f450a241"},{"applicationId":"a8b6bf88-1d1a-4626-b040-9a729ea93c65","roleDefinitionId":"45c8267c-80ba-4b96-9a43-115b8f49fccd"}],"resourceTypes":[{"resourceType":"availabilitySets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations/usages","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations/usages","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"sharedVMImages","locations":["West
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"sharedVMImages","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"sharedVMImages/versions","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"locations/capsoperations","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"disks","locations":["Southeast
@@ -354,27 +408,27 @@ http_interactions:
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"snapshots","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"snapshots","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"locations/diskoperations","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"locations/diskoperations","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"images","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"images","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"]},{"resourceType":"locations/logAnalytics","locations":["East
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"]},{"resourceType":"locations/logAnalytics","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
         US","East US","South Central US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
@@ -444,7 +498,10 @@ http_interactions:
         Central US","West Europe","North Europe","East US","UK West","UK South","West
         Central US","West US 2","South India","Central India","West India","Canada
         East","Canada Central","Korea South","Korea Central"],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"managedClusters","locations":["East
-        US","West Europe","Central US","Canada Central","Canada East"],"apiVersions":["2017-08-31"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
+        US","West Europe","Central US","Canada Central","Canada East"],"apiVersions":["2017-08-31"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operationresults","locations":["East
+        US","West Europe","Central US","UK West","UK South","West Central US","West
+        US 2","South India","Central India","West India","Canada East","Canada Central","Korea
+        South","Korea Central"],"apiVersions":["2017-08-31","2016-03-30"]},{"resourceType":"locations/operations","locations":["Japan
         East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
@@ -491,7 +548,12 @@ http_interactions:
         US","East Asia","East US","East US 2","Japan East","Japan West","North Central
         US","North Europe","South Central US","South India","Southeast Asia","West
         Central US","West Europe","West India","West US","West US 2","UK West","UK
-        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"},{"applicationId":"f5c26e74-f226-4ae8-85f0-b4af0080ac9e","roleDefinitionId":"529d7ae6-e892-4d43-809d-8547aeb90643"}],"resourceTypes":[{"resourceType":"components","locations":["East
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/consumergroups","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/disasterrecoveryconfigs","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"},{"applicationId":"f5c26e74-f226-4ae8-85f0-b4af0080ac9e","roleDefinitionId":"529d7ae6-e892-4d43-809d-8547aeb90643"}],"resourceTypes":[{"resourceType":"components","locations":["East
         US","South Central US","North Europe","West Europe","Southeast Asia","West
         US 2"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
         US","South Central US","North Europe","West Europe","Southeast Asia","West
@@ -507,7 +569,7 @@ http_interactions:
         US","South Central US","North Europe","West Europe","Southeast Asia","West
         US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"listMigrationdate","locations":["East
         US","South Central US","North Europe","West Europe","Southeast Asia","West
-        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2018-03-01","2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
@@ -558,32 +620,32 @@ http_interactions:
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/accessPolicies","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"vaults/accessPolicies","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-10-01","2015-06-01","2014-12-19-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"deletedVaults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01","2014-12-19-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"deletedVaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-10-01"]},{"resourceType":"locations/deletedVaults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations/deletedVaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
         Central US","West Europe","Southeast Asia","Japan East","West Central US"],"apiVersions":["2016-04-01"]},{"resourceType":"webServices","locations":["South
         Central US","West Europe","Southeast Asia","Japan East","East US 2","West
         Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"operations","locations":["South
@@ -609,97 +671,102 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"networkWatchers/lenses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"networkWatchers/lenses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2018-02-01","2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"ddosProtectionPlans","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","West
         US 2","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
@@ -790,7 +857,7 @@ http_interactions:
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
         West","Korea Central","Korea South"],"apiVersions":["2017-07-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ResourceHealth","namespace":"Microsoft.ResourceHealth","authorizations":[{"applicationId":"8bdebf23-c0fe-4187-a378-717ad86f6a53","roleDefinitionId":"cc026344-c8b1-4561-83ba-59eba84b27cc"}],"resourceTypes":[{"resourceType":"availabilityStatuses","locations":[],"apiVersions":["2017-07-01","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"notifications","locations":["Australia
-        Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Security","namespace":"Microsoft.Security","authorization":{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
+        Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Security","namespace":"Microsoft.Security","authorizations":[{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},{"applicationId":"fc780465-2017-40d4-a0c5-307022471b92"}],"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatuses","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/virtualMachines","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/endpoints","locations":["Central
@@ -842,620 +909,650 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Central India","South
         India"],"apiVersions":["2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Sql","namespace":"Microsoft.Sql","authorizations":[{"applicationId":"e4ab13ed-33cb-41b4-9140-6e264582cf85","roleDefinitionId":"ec3ddc95-44dc-47a2-9926-5e9f5ffd44ec"},{"applicationId":"0130cc9f-7ac5-4026-bd5f-80a08a54e6d9","roleDefinitionId":"45e8abf8-0ec4-44f3-9c37-cff4f7779302"},{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},{"applicationId":"76c7f279-7959-468f-8943-3954880e0d8c","roleDefinitionId":"7f7513a8-73f9-4c5f-97a2-c41f0ea783ef"}],"resourceTypes":[{"resourceType":"operations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/capabilities","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/databaseAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/databaseOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverKeyOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/keys","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/encryptionProtector","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/usages","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01","2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/communicationLinks","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administrators","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administratorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/restorableDroppedDatabases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recoverableDatabases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/geoBackupPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/importExportOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/operationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/backupLongTermRetentionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/automaticTuning","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/automaticTuning","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/databases/transparentDataEncryption","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recommendedElasticPools","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/auditingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/connectionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/connectionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies/rules","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/securityAlertPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/securityAlertPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/auditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/extendedAuditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/elasticpools","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-09-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/jobAgentOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/jobAgentAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/disasterRecoveryConfiguration","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/dnsAliases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/failoverGroups","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/virtualNetworkRules","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/virtualNetworkRulesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/virtualNetworkRulesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/databaseRestoreAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metricDefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/aggregatedDatabaseMetrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metricdefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries/queryText","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPools/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/extensions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPoolEstimates","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditRecords","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentScans","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/vulnerabilityAssessments","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessment","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/syncGroups","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups/syncMembers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/syncAgents","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"managedInstances/administrators","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/databases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metricDefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/administratorAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/administratorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncMemberOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncAgentOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncDatabaseIds","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorizations":[{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},{"applicationId":"e406a681-f3d4-42a8-90b6-c2b029497af1"}],"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/capabilities","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/databaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"locations/databaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverKeyOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/keys","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/encryptionProtector","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01","2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/communicationLinks","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/restorableDroppedDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recoverableDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/geoBackupPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/importExportOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/operationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/backupLongTermRetentionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/databases/transparentDataEncryption","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recommendedElasticPools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies/rules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/extendedAuditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/elasticPoolAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/elasticPoolOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/elasticpools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-09-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/jobAgentOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/jobAgentAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/disasterRecoveryConfiguration","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/dnsAliases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/failoverGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/virtualNetworkRules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/virtualNetworkRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/virtualNetworkRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/databaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/aggregatedDatabaseMetrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metricdefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries/queryText","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPools/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/extensions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPoolEstimates","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditRecords","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentScans","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/vulnerabilityAssessments","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessment","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/syncGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups/syncMembers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/syncAgents","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"managedInstances/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/administratorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncMemberOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncAgentOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncDatabaseIds","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/longTermRetentionPolicyOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionPolicyAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionBackupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionBackupAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorizations":[{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},{"applicationId":"e406a681-f3d4-42a8-90b6-c2b029497af1"}],"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/asyncoperations","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/asyncoperations","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/listAccountSas","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/listAccountSas","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/listServiceSas","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/listServiceSas","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/blobServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/blobServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/tableServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/tableServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/queueServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/queueServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/fileServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/fileServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01","2016-01-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01","2016-01-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
         US","West US","West Europe","North Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":["East
         US","West US","West Europe","North Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.visualstudio","namespace":"microsoft.visualstudio","authorization":{"applicationId":"499b84ac-1321-427f-aa17-267ca6975798","roleDefinitionId":"6a18f445-86f0-4e2e-b8a9-6b9b5677e3d8"},"resourceTypes":[{"resourceType":"account","locations":["North
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.visualstudio","namespace":"microsoft.visualstudio","authorization":{"applicationId":"499b84ac-1321-427f-aa17-267ca6975798","roleDefinitionId":"6a18f445-86f0-4e2e-b8a9-6b9b5677e3d8"},"resourceTypes":[{"resourceType":"account","locations":["North
         Central US","South Central US","East US","West US","Central US","North Europe","West
         Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
         East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/project","locations":["North
@@ -1739,12 +1836,12 @@ http_interactions:
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","Canada Central","Canada East","UK South","UK West","West US 2","West
-        Central US","South India","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","South India","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","South India","Canada Central","Canada East","UK South","UK West","West
-        US 2","West Central US","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Capacity","namespace":"Microsoft.Capacity","authorization":{"applicationId":"4d0ad6c7-f6c3-46d8-ab0d-1406d5e6c86b","roleDefinitionId":"FD9C0A9A-4DB9-4F41-8A61-98385DEB6E2D"},"resourceTypes":[{"resourceType":"resources","locations":["South
+        US 2","West Central US","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Capacity","namespace":"Microsoft.Capacity","authorization":{"applicationId":"4d0ad6c7-f6c3-46d8-ab0d-1406d5e6c86b","roleDefinitionId":"FD9C0A9A-4DB9-4F41-8A61-98385DEB6E2D"},"resourceTypes":[{"resourceType":"resources","locations":["South
         Central US"],"apiVersions":["2017-11-01"]},{"resourceType":"reservationOrders","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/reservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/reservations/revisions","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"catalogs","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"appliedReservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"checkOffers","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"checkScopes","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"calculatePrice","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/calculateRefund","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/return","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/split","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/merge","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"validateReservationOrder","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/availableScopes","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Cdn","namespace":"Microsoft.Cdn","resourceTypes":[{"resourceType":"profiles","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
@@ -1820,9 +1917,9 @@ http_interactions:
         2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/updateAccountsCreationSettings","locations":["West
         US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/accountsCreationSettings","locations":["West
         US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2016-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Commerce","namespace":"Microsoft.Commerce","resourceTypes":[{"resourceType":"UsageAggregates","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]},{"resourceType":"RateCard","locations":[],"apiVersions":["2016-08-31-preview","2015-06-01-preview","2015-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Consumption","namespace":"Microsoft.Consumption","resourceTypes":[{"resourceType":"ReservationSummaries","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationTransactions","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Balances","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Marketplaces","locations":[],"apiVersions":["2018-01-31"]},{"resourceType":"Pricesheets","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationDetails","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Budgets","locations":[],"apiVersions":["2018-01-31","2017-12-30-preview"]},{"resourceType":"Terms","locations":[],"apiVersions":["2018-01-31","2017-12-30-preview"]},{"resourceType":"UsageDetails","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview","2017-04-24-preview"]},{"resourceType":"Operations","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview","2017-04-24-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerInstance","namespace":"Microsoft.ContainerInstance","resourceTypes":[{"resourceType":"containerGroups","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/usages","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/operations","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/operations","locations":["West
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
         US"],"apiVersions":["2016-04-08"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.CustomerInsights","namespace":"Microsoft.CustomerInsights","authorization":{"applicationId":"38c77d00-5fcb-4cce-9d93-af4738258e3c","roleDefinitionId":"E006F9C7-F333-477C-8AD6-1F3A9FE87F55"},"resourceTypes":[{"resourceType":"hubs","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/profiles","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/interactions","locations":["East
@@ -1839,7 +1936,9 @@ http_interactions:
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"operations","locations":["East
         US 2"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Databricks","namespace":"Microsoft.Databricks","authorizations":[{"applicationId":"d9327919-6775-4843-9037-3fb0fb0473cb","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},{"applicationId":"2ff814a6-3304-4ab8-85cb-cd0e6f879c1d","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"}],"resourceTypes":[{"resourceType":"workspaces","locations":["West
         US","East US 2","West Europe","East US","North Europe","Southeast Asia","East
-        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]},{"resourceType":"locations","locations":["West
+        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2017-09-01-preview"]},{"resourceType":"workspaces/virtualNetworkPeerings","locations":["West
+        US","East US 2","West Europe","North Europe","East US","Southeast Asia","East
+        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01"]},{"resourceType":"locations","locations":["West
         US","East US 2","West Europe","North Europe","East US","Southeast Asia"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
         US","East US 2","West Europe","East US","North Europe","Southeast Asia","East
         Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataCatalog","namespace":"Microsoft.DataCatalog","resourceTypes":[{"resourceType":"catalogs","locations":["East
@@ -1863,23 +1962,26 @@ http_interactions:
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers/listSasTokens","locations":["East
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataLakeStore","namespace":"Microsoft.DataLakeStore","authorization":{"applicationId":"e9f49c6b-5ce5-44c8-925d-015017e9f7ad","roleDefinitionId":"17eb9cca-f08a-4499-b2d3-852d175f614f"},"resourceTypes":[{"resourceType":"accounts","locations":["East
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/firewallRules","locations":["East
-        US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataMigration","namespace":"Microsoft.DataMigration","authorization":{"applicationId":"a4bad4aa-bf02-4631-9f78-a64ffdba8150","roleDefinitionId":"b831a21d-db98-4760-89cb-bef871952df1","managedByRoleDefinitionId":"6256fb55-9e59-4018-a9e1-76b11c0a4c89"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services/projects","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationStatuses","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
+        US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataMigration","namespace":"Microsoft.DataMigration","authorization":{"applicationId":"a4bad4aa-bf02-4631-9f78-a64ffdba8150","roleDefinitionId":"b831a21d-db98-4760-89cb-bef871952df1","managedByRoleDefinitionId":"6256fb55-9e59-4018-a9e1-76b11c0a4c89"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services/projects","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationStatuses","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
-        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/recoverableServers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
@@ -1903,7 +2005,10 @@ http_interactions:
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
-        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/recoverableServers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
@@ -1959,12 +2064,7 @@ http_interactions:
         US 2","East US","West US","Central US","East US 2","West Central US","West
         Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
         US 2","East US","West US","Central US","East US 2","West Central US","West
-        Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","West
-        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
-        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
-        India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/consumergroups","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/disasterrecoveryconfigs","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
         US 2","South Central US","Central US","Australia Southeast","Central India","West
         Central US","West US 2","Canada East","Canada Central","Brazil South","UK
         South","UK West","East Asia","Australia East","Japan East","Japan West","North
@@ -2075,7 +2175,7 @@ http_interactions:
         West","Japan East","East Asia","Southeast Asia","West Europe","North Europe","East
         US","West US","Australia East","Australia Southeast","Central US","Brazil
         South","Central India","West India","South India","South Central US","Canada
-        Central","Canada East","West Central US","West US 2"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
+        Central","Canada East","West Central US","West US 2"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-05","2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
         Central US","East US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"operations","locations":["West
         Central US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
         Central US","East US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.PolicyInsights","namespace":"Microsoft.PolicyInsights","authorization":{"applicationId":"1d78a85d-813d-46f0-b496-dd72f50a3ec0","roleDefinitionId":"63d2b225-4c34-4641-8768-21a1f7c68ce8"},"resourceTypes":[{"resourceType":"policyEvents","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"policyStates","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
@@ -2107,12 +2207,12 @@ http_interactions:
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
         Central US","South Central US","North Europe","West Europe","East Asia","Southeast
         Asia","West US","East US","Japan West","Japan East","Brazil South","Central
         US","East US 2","Australia East","Australia Southeast","South India","Central
@@ -2137,7 +2237,8 @@ http_interactions:
         US","West US 2","East US","East US 2","North Europe","West Europe","Southeast
         Asia","East Asia","North Central US","South Central US","Japan West","Australia
         East","Brazil South","Central India","West Central US","Canada Central","UK
-        South"],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ServiceBus","namespace":"Microsoft.ServiceBus","authorization":{"applicationId":"80a10ef9-8168-493d-abf9-3297c4ef6e3c","roleDefinitionId":"2b7763f7-bbe2-4e19-befe-28c79f1cf7f7"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        South"],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.SecurityGraph","namespace":"Microsoft.SecurityGraph","resourceTypes":[{"resourceType":"operations","locations":["West
+        US"],"apiVersions":["2017-04-01-preview"]},{"resourceType":"diagnosticSettings","locations":[],"apiVersions":["2017-04-01-preview"]},{"resourceType":"diagnosticSettingsCategories","locations":[],"apiVersions":["2017-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ServiceBus","namespace":"Microsoft.ServiceBus","authorization":{"applicationId":"80a10ef9-8168-493d-abf9-3297c4ef6e3c","roleDefinitionId":"2b7763f7-bbe2-4e19-befe-28c79f1cf7f7"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US 2","West
         US","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
@@ -2152,40 +2253,50 @@ http_interactions:
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/clusterVersions","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"clusters/applications","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operations","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/clusterVersions","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/environments","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operations","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
         Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applianceDefinitions","locations":["West
         Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applications","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
-        Central US"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
+        Central US"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
         US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
         US","Canada Central","Canada East","Central US","East US 2","UK South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups","locations":["West
         US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
@@ -2276,10 +2387,10 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:08 GMT
+  recorded_at: Tue, 13 Mar 2018 09:04:22 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups/miq-azure-test4?api-version=2017-08-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2293,7 +2404,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1NDMsIm5iZiI6MTUyMDQ1MzU0MywiZXhwIjoxNTIwNDU3NDQzLCJhaW8iOiJZMk5nWUtnVTcxZFYzaEY3dGlIOFI4YzcyODZyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQXVkZnZJVlNIRVN2R3lpN0gySUFBQSIsInZlciI6IjEuMCJ9.DIpJSVBILdjgWTsPUuSjfYAwOg3J39WtKpji-H2_QiIDtP9TwVbFGnsY0qCNBvHBZJiEuXbpkNkRR_y2XGl6TT7BJe6jR9wqMEM3514u4JpwBgWH2aCbnLTjOo8JdqbphalN38iEWVwiUH2p4k7G3zDvZM6LsO9UGllA4K_AfRYfBosdPxqJjWgH3ZfgbBMMIvY5Z-Lr8-Z_AE_erdyYmIRc2mzUpWbQWdgzmm-PjH1-TaP4yzKckX5lnY34x5NHv8Hw55wiWxTPrWliHDnXNg-PAubyLnXwHQqDJqOUyNjgaa26Ru8nhB5XSlpRR19x4NVnosl2DIOgtF63sHTbnw
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA5MzE1NjAsIm5iZiI6MTUyMDkzMTU2MCwiZXhwIjoxNTIwOTM1NDYwLCJhaW8iOiJZMk5nWUxqUDVXV21iYmI2MkdUWHZCUENKZXQvQVFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVE01anY1UEFBRVd6a1hOaW9Bb3dBQSIsInZlciI6IjEuMCJ9.FYylCkPbMHu1fddTDYKDcVuM0tK_R8TmGMHu8pUp8vhoBNXx237D9LFxn7_Ef3qa95SLDvHD9hTxBX9m6ObWBtkuuwv5xc6V_70wRGfa2JX4vZDkz6lcW_QbH8pvWHQc9lXeWvF-MXvcrEB02ue4PAOgcbRw378dO3AoA5Frkefg8dDrgcp56bVOw23Ekem7Tdud_rf1Dm1Mfsqyu9sIxGBBsCcOBq33fuHaWsVoq3cb-XW8_lCLngCt3ppjMg4IBxnmTad3egCk9DPFQSnJgKua2PSAqYMTRsW-DRJSj9AOCCcExyhXjeYfkB740uLDcwgsumM2S5JcjFUH5v7iZQ
   response:
     status:
       code: 200
@@ -2303,685 +2414,31 @@ http_interactions:
       - no-cache
       Pragma:
       - no-cache
-      Transfer-Encoding:
-      - chunked
       Content-Type:
       - application/json; charset=utf-8
       Expires:
       - "-1"
-      Etag:
-      - W/"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67"
       Vary:
       - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14929'
       X-Ms-Request-Id:
-      - 8587a17f-4d4f-40f4-ba72-41a10bc87fe5
+      - f7c4ce82-d430-457c-baa0-72cfdafcedea
+      X-Ms-Correlation-Request-Id:
+      - f7c4ce82-d430-457c-baa0-72cfdafcedea
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180313T090423Z:f7c4ce82-d430-457c-baa0-72cfdafcedea
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14771'
-      X-Ms-Correlation-Request-Id:
-      - fe4af727-9d77-430c-a42a-ca692887e7ca
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201811Z:fe4af727-9d77-430c-a42a-ca692887e7ca
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:18:10 GMT
+      - Tue, 13 Mar 2018 09:04:23 GMT
+      Content-Length:
+      - '183'
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1\",\r\n
-        \ \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"7ab88756-810f-4083-95db-8b05d50e38f2\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ],\r\n          \"inboundNatRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"backendIPConfigurations\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\"\r\n
-        \           }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-rule\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\":
-        80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\"\r\n
-        \         },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n
-        \       \"name\": \"rspec-lb-probe\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-NAT\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 3441,\r\n          \"backendPort\":
-        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
+      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4","name":"miq-azure-test4","location":"eastus","properties":{"provisioningState":"Succeeded"}}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:11 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1NDMsIm5iZiI6MTUyMDQ1MzU0MywiZXhwIjoxNTIwNDU3NDQzLCJhaW8iOiJZMk5nWUtnVTcxZFYzaEY3dGlIOFI4YzcyODZyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQXVkZnZJVlNIRVN2R3lpN0gySUFBQSIsInZlciI6IjEuMCJ9.DIpJSVBILdjgWTsPUuSjfYAwOg3J39WtKpji-H2_QiIDtP9TwVbFGnsY0qCNBvHBZJiEuXbpkNkRR_y2XGl6TT7BJe6jR9wqMEM3514u4JpwBgWH2aCbnLTjOo8JdqbphalN38iEWVwiUH2p4k7G3zDvZM6LsO9UGllA4K_AfRYfBosdPxqJjWgH3ZfgbBMMIvY5Z-Lr8-Z_AE_erdyYmIRc2mzUpWbQWdgzmm-PjH1-TaP4yzKckX5lnY34x5NHv8Hw55wiWxTPrWliHDnXNg-PAubyLnXwHQqDJqOUyNjgaa26Ru8nhB5XSlpRR19x4NVnosl2DIOgtF63sHTbnw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"7a8e5fe7-f777-4435-992b-a54f28c2f28c"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - bd2243d7-370e-4a72-aed9-6196f0502557
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14983'
-      X-Ms-Correlation-Request-Id:
-      - d38af261-201d-4f3c-bc8f-6fa1b03ab5e9
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201811Z:d38af261-201d-4f3c-bc8f-6fa1b03ab5e9
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:18:11 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb2\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2\",\r\n
-        \ \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"e2e30a77-f81b-43fc-9693-08303e43deed\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/backendAddressPools/rspec-lb2-pool\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\r\n
-        \       }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\": [],\r\n    \"probes\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-probe\",\r\n        \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/probes/rspec-lb2-probe\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\": [],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:11 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1NDMsIm5iZiI6MTUyMDQ1MzU0MywiZXhwIjoxNTIwNDU3NDQzLCJhaW8iOiJZMk5nWUtnVTcxZFYzaEY3dGlIOFI4YzcyODZyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQXVkZnZJVlNIRVN2R3lpN0gySUFBQSIsInZlciI6IjEuMCJ9.DIpJSVBILdjgWTsPUuSjfYAwOg3J39WtKpji-H2_QiIDtP9TwVbFGnsY0qCNBvHBZJiEuXbpkNkRR_y2XGl6TT7BJe6jR9wqMEM3514u4JpwBgWH2aCbnLTjOo8JdqbphalN38iEWVwiUH2p4k7G3zDvZM6LsO9UGllA4K_AfRYfBosdPxqJjWgH3ZfgbBMMIvY5Z-Lr8-Z_AE_erdyYmIRc2mzUpWbQWdgzmm-PjH1-TaP4yzKckX5lnY34x5NHv8Hw55wiWxTPrWliHDnXNg-PAubyLnXwHQqDJqOUyNjgaa26Ru8nhB5XSlpRR19x4NVnosl2DIOgtF63sHTbnw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 81d37480-f66e-46ea-8ab8-83a6c5c843dc
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14972'
-      X-Ms-Correlation-Request-Id:
-      - 7716bf1d-8817-4e13-8b0d-aa16e3186355
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201812Z:7716bf1d-8817-4e13-8b0d-aa16e3186355
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:18:11 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1\",\r\n
-        \ \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"7ab88756-810f-4083-95db-8b05d50e38f2\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ],\r\n          \"inboundNatRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"backendIPConfigurations\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\"\r\n
-        \           }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-rule\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\":
-        80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\"\r\n
-        \         },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n
-        \       \"name\": \"rspec-lb-probe\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-NAT\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 3441,\r\n          \"backendPort\":
-        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:12 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1NDMsIm5iZiI6MTUyMDQ1MzU0MywiZXhwIjoxNTIwNDU3NDQzLCJhaW8iOiJZMk5nWUtnVTcxZFYzaEY3dGlIOFI4YzcyODZyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQXVkZnZJVlNIRVN2R3lpN0gySUFBQSIsInZlciI6IjEuMCJ9.DIpJSVBILdjgWTsPUuSjfYAwOg3J39WtKpji-H2_QiIDtP9TwVbFGnsY0qCNBvHBZJiEuXbpkNkRR_y2XGl6TT7BJe6jR9wqMEM3514u4JpwBgWH2aCbnLTjOo8JdqbphalN38iEWVwiUH2p4k7G3zDvZM6LsO9UGllA4K_AfRYfBosdPxqJjWgH3ZfgbBMMIvY5Z-Lr8-Z_AE_erdyYmIRc2mzUpWbQWdgzmm-PjH1-TaP4yzKckX5lnY34x5NHv8Hw55wiWxTPrWliHDnXNg-PAubyLnXwHQqDJqOUyNjgaa26Ru8nhB5XSlpRR19x4NVnosl2DIOgtF63sHTbnw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"7a8e5fe7-f777-4435-992b-a54f28c2f28c"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 6b713de4-c6c1-4b49-8994-36969b08d2f2
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14974'
-      X-Ms-Correlation-Request-Id:
-      - baf22e2b-2709-4294-a022-793e5cb00fd8
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201812Z:baf22e2b-2709-4294-a022-793e5cb00fd8
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:18:11 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb2\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2\",\r\n
-        \ \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"e2e30a77-f81b-43fc-9693-08303e43deed\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/backendAddressPools/rspec-lb2-pool\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\r\n
-        \       }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\": [],\r\n    \"probes\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-probe\",\r\n        \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/probes/rspec-lb2-probe\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\": [],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:12 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1NDMsIm5iZiI6MTUyMDQ1MzU0MywiZXhwIjoxNTIwNDU3NDQzLCJhaW8iOiJZMk5nWUtnVTcxZFYzaEY3dGlIOFI4YzcyODZyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQXVkZnZJVlNIRVN2R3lpN0gySUFBQSIsInZlciI6IjEuMCJ9.DIpJSVBILdjgWTsPUuSjfYAwOg3J39WtKpji-H2_QiIDtP9TwVbFGnsY0qCNBvHBZJiEuXbpkNkRR_y2XGl6TT7BJe6jR9wqMEM3514u4JpwBgWH2aCbnLTjOo8JdqbphalN38iEWVwiUH2p4k7G3zDvZM6LsO9UGllA4K_AfRYfBosdPxqJjWgH3ZfgbBMMIvY5Z-Lr8-Z_AE_erdyYmIRc2mzUpWbQWdgzmm-PjH1-TaP4yzKckX5lnY34x5NHv8Hw55wiWxTPrWliHDnXNg-PAubyLnXwHQqDJqOUyNjgaa26Ru8nhB5XSlpRR19x4NVnosl2DIOgtF63sHTbnw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 135af3f5-29a6-4124-9d68-2e36e6ca65c9
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14987'
-      X-Ms-Correlation-Request-Id:
-      - 47c3e898-ae72-4329-8538-1887915ebf8e
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201813Z:47c3e898-ae72-4329-8538-1887915ebf8e
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:18:12 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1\",\r\n
-        \ \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"7ab88756-810f-4083-95db-8b05d50e38f2\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ],\r\n          \"inboundNatRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"backendIPConfigurations\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\"\r\n
-        \           }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-rule\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\":
-        80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\"\r\n
-        \         },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n
-        \       \"name\": \"rspec-lb-probe\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-NAT\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 3441,\r\n          \"backendPort\":
-        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:13 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1NDMsIm5iZiI6MTUyMDQ1MzU0MywiZXhwIjoxNTIwNDU3NDQzLCJhaW8iOiJZMk5nWUtnVTcxZFYzaEY3dGlIOFI4YzcyODZyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQXVkZnZJVlNIRVN2R3lpN0gySUFBQSIsInZlciI6IjEuMCJ9.DIpJSVBILdjgWTsPUuSjfYAwOg3J39WtKpji-H2_QiIDtP9TwVbFGnsY0qCNBvHBZJiEuXbpkNkRR_y2XGl6TT7BJe6jR9wqMEM3514u4JpwBgWH2aCbnLTjOo8JdqbphalN38iEWVwiUH2p4k7G3zDvZM6LsO9UGllA4K_AfRYfBosdPxqJjWgH3ZfgbBMMIvY5Z-Lr8-Z_AE_erdyYmIRc2mzUpWbQWdgzmm-PjH1-TaP4yzKckX5lnY34x5NHv8Hw55wiWxTPrWliHDnXNg-PAubyLnXwHQqDJqOUyNjgaa26Ru8nhB5XSlpRR19x4NVnosl2DIOgtF63sHTbnw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"7a8e5fe7-f777-4435-992b-a54f28c2f28c"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 4ed17ae3-b6be-47af-aa16-050f351bbfe2
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14968'
-      X-Ms-Correlation-Request-Id:
-      - 3e076e44-88db-45a9-b010-7ed00e96c40d
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201813Z:3e076e44-88db-45a9-b010-7ed00e96c40d
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:18:13 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb2\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2\",\r\n
-        \ \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"e2e30a77-f81b-43fc-9693-08303e43deed\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/backendAddressPools/rspec-lb2-pool\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\r\n
-        \       }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\": [],\r\n    \"probes\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-probe\",\r\n        \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/probes/rspec-lb2-probe\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\": [],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:13 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1NDMsIm5iZiI6MTUyMDQ1MzU0MywiZXhwIjoxNTIwNDU3NDQzLCJhaW8iOiJZMk5nWUtnVTcxZFYzaEY3dGlIOFI4YzcyODZyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQXVkZnZJVlNIRVN2R3lpN0gySUFBQSIsInZlciI6IjEuMCJ9.DIpJSVBILdjgWTsPUuSjfYAwOg3J39WtKpji-H2_QiIDtP9TwVbFGnsY0qCNBvHBZJiEuXbpkNkRR_y2XGl6TT7BJe6jR9wqMEM3514u4JpwBgWH2aCbnLTjOo8JdqbphalN38iEWVwiUH2p4k7G3zDvZM6LsO9UGllA4K_AfRYfBosdPxqJjWgH3ZfgbBMMIvY5Z-Lr8-Z_AE_erdyYmIRc2mzUpWbQWdgzmm-PjH1-TaP4yzKckX5lnY34x5NHv8Hw55wiWxTPrWliHDnXNg-PAubyLnXwHQqDJqOUyNjgaa26Ru8nhB5XSlpRR19x4NVnosl2DIOgtF63sHTbnw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"a38434c8-7b23-4092-b7c6-402238eac0dc"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 53da56b7-e607-41ce-80e7-0b0d9a4a84c5
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14970'
-      X-Ms-Correlation-Request-Id:
-      - 4f1be652-48b2-4c3b-b192-441350bb7f83
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201814Z:4f1be652-48b2-4c3b-b192-441350bb7f83
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:18:13 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb1-LoadBalancerFrontEnd\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\",\r\n
-        \ \"etag\": \"W/\\\"a38434c8-7b23-4092-b7c6-402238eac0dc\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"f28e0f25-b372-4edf-97d9-13a9e3b4ba2d\",\r\n    \"ipAddress\":
-        \"40.71.82.83\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\":
-        \"Static\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipTags\": [],\r\n
-        \   \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
-        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:14 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM1NDMsIm5iZiI6MTUyMDQ1MzU0MywiZXhwIjoxNTIwNDU3NDQzLCJhaW8iOiJZMk5nWUtnVTcxZFYzaEY3dGlIOFI4YzcyODZyQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiQXVkZnZJVlNIRVN2R3lpN0gySUFBQSIsInZlciI6IjEuMCJ9.DIpJSVBILdjgWTsPUuSjfYAwOg3J39WtKpji-H2_QiIDtP9TwVbFGnsY0qCNBvHBZJiEuXbpkNkRR_y2XGl6TT7BJe6jR9wqMEM3514u4JpwBgWH2aCbnLTjOo8JdqbphalN38iEWVwiUH2p4k7G3zDvZM6LsO9UGllA4K_AfRYfBosdPxqJjWgH3ZfgbBMMIvY5Z-Lr8-Z_AE_erdyYmIRc2mzUpWbQWdgzmm-PjH1-TaP4yzKckX5lnY34x5NHv8Hw55wiWxTPrWliHDnXNg-PAubyLnXwHQqDJqOUyNjgaa26Ru8nhB5XSlpRR19x4NVnosl2DIOgtF63sHTbnw
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"cddd97d1-6111-4477-8a00-3dc885237a1d"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 6dd065f2-0c0c-4361-9c56-0a3bc90ffd66
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14978'
-      X-Ms-Correlation-Request-Id:
-      - ce6d1973-b208-4e90-b20e-3b68d73a8a30
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201816Z:ce6d1973-b208-4e90-b20e-3b68d73a8a30
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:18:16 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb2-publicip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\",\r\n
-        \ \"etag\": \"W/\\\"cddd97d1-6111-4477-8a00-3dc885237a1d\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"83e7257d-ab94-4229-8eb5-4798f37ef28d\",\r\n    \"publicIPAddressVersion\":
-        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
-        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
-        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:18:17 GMT
+  recorded_at: Tue, 13 Mar 2018 09:04:23 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted_scope/security_group_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted_scope/security_group_refresh.yml
@@ -1,6 +1,62 @@
 ---
 http_interactions:
 - request:
+    method: post
+    uri: https://login.microsoftonline.com/AZURE_TENANT_ID/oauth2/token
+    body:
+      encoding: UTF-8
+      string: grant_type=client_credentials&client_id=AZURE_CLIENT_ID&client_secret=AZURE_CLIENT_SECRET&resource=https%3A%2F%2Fmanagement.azure.com%2F
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Server:
+      - Microsoft-IIS/10.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Ms-Request-Id:
+      - 01f900cd-ed02-4e2a-9bf9-f1fce3993400
+      P3p:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Set-Cookie:
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzDVUUW0s-PtS_XHIf6XQbFkHHq45E1blm-8xk8FWm5Ch01WInkC8TUk4MFsb9BPWvSj4BYDw-MSL8S2wkEK7QEz6UUesTlt3yU0KqwLFGllaBll8i_eJPjVpA1b5iB3eopyDjEUTlrFeSs4bAyAmPhz_H1dvDwBjrbonioRwfUF4gAA;
+        domain=.login.microsoftonline.com; path=/; secure; HttpOnly
+      - stsservicecookie=ests; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=004; path=/; secure; HttpOnly
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Tue, 13 Mar 2018 09:06:51 GMT
+      Content-Length:
+      - '1505'
+    body:
+      encoding: UTF-8
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1520935612","not_before":"1520931712","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA5MzE3MTIsIm5iZiI6MTUyMDkzMTcxMiwiZXhwIjoxNTIwOTM1NjEyLCJhaW8iOiJZMk5nWUxDUE1wMmdMcjlDNk5QNUYrbzhLdmYyQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoielFENUFRTHRLazZiLWZIODQ1azBBQSIsInZlciI6IjEuMCJ9.cK9H8o5_qDBaZ657Qfk9O3UsvVWHO1CCzIi_sIQ1pjrWVRBjh47oXcOXRy-n94v7iqnAzZkKnbKU8Jh6_mJWYYV3toe2grd9qjmWVWYwB3ncXTAJBNgbcQ6x7vlIQHNArhDQbAhivXzMXaIyHRxAgbeMPnCuTQp4CtBlqYIL3iRdyzDqyUkm_T3uPYonBDxDwvVnKSytux8jehd88dylZ6W4AeFAFBp9ac2__ZgNtR2K-x3IWJtOCIeRisJ6o3N7t3X_VZyApkNH4BKhlLdO4KR59mgdE9vSQs5In9jH_edZsOATK2WBO2_W8KOcWYbw8AL0iyO-_ulD4l2AiKyOng"}'
+    http_version: 
+  recorded_at: Tue, 13 Mar 2018 09:06:52 GMT
+- request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
     body:
@@ -16,7 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA5MzE3MTIsIm5iZiI6MTUyMDkzMTcxMiwiZXhwIjoxNTIwOTM1NjEyLCJhaW8iOiJZMk5nWUxDUE1wMmdMcjlDNk5QNUYrbzhLdmYyQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoielFENUFRTHRLazZiLWZIODQ1azBBQSIsInZlciI6IjEuMCJ9.cK9H8o5_qDBaZ657Qfk9O3UsvVWHO1CCzIi_sIQ1pjrWVRBjh47oXcOXRy-n94v7iqnAzZkKnbKU8Jh6_mJWYYV3toe2grd9qjmWVWYwB3ncXTAJBNgbcQ6x7vlIQHNArhDQbAhivXzMXaIyHRxAgbeMPnCuTQp4CtBlqYIL3iRdyzDqyUkm_T3uPYonBDxDwvVnKSytux8jehd88dylZ6W4AeFAFBp9ac2__ZgNtR2K-x3IWJtOCIeRisJ6o3N7t3X_VZyApkNH4BKhlLdO4KR59mgdE9vSQs5In9jH_edZsOATK2WBO2_W8KOcWYbw8AL0iyO-_ulD4l2AiKyOng
   response:
     status:
       code: 200
@@ -35,26 +91,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14997'
+      - '14999'
       X-Ms-Request-Id:
-      - cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - e9b520b9-f25a-4562-aeb1-fa56d74b82f7
       X-Ms-Correlation-Request-Id:
-      - cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - e9b520b9-f25a-4562-aeb1-fa56d74b82f7
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102417Z:cbbeeb53-f2bb-46d2-b273-886b9a1b8ede
+      - WESTEUROPE:20180313T090652Z:e9b520b9-f25a-4562-aeb1-fa56d74b82f7
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:17 GMT
+      - Tue, 13 Mar 2018 09:06:52 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID","subscriptionId":"AZURE_SUBSCRIPTION_ID","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:22 GMT
+  recorded_at: Tue, 13 Mar 2018 09:06:52 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers?api-version=2015-01-01
@@ -71,7 +127,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA5MzE3MTIsIm5iZiI6MTUyMDkzMTcxMiwiZXhwIjoxNTIwOTM1NjEyLCJhaW8iOiJZMk5nWUxDUE1wMmdMcjlDNk5QNUYrbzhLdmYyQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoielFENUFRTHRLazZiLWZIODQ1azBBQSIsInZlciI6IjEuMCJ9.cK9H8o5_qDBaZ657Qfk9O3UsvVWHO1CCzIi_sIQ1pjrWVRBjh47oXcOXRy-n94v7iqnAzZkKnbKU8Jh6_mJWYYV3toe2grd9qjmWVWYwB3ncXTAJBNgbcQ6x7vlIQHNArhDQbAhivXzMXaIyHRxAgbeMPnCuTQp4CtBlqYIL3iRdyzDqyUkm_T3uPYonBDxDwvVnKSytux8jehd88dylZ6W4AeFAFBp9ac2__ZgNtR2K-x3IWJtOCIeRisJ6o3N7t3X_VZyApkNH4BKhlLdO4KR59mgdE9vSQs5In9jH_edZsOATK2WBO2_W8KOcWYbw8AL0iyO-_ulD4l2AiKyOng
   response:
     status:
       code: 200
@@ -88,21 +144,21 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
+      - '14909'
       X-Ms-Request-Id:
-      - fe3532ca-59a2-474e-9094-8a3697b82bef
+      - 4e9ed1bd-bccc-49fd-843d-5194b01095ee
       X-Ms-Correlation-Request-Id:
-      - fe3532ca-59a2-474e-9094-8a3697b82bef
+      - 4e9ed1bd-bccc-49fd-843d-5194b01095ee
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102419Z:fe3532ca-59a2-474e-9094-8a3697b82bef
+      - WESTEUROPE:20180313T090654Z:4e9ed1bd-bccc-49fd-843d-5194b01095ee
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:18 GMT
+      - Tue, 13 Mar 2018 09:06:53 GMT
       Content-Length:
-      - '320853'
+      - '322992'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"},{"applicationId":"d87dcbc6-a371-462e-88e3-28ad15ec4e64","roleDefinitionId":"861776c5-e0df-4f95-be4f-ac1eec193323"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["East
@@ -442,7 +498,10 @@ http_interactions:
         Central US","West Europe","North Europe","East US","UK West","UK South","West
         Central US","West US 2","South India","Central India","West India","Canada
         East","Canada Central","Korea South","Korea Central"],"apiVersions":["2017-07-01","2017-01-31","2016-09-30","2016-03-30"]},{"resourceType":"managedClusters","locations":["East
-        US","West Europe","Central US","Canada Central","Canada East"],"apiVersions":["2017-08-31"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operations","locations":["Japan
+        US","West Europe","Central US","Canada Central","Canada East"],"apiVersions":["2017-08-31"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-08-31","2017-01-31","2016-09-30","2016-03-30","2015-11-01-preview"]},{"resourceType":"locations/operationresults","locations":["East
+        US","West Europe","Central US","UK West","UK South","West Central US","West
+        US 2","South India","Central India","West India","Canada East","Canada Central","Korea
+        South","Korea Central"],"apiVersions":["2017-08-31","2016-03-30"]},{"resourceType":"locations/operations","locations":["Japan
         East","Central US","East US 2","Japan West","East Asia","South Central US","Australia
         East","Australia Southeast","Brazil South","Southeast Asia","West US","North
         Central US","West Europe","North Europe","East US","UK West","UK South","West
@@ -510,7 +569,7 @@ http_interactions:
         US","South Central US","North Europe","West Europe","Southeast Asia","West
         US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"listMigrationdate","locations":["East
         US","South Central US","North Europe","West Europe","Southeast Asia","West
-        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
+        US 2"],"apiVersions":["2017-10-01"]},{"resourceType":"logprofiles","locations":[],"apiVersions":["2016-03-01"]},{"resourceType":"metricalerts","locations":["Global"],"apiVersions":["2018-03-01","2017-09-01-preview"]},{"resourceType":"alertrules","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","UK South","UK West","South
@@ -612,47 +671,47 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"networkWatchers/lenses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"networkWatchers/lenses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
@@ -662,47 +721,52 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2018-02-01","2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2018-03-01","2018-02-01","2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"ddosProtectionPlans","locations":["West
+        US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
+        Central US","South Central US","Central US","East US 2","Japan East","Japan
+        West","Brazil South","Australia East","Australia Southeast","Central India","South
+        India","West India","Canada Central","Canada East","West Central US","West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-03-01","2018-02-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","West
         US 2","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
@@ -1438,57 +1502,57 @@ http_interactions:
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/asyncoperations","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/asyncoperations","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/listAccountSas","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/listAccountSas","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/listServiceSas","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/listServiceSas","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/blobServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/blobServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/tableServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/tableServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/queueServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/queueServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/fileServices","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"storageAccounts/fileServices","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01","2016-01-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01","2016-01-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-07-01"]},{"resourceType":"usages","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-06-01","2016-12-01","2016-05-01","2016-01-01","2015-06-15","2015-05-01-preview"]},{"resourceType":"storageAccounts/services","locations":["East
         US","West US","West Europe","North Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":["East
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":["East
         US","West US","West Europe","North Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","East US 2","Central
         US","Australia East","Australia Southeast","Brazil South","South India","Central
         India","West India","Canada East","Canada Central","West US 2","West Central
-        US","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.visualstudio","namespace":"microsoft.visualstudio","authorization":{"applicationId":"499b84ac-1321-427f-aa17-267ca6975798","roleDefinitionId":"6a18f445-86f0-4e2e-b8a9-6b9b5677e3d8"},"resourceTypes":[{"resourceType":"account","locations":["North
+        US","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.visualstudio","namespace":"microsoft.visualstudio","authorization":{"applicationId":"499b84ac-1321-427f-aa17-267ca6975798","roleDefinitionId":"6a18f445-86f0-4e2e-b8a9-6b9b5677e3d8"},"resourceTypes":[{"resourceType":"account","locations":["North
         Central US","South Central US","East US","West US","Central US","North Europe","West
         Europe","East Asia","Southeast Asia","Japan East","Japan West","Brazil South","Australia
         East","West India","Central India","South India","West US 2","Canada Central"],"apiVersions":["2014-04-01-preview","2014-02-26"]},{"resourceType":"account/project","locations":["North
@@ -2173,7 +2237,8 @@ http_interactions:
         US","West US 2","East US","East US 2","North Europe","West Europe","Southeast
         Asia","East Asia","North Central US","South Central US","Japan West","Australia
         East","Brazil South","Central India","West Central US","Canada Central","UK
-        South"],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ServiceBus","namespace":"Microsoft.ServiceBus","authorization":{"applicationId":"80a10ef9-8168-493d-abf9-3297c4ef6e3c","roleDefinitionId":"2b7763f7-bbe2-4e19-befe-28c79f1cf7f7"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        South"],"apiVersions":["2015-08-19"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-08-19","2015-02-28"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.SecurityGraph","namespace":"Microsoft.SecurityGraph","resourceTypes":[{"resourceType":"operations","locations":["West
+        US"],"apiVersions":["2017-04-01-preview"]},{"resourceType":"diagnosticSettings","locations":[],"apiVersions":["2017-04-01-preview"]},{"resourceType":"diagnosticSettingsCategories","locations":[],"apiVersions":["2017-04-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ServiceBus","namespace":"Microsoft.ServiceBus","authorization":{"applicationId":"80a10ef9-8168-493d-abf9-3297c4ef6e3c","roleDefinitionId":"2b7763f7-bbe2-4e19-befe-28c79f1cf7f7"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US 2","West
         US","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
@@ -2322,10 +2387,10 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:23 GMT
+  recorded_at: Tue, 13 Mar 2018 09:06:54 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1?api-version=2018-01-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg?api-version=2018-03-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2339,7 +2404,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA5MzE3MTIsIm5iZiI6MTUyMDkzMTcxMiwiZXhwIjoxNTIwOTM1NjEyLCJhaW8iOiJZMk5nWUxDUE1wMmdMcjlDNk5QNUYrbzhLdmYyQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoielFENUFRTHRLazZiLWZIODQ1azBBQSIsInZlciI6IjEuMCJ9.cK9H8o5_qDBaZ657Qfk9O3UsvVWHO1CCzIi_sIQ1pjrWVRBjh47oXcOXRy-n94v7iqnAzZkKnbKU8Jh6_mJWYYV3toe2grd9qjmWVWYwB3ncXTAJBNgbcQ6x7vlIQHNArhDQbAhivXzMXaIyHRxAgbeMPnCuTQp4CtBlqYIL3iRdyzDqyUkm_T3uPYonBDxDwvVnKSytux8jehd88dylZ6W4AeFAFBp9ac2__ZgNtR2K-x3IWJtOCIeRisJ6o3N7t3X_VZyApkNH4BKhlLdO4KR59mgdE9vSQs5In9jH_edZsOATK2WBO2_W8KOcWYbw8AL0iyO-_ulD4l2AiKyOng
   response:
     status:
       code: 200
@@ -2356,294 +2421,109 @@ http_interactions:
       Expires:
       - "-1"
       Etag:
-      - W/"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67"
+      - W/"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a"
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - '080de667-081e-4d58-9e94-9e7243d4200e'
+      - aa4b98d3-915f-4ec1-8ae6-10719cb39dc6
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
+      - '14931'
       X-Ms-Correlation-Request-Id:
-      - '093d49ac-c85f-440e-956b-955b6698dd19'
+      - f2642391-27db-4a06-b918-813c6cd4d649
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102419Z:093d49ac-c85f-440e-956b-955b6698dd19
+      - WESTEUROPE:20180313T090656Z:f2642391-27db-4a06-b918-813c6cd4d649
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Mon, 12 Mar 2018 10:24:19 GMT
+      - Tue, 13 Mar 2018 09:06:55 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb1\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1\",\r\n
-        \ \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"7ab88756-810f-4083-95db-8b05d50e38f2\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
+      string: "{\r\n  \"name\": \"miqazure-linux-managed-nsg\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg\",\r\n
+        \ \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n  \"type\":
+        \"Microsoft.Network/networkSecurityGroups\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\":
+        \"b4611f96-94a8-4486-94c5-16bb6c7a5c84\",\r\n    \"securityRules\": [\r\n
+        \     {\r\n        \"name\": \"default-allow-ssh\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/securityRules/default-allow-ssh\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ],\r\n          \"inboundNatRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
+        \         \"protocol\": \"TCP\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"22\",\r\n          \"sourceAddressPrefix\":
+        \"*\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n          \"access\":
+        \"Allow\",\r\n          \"priority\": 1000,\r\n          \"direction\": \"Inbound\",\r\n
+        \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      }\r\n    ],\r\n    \"defaultSecurityRules\": [\r\n
+        \     {\r\n        \"name\": \"AllowVnetInBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/AllowVnetInBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"backendIPConfigurations\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \           },\r\n            {\r\n              \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1\"\r\n
-        \           }\r\n          ],\r\n          \"loadBalancingRules\": [\r\n            {\r\n
-        \             \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-rule\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
+        \         \"description\": \"Allow inbound traffic from all VMs in VNET\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"VirtualNetwork\",\r\n          \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n          \"direction\":
+        \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowAzureLoadBalancerInBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/AllowAzureLoadBalancerInBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 80,\r\n          \"backendPort\":
-        80,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"loadDistribution\": \"Default\",\r\n          \"backendAddressPool\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool\"\r\n
-        \         },\r\n          \"probe\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"probes\": [\r\n      {\r\n
-        \       \"name\": \"rspec-lb-probe\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/probes/rspec-lb-probe\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
+        \         \"description\": \"Allow inbound traffic from azure load balancer\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"AzureLoadBalancer\",\r\n          \"destinationAddressPrefix\": \"*\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65001,\r\n          \"direction\":
+        \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllInBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/DenyAllInBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2,\r\n          \"loadBalancingRules\": [\r\n            {\r\n              \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/loadBalancingRules/rspec-lb1-rule\"\r\n
-        \           }\r\n          ]\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb1-NAT\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT\",\r\n
-        \       \"etag\": \"W/\\\"fcf2a6a6-dd42-4af7-8096-bc40dd8fce67\\\"\",\r\n
+        \         \"description\": \"Deny all inbound traffic\",\r\n          \"protocol\":
+        \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\":
+        \"*\",\r\n          \"sourceAddressPrefix\": \"*\",\r\n          \"destinationAddressPrefix\":
+        \"*\",\r\n          \"access\": \"Deny\",\r\n          \"priority\": 65500,\r\n
+        \         \"direction\": \"Inbound\",\r\n          \"sourcePortRanges\": [],\r\n
+        \         \"destinationPortRanges\": [],\r\n          \"sourceAddressPrefixes\":
+        [],\r\n          \"destinationAddressPrefixes\": []\r\n        }\r\n      },\r\n
+        \     {\r\n        \"name\": \"AllowVnetOutBound\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/AllowVnetOutBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
         \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"frontendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \         },\r\n          \"frontendPort\": 3441,\r\n          \"backendPort\":
-        3389,\r\n          \"enableFloatingIP\": false,\r\n          \"idleTimeoutInMinutes\":
-        4,\r\n          \"protocol\": \"Tcp\",\r\n          \"enableDestinationServiceEndpoint\":
-        false,\r\n          \"backendIPConfiguration\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
+        \         \"description\": \"Allow outbound traffic from all VMs to all VMs
+        in VNET\",\r\n          \"protocol\": \"*\",\r\n          \"sourcePortRange\":
+        \"*\",\r\n          \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"VirtualNetwork\",\r\n          \"destinationAddressPrefix\": \"VirtualNetwork\",\r\n
+        \         \"access\": \"Allow\",\r\n          \"priority\": 65000,\r\n          \"direction\":
+        \"Outbound\",\r\n          \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"AllowInternetOutBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/AllowInternetOutBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Allow outbound traffic from all VMs to Internet\",\r\n
+        \         \"protocol\": \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n
+        \         \"destinationPortRange\": \"*\",\r\n          \"sourceAddressPrefix\":
+        \"*\",\r\n          \"destinationAddressPrefix\": \"Internet\",\r\n          \"access\":
+        \"Allow\",\r\n          \"priority\": 65001,\r\n          \"direction\": \"Outbound\",\r\n
+        \         \"sourcePortRanges\": [],\r\n          \"destinationPortRanges\":
+        [],\r\n          \"sourceAddressPrefixes\": [],\r\n          \"destinationAddressPrefixes\":
+        []\r\n        }\r\n      },\r\n      {\r\n        \"name\": \"DenyAllOutBound\",\r\n
+        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/DenyAllOutBound\",\r\n
+        \       \"etag\": \"W/\\\"13cb2c61-c6bf-41ea-a9eb-f78ceddbf79a\\\"\",\r\n
+        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
+        \         \"description\": \"Deny all outbound traffic\",\r\n          \"protocol\":
+        \"*\",\r\n          \"sourcePortRange\": \"*\",\r\n          \"destinationPortRange\":
+        \"*\",\r\n          \"sourceAddressPrefix\": \"*\",\r\n          \"destinationAddressPrefix\":
+        \"*\",\r\n          \"access\": \"Deny\",\r\n          \"priority\": 65500,\r\n
+        \         \"direction\": \"Outbound\",\r\n          \"sourcePortRanges\":
+        [],\r\n          \"destinationPortRanges\": [],\r\n          \"sourceAddressPrefixes\":
+        [],\r\n          \"destinationAddressPrefixes\": []\r\n        }\r\n      }\r\n
+        \   ],\r\n    \"networkInterfaces\": [\r\n      {\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944\"\r\n
+        \     }\r\n    ]\r\n  }\r\n}"
     http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:24 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"7a8e5fe7-f777-4435-992b-a54f28c2f28c"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - bd22ca22-a01f-4ecf-9230-a4558fb66931
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Correlation-Request-Id:
-      - 19c674a8-c8da-4b5e-8265-5ebc21926459
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102420Z:19c674a8-c8da-4b5e-8265-5ebc21926459
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Mon, 12 Mar 2018 10:24:19 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb2\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2\",\r\n
-        \ \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n  \"type\":
-        \"Microsoft.Network/loadBalancers\",\r\n  \"location\": \"eastus\",\r\n  \"properties\":
-        {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"resourceGuid\": \"e2e30a77-f81b-43fc-9693-08303e43deed\",\r\n
-        \   \"frontendIPConfigurations\": [\r\n      {\r\n        \"name\": \"LoadBalancerFrontEnd\",\r\n
-        \       \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAllocationMethod\": \"Dynamic\",\r\n          \"publicIPAddress\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\"\r\n
-        \         }\r\n        }\r\n      }\r\n    ],\r\n    \"backendAddressPools\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-pool\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/backendAddressPools/rspec-lb2-pool\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\"\r\n
-        \       }\r\n      }\r\n    ],\r\n    \"loadBalancingRules\": [],\r\n    \"probes\":
-        [\r\n      {\r\n        \"name\": \"rspec-lb2-probe\",\r\n        \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/probes/rspec-lb2-probe\",\r\n
-        \       \"etag\": \"W/\\\"7a8e5fe7-f777-4435-992b-a54f28c2f28c\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"protocol\": \"Http\",\r\n          \"port\": 80,\r\n          \"requestPath\":
-        \"/\",\r\n          \"intervalInSeconds\": 5,\r\n          \"numberOfProbes\":
-        2\r\n        }\r\n      }\r\n    ],\r\n    \"inboundNatRules\": [],\r\n    \"outboundNatRules\":
-        [],\r\n    \"inboundNatPools\": []\r\n  },\r\n  \"sku\": {\r\n    \"name\":
-        \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:25 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"a38434c8-7b23-4092-b7c6-402238eac0dc"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 0fd15240-6a1c-4b39-a4f6-aa53fd8591c2
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14986'
-      X-Ms-Correlation-Request-Id:
-      - 5cc03163-922e-41a1-9601-dba2d7cf2a81
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102421Z:5cc03163-922e-41a1-9601-dba2d7cf2a81
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Mon, 12 Mar 2018 10:24:20 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb1-LoadBalancerFrontEnd\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd\",\r\n
-        \ \"etag\": \"W/\\\"a38434c8-7b23-4092-b7c6-402238eac0dc\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"f28e0f25-b372-4edf-97d9-13a9e3b4ba2d\",\r\n    \"ipAddress\":
-        \"40.71.82.83\",\r\n    \"publicIPAddressVersion\": \"IPv4\",\r\n    \"publicIPAllocationMethod\":
-        \"Static\",\r\n    \"idleTimeoutInMinutes\": 4,\r\n    \"ipTags\": [],\r\n
-        \   \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
-        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:25 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk5MjQsIm5iZiI6MTUyMDg0OTkyNCwiZXhwIjoxNTIwODUzODI0LCJhaW8iOiJZMk5nWUxCa3Zyb2s5WWZjdGNEWTFkbi94STdlQndBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoibDNaYTVkMUk0MC1hSmk3d1hOOGtBQSIsInZlciI6IjEuMCJ9.b1D1rRo_uTAC7qZ8RGdWnzSmuwNKkwpRd_pmHCZnUt5xcaZ6KUwNX04EtD9wwDbjCLIa9NMW7UC6E-zaLIgbC-A7oyW7un8s1Fcy8NqeILga6AD_ozYC2oFv_JkNR9lw-JaTG4Oh0KAmNmecU6nJveldLVzFCpsCII3oSsrPM6xyb85O5H9lSlLLUXzUp2fmsZUIAPg0z3QHhZWlPKre_TimwR-pjzhRtMXtcbZi92Rn0ZacMLqjoGROxmpbcLU_hMnEqhKfMZqzruUteZGaSzdkZbGCqUykr_wt_byjKDVMA2c-8r_HPkEFgzMEndCq_zuuBKoWo2BhFhk-_8YAZQ
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"cddd97d1-6111-4477-8a00-3dc885237a1d"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 1403e5b6-8fa0-4cd3-89b1-76b6c4fd805b
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14988'
-      X-Ms-Correlation-Request-Id:
-      - e4a5f369-a742-466f-bd8f-42e17eaaf9c9
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180312T102421Z:e4a5f369-a742-466f-bd8f-42e17eaaf9c9
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Mon, 12 Mar 2018 10:24:21 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"rspec-lb2-publicip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip\",\r\n
-        \ \"etag\": \"W/\\\"cddd97d1-6111-4477-8a00-3dc885237a1d\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"83e7257d-ab94-4229-8eb5-4798f37ef28d\",\r\n    \"publicIPAddressVersion\":
-        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
-        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd\"\r\n
-        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
-        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Mon, 12 Mar 2018 10:24:26 GMT
+  recorded_at: Tue, 13 Mar 2018 09:06:56 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted_scope/template_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted_scope/template_refresh.yml
@@ -37,25 +37,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 1e6125d3-29d2-4810-9f3c-16db1a600000
+      - 71fc6ec0-16f4-4355-aec0-489160bd2400
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzd7CN_mdHB8lr8j-IrqSFbJfJWu1fpsly8w9nndqRNN4kGJaxIIbwDzSckkO7c8ZRN7cXWQ0uqMLmoHO2vDxIn6rq_NDwg70R4LUEjSPq30I9znBYrDD6lMa6YIsDNpC1q9AnUHYuxI5QyOBHiAVg5Wh78j8jvVLVJhRVUKtgpQcgAA;
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHz8SSHk4gmczg2Iz6p5qLpsCLfy37L7FmLa3B2FF0oirvcUpqid-u6u17zriD2jx1P6DcQkHjEbhhi66X9mphQEz9v9X6NBFkRU-mhGxvOazhDvsaey34Hxgj8p4ifbarXm3PHrWOixjoOzd9LofQg4Wj6j_ZYbE_T2jiN4yaeNg8gAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=007; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=003; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Wed, 07 Mar 2018 20:15:22 GMT
+      - Mon, 12 Mar 2018 10:22:31 GMT
       Content-Length:
       - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1520457322","not_before":"1520453422","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MjIsIm5iZiI6MTUyMDQ1MzQyMiwiZXhwIjoxNTIwNDU3MzIyLCJhaW8iOiJZMk5nWUxoellPWHF0WktxWGt5aTlYL21zTnhLQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMHlWaEh0SXBFRWlmUEJiYkdtQUFBQSIsInZlciI6IjEuMCJ9.QP6A55sbs1vcfUsm1cecTY5pxZmIqB-C8_KOg4kViYSlKjKM-gEfjTaWcsUxAn13OAXQwFsofoALvy8ljyBM9DY9WXXP834p1cYaV8b-hMCO6psMAmthDKtCr19YaqbwfxkC3e_yopKPRFEFMN8ZHdJDNfMFkBYh8vXgYyWx9HlojlH9p3Rf63zoO3gMsLvs5k5GksnAhRkxK4_kESH60F9wQdal_rvhmgSKqcQNSH0n19QWrKO4TPXldXXC0hLXPLpQlUFbe_3Z2Ld7C7Hw4od07vmK-IB9HudOOOWpF4a-nCptigsbLLNDsbly7kXaiZdDNv6FxEHO2ihXOS-E3A"}'
+      string: '{"token_type":"Bearer","expires_in":"3600","ext_expires_in":"0","expires_on":"1520853751","not_before":"1520849851","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk4NTEsIm5iZiI6MTUyMDg0OTg1MSwiZXhwIjoxNTIwODUzNzUxLCJhaW8iOiJZMk5nWUdnMTdtbnB1TkxmdjhIZFd1M3MzNEFxQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoid0c3OGNmUVdWVU91d0VpUllMMGtBQSIsInZlciI6IjEuMCJ9.k3cg0W62L17a8oBj2LTqWNoP5vRlbfK38MP5Ri8Pd7XZzNvY5b_2C4aLzm2cnOci90jzEXKXLjhwJUF3OiPciavyrCme8MZtFHWMDRdOTfJS144MJfmk-fuNHf3UrJG6Bx0VDx8yI41oigsMKYrlXu9DJEyPNr9c9L0HSMT8F3sXGezL5mbwsDDBQdcq92mJpTb4E4r1o97h_kdv8WVJL8UdLKOc2c8QQB4c87lx9q-Ux11_XV-Cd5UCxtDDsStPEnALG_4_Q8cq65EcFKGRkMGMZ2LKary2pbnNZqRJrqKQpJgy79oCeFkSKvP6qeXxkOoeGYJd8G5j-mfE0tprYw"}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:22 GMT
+  recorded_at: Mon, 12 Mar 2018 10:22:36 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -72,7 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MjIsIm5iZiI6MTUyMDQ1MzQyMiwiZXhwIjoxNTIwNDU3MzIyLCJhaW8iOiJZMk5nWUxoellPWHF0WktxWGt5aTlYL21zTnhLQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMHlWaEh0SXBFRWlmUEJiYkdtQUFBQSIsInZlciI6IjEuMCJ9.QP6A55sbs1vcfUsm1cecTY5pxZmIqB-C8_KOg4kViYSlKjKM-gEfjTaWcsUxAn13OAXQwFsofoALvy8ljyBM9DY9WXXP834p1cYaV8b-hMCO6psMAmthDKtCr19YaqbwfxkC3e_yopKPRFEFMN8ZHdJDNfMFkBYh8vXgYyWx9HlojlH9p3Rf63zoO3gMsLvs5k5GksnAhRkxK4_kESH60F9wQdal_rvhmgSKqcQNSH0n19QWrKO4TPXldXXC0hLXPLpQlUFbe_3Z2Ld7C7Hw4od07vmK-IB9HudOOOWpF4a-nCptigsbLLNDsbly7kXaiZdDNv6FxEHO2ihXOS-E3A
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk4NTEsIm5iZiI6MTUyMDg0OTg1MSwiZXhwIjoxNTIwODUzNzUxLCJhaW8iOiJZMk5nWUdnMTdtbnB1TkxmdjhIZFd1M3MzNEFxQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoid0c3OGNmUVdWVU91d0VpUllMMGtBQSIsInZlciI6IjEuMCJ9.k3cg0W62L17a8oBj2LTqWNoP5vRlbfK38MP5Ri8Pd7XZzNvY5b_2C4aLzm2cnOci90jzEXKXLjhwJUF3OiPciavyrCme8MZtFHWMDRdOTfJS144MJfmk-fuNHf3UrJG6Bx0VDx8yI41oigsMKYrlXu9DJEyPNr9c9L0HSMT8F3sXGezL5mbwsDDBQdcq92mJpTb4E4r1o97h_kdv8WVJL8UdLKOc2c8QQB4c87lx9q-Ux11_XV-Cd5UCxtDDsStPEnALG_4_Q8cq65EcFKGRkMGMZ2LKary2pbnNZqRJrqKQpJgy79oCeFkSKvP6qeXxkOoeGYJd8G5j-mfE0tprYw
   response:
     status:
       code: 200
@@ -91,26 +91,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14999'
+      - '14996'
       X-Ms-Request-Id:
-      - 889d681f-3469-4aaa-9e9b-82f794958c51
+      - f02b0108-5060-4092-82f9-7a5cf8e1a137
       X-Ms-Correlation-Request-Id:
-      - 889d681f-3469-4aaa-9e9b-82f794958c51
+      - f02b0108-5060-4092-82f9-7a5cf8e1a137
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201522Z:889d681f-3469-4aaa-9e9b-82f794958c51
+      - WESTEUROPE:20180312T102232Z:f02b0108-5060-4092-82f9-7a5cf8e1a137
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:15:21 GMT
+      - Mon, 12 Mar 2018 10:22:31 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID","subscriptionId":"AZURE_SUBSCRIPTION_ID","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:22 GMT
+  recorded_at: Mon, 12 Mar 2018 10:22:36 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers?api-version=2015-01-01
@@ -127,7 +127,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MjIsIm5iZiI6MTUyMDQ1MzQyMiwiZXhwIjoxNTIwNDU3MzIyLCJhaW8iOiJZMk5nWUxoellPWHF0WktxWGt5aTlYL21zTnhLQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMHlWaEh0SXBFRWlmUEJiYkdtQUFBQSIsInZlciI6IjEuMCJ9.QP6A55sbs1vcfUsm1cecTY5pxZmIqB-C8_KOg4kViYSlKjKM-gEfjTaWcsUxAn13OAXQwFsofoALvy8ljyBM9DY9WXXP834p1cYaV8b-hMCO6psMAmthDKtCr19YaqbwfxkC3e_yopKPRFEFMN8ZHdJDNfMFkBYh8vXgYyWx9HlojlH9p3Rf63zoO3gMsLvs5k5GksnAhRkxK4_kESH60F9wQdal_rvhmgSKqcQNSH0n19QWrKO4TPXldXXC0hLXPLpQlUFbe_3Z2Ld7C7Hw4od07vmK-IB9HudOOOWpF4a-nCptigsbLLNDsbly7kXaiZdDNv6FxEHO2ihXOS-E3A
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk4NTEsIm5iZiI6MTUyMDg0OTg1MSwiZXhwIjoxNTIwODUzNzUxLCJhaW8iOiJZMk5nWUdnMTdtbnB1TkxmdjhIZFd1M3MzNEFxQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoid0c3OGNmUVdWVU91d0VpUllMMGtBQSIsInZlciI6IjEuMCJ9.k3cg0W62L17a8oBj2LTqWNoP5vRlbfK38MP5Ri8Pd7XZzNvY5b_2C4aLzm2cnOci90jzEXKXLjhwJUF3OiPciavyrCme8MZtFHWMDRdOTfJS144MJfmk-fuNHf3UrJG6Bx0VDx8yI41oigsMKYrlXu9DJEyPNr9c9L0HSMT8F3sXGezL5mbwsDDBQdcq92mJpTb4E4r1o97h_kdv8WVJL8UdLKOc2c8QQB4c87lx9q-Ux11_XV-Cd5UCxtDDsStPEnALG_4_Q8cq65EcFKGRkMGMZ2LKary2pbnNZqRJrqKQpJgy79oCeFkSKvP6qeXxkOoeGYJd8G5j-mfE0tprYw
   response:
     status:
       code: 200
@@ -144,39 +144,37 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14975'
+      - '14983'
       X-Ms-Request-Id:
-      - 772df49f-406a-41b4-b86d-84f0d5c29e54
+      - c263cbdd-3c73-44f6-b4d2-be17f8f32b7e
       X-Ms-Correlation-Request-Id:
-      - 772df49f-406a-41b4-b86d-84f0d5c29e54
+      - c263cbdd-3c73-44f6-b4d2-be17f8f32b7e
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201524Z:772df49f-406a-41b4-b86d-84f0d5c29e54
+      - WESTEUROPE:20180312T102233Z:c263cbdd-3c73-44f6-b4d2-be17f8f32b7e
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:15:23 GMT
+      - Mon, 12 Mar 2018 10:22:33 GMT
       Content-Length:
-      - '310901'
+      - '320853'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"},{"applicationId":"d87dcbc6-a371-462e-88e3-28ad15ec4e64","roleDefinitionId":"861776c5-e0df-4f95-be4f-ac1eec193323"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
+      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"},{"applicationId":"d87dcbc6-a371-462e-88e3-28ad15ec4e64","roleDefinitionId":"861776c5-e0df-4f95-be4f-ac1eec193323"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["East
+        Asia","Southeast Asia","Australia East","Australia Southeast","Japan East","Japan
+        West","Central India","South India","West India","West Europe","North Europe","Canada
+        Central","Canada East","Brazil South","West US","Central US","East US","South
+        Central US","East US 2","West Central US","North Central US","West US 2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
         US","Central US","East US","South Central US","West Europe","North Europe","East
         Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
         Central US","North Central US","Japan East","Japan West","Brazil South","Central
         India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"operations","locations":["West
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["East
+        Asia","Southeast Asia","Australia East","Australia Southeast","Japan East","Japan
+        West","Central India","South India","West India","West Europe","North Europe","Canada
+        Central","Canada East","Brazil South","West US","Central US","East US","South
+        Central US","East US 2","West Central US","North Central US","West US 2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"operations","locations":["West
         US","Central US","East US","South Central US","West Europe","North Europe","East
         Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
         Central US","North Central US","Japan East","Japan West","Brazil South","Central
@@ -232,177 +230,177 @@ http_interactions:
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/internalLoadBalancers","locations":[],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"domainNames/slots/roles/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"domainNames/slots/roles/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"domainNames/capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"domainNames/serviceCertificates","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
         US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
         Central","Canada East","UK South","UK West","West US","Central US","South
         Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
-        East","Australia Southeast","West US 2","West Central US","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        East","Australia Southeast","West US 2","West Central US","France Central","South
+        India","Central India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
         US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
         Central","Canada East","UK South","UK West","West US","Central US","South
         Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
-        East","Australia Southeast","West US 2","West Central US","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metrics","locations":["North
+        East","Australia Southeast","West US 2","West Central US","France Central","South
+        India","Central India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metrics","locations":["North
         Central US","South Central US","East US","East US 2","Canada Central","Canada
         East","West US","West US 2","West Central US","Central US","East Asia","Southeast
         Asia","North Europe","West Europe","UK South","UK West","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"resourceTypes","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"moveSubscriptionResources","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"validateSubscriptionMoveAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operationStatuses","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operatingSystems","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"operatingSystemFamilies","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicNetwork","namespace":"Microsoft.ClassicNetwork","resourceTypes":[{"resourceType":"virtualNetworks","locations":["East
+        India","West India","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"resourceTypes","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"moveSubscriptionResources","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"validateSubscriptionMoveAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operationStatuses","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operatingSystems","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"operatingSystemFamilies","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicNetwork","namespace":"Microsoft.ClassicNetwork","resourceTypes":[{"resourceType":"virtualNetworks","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"virtualNetworks/remoteVirtualNetworkPeeringProxies","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01"]},{"resourceType":"virtualNetworks/remoteVirtualNetworkPeeringProxies","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"reservedIps","locations":["East
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01"]},{"resourceType":"reservedIps","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"gatewaySupportedDevices","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"networkSecurityGroups","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"gatewaySupportedDevices","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"networkSecurityGroups","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicStorage","namespace":"Microsoft.ClassicStorage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"expressRouteCrossConnections","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"expressRouteCrossConnections/peerings","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicStorage","namespace":"Microsoft.ClassicStorage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkStorageAccountAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"storageAccounts/services","locations":["West
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkStorageAccountAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"storageAccounts/services","locations":["West
         US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
         Asia","Australia East","Australia Southeast","South India","Central India","West
         India","West US 2","West Central US","East US","East US 2","North Central
         US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
-        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/diagnosticSettings","locations":["West
+        South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/diagnosticSettings","locations":["West
         US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
         Asia","Australia East","Australia Southeast","South India","Central India","West
         India","West US 2","West Central US","East US","East US 2","North Central
         US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
-        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"disks","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"images","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"vmImages","locations":[],"apiVersions":["2016-11-01"]},{"resourceType":"publicImages","locations":[],"apiVersions":["2016-11-01","2016-04-01"]},{"resourceType":"osImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"osPlatformImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute","namespace":"Microsoft.Compute","authorizations":[{"applicationId":"60e6cd67-9c8c-4951-9b3c-23c25a2169af","roleDefinitionId":"e4770acb-272e-4dc8-87f3-12f44a612224"},{"applicationId":"a303894e-f1d8-4a37-bf10-67aa654a0596","roleDefinitionId":"903ac751-8ad5-4e5a-bfc2-5e49f450a241"},{"applicationId":"a8b6bf88-1d1a-4626-b040-9a729ea93c65","roleDefinitionId":"45c8267c-80ba-4b96-9a43-115b8f49fccd"}],"resourceTypes":[{"resourceType":"availabilitySets","locations":["East
+        South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"disks","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"images","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"vmImages","locations":[],"apiVersions":["2016-11-01"]},{"resourceType":"storageAccounts/vmImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"publicImages","locations":[],"apiVersions":["2016-11-01","2016-04-01"]},{"resourceType":"osImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"osPlatformImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute","namespace":"Microsoft.Compute","authorizations":[{"applicationId":"60e6cd67-9c8c-4951-9b3c-23c25a2169af","roleDefinitionId":"e4770acb-272e-4dc8-87f3-12f44a612224"},{"applicationId":"a303894e-f1d8-4a37-bf10-67aa654a0596","roleDefinitionId":"903ac751-8ad5-4e5a-bfc2-5e49f450a241"},{"applicationId":"a8b6bf88-1d1a-4626-b040-9a729ea93c65","roleDefinitionId":"45c8267c-80ba-4b96-9a43-115b8f49fccd"}],"resourceTypes":[{"resourceType":"availabilitySets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations/usages","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations/usages","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"sharedVMImages","locations":["West
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"sharedVMImages","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"sharedVMImages/versions","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"locations/capsoperations","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"disks","locations":["Southeast
@@ -410,27 +408,27 @@ http_interactions:
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"snapshots","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"snapshots","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"locations/diskoperations","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"locations/diskoperations","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"images","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"images","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"]},{"resourceType":"locations/logAnalytics","locations":["East
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"]},{"resourceType":"locations/logAnalytics","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
         US","East US","South Central US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
@@ -547,7 +545,12 @@ http_interactions:
         US","East Asia","East US","East US 2","Japan East","Japan West","North Central
         US","North Europe","South Central US","South India","Southeast Asia","West
         Central US","West Europe","West India","West US","West US 2","UK West","UK
-        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"},{"applicationId":"f5c26e74-f226-4ae8-85f0-b4af0080ac9e","roleDefinitionId":"529d7ae6-e892-4d43-809d-8547aeb90643"}],"resourceTypes":[{"resourceType":"components","locations":["East
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/consumergroups","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/disasterrecoveryconfigs","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"},{"applicationId":"f5c26e74-f226-4ae8-85f0-b4af0080ac9e","roleDefinitionId":"529d7ae6-e892-4d43-809d-8547aeb90643"}],"resourceTypes":[{"resourceType":"components","locations":["East
         US","South Central US","North Europe","West Europe","Southeast Asia","West
         US 2"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
         US","South Central US","North Europe","West Europe","Southeast Asia","West
@@ -614,32 +617,32 @@ http_interactions:
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/accessPolicies","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"vaults/accessPolicies","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-10-01","2015-06-01","2014-12-19-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"deletedVaults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01","2014-12-19-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"deletedVaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-10-01"]},{"resourceType":"locations/deletedVaults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations/deletedVaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
         Central US","West Europe","Southeast Asia","Japan East","West Central US"],"apiVersions":["2016-04-01"]},{"resourceType":"webServices","locations":["South
         Central US","West Europe","Southeast Asia","Japan East","East US 2","West
         Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"operations","locations":["South
@@ -665,97 +668,97 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"networkWatchers/lenses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"networkWatchers/lenses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","West
         US 2","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
@@ -846,7 +849,7 @@ http_interactions:
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
         West","Korea Central","Korea South"],"apiVersions":["2017-07-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ResourceHealth","namespace":"Microsoft.ResourceHealth","authorizations":[{"applicationId":"8bdebf23-c0fe-4187-a378-717ad86f6a53","roleDefinitionId":"cc026344-c8b1-4561-83ba-59eba84b27cc"}],"resourceTypes":[{"resourceType":"availabilityStatuses","locations":[],"apiVersions":["2017-07-01","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"notifications","locations":["Australia
-        Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Security","namespace":"Microsoft.Security","authorization":{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
+        Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Security","namespace":"Microsoft.Security","authorizations":[{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},{"applicationId":"fc780465-2017-40d4-a0c5-307022471b92"}],"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatuses","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/virtualMachines","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/endpoints","locations":["Central
@@ -898,565 +901,595 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Central India","South
         India"],"apiVersions":["2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Sql","namespace":"Microsoft.Sql","authorizations":[{"applicationId":"e4ab13ed-33cb-41b4-9140-6e264582cf85","roleDefinitionId":"ec3ddc95-44dc-47a2-9926-5e9f5ffd44ec"},{"applicationId":"0130cc9f-7ac5-4026-bd5f-80a08a54e6d9","roleDefinitionId":"45e8abf8-0ec4-44f3-9c37-cff4f7779302"},{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},{"applicationId":"76c7f279-7959-468f-8943-3954880e0d8c","roleDefinitionId":"7f7513a8-73f9-4c5f-97a2-c41f0ea783ef"}],"resourceTypes":[{"resourceType":"operations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/capabilities","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/databaseAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/databaseOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverKeyOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/keys","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/encryptionProtector","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/usages","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01","2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/communicationLinks","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administrators","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administratorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/restorableDroppedDatabases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recoverableDatabases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/geoBackupPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/importExportOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/operationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/backupLongTermRetentionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/automaticTuning","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/automaticTuning","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/databases/transparentDataEncryption","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recommendedElasticPools","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/auditingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/connectionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/connectionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies/rules","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/securityAlertPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/securityAlertPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/auditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/extendedAuditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/elasticpools","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-09-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/jobAgentOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/jobAgentAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/disasterRecoveryConfiguration","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/dnsAliases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/failoverGroups","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/virtualNetworkRules","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/virtualNetworkRulesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/virtualNetworkRulesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/databaseRestoreAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metricDefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/aggregatedDatabaseMetrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metricdefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries/queryText","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPools/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/extensions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPoolEstimates","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditRecords","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentScans","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/vulnerabilityAssessments","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessment","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/syncGroups","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups/syncMembers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/syncAgents","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"managedInstances/administrators","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/databases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metricDefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/administratorAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/administratorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncMemberOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncAgentOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncDatabaseIds","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorizations":[{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},{"applicationId":"e406a681-f3d4-42a8-90b6-c2b029497af1"}],"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/capabilities","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/databaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"locations/databaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverKeyOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/keys","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/encryptionProtector","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01","2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/communicationLinks","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/restorableDroppedDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recoverableDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/geoBackupPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/importExportOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/operationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/backupLongTermRetentionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/databases/transparentDataEncryption","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recommendedElasticPools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies/rules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/extendedAuditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/elasticPoolAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/elasticPoolOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/elasticpools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-09-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/jobAgentOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/jobAgentAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/disasterRecoveryConfiguration","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/dnsAliases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/failoverGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/virtualNetworkRules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/virtualNetworkRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/virtualNetworkRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/databaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/aggregatedDatabaseMetrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metricdefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries/queryText","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPools/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/extensions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPoolEstimates","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditRecords","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentScans","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/vulnerabilityAssessments","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessment","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/syncGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups/syncMembers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/syncAgents","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"managedInstances/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/administratorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncMemberOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncAgentOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncDatabaseIds","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/longTermRetentionPolicyOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionPolicyAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionBackupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionBackupAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorizations":[{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},{"applicationId":"e406a681-f3d4-42a8-90b6-c2b029497af1"}],"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
@@ -1795,12 +1828,12 @@ http_interactions:
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","Canada Central","Canada East","UK South","UK West","West US 2","West
-        Central US","South India","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","South India","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","South India","Canada Central","Canada East","UK South","UK West","West
-        US 2","West Central US","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Capacity","namespace":"Microsoft.Capacity","authorization":{"applicationId":"4d0ad6c7-f6c3-46d8-ab0d-1406d5e6c86b","roleDefinitionId":"FD9C0A9A-4DB9-4F41-8A61-98385DEB6E2D"},"resourceTypes":[{"resourceType":"resources","locations":["South
+        US 2","West Central US","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Capacity","namespace":"Microsoft.Capacity","authorization":{"applicationId":"4d0ad6c7-f6c3-46d8-ab0d-1406d5e6c86b","roleDefinitionId":"FD9C0A9A-4DB9-4F41-8A61-98385DEB6E2D"},"resourceTypes":[{"resourceType":"resources","locations":["South
         Central US"],"apiVersions":["2017-11-01"]},{"resourceType":"reservationOrders","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/reservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/reservations/revisions","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"catalogs","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"appliedReservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"checkOffers","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"checkScopes","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"calculatePrice","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/calculateRefund","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/return","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/split","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/merge","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"validateReservationOrder","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/availableScopes","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Cdn","namespace":"Microsoft.Cdn","resourceTypes":[{"resourceType":"profiles","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
@@ -1876,9 +1909,9 @@ http_interactions:
         2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/updateAccountsCreationSettings","locations":["West
         US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/accountsCreationSettings","locations":["West
         US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2016-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Commerce","namespace":"Microsoft.Commerce","resourceTypes":[{"resourceType":"UsageAggregates","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]},{"resourceType":"RateCard","locations":[],"apiVersions":["2016-08-31-preview","2015-06-01-preview","2015-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Consumption","namespace":"Microsoft.Consumption","resourceTypes":[{"resourceType":"ReservationSummaries","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationTransactions","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Balances","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Marketplaces","locations":[],"apiVersions":["2018-01-31"]},{"resourceType":"Pricesheets","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationDetails","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Budgets","locations":[],"apiVersions":["2018-01-31","2017-12-30-preview"]},{"resourceType":"Terms","locations":[],"apiVersions":["2018-01-31","2017-12-30-preview"]},{"resourceType":"UsageDetails","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview","2017-04-24-preview"]},{"resourceType":"Operations","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview","2017-04-24-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerInstance","namespace":"Microsoft.ContainerInstance","resourceTypes":[{"resourceType":"containerGroups","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/usages","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/operations","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/operations","locations":["West
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
         US"],"apiVersions":["2016-04-08"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.CustomerInsights","namespace":"Microsoft.CustomerInsights","authorization":{"applicationId":"38c77d00-5fcb-4cce-9d93-af4738258e3c","roleDefinitionId":"E006F9C7-F333-477C-8AD6-1F3A9FE87F55"},"resourceTypes":[{"resourceType":"hubs","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/profiles","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/interactions","locations":["East
@@ -1895,7 +1928,9 @@ http_interactions:
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"operations","locations":["East
         US 2"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Databricks","namespace":"Microsoft.Databricks","authorizations":[{"applicationId":"d9327919-6775-4843-9037-3fb0fb0473cb","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},{"applicationId":"2ff814a6-3304-4ab8-85cb-cd0e6f879c1d","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"}],"resourceTypes":[{"resourceType":"workspaces","locations":["West
         US","East US 2","West Europe","East US","North Europe","Southeast Asia","East
-        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]},{"resourceType":"locations","locations":["West
+        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2017-09-01-preview"]},{"resourceType":"workspaces/virtualNetworkPeerings","locations":["West
+        US","East US 2","West Europe","North Europe","East US","Southeast Asia","East
+        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01"]},{"resourceType":"locations","locations":["West
         US","East US 2","West Europe","North Europe","East US","Southeast Asia"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
         US","East US 2","West Europe","East US","North Europe","Southeast Asia","East
         Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataCatalog","namespace":"Microsoft.DataCatalog","resourceTypes":[{"resourceType":"catalogs","locations":["East
@@ -1919,23 +1954,26 @@ http_interactions:
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers/listSasTokens","locations":["East
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataLakeStore","namespace":"Microsoft.DataLakeStore","authorization":{"applicationId":"e9f49c6b-5ce5-44c8-925d-015017e9f7ad","roleDefinitionId":"17eb9cca-f08a-4499-b2d3-852d175f614f"},"resourceTypes":[{"resourceType":"accounts","locations":["East
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/firewallRules","locations":["East
-        US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataMigration","namespace":"Microsoft.DataMigration","authorization":{"applicationId":"a4bad4aa-bf02-4631-9f78-a64ffdba8150","roleDefinitionId":"b831a21d-db98-4760-89cb-bef871952df1","managedByRoleDefinitionId":"6256fb55-9e59-4018-a9e1-76b11c0a4c89"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services/projects","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationStatuses","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
+        US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataMigration","namespace":"Microsoft.DataMigration","authorization":{"applicationId":"a4bad4aa-bf02-4631-9f78-a64ffdba8150","roleDefinitionId":"b831a21d-db98-4760-89cb-bef871952df1","managedByRoleDefinitionId":"6256fb55-9e59-4018-a9e1-76b11c0a4c89"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services/projects","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationStatuses","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
-        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/recoverableServers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
@@ -1959,7 +1997,10 @@ http_interactions:
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
-        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/recoverableServers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
@@ -2015,12 +2056,7 @@ http_interactions:
         US 2","East US","West US","Central US","East US 2","West Central US","West
         Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
         US 2","East US","West US","Central US","East US 2","West Central US","West
-        Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","West
-        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
-        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
-        India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/consumergroups","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/disasterrecoveryconfigs","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
         US 2","South Central US","Central US","Australia Southeast","Central India","West
         Central US","West US 2","Canada East","Canada Central","Brazil South","UK
         South","UK West","East Asia","Australia East","Japan East","Japan West","North
@@ -2131,7 +2167,7 @@ http_interactions:
         West","Japan East","East Asia","Southeast Asia","West Europe","North Europe","East
         US","West US","Australia East","Australia Southeast","Central US","Brazil
         South","Central India","West India","South India","South Central US","Canada
-        Central","Canada East","West Central US","West US 2"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
+        Central","Canada East","West Central US","West US 2"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-05","2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
         Central US","East US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"operations","locations":["West
         Central US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
         Central US","East US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.PolicyInsights","namespace":"Microsoft.PolicyInsights","authorization":{"applicationId":"1d78a85d-813d-46f0-b496-dd72f50a3ec0","roleDefinitionId":"63d2b225-4c34-4641-8768-21a1f7c68ce8"},"resourceTypes":[{"resourceType":"policyEvents","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"policyStates","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
@@ -2163,12 +2199,12 @@ http_interactions:
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
         Central US","South Central US","North Europe","West Europe","East Asia","Southeast
         Asia","West US","East US","Japan West","Japan East","Brazil South","Central
         US","East US 2","Australia East","Australia Southeast","South India","Central
@@ -2208,40 +2244,50 @@ http_interactions:
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/clusterVersions","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"clusters/applications","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operations","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/clusterVersions","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/environments","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operations","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
         Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applianceDefinitions","locations":["West
         Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applications","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
-        Central US"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
+        Central US"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
         US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
         US","Canada Central","Canada East","Central US","East US 2","UK South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups","locations":["West
         US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
@@ -2332,7 +2378,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:24 GMT
+  recorded_at: Mon, 12 Mar 2018 10:22:39 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Storage/storageAccounts?api-version=2017-10-01
@@ -2349,7 +2395,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MjIsIm5iZiI6MTUyMDQ1MzQyMiwiZXhwIjoxNTIwNDU3MzIyLCJhaW8iOiJZMk5nWUxoellPWHF0WktxWGt5aTlYL21zTnhLQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMHlWaEh0SXBFRWlmUEJiYkdtQUFBQSIsInZlciI6IjEuMCJ9.QP6A55sbs1vcfUsm1cecTY5pxZmIqB-C8_KOg4kViYSlKjKM-gEfjTaWcsUxAn13OAXQwFsofoALvy8ljyBM9DY9WXXP834p1cYaV8b-hMCO6psMAmthDKtCr19YaqbwfxkC3e_yopKPRFEFMN8ZHdJDNfMFkBYh8vXgYyWx9HlojlH9p3Rf63zoO3gMsLvs5k5GksnAhRkxK4_kESH60F9wQdal_rvhmgSKqcQNSH0n19QWrKO4TPXldXXC0hLXPLpQlUFbe_3Z2Ld7C7Hw4od07vmK-IB9HudOOOWpF4a-nCptigsbLLNDsbly7kXaiZdDNv6FxEHO2ihXOS-E3A
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk4NTEsIm5iZiI6MTUyMDg0OTg1MSwiZXhwIjoxNTIwODUzNzUxLCJhaW8iOiJZMk5nWUdnMTdtbnB1TkxmdjhIZFd1M3MzNEFxQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoid0c3OGNmUVdWVU91d0VpUllMMGtBQSIsInZlciI6IjEuMCJ9.k3cg0W62L17a8oBj2LTqWNoP5vRlbfK38MP5Ri8Pd7XZzNvY5b_2C4aLzm2cnOci90jzEXKXLjhwJUF3OiPciavyrCme8MZtFHWMDRdOTfJS144MJfmk-fuNHf3UrJG6Bx0VDx8yI41oigsMKYrlXu9DJEyPNr9c9L0HSMT8F3sXGezL5mbwsDDBQdcq92mJpTb4E4r1o97h_kdv8WVJL8UdLKOc2c8QQB4c87lx9q-Ux11_XV-Cd5UCxtDDsStPEnALG_4_Q8cq65EcFKGRkMGMZ2LKary2pbnNZqRJrqKQpJgy79oCeFkSKvP6qeXxkOoeGYJd8G5j-mfE0tprYw
   response:
     status:
       code: 200
@@ -2366,24 +2412,24 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - a3cadb5f-079f-4c55-b317-d549f9b3697c
+      - 11445024-4e35-4d32-aa1b-b639d5ce35a2
       X-Ms-Correlation-Request-Id:
-      - a3cadb5f-079f-4c55-b317-d549f9b3697c
+      - 11445024-4e35-4d32-aa1b-b639d5ce35a2
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201527Z:a3cadb5f-079f-4c55-b317-d549f9b3697c
+      - WESTEUROPE:20180312T102241Z:11445024-4e35-4d32-aa1b-b639d5ce35a2
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:15:27 GMT
+      - Mon, 12 Mar 2018 10:22:41 GMT
       Content-Length:
       - '8649'
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686","name":"miqazuretest18686","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T17:22:54.7808677Z","primaryEndpoints":{"blob":"https://miqazuretest18686.blob.core.windows.net/","queue":"https://miqazuretest18686.queue.core.windows.net/","table":"https://miqazuretest18686.table.core.windows.net/","file":"https://miqazuretest18686.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047","name":"miqazuretest14047","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T17:30:25.7028008Z","primaryEndpoints":{"blob":"https://miqazuretest14047.blob.core.windows.net/","queue":"https://miqazuretest14047.queue.core.windows.net/","table":"https://miqazuretest14047.table.core.windows.net/","file":"https://miqazuretest14047.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Premium_LRS","tier":"Premium"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb","name":"rspeclb","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-09-02T16:29:11.6823797Z","primaryEndpoints":{"blob":"https://rspeclb.blob.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor","name":"spec0deply1stor","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.3305055Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-04-04T23:05:07.8274794Z","primaryEndpoints":{"blob":"https://spec0deply1stor.blob.core.windows.net/","queue":"https://spec0deply1stor.queue.core.windows.net/","table":"https://spec0deply1stor.table.core.windows.net/","file":"https://spec0deply1stor.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Storage/storageAccounts/miqazuretest26611","name":"miqazuretest26611","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2211656Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2211656Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-05-02T18:01:29.2743021Z","primaryEndpoints":{"blob":"https://miqazuretest26611.blob.core.windows.net/","queue":"https://miqazuretest26611.queue.core.windows.net/","table":"https://miqazuretest26611.table.core.windows.net/","file":"https://miqazuretest26611.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487","name":"miqazuretest16487","type":"Microsoft.Storage/storageAccounts","location":"eastus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.2055285Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T17:26:55.3231669Z","primaryEndpoints":{"blob":"https://miqazuretest16487.blob.core.windows.net/","queue":"https://miqazuretest16487.queue.core.windows.net/","table":"https://miqazuretest16487.table.core.windows.net/","file":"https://miqazuretest16487.file.core.windows.net/"},"primaryLocation":"eastus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_LRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Storage/storageAccounts/miqazuretest32946","name":"miqazuretest32946","type":"Microsoft.Storage/storageAccounts","location":"westus","tags":{"delete":"false"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.0404359Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.0404359Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T21:18:37.0793411Z","primaryEndpoints":{"blob":"https://miqazuretest32946.blob.core.windows.net/","queue":"https://miqazuretest32946.queue.core.windows.net/","table":"https://miqazuretest32946.table.core.windows.net/","file":"https://miqazuretest32946.file.core.windows.net/"},"primaryLocation":"westus","statusOfPrimary":"available"}},{"sku":{"name":"Standard_RAGRS","tier":"Standard"},"kind":"Storage","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Storage/storageAccounts/miqazureshared1","name":"miqazureshared1","type":"Microsoft.Storage/storageAccounts","location":"centralus","tags":{"test":"true"},"properties":{"networkAcls":{"bypass":"AzureServices","virtualNetworkRules":[],"ipRules":[],"defaultAction":"Allow"},"supportsHttpsTrafficOnly":false,"encryption":{"services":{"file":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.1935084Z"},"blob":{"enabled":true,"lastEnabledTime":"2018-01-10T02:02:55.1935084Z"}},"keySource":"Microsoft.Storage"},"provisioningState":"Succeeded","creationTime":"2016-03-18T20:42:52.498085Z","primaryEndpoints":{"blob":"https://miqazureshared1.blob.core.windows.net/","queue":"https://miqazureshared1.queue.core.windows.net/","table":"https://miqazureshared1.table.core.windows.net/","file":"https://miqazureshared1.file.core.windows.net/"},"primaryLocation":"centralus","statusOfPrimary":"available","secondaryLocation":"eastus2","statusOfSecondary":"available","secondaryEndpoints":{"blob":"https://miqazureshared1-secondary.blob.core.windows.net/","queue":"https://miqazureshared1-secondary.queue.core.windows.net/","table":"https://miqazureshared1-secondary.table.core.windows.net/"}}}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:27 GMT
+  recorded_at: Mon, 12 Mar 2018 10:22:46 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest18686/listKeys?api-version=2017-10-01
@@ -2400,7 +2446,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MjIsIm5iZiI6MTUyMDQ1MzQyMiwiZXhwIjoxNTIwNDU3MzIyLCJhaW8iOiJZMk5nWUxoellPWHF0WktxWGt5aTlYL21zTnhLQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMHlWaEh0SXBFRWlmUEJiYkdtQUFBQSIsInZlciI6IjEuMCJ9.QP6A55sbs1vcfUsm1cecTY5pxZmIqB-C8_KOg4kViYSlKjKM-gEfjTaWcsUxAn13OAXQwFsofoALvy8ljyBM9DY9WXXP834p1cYaV8b-hMCO6psMAmthDKtCr19YaqbwfxkC3e_yopKPRFEFMN8ZHdJDNfMFkBYh8vXgYyWx9HlojlH9p3Rf63zoO3gMsLvs5k5GksnAhRkxK4_kESH60F9wQdal_rvhmgSKqcQNSH0n19QWrKO4TPXldXXC0hLXPLpQlUFbe_3Z2Ld7C7Hw4od07vmK-IB9HudOOOWpF4a-nCptigsbLLNDsbly7kXaiZdDNv6FxEHO2ihXOS-E3A
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk4NTEsIm5iZiI6MTUyMDg0OTg1MSwiZXhwIjoxNTIwODUzNzUxLCJhaW8iOiJZMk5nWUdnMTdtbnB1TkxmdjhIZFd1M3MzNEFxQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoid0c3OGNmUVdWVU91d0VpUllMMGtBQSIsInZlciI6IjEuMCJ9.k3cg0W62L17a8oBj2LTqWNoP5vRlbfK38MP5Ri8Pd7XZzNvY5b_2C4aLzm2cnOci90jzEXKXLjhwJUF3OiPciavyrCme8MZtFHWMDRdOTfJS144MJfmk-fuNHf3UrJG6Bx0VDx8yI41oigsMKYrlXu9DJEyPNr9c9L0HSMT8F3sXGezL5mbwsDDBQdcq92mJpTb4E4r1o97h_kdv8WVJL8UdLKOc2c8QQB4c87lx9q-Ux11_XV-Cd5UCxtDDsStPEnALG_4_Q8cq65EcFKGRkMGMZ2LKary2pbnNZqRJrqKQpJgy79oCeFkSKvP6qeXxkOoeGYJd8G5j-mfE0tprYw
       Content-Length:
       - '0'
   response:
@@ -2421,26 +2467,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 152f58fb-eca9-4e00-adc6-8d3f50ff2ff4
+      - 0c3d4c58-ea9f-4d1f-a983-769b8577c85f
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1199'
+      - '1197'
       X-Ms-Correlation-Request-Id:
-      - 78f77040-d119-4be9-87cd-f6ca708b51ff
+      - 7d99bc73-a118-4deb-9311-516565bd721f
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201527Z:78f77040-d119-4be9-87cd-f6ca708b51ff
+      - WESTEUROPE:20180312T102245Z:7d99bc73-a118-4deb-9311-516565bd721f
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:15:27 GMT
+      - Mon, 12 Mar 2018 10:22:45 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keys":[{"keyName":"key1","value":"32PV5jeBt8nw1XvFbZokY26SXchbD6H2tw/YrteEYVE0kpMLKrZ74VrwaIjDyucdi/RxDaAlf7dJIilLS7muNw==","permissions":"Full"},{"keyName":"key2","value":"Eo5x9CQJL1/wl6Tkj5N7M5eEdw6Hym6AeyTt3xjcDl30sV8Iadro6ywZzOHQwNDlmrDaBF6x2a9ZFL7zswxQ7w==","permissions":"Full"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:28 GMT
+  recorded_at: Mon, 12 Mar 2018 10:22:50 GMT
 - request:
     method: get
     uri: https://miqazuretest18686.blob.core.windows.net/?comp=list
@@ -2457,13 +2503,13 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:15:28 GMT
+      - Mon, 12 Mar 2018 10:22:50 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
       - 'true'
       Authorization:
-      - SharedKey miqazuretest18686:IZ9KO/ivVyHw1Wd3HJJ0AM17jgweQKzgQqGzTy3MP8k=
+      - SharedKey miqazuretest18686:tsY1izdGGwdP+UEwFJjptnIlQYp/nQkitqY3F8otU4c=
   response:
     status:
       code: 200
@@ -2476,17 +2522,17 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - d2d14136-001e-00d3-3851-b699da000000
+      - 7315b93a-001e-008a-7cec-b99c5c000000
       X-Ms-Version:
       - '2016-05-31'
       Date:
-      - Wed, 07 Mar 2018 20:15:28 GMT
+      - Mon, 12 Mar 2018 10:22:45 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9taXFhenVyZXRlc3QxODY4Ni5ibG9iLmNvcmUud2luZG93cy5uZXQvIj48Q29udGFpbmVycz48Q29udGFpbmVyPjxOYW1lPmJvb3RkaWFnbm9zdGljcy1taXF0ZXN0cmgtMDNlODQ2N2ItYmFhYi00ODY3LTljYzQtMTU3MzM2YjdlMmU0PC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPkZyaSwgMTggTWFyIDIwMTYgMTc6MjM6MjggR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPiIweDhEMzRGNTIwNTFCRENDMCI8L0V0YWc+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQ29udGFpbmVyPjxDb250YWluZXI+PE5hbWU+dmhkczwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5GcmksIDE4IE1hciAyMDE2IDE3OjIzOjI4IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4iMHg4RDM0RjUyMDU0RDgwMDUiPC9FdGFnPjxMZWFzZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJhdGlvbj5pbmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48L1Byb3BlcnRpZXM+PC9Db250YWluZXI+PC9Db250YWluZXJzPjxOZXh0TWFya2VyIC8+PC9FbnVtZXJhdGlvblJlc3VsdHM+
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:28 GMT
+  recorded_at: Mon, 12 Mar 2018 10:22:51 GMT
 - request:
     method: get
     uri: https://miqazuretest18686.blob.core.windows.net/vhds?comp=list&restype=container
@@ -2503,13 +2549,13 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:15:28 GMT
+      - Mon, 12 Mar 2018 10:22:51 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
       - 'true'
       Authorization:
-      - SharedKey miqazuretest18686:scYUoijcsv3QKOuwLP0HLOyN6ln2YmXFWYWtrg9TDzc=
+      - SharedKey miqazuretest18686:FilpQQbQMR5yVuR606DMViWOpVaoTCq/oiiKPGujbTQ=
   response:
     status:
       code: 200
@@ -2522,17 +2568,17 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - b1a9ac3b-001e-0073-8051-b656bc000000
+      - 55588d64-001e-0022-52ec-b94849000000
       X-Ms-Version:
       - '2016-05-31'
       Date:
-      - Wed, 07 Mar 2018 20:15:28 GMT
+      - Mon, 12 Mar 2018 10:22:46 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9taXFhenVyZXRlc3QxODY4Ni5ibG9iLmNvcmUud2luZG93cy5uZXQvIiBDb250YWluZXJOYW1lPSJ2aGRzIj48QmxvYnM+PEJsb2I+PE5hbWU+bWlxLXRlc3QtcmhlbDEyMDE2MjE4MTEyMjQzLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5XZWQsIDA3IE1hciAyMDE4IDIwOjE1OjI3IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhENTg0NjgyQjE1RDgxQTwvRXRhZz48Q29udGVudC1MZW5ndGg+MzIyMTIyNTUyMzI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5kUUwrWEhqRk5QZG9NRXdlSTYzZndRPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4zNzE8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+bG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5sZWFzZWQ8L0xlYXNlU3RhdGU+PExlYXNlRHVyYXRpb24+aW5maW5pdGU8L0xlYXNlRHVyYXRpb24+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PC9CbG9icz48TmV4dE1hcmtlciAvPjwvRW51bWVyYXRpb25SZXN1bHRzPg==
+        77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9taXFhenVyZXRlc3QxODY4Ni5ibG9iLmNvcmUud2luZG93cy5uZXQvIiBDb250YWluZXJOYW1lPSJ2aGRzIj48QmxvYnM+PEJsb2I+PE5hbWU+bWlxLXRlc3QtcmhlbDEyMDE2MjE4MTEyMjQzLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5Nb24sIDEyIE1hciAyMDE4IDEwOjIyOjQyIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhENTg4MDMzMEFBNzI1QzwvRXRhZz48Q29udGVudC1MZW5ndGg+MzIyMTIyNTUyMzI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5kUUwrWEhqRk5QZG9NRXdlSTYzZndRPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4zNzI8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+bG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5sZWFzZWQ8L0xlYXNlU3RhdGU+PExlYXNlRHVyYXRpb24+aW5maW5pdGU8L0xlYXNlRHVyYXRpb24+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PC9CbG9icz48TmV4dE1hcmtlciAvPjwvRW51bWVyYXRpb25SZXN1bHRzPg==
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:29 GMT
+  recorded_at: Mon, 12 Mar 2018 10:22:51 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest14047/listKeys?api-version=2017-10-01
@@ -2549,7 +2595,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MjIsIm5iZiI6MTUyMDQ1MzQyMiwiZXhwIjoxNTIwNDU3MzIyLCJhaW8iOiJZMk5nWUxoellPWHF0WktxWGt5aTlYL21zTnhLQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMHlWaEh0SXBFRWlmUEJiYkdtQUFBQSIsInZlciI6IjEuMCJ9.QP6A55sbs1vcfUsm1cecTY5pxZmIqB-C8_KOg4kViYSlKjKM-gEfjTaWcsUxAn13OAXQwFsofoALvy8ljyBM9DY9WXXP834p1cYaV8b-hMCO6psMAmthDKtCr19YaqbwfxkC3e_yopKPRFEFMN8ZHdJDNfMFkBYh8vXgYyWx9HlojlH9p3Rf63zoO3gMsLvs5k5GksnAhRkxK4_kESH60F9wQdal_rvhmgSKqcQNSH0n19QWrKO4TPXldXXC0hLXPLpQlUFbe_3Z2Ld7C7Hw4od07vmK-IB9HudOOOWpF4a-nCptigsbLLNDsbly7kXaiZdDNv6FxEHO2ihXOS-E3A
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk4NTEsIm5iZiI6MTUyMDg0OTg1MSwiZXhwIjoxNTIwODUzNzUxLCJhaW8iOiJZMk5nWUdnMTdtbnB1TkxmdjhIZFd1M3MzNEFxQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoid0c3OGNmUVdWVU91d0VpUllMMGtBQSIsInZlciI6IjEuMCJ9.k3cg0W62L17a8oBj2LTqWNoP5vRlbfK38MP5Ri8Pd7XZzNvY5b_2C4aLzm2cnOci90jzEXKXLjhwJUF3OiPciavyrCme8MZtFHWMDRdOTfJS144MJfmk-fuNHf3UrJG6Bx0VDx8yI41oigsMKYrlXu9DJEyPNr9c9L0HSMT8F3sXGezL5mbwsDDBQdcq92mJpTb4E4r1o97h_kdv8WVJL8UdLKOc2c8QQB4c87lx9q-Ux11_XV-Cd5UCxtDDsStPEnALG_4_Q8cq65EcFKGRkMGMZ2LKary2pbnNZqRJrqKQpJgy79oCeFkSKvP6qeXxkOoeGYJd8G5j-mfE0tprYw
       Content-Length:
       - '0'
   response:
@@ -2570,26 +2616,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - b8c4db24-2865-4e1b-b61a-f1b2b869863a
+      - 3ed920e4-9971-4e09-9615-30d07d16a52f
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1199'
+      - '1196'
       X-Ms-Correlation-Request-Id:
-      - 8efa0338-35a8-4b81-a4e1-ba0fef95d880
+      - a9ce82a7-329a-499b-b375-51ab4dd11b05
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201529Z:8efa0338-35a8-4b81-a4e1-ba0fef95d880
+      - WESTEUROPE:20180312T102247Z:a9ce82a7-329a-499b-b375-51ab4dd11b05
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:15:28 GMT
+      - Mon, 12 Mar 2018 10:22:47 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keys":[{"keyName":"key1","value":"9hGLwV9mjvAc1ARzeGwpsS9oZPLqOBzHCCHjeixyt1wpPYVn32cXmm3Gs9ogFPXZhDH61PAXxud0Dg/qwOnJ1w==","permissions":"Full"},{"keyName":"key2","value":"FfW8btVjJE2LkKHvN8Prr3FDX71BrS4SnMkONq2fLVPPm6x7vqqjeDSWDh17aI4CBLYf3Y1pc6njkbz53HdMYg==","permissions":"Full"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:29 GMT
+  recorded_at: Mon, 12 Mar 2018 10:22:52 GMT
 - request:
     method: get
     uri: https://miqazuretest14047.blob.core.windows.net/?comp=list
@@ -2606,13 +2652,13 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:15:29 GMT
+      - Mon, 12 Mar 2018 10:22:52 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
       - 'true'
       Authorization:
-      - SharedKey miqazuretest14047:8d7g5X6Nqa511bchlJgckaSePuyuqrN30jYCo2+NXHo=
+      - SharedKey miqazuretest14047:ZMLlnrPlZyujd7eJ1J2n9/nucyhAvKJf/RklxGm4Vfw=
   response:
     status:
       code: 200
@@ -2625,17 +2671,17 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 6f099568-001e-0092-0d51-b6b1c9000000
+      - 5537470b-001e-011e-75ec-b9bac7000000
       X-Ms-Version:
       - '2016-05-31'
       Date:
-      - Wed, 07 Mar 2018 20:15:29 GMT
+      - Mon, 12 Mar 2018 10:22:48 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9taXFhenVyZXRlc3QxNDA0Ny5ibG9iLmNvcmUud2luZG93cy5uZXQvIj48Q29udGFpbmVycz48Q29udGFpbmVyPjxOYW1lPmJvb3RkaWFnbm9zdGljcy1taXFhenVyZWMtNzk2YzViY2MtMzM4YS00NDhkLWI2MWMtMTY1Mjc5YTdmYjNlPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPk1vbiwgMjEgTWFyIDIwMTYgMTY6NTA6MTMgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPiIweDhEMzUxQThERjlBNjcxNCI8L0V0YWc+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQ29udGFpbmVyPjxDb250YWluZXI+PE5hbWU+Ym9vdGRpYWdub3N0aWNzLW1pcXRlc3R3aS02ZTU1NWI4OC0zZmQ0LTRiNzItYTQwNC00YmJhNWQxMWRlOTM8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+RnJpLCAxOCBNYXIgMjAxNiAxNzozMDo1OSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+IjB4OEQzNEY1MzEyNTlFMTY1IjwvRXRhZz48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48L1Byb3BlcnRpZXM+PC9Db250YWluZXI+PENvbnRhaW5lcj48TmFtZT5ib290ZGlhZ25vc3RpY3MtbWlxdGVzdHdpLWI5N2ZmNDg4LWUxMTQtNDBlZC04ZDdhLWY0NTAwZDczZWVjMDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UdWUsIDIyIE1hciAyMDE2IDE2OjE3OjA2IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4iMHg4RDM1MjZENjk4RUQxODkiPC9FdGFnPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0NvbnRhaW5lcj48Q29udGFpbmVyPjxOYW1lPmJvb3RkaWFnbm9zdGljcy1taXF0ZXN0d2ktZTE3YTk1YjAtZjRmYi00MTk2LTkzYzUtMGM4YmU3ZDVjNTM2PC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlR1ZSwgMjIgTWFyIDIwMTYgMTY6NDA6MzEgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPiIweDhEMzUyNzBBRURCNTBBQiI8L0V0YWc+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQ29udGFpbmVyPjxDb250YWluZXI+PE5hbWU+Y29waWVzPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPkZyaSwgMTcgSnVuIDIwMTYgMTQ6MDk6MDUgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPiIweDhEMzk2QjhGMTE4M0QzMiI8L0V0YWc+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQ29udGFpbmVyPjxDb250YWluZXI+PE5hbWU+bWFuYWdlaXE8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+V2VkLCAyMCBBcHIgMjAxNiAxNjowNDo1NCBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+IjB4OEQzNjkzNTgyRkJENTg0IjwvRXRhZz48TGVhc2VTdGF0dXM+bG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5sZWFzZWQ8L0xlYXNlU3RhdGU+PExlYXNlRHVyYXRpb24+aW5maW5pdGU8L0xlYXNlRHVyYXRpb24+PC9Qcm9wZXJ0aWVzPjwvQ29udGFpbmVyPjxDb250YWluZXI+PE5hbWU+c3lzdGVtPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlR1ZSwgMjIgTWFyIDIwMTYgMTc6MDg6MDEgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPiIweDhEMzUyNzQ4NjUxNkJGOCI8L0V0YWc+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQ29udGFpbmVyPjxDb250YWluZXI+PE5hbWU+dmhkczwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5GcmksIDE4IE1hciAyMDE2IDE3OjMwOjU5IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4iMHg4RDM0RjUzMTI3NjQ5RUUiPC9FdGFnPjxMZWFzZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJhdGlvbj5pbmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48L1Byb3BlcnRpZXM+PC9Db250YWluZXI+PC9Db250YWluZXJzPjxOZXh0TWFya2VyIC8+PC9FbnVtZXJhdGlvblJlc3VsdHM+
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:30 GMT
+  recorded_at: Mon, 12 Mar 2018 10:22:53 GMT
 - request:
     method: get
     uri: https://miqazuretest14047.blob.core.windows.net/copies?comp=list&restype=container
@@ -2652,13 +2698,13 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:15:30 GMT
+      - Mon, 12 Mar 2018 10:22:53 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
       - 'true'
       Authorization:
-      - SharedKey miqazuretest14047:Fu8qJyhqekm8f11q/S5owR/SJ+v8HvmVz39gSenXseU=
+      - SharedKey miqazuretest14047:blFlhxSe4IBmjDkjyTF7l6sWX4pJe2svvZxgfhcRQk8=
   response:
     status:
       code: 200
@@ -2671,17 +2717,17 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 2b8f3459-001e-0122-3a51-b60e1c000000
+      - 283d3752-001e-00aa-6cec-b9f090000000
       X-Ms-Version:
       - '2016-05-31'
       Date:
-      - Wed, 07 Mar 2018 20:15:30 GMT
+      - Mon, 12 Mar 2018 10:22:49 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9taXFhenVyZXRlc3QxNDA0Ny5ibG9iLmNvcmUud2luZG93cy5uZXQvIiBDb250YWluZXJOYW1lPSJjb3BpZXMiPjxCbG9icz48QmxvYj48TmFtZT50ZXN0LXdpbjJrMTItY29waWVkLXsxMjM0NX08L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+RnJpLCAxNyBKdW4gMjAxNiAxNDoxMzozMCBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDM5NkI5OEYyOUQ3NEM8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjE8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48L0Jsb2JzPjxOZXh0TWFya2VyIC8+PC9FbnVtZXJhdGlvblJlc3VsdHM+
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:31 GMT
+  recorded_at: Mon, 12 Mar 2018 10:22:54 GMT
 - request:
     method: get
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq?comp=list&restype=container
@@ -2698,13 +2744,13 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:15:31 GMT
+      - Mon, 12 Mar 2018 10:22:54 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
       - 'true'
       Authorization:
-      - SharedKey miqazuretest14047:UJbH1BEojws/xcT7RazgNRwL83C2h6IgxO0JXysf2kk=
+      - SharedKey miqazuretest14047:olaFCMzRtotbq0hekAa1INMa9r4LdVmRp8OHv92G1zU=
   response:
     status:
       code: 200
@@ -2717,17 +2763,17 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 10846c56-001e-0072-5151-b65741000000
+      - bb062084-001e-00c2-67ec-b9aec1000000
       X-Ms-Version:
       - '2016-05-31'
       Date:
-      - Wed, 07 Mar 2018 20:15:30 GMT
+      - Mon, 12 Mar 2018 10:22:49 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9taXFhenVyZXRlc3QxNDA0Ny5ibG9iLmNvcmUud2luZG93cy5uZXQvIiBDb250YWluZXJOYW1lPSJtYW5hZ2VpcSI+PEJsb2JzPjxCbG9iPjxOYW1lPmF6ZG11MDAwNF85YzcwNjBiYi0yN2Y5LTRmOTAtYjc4NS1lMTg5NzE2MjY5ZjgudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlR1ZSwgMjcgU2VwIDIwMTYgMTg6MzU6MjUgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzRTcwNTBCRjU2NDJEPC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj40PC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+YXpkbXUwMDA1X2IyZDkxYTdlLWY0ZTEtNDI4OS1iNGU3LTFjNWZhMmRkZTQyZS52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VGh1LCAwNiBPY3QgMjAxNiAxODozNTo0NSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDNFRTE3OTYwRjUxREI8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjE8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5hemRtdTAwMDZfYmZhMTEzNTctNmE4MC00ZGUxLWIzOTUtNjdlODcwYzE0YTkxLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UaHUsIDA2IE9jdCAyMDE2IDE4OjM1OjQ2IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0VFMTc5NjM3MDdDNzwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MTwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmF6ZG11MDAwNy42ZDQ1Y2VjZC00N2U2LTRjNGMtYjFlMi1hYmQzYzFkNmRlOTcuc3RhdHVzPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlNhdCwgMDggT2N0IDIwMTYgMTQ6MDE6NTcgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzRUY4M0FBODk5NjE3PC9FdGFnPjxDb250ZW50LUxlbmd0aD41MTc8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5PR3Vxb1pIVThNUCtwT3RlWGZuTzNBPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48QmxvYlR5cGU+QmxvY2tCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5hemRtdTAwMDdfNmZmY2VhOWMtZDM2Zi00ZGVhLThjMDMtY2NiNWM2NWY3YjAxLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5TYXQsIDA4IE9jdCAyMDE2IDE0OjAyOjEwIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0VGODNCMjU2QkREMzwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MzwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJhdGlvbj5pbmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5hemRtdTAwMDguOWNjYTAwOGQtYzY2Zi00YzI1LWJmMjEtYjgyZDQ1OWM4YWIyLnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5TYXQsIDE1IE9jdCAyMDE2IDE0OjAyOjEzIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0Y1MDNERDBEQTk0RDwvRXRhZz48Q29udGVudC1MZW5ndGg+NTE3PC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+cTI5OTBmRkU1TGMwZHlUM0QrdVpzQT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+YXpkbXUwMDA4XzM3NzAwMDlmLWMzMjUtNDNmYS1hODMwLTFlMmJkNGNhMmFmOC52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+U2F0LCAxNSBPY3QgMjAxNiAxNDowMjoyMyBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDNGNTAzRTJFRUIyMTE8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjk8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+bG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5sZWFzZWQ8L0xlYXNlU3RhdGU+PExlYXNlRHVyYXRpb24+aW5maW5pdGU8L0xlYXNlRHVyYXRpb24+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+YXpkbXUwMDA5LmRhNDMxZTJjLWIwZjktNGFhYy1iZDMyLWMxYThiNTQzYWU1MC5zdGF0dXM8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+U2F0LCAxNSBPY3QgMjAxNiAxNDowNTo0MiBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDNGNTA0NTlDQTNCODM8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjUxNzwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PjVqNklnZHByRW15Y2p4WkdJTEQ1cWc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjxCbG9iVHlwZT5CbG9ja0Jsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmF6ZG11MDAwOV8yMWRmMzc2MC03MzBlLTRkNjYtYTUwOS04ZmQ3YmQzY2FhMWMudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlNhdCwgMTUgT2N0IDIwMTYgMTQ6MDU6NTUgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzRjUwNDYxNjNCRkY4PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4xMTwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJhdGlvbj5pbmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5hemRtdTAwMTAuYTIxMmY0NTAtMmVmYi00YTQwLWIyMmUtMGMzNzExZWJlYzU2LnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5TYXQsIDE1IE9jdCAyMDE2IDE0OjA3OjE5IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0Y1MDQ5M0JGMEUyMTwvRXRhZz48Q29udGVudC1MZW5ndGg+NTE3PC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+Y3hNbEJPSmNNODBFaGpWTnEvM0VhQT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+YXpkbXUwMDEwXzM0NGQ2M2ZkLTU2ODMtNDg3ZS1iM2VmLWI4NjMzZmIxYzdmMi52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+U2F0LCAxNSBPY3QgMjAxNiAxNDowNzozNSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDNGNTA0OUQyMEEyNTQ8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjk8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+bG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5sZWFzZWQ8L0xlYXNlU3RhdGU+PExlYXNlRHVyYXRpb24+aW5maW5pdGU8L0xlYXNlRHVyYXRpb24+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+YXpkbXUwMDExLmRjNzU0YmVkLTMyZDgtNGY1MC05NTJkLTRkMDk1OGNjY2Q5OS5zdGF0dXM8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+U2F0LCAxNSBPY3QgMjAxNiAxNDoxMDoxOCBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDNGNTA0RkU2RkU2OTQ8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjUxNzwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlBCaXZKVXV0MlVMaXE3bjhPN2ZzSXc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjxCbG9iVHlwZT5CbG9ja0Jsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmF6ZG11MDAxMV81YWJjMDZiOC0zOTczLTRmNDAtYWJkOC0zNGRhMDJlMzFlZjYudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlNhdCwgMTUgT2N0IDIwMTYgMTQ6MTA6MzcgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzRjUwNTA5OEM4RjM1PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4zPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+bGVhc2VkPC9MZWFzZVN0YXRlPjxMZWFzZUR1cmF0aW9uPmluZmluaXRlPC9MZWFzZUR1cmF0aW9uPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmF6ZG11MDAxMi5hZDUyYzIxYi1hZjNiLTQ2ZTItYWRmYy1kODc5ODQ2MTM0YWYuc3RhdHVzPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlNhdCwgMTUgT2N0IDIwMTYgMTQ6MTM6MTcgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzRjUwNTY5NEM2RDlGPC9FdGFnPjxDb250ZW50LUxlbmd0aD41MTc8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5LdDdVQmdSbUh4Y0VxdkpUUk1WZmdnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48QmxvYlR5cGU+QmxvY2tCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5hemRtdTAwMTJfYmZjMTIxMTktYWI1My00ZjgyLWJlOWItZDQ3MTcwYWI4YWIyLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5TYXQsIDE1IE9jdCAyMDE2IDE0OjEzOjM0IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0Y1MDU3MkUwREUyNTwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+NjwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJhdGlvbj5pbmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5iaWxseTFfMjA0MDFiMjctOWRhNC00Mjc2LWEzOTAtZDU5NDk1YWVhOTU0LnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UaHUsIDE1IFNlcCAyMDE2IDIyOjEwOjUxIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0REQjUyNzk4OEU0RDwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MTwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmJpbGx5Ml8yZGZiODYxMy1jMWMxLTQ1NjItOTMwNy1kYjhjOWIxYjI0MjYudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPkZyaSwgMTYgU2VwIDIwMTYgMTI6NDM6NTUgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzREUyRjFGMDMyNTg0PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4xPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+YnJvbmFnaDAzMTZpXzRjZmMyYjY2LWFiYmYtNDVkYS04YTlmLTMwNzQ2YmQ1NWQ2ZC52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+V2VkLCAyNiBKdWwgMjAxNyAyMDo1ODo1MCBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDRENDY5MURERDk5RUU8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjkxPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+YnJvbmFnaDMxNmdfMjEzN2NlYzEtYTM2ZC00YmJkLWE4ZDMtNTlkNjg2MmMyYmI5LnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5Nb24sIDMwIE9jdCAyMDE3IDE5OjUyOjEyIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhENTFGQ0ZCNkFCRjg3MDwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MjMwNDwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmJyb25hZ2gzMTZoX2JmY2Q1YTA5LTEwZjUtNDY2NC04MTMzLWYzZjUzNTU0Yjg2OC52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+V2VkLCAyNCBKYW4gMjAxOCAxOTo1MDowNSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDU2MzYzQUEzNDNFRDM8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjMyNzwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJhdGlvbj5pbmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5icm9uYWdoNDI3Xzk1NDU4NDk0LTQ0NDYtNDUwZC05YTRhLTc5MmQxNGQwOTcxNy52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+TW9uLCAzMCBPY3QgMjAxNyAxOTo1NTozNSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDUxRkQwMkY4ODdBNTk8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjY1PC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+YnJvbmFnaGZpcDcxNGFfNGE2M2RmOTktOWY3My00YjhkLTkyM2YtZGMwNjYxN2Q2NjBkLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5XZWQsIDAzIEF1ZyAyMDE2IDE1OjM0OjAxIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0JCQjM5ODA0MUFCNDwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MTE5PC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+YnJvbmFnaG5vcG9ydF85OTQzYTQ5OS1iMmVjLTQxZTMtOWE4NS1jMTQ0OTRmMThjZWMudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPk1vbiwgMjUgSnVsIDIwMTYgMTY6Mzg6NTEgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzQjRBQTI5MEIwRDE1PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4xMDc8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5icm9uYWdocmV1c2VpcF9jMzNhNjU0OS1jYzRkLTRlM2YtOTQ1ZC0yOGI2Y2EwODgwZjAudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPldlZCwgMDMgQXVnIDIwMTYgMTU6MzM6NDggR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzQkJCMzkwMUJERTJFPC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4xMDI8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5icm9uYWdocnNwZWMzXzAzNGM5MzhiLWVhYTktNDM5OS04ZWQyLWNiNzIxNmZhYmYwYi52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VGh1LCAyOCBBcHIgMjAxNiAxNDoxMjo0OSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDM2RjZGMkUyOTk2MkY8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjEzPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+YnJvbmFnaHRlc3QyM19lMjM2MDlmYi05YzdjLTQxM2MtOWJlNi05YTBlMWM5Y2RiZDcudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPkZyaSwgMTMgTWF5IDIwMTYgMjE6MTE6NDggR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzN0I3MzMyNzI4RTNDPC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4yPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+YnJvbmFnaHdpdGhzXzczYjlhOTVhLWRkZTEtNDNiNS04MTM5LTJiYjA0NjVkMzkxYS52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VGh1LCAyOCBBcHIgMjAxNiAxNDo1NjozNSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDM2Rjc1NEI0Qjg0RTY8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjM8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5ic21ldHJpY3NfMjA3NTNhZjgtNWFiOC00NWFmLTg1NDUtNGVjMDk2OTg1YWE0LnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UaHUsIDE3IE5vdiAyMDE2IDE5OjIxOjUwIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhENDBGMUVGQjM2MTU3MTwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MTM8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5id2VpdGVzdF8wMDAyX2ExNTZiZTljLTJmYmUtNDFlYi05NTY0LWZiY2IyNTUzZWUzMy52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VHVlLCAyOSBOb3YgMjAxNiAxNDo1NzoxNiBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDQxODY4MDJDNTY2NzE8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjk5NjwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmRiZXJnZXItZGVsZXRlX2EyYTVkNDNmLWFhMDUtNGQ2MS04ZGE4LTk1MDg2YTRkMzU3ZS52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+V2VkLCAxMiBBcHIgMjAxNyAxNzo1Mzo0NSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDQ4MUNDRERCNUUzRjk8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjc8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5kYmVyZ2VyLWRlbGV0ZW1lMV9lZWZjMTcyNy0wMTliLTQyODUtYTVmOC0wODY5ZWZlOGEwMzcudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPkZyaSwgMjYgQXVnIDIwMTYgMjI6NDg6MDIgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzQ0UwMzA5NDY5RUM0PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4xPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+ZGJlcmdlcnByb3YxLmY3YmEyZGUxLTJiMzMtNDU4NS05YTdiLTJiYWQyZGFkZjY2NC5zdGF0dXM8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+U2F0LCAwMyBTZXAgMjAxNiAxNDowODoxNyBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDNENDAzQzBFODU2OUI8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjQ2MTY8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5mRnhTek9RUjVEUFNzSnphRmMvV1l3PT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48QmxvYlR5cGU+QmxvY2tCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5kYmVyZ2VycHJvdjFfN2I3MjdiYWQtY2I4My00YWEyLWE3NjgtMDc0Yzg3N2Q2YjNiLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5TYXQsIDAzIFNlcCAyMDE2IDE0OjA4OjMxIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0Q0MDNDOTMwNzYyMzwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+OTg8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+bG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5sZWFzZWQ8L0xlYXNlU3RhdGU+PExlYXNlRHVyYXRpb24+aW5maW5pdGU8L0xlYXNlRHVyYXRpb24+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+ZGJlcmdlcnByb3YxXzlhNzhhYTRjLWQ1ZjYtNGQ1OC1iMDgzLTkwNjkxZWRhN2I2NC52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VGh1LCAwMSBTZXAgMjAxNiAxOTo0ODo0NSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDNEMkEwRkJDQUNERDM8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjIzODwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmRiZXJnZXJwcm92Ml9hN2JlNmQzNi1kMGNhLTRmYWQtOGNkMC1mYzJmMDQ4ZTA0NDYudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlRodSwgMDEgU2VwIDIwMTYgMTk6NDg6NTQgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzRDJBMTAxQTU0QTU4PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4xNjU8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5kYmVyZ2VyeF82MDg3M2E2ZS03MDllLTQwOWYtODA0OC05ZGNhYmMwOWQ0NjcudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPk1vbiwgMDMgQXByIDIwMTcgMTg6NTY6MDAgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQ0N0FDMzExQjgzMDZCPC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj41PC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+ZHJldzFfNWMzNWY2OTUtYjJhZS00ZDg2LTkzN2YtZmNjNmZjYmI5ZmIwLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UaHUsIDE1IFNlcCAyMDE2IDIyOjI4OjQ4IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0REQjdBOTZCODAwMDwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MTwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmRyZXdhenVyZTAwMDEuYTAxNWQ4YzYtNDlhYy00ZDhmLTg0MzMtZjUzZTViODkxNWQyLnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5TYXQsIDE1IE9jdCAyMDE2IDE0OjE2OjI2IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0Y1MDVEOTZDRkFFRjwvRXRhZz48Q29udGVudC1MZW5ndGg+NTE3PC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+ODZTUmhRdVlOcFo4SnpINEIyLzVpZz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+ZHJld2F6dXJlMDAwMV80YmM3ZDEyMi1jYzMxLTQxNTAtYWJjZS1jMTdlMGJiOWE5Y2YudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlNhdCwgMTUgT2N0IDIwMTYgMTQ6MTY6MzggR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzRjUwNUUwQTY5NEI4PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj43PC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+bGVhc2VkPC9MZWFzZVN0YXRlPjxMZWFzZUR1cmF0aW9uPmluZmluaXRlPC9MZWFzZUR1cmF0aW9uPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmRyZXdhenVyZTAwMDIuMzA4ZGFhYWUtZGFjMS00ODRlLThhYzgtOThkYjA0NGFjYzMyLnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5TYXQsIDE1IE9jdCAyMDE2IDE0OjE5OjI3IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0Y1MDY0NUI2RDg5MDwvRXRhZz48Q29udGVudC1MZW5ndGg+NTE3PC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+NWdKbVFmakZ3VTNBcEhUdEFFbVp4Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+ZHJld2F6dXJlMDAwMl9lZTlmNjhlMC00ZGIyLTQ3NjctOTFjNi0wMjI1NTRkNjVhOGIudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlNhdCwgMTUgT2N0IDIwMTYgMTQ6MTk6NDIgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzRjUwNjRFNDExMjI2PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj42PC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+bGVhc2VkPC9MZWFzZVN0YXRlPjxMZWFzZUR1cmF0aW9uPmluZmluaXRlPC9MZWFzZUR1cmF0aW9uPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmpiX3dpbl9kZW1vX3ZtX2FkODljMDgwLThiMWQtNDdhMi04YTczLWVlNmQ3YTUzYzZjYy52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VHVlLCAwOSBNYXkgMjAxNyAxOTozNjo1NiBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDQ5NzEyQzBGNzExMzU8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjU8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5qdWxpYW5fdGVzdF8wMDFfNzJjNDBhYTgtMGIxNi00MWE5LTlhZTgtYTFhYTc3YjBlOTk2LnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5XZWQsIDA3IE1hciAyMDE4IDIwOjE1OjMwIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhENTg0NjgyQ0U2RTk1RTwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MjwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJhdGlvbj5pbmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5sdWN5XzJfZWVmMDc4YTgtOWJmZS00NjllLTkzNDAtZTAzNDJhNGZlM2JjLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UdWUsIDI5IE5vdiAyMDE2IDE2OjA3OjA3IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhENDE4NzFDNEU1QUM0QjwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MjwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmx1Y3lfM19kMTI0YjQyYy03Y2YxLTQxODQtOTY4My03OTljNTg0YTU5MTkudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlRodSwgMDMgQXVnIDIwMTcgMjA6Mzc6MDcgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQ0REFBRjY4NUFCMjk3PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj40PC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+bHVjeV80XzI2MTg1N2IxLWZiMzUtNGNlMC1iN2I3LWZkMTQ4YzdlNmViZC52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VHVlLCAyOSBOb3YgMjAxNiAxODo0Njo1NSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDQxODg4MTc2OThBNDg8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjE8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5zZWN0ZXN0Ml84NGFkN2IyYi05MTAwLTQwZGItODk5Ny1hMzE5MTJjZjI3YzEudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPldlZCwgMjAgQXByIDIwMTYgMTg6MTg6MjYgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzNjk0ODJBOTI3Rjk1PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4xPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+dGVzdC1iaWxseS1henVyZTMzX2E2NzZjYTM0LWM0M2YtNGY1OC1hOTZjLTMwY2YwNjQ1ZjZlYS52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+TW9uLCAxMiBTZXAgMjAxNiAxNzoyNTozOSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDNEQjMxRDBEREY5RUY8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjM8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT50ZXN0LWJpbGx5LWF6dXJlMzRfM2MxY2MyYjYtMTc0YS00M2JiLTlkMzAtYjM0OTU0NDRkOWY2LnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5Nb24sIDEyIFNlcCAyMDE2IDE3OjIwOjM5IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0RCMzExRTJCOERGRDwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MTwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPnRlc3QtYmlsbHktYXp1cmUzNV9jYWVhZjRhZi1iNDg2LTRlZGMtOTg0Ny1iNjU4YTBlMTk3YzIudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlR1ZSwgMTMgU2VwIDIwMTYgMTU6NDQ6NTcgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzREJFQ0U5RTkxRkNEPC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4xPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+dGVzdC1iaWxseS1henVyZTM2X2Y4OGY1OWE3LWNjNmYtNDQ2NC04OGJhLTYxYWRjYTc5MmVjYy52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VHVlLCAxMyBTZXAgMjAxNiAxNjoxNjoyNyBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDNEQkYxNTA5QTkyOUM8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjE8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT50ZXN0LWJpbGx5LWF6dXJlMzhfZTkzNGUzZjAtZjNkOC00YjViLTgwMTUtNTVlNWJkMzkyY2JjLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UdWUsIDEzIFNlcCAyMDE2IDIxOjIyOjU5IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0RDMUMyMkZEMjlCNTwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MTwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPnRlc3QtYmlsbHktYXp1cmU0MF83OGMwYWUxYy0yYjEyLTRhYTgtYmIzYy1iZjYyNzBjMTFkMWMudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlRodSwgMTUgU2VwIDIwMTYgMjE6MDU6MTcgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzRERBQkZGMjVBRDlGPC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4xPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+dGVzdC1iaWxseS1henVyZTUxX2Q4ZDE1ODgwLTE5MWYtNDIyMS05OWNjLWNiMTAyYmE0ZGNmOC52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+RnJpLCAyMyBTZXAgMjAxNiAxNDoxODo0NiBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDNFM0JDODdGNkU3NDA8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjE8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT50ZXN0LWJpbGx5YTM3X2YyZjBlOTYyLWQzYzctNDAyOS05YjJkLTE0OTgyZTY2NzAxNi52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VGh1LCAxNSBTZXAgMjAxNiAxNDo1OTowNCBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDNERDc4RDYxN0ZFQzM8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjE8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT50ZXN0YmlsbHlhYWFfOTUzZTkxM2QtNjYyNS00NzFmLWI2ZjAtNGU5MzUzNzIzYzM5LnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UaHUsIDE1IFNlcCAyMDE2IDE0OjU5OjM5IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0RENzhFQUFBMTdDRjwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MTwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPnRlc3RiaWxseXp6enpfNDNjZmEzMGUtMmQ3Mi00OWFmLWE3MmQtMWU3NjRkZmJmNzU2LnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UaHUsIDE1IFNlcCAyMDE2IDE1OjA0OjMxIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0RENzk5OEY2MUNCMjwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MjwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjwvQmxvYnM+PE5leHRNYXJrZXIgLz48L0VudW1lcmF0aW9uUmVzdWx0cz4=
+        77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9taXFhenVyZXRlc3QxNDA0Ny5ibG9iLmNvcmUud2luZG93cy5uZXQvIiBDb250YWluZXJOYW1lPSJtYW5hZ2VpcSI+PEJsb2JzPjxCbG9iPjxOYW1lPmF6ZG11MDAwNF85YzcwNjBiYi0yN2Y5LTRmOTAtYjc4NS1lMTg5NzE2MjY5ZjgudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlR1ZSwgMjcgU2VwIDIwMTYgMTg6MzU6MjUgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzRTcwNTBCRjU2NDJEPC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj40PC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+YXpkbXUwMDA1X2IyZDkxYTdlLWY0ZTEtNDI4OS1iNGU3LTFjNWZhMmRkZTQyZS52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VGh1LCAwNiBPY3QgMjAxNiAxODozNTo0NSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDNFRTE3OTYwRjUxREI8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjE8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5hemRtdTAwMDZfYmZhMTEzNTctNmE4MC00ZGUxLWIzOTUtNjdlODcwYzE0YTkxLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UaHUsIDA2IE9jdCAyMDE2IDE4OjM1OjQ2IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0VFMTc5NjM3MDdDNzwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MTwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmF6ZG11MDAwNy42ZDQ1Y2VjZC00N2U2LTRjNGMtYjFlMi1hYmQzYzFkNmRlOTcuc3RhdHVzPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlNhdCwgMDggT2N0IDIwMTYgMTQ6MDE6NTcgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzRUY4M0FBODk5NjE3PC9FdGFnPjxDb250ZW50LUxlbmd0aD41MTc8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5PR3Vxb1pIVThNUCtwT3RlWGZuTzNBPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48QmxvYlR5cGU+QmxvY2tCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5hemRtdTAwMDdfNmZmY2VhOWMtZDM2Zi00ZGVhLThjMDMtY2NiNWM2NWY3YjAxLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5TYXQsIDA4IE9jdCAyMDE2IDE0OjAyOjEwIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0VGODNCMjU2QkREMzwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MzwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJhdGlvbj5pbmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5hemRtdTAwMDguOWNjYTAwOGQtYzY2Zi00YzI1LWJmMjEtYjgyZDQ1OWM4YWIyLnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5TYXQsIDE1IE9jdCAyMDE2IDE0OjAyOjEzIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0Y1MDNERDBEQTk0RDwvRXRhZz48Q29udGVudC1MZW5ndGg+NTE3PC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+cTI5OTBmRkU1TGMwZHlUM0QrdVpzQT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+YXpkbXUwMDA4XzM3NzAwMDlmLWMzMjUtNDNmYS1hODMwLTFlMmJkNGNhMmFmOC52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+U2F0LCAxNSBPY3QgMjAxNiAxNDowMjoyMyBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDNGNTAzRTJFRUIyMTE8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjk8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+bG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5sZWFzZWQ8L0xlYXNlU3RhdGU+PExlYXNlRHVyYXRpb24+aW5maW5pdGU8L0xlYXNlRHVyYXRpb24+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+YXpkbXUwMDA5LmRhNDMxZTJjLWIwZjktNGFhYy1iZDMyLWMxYThiNTQzYWU1MC5zdGF0dXM8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+U2F0LCAxNSBPY3QgMjAxNiAxNDowNTo0MiBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDNGNTA0NTlDQTNCODM8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjUxNzwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PjVqNklnZHByRW15Y2p4WkdJTEQ1cWc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjxCbG9iVHlwZT5CbG9ja0Jsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmF6ZG11MDAwOV8yMWRmMzc2MC03MzBlLTRkNjYtYTUwOS04ZmQ3YmQzY2FhMWMudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlNhdCwgMTUgT2N0IDIwMTYgMTQ6MDU6NTUgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzRjUwNDYxNjNCRkY4PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4xMTwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJhdGlvbj5pbmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5hemRtdTAwMTAuYTIxMmY0NTAtMmVmYi00YTQwLWIyMmUtMGMzNzExZWJlYzU2LnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5TYXQsIDE1IE9jdCAyMDE2IDE0OjA3OjE5IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0Y1MDQ5M0JGMEUyMTwvRXRhZz48Q29udGVudC1MZW5ndGg+NTE3PC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+Y3hNbEJPSmNNODBFaGpWTnEvM0VhQT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+YXpkbXUwMDEwXzM0NGQ2M2ZkLTU2ODMtNDg3ZS1iM2VmLWI4NjMzZmIxYzdmMi52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+U2F0LCAxNSBPY3QgMjAxNiAxNDowNzozNSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDNGNTA0OUQyMEEyNTQ8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjk8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+bG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5sZWFzZWQ8L0xlYXNlU3RhdGU+PExlYXNlRHVyYXRpb24+aW5maW5pdGU8L0xlYXNlRHVyYXRpb24+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+YXpkbXUwMDExLmRjNzU0YmVkLTMyZDgtNGY1MC05NTJkLTRkMDk1OGNjY2Q5OS5zdGF0dXM8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+U2F0LCAxNSBPY3QgMjAxNiAxNDoxMDoxOCBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDNGNTA0RkU2RkU2OTQ8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjUxNzwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlBCaXZKVXV0MlVMaXE3bjhPN2ZzSXc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjxCbG9iVHlwZT5CbG9ja0Jsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmF6ZG11MDAxMV81YWJjMDZiOC0zOTczLTRmNDAtYWJkOC0zNGRhMDJlMzFlZjYudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlNhdCwgMTUgT2N0IDIwMTYgMTQ6MTA6MzcgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzRjUwNTA5OEM4RjM1PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4zPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+bGVhc2VkPC9MZWFzZVN0YXRlPjxMZWFzZUR1cmF0aW9uPmluZmluaXRlPC9MZWFzZUR1cmF0aW9uPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmF6ZG11MDAxMi5hZDUyYzIxYi1hZjNiLTQ2ZTItYWRmYy1kODc5ODQ2MTM0YWYuc3RhdHVzPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlNhdCwgMTUgT2N0IDIwMTYgMTQ6MTM6MTcgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzRjUwNTY5NEM2RDlGPC9FdGFnPjxDb250ZW50LUxlbmd0aD41MTc8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5LdDdVQmdSbUh4Y0VxdkpUUk1WZmdnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48QmxvYlR5cGU+QmxvY2tCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5hemRtdTAwMTJfYmZjMTIxMTktYWI1My00ZjgyLWJlOWItZDQ3MTcwYWI4YWIyLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5TYXQsIDE1IE9jdCAyMDE2IDE0OjEzOjM0IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0Y1MDU3MkUwREUyNTwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+NjwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJhdGlvbj5pbmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5iaWxseTFfMjA0MDFiMjctOWRhNC00Mjc2LWEzOTAtZDU5NDk1YWVhOTU0LnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UaHUsIDE1IFNlcCAyMDE2IDIyOjEwOjUxIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0REQjUyNzk4OEU0RDwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MTwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmJpbGx5Ml8yZGZiODYxMy1jMWMxLTQ1NjItOTMwNy1kYjhjOWIxYjI0MjYudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPkZyaSwgMTYgU2VwIDIwMTYgMTI6NDM6NTUgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzREUyRjFGMDMyNTg0PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4xPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+YnJvbmFnaDAzMTZpXzRjZmMyYjY2LWFiYmYtNDVkYS04YTlmLTMwNzQ2YmQ1NWQ2ZC52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+V2VkLCAyNiBKdWwgMjAxNyAyMDo1ODo1MCBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDRENDY5MURERDk5RUU8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjkxPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+YnJvbmFnaDMxNmdfMjEzN2NlYzEtYTM2ZC00YmJkLWE4ZDMtNTlkNjg2MmMyYmI5LnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5Nb24sIDMwIE9jdCAyMDE3IDE5OjUyOjEyIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhENTFGQ0ZCNkFCRjg3MDwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MjMwNDwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmJyb25hZ2gzMTZoX2JmY2Q1YTA5LTEwZjUtNDY2NC04MTMzLWYzZjUzNTU0Yjg2OC52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+V2VkLCAyNCBKYW4gMjAxOCAxOTo1MDowNSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDU2MzYzQUEzNDNFRDM8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjMyNzwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJhdGlvbj5pbmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5icm9uYWdoNDI3Xzk1NDU4NDk0LTQ0NDYtNDUwZC05YTRhLTc5MmQxNGQwOTcxNy52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+TW9uLCAzMCBPY3QgMjAxNyAxOTo1NTozNSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDUxRkQwMkY4ODdBNTk8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjY1PC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+YnJvbmFnaGZpcDcxNGFfNGE2M2RmOTktOWY3My00YjhkLTkyM2YtZGMwNjYxN2Q2NjBkLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5XZWQsIDAzIEF1ZyAyMDE2IDE1OjM0OjAxIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0JCQjM5ODA0MUFCNDwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MTE5PC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+YnJvbmFnaG5vcG9ydF85OTQzYTQ5OS1iMmVjLTQxZTMtOWE4NS1jMTQ0OTRmMThjZWMudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPk1vbiwgMjUgSnVsIDIwMTYgMTY6Mzg6NTEgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzQjRBQTI5MEIwRDE1PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4xMDc8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5icm9uYWdocmV1c2VpcF9jMzNhNjU0OS1jYzRkLTRlM2YtOTQ1ZC0yOGI2Y2EwODgwZjAudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPldlZCwgMDMgQXVnIDIwMTYgMTU6MzM6NDggR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzQkJCMzkwMUJERTJFPC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4xMDI8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5icm9uYWdocnNwZWMzXzAzNGM5MzhiLWVhYTktNDM5OS04ZWQyLWNiNzIxNmZhYmYwYi52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VGh1LCAyOCBBcHIgMjAxNiAxNDoxMjo0OSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDM2RjZGMkUyOTk2MkY8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjEzPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+YnJvbmFnaHRlc3QyM19lMjM2MDlmYi05YzdjLTQxM2MtOWJlNi05YTBlMWM5Y2RiZDcudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPkZyaSwgMTMgTWF5IDIwMTYgMjE6MTE6NDggR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzN0I3MzMyNzI4RTNDPC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4yPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+YnJvbmFnaHdpdGhzXzczYjlhOTVhLWRkZTEtNDNiNS04MTM5LTJiYjA0NjVkMzkxYS52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VGh1LCAyOCBBcHIgMjAxNiAxNDo1NjozNSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDM2Rjc1NEI0Qjg0RTY8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjM8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5ic21ldHJpY3NfMjA3NTNhZjgtNWFiOC00NWFmLTg1NDUtNGVjMDk2OTg1YWE0LnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UaHUsIDE3IE5vdiAyMDE2IDE5OjIxOjUwIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhENDBGMUVGQjM2MTU3MTwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MTM8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5id2VpdGVzdF8wMDAyX2ExNTZiZTljLTJmYmUtNDFlYi05NTY0LWZiY2IyNTUzZWUzMy52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VHVlLCAyOSBOb3YgMjAxNiAxNDo1NzoxNiBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDQxODY4MDJDNTY2NzE8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjk5NjwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmRiZXJnZXItZGVsZXRlX2EyYTVkNDNmLWFhMDUtNGQ2MS04ZGE4LTk1MDg2YTRkMzU3ZS52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+V2VkLCAxMiBBcHIgMjAxNyAxNzo1Mzo0NSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDQ4MUNDRERCNUUzRjk8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjc8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5kYmVyZ2VyLWRlbGV0ZW1lMV9lZWZjMTcyNy0wMTliLTQyODUtYTVmOC0wODY5ZWZlOGEwMzcudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPkZyaSwgMjYgQXVnIDIwMTYgMjI6NDg6MDIgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzQ0UwMzA5NDY5RUM0PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4xPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+ZGJlcmdlcnByb3YxLmY3YmEyZGUxLTJiMzMtNDU4NS05YTdiLTJiYWQyZGFkZjY2NC5zdGF0dXM8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+U2F0LCAwMyBTZXAgMjAxNiAxNDowODoxNyBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDNENDAzQzBFODU2OUI8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjQ2MTY8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5mRnhTek9RUjVEUFNzSnphRmMvV1l3PT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48QmxvYlR5cGU+QmxvY2tCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5kYmVyZ2VycHJvdjFfN2I3MjdiYWQtY2I4My00YWEyLWE3NjgtMDc0Yzg3N2Q2YjNiLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5TYXQsIDAzIFNlcCAyMDE2IDE0OjA4OjMxIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0Q0MDNDOTMwNzYyMzwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+OTg8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+bG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5sZWFzZWQ8L0xlYXNlU3RhdGU+PExlYXNlRHVyYXRpb24+aW5maW5pdGU8L0xlYXNlRHVyYXRpb24+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+ZGJlcmdlcnByb3YxXzlhNzhhYTRjLWQ1ZjYtNGQ1OC1iMDgzLTkwNjkxZWRhN2I2NC52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VGh1LCAwMSBTZXAgMjAxNiAxOTo0ODo0NSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDNEMkEwRkJDQUNERDM8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjIzODwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmRiZXJnZXJwcm92Ml9hN2JlNmQzNi1kMGNhLTRmYWQtOGNkMC1mYzJmMDQ4ZTA0NDYudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlRodSwgMDEgU2VwIDIwMTYgMTk6NDg6NTQgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzRDJBMTAxQTU0QTU4PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4xNjU8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5kYmVyZ2VyeF82MDg3M2E2ZS03MDllLTQwOWYtODA0OC05ZGNhYmMwOWQ0NjcudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPk1vbiwgMDMgQXByIDIwMTcgMTg6NTY6MDAgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQ0N0FDMzExQjgzMDZCPC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj41PC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+ZHJlMDAwMV9kZDM4MDMyMC03YWQxLTQ4NTktYWY3YS04YTg1OTA5NGQzZDcudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPk1vbiwgMTIgTWFyIDIwMTggMTA6MjI6NDcgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQ1ODgwMzMzNUM1OTE3PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4zPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+bGVhc2VkPC9MZWFzZVN0YXRlPjxMZWFzZUR1cmF0aW9uPmluZmluaXRlPC9MZWFzZUR1cmF0aW9uPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmRyZTAwMDJfZDU5MzUzMzgtOTljOC00YjQyLThjNmItMDkzMjMzZDM4ZGNmLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5Nb24sIDEyIE1hciAyMDE4IDEwOjIyOjQ3IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhENTg4MDMzMzVFN0M3RTwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MjwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJhdGlvbj5pbmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5kcmUwMDAzXzYyYzhhZjA1LTY1ZjgtNDI0Yy04OTU0LWRjY2MwYWM4ZTI3Yi52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+TW9uLCAxMiBNYXIgMjAxOCAxMDoyMjo0MiBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDU4ODAzMzA5NUQzRDk8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjM8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+bG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5sZWFzZWQ8L0xlYXNlU3RhdGU+PExlYXNlRHVyYXRpb24+aW5maW5pdGU8L0xlYXNlRHVyYXRpb24+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+ZHJldzFfNWMzNWY2OTUtYjJhZS00ZDg2LTkzN2YtZmNjNmZjYmI5ZmIwLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UaHUsIDE1IFNlcCAyMDE2IDIyOjI4OjQ4IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0REQjdBOTZCODAwMDwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MTwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmRyZXdBenVyZVRlc3QxMDAwNF8zMWQyYzk1OC0wNjQ2LTQ5NGQtOWZjYi00ZDNkMGQyNTgwMWIudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPk1vbiwgMTIgTWFyIDIwMTggMTA6MjI6NDQgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQ1ODgwMzMxREE2MzYxPC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4zPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+bGVhc2VkPC9MZWFzZVN0YXRlPjxMZWFzZUR1cmF0aW9uPmluZmluaXRlPC9MZWFzZUR1cmF0aW9uPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmRyZXdhenVyZTAwMDEuYTAxNWQ4YzYtNDlhYy00ZDhmLTg0MzMtZjUzZTViODkxNWQyLnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5TYXQsIDE1IE9jdCAyMDE2IDE0OjE2OjI2IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0Y1MDVEOTZDRkFFRjwvRXRhZz48Q29udGVudC1MZW5ndGg+NTE3PC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+ODZTUmhRdVlOcFo4SnpINEIyLzVpZz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+ZHJld2F6dXJlMDAwMV80YmM3ZDEyMi1jYzMxLTQxNTAtYWJjZS1jMTdlMGJiOWE5Y2YudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlNhdCwgMTUgT2N0IDIwMTYgMTQ6MTY6MzggR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzRjUwNUUwQTY5NEI4PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj43PC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+bGVhc2VkPC9MZWFzZVN0YXRlPjxMZWFzZUR1cmF0aW9uPmluZmluaXRlPC9MZWFzZUR1cmF0aW9uPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmRyZXdhenVyZTAwMDIuMzA4ZGFhYWUtZGFjMS00ODRlLThhYzgtOThkYjA0NGFjYzMyLnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5TYXQsIDE1IE9jdCAyMDE2IDE0OjE5OjI3IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0Y1MDY0NUI2RDg5MDwvRXRhZz48Q29udGVudC1MZW5ndGg+NTE3PC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+NWdKbVFmakZ3VTNBcEhUdEFFbVp4Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+ZHJld2F6dXJlMDAwMl9lZTlmNjhlMC00ZGIyLTQ3NjctOTFjNi0wMjI1NTRkNjVhOGIudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlNhdCwgMTUgT2N0IDIwMTYgMTQ6MTk6NDIgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzRjUwNjRFNDExMjI2PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj42PC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+bGVhc2VkPC9MZWFzZVN0YXRlPjxMZWFzZUR1cmF0aW9uPmluZmluaXRlPC9MZWFzZUR1cmF0aW9uPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmpiX3dpbl9kZW1vX3ZtX2FkODljMDgwLThiMWQtNDdhMi04YTczLWVlNmQ3YTUzYzZjYy52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VHVlLCAwOSBNYXkgMjAxNyAxOTozNjo1NiBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDQ5NzEyQzBGNzExMzU8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjU8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5qdWxpYW5fdGVzdF8wMDFfNzJjNDBhYTgtMGIxNi00MWE5LTlhZTgtYTFhYTc3YjBlOTk2LnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5Nb24sIDEyIE1hciAyMDE4IDEwOjIyOjQ3IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhENTg4MDMzM0U2QjlCMzwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MjwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJhdGlvbj5pbmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5sdWN5XzJfZWVmMDc4YTgtOWJmZS00NjllLTkzNDAtZTAzNDJhNGZlM2JjLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UdWUsIDI5IE5vdiAyMDE2IDE2OjA3OjA3IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhENDE4NzFDNEU1QUM0QjwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MjwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPmx1Y3lfM19kMTI0YjQyYy03Y2YxLTQxODQtOTY4My03OTljNTg0YTU5MTkudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlRodSwgMDMgQXVnIDIwMTcgMjA6Mzc6MDcgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQ0REFBRjY4NUFCMjk3PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj40PC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+bHVjeV80XzI2MTg1N2IxLWZiMzUtNGNlMC1iN2I3LWZkMTQ4YzdlNmViZC52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VHVlLCAyOSBOb3YgMjAxNiAxODo0Njo1NSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDQxODg4MTc2OThBNDg8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjE8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5zZWN0ZXN0Ml84NGFkN2IyYi05MTAwLTQwZGItODk5Ny1hMzE5MTJjZjI3YzEudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPldlZCwgMjAgQXByIDIwMTYgMTg6MTg6MjYgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzNjk0ODJBOTI3Rjk1PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4xPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+dGVzdC1iaWxseS1henVyZTMzX2E2NzZjYTM0LWM0M2YtNGY1OC1hOTZjLTMwY2YwNjQ1ZjZlYS52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+TW9uLCAxMiBTZXAgMjAxNiAxNzoyNTozOSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDNEQjMxRDBEREY5RUY8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjM8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT50ZXN0LWJpbGx5LWF6dXJlMzRfM2MxY2MyYjYtMTc0YS00M2JiLTlkMzAtYjM0OTU0NDRkOWY2LnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5Nb24sIDEyIFNlcCAyMDE2IDE3OjIwOjM5IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0RCMzExRTJCOERGRDwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MTwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPnRlc3QtYmlsbHktYXp1cmUzNV9jYWVhZjRhZi1iNDg2LTRlZGMtOTg0Ny1iNjU4YTBlMTk3YzIudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlR1ZSwgMTMgU2VwIDIwMTYgMTU6NDQ6NTcgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzREJFQ0U5RTkxRkNEPC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4xPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+dGVzdC1iaWxseS1henVyZTM2X2Y4OGY1OWE3LWNjNmYtNDQ2NC04OGJhLTYxYWRjYTc5MmVjYy52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VHVlLCAxMyBTZXAgMjAxNiAxNjoxNjoyNyBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDNEQkYxNTA5QTkyOUM8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjE8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT50ZXN0LWJpbGx5LWF6dXJlMzhfZTkzNGUzZjAtZjNkOC00YjViLTgwMTUtNTVlNWJkMzkyY2JjLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UdWUsIDEzIFNlcCAyMDE2IDIxOjIyOjU5IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0RDMUMyMkZEMjlCNTwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MTwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPnRlc3QtYmlsbHktYXp1cmU0MF83OGMwYWUxYy0yYjEyLTRhYTgtYmIzYy1iZjYyNzBjMTFkMWMudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlRodSwgMTUgU2VwIDIwMTYgMjE6MDU6MTcgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzRERBQkZGMjVBRDlGPC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4xPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+dGVzdC1iaWxseS1henVyZTUxX2Q4ZDE1ODgwLTE5MWYtNDIyMS05OWNjLWNiMTAyYmE0ZGNmOC52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+RnJpLCAyMyBTZXAgMjAxNiAxNDoxODo0NiBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDNFM0JDODdGNkU3NDA8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjE8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT50ZXN0LWJpbGx5YTM3X2YyZjBlOTYyLWQzYzctNDAyOS05YjJkLTE0OTgyZTY2NzAxNi52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VGh1LCAxNSBTZXAgMjAxNiAxNDo1OTowNCBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDNERDc4RDYxN0ZFQzM8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjE8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT50ZXN0YmlsbHlhYWFfOTUzZTkxM2QtNjYyNS00NzFmLWI2ZjAtNGU5MzUzNzIzYzM5LnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UaHUsIDE1IFNlcCAyMDE2IDE0OjU5OjM5IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0RENzhFQUFBMTdDRjwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MTwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPnRlc3RiaWxseXp6enpfNDNjZmEzMGUtMmQ3Mi00OWFmLWE3MmQtMWU3NjRkZmJmNzU2LnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UaHUsIDE1IFNlcCAyMDE2IDE1OjA0OjMxIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0RENzk5OEY2MUNCMjwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MjwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjwvQmxvYnM+PE5leHRNYXJrZXIgLz48L0VudW1lcmF0aW9uUmVzdWx0cz4=
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:31 GMT
+  recorded_at: Mon, 12 Mar 2018 10:22:55 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/azdmu0004_9c7060bb-27f9-4f90-b785-e189716269f8.vhd
@@ -2744,7 +2790,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:15:31 GMT
+      - Mon, 12 Mar 2018 10:22:55 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -2752,7 +2798,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:uFI4b+G8a1EzoXUPqfItfAQGWVRZs/L+kJ1nBlja4gk=
+      - SharedKey miqazuretest14047:pZU5Lp/ax7GC4c8ATyhbUfcm1NPCbB5xjzCqacUiUak=
   response:
     status:
       code: 200
@@ -2773,7 +2819,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - ef073895-001e-0076-0351-b6a2c3000000
+      - 69e1983e-001e-00ee-3fec-b92cfc000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -2797,12 +2843,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:15:31 GMT
+      - Mon, 12 Mar 2018 10:22:51 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:32 GMT
+  recorded_at: Mon, 12 Mar 2018 10:22:56 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/azdmu0005_b2d91a7e-f4e1-4289-b4e7-1c5fa2dde42e.vhd
@@ -2819,7 +2865,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:15:32 GMT
+      - Mon, 12 Mar 2018 10:22:56 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -2827,7 +2873,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:ZlHq6yx7gp46eah1W/HwQMl7gJevo2MdAu3/AanIbpw=
+      - SharedKey miqazuretest14047:7/jqyeYuFqu//4eU2JWPyN+Kze4DOvgQw/jBQk4fLBk=
   response:
     status:
       code: 200
@@ -2848,7 +2894,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 738061a9-001e-012e-2751-b6e0ed000000
+      - 4ac7d8c1-001e-00c0-3cec-b9ac3b000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -2872,12 +2918,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:15:32 GMT
+      - Mon, 12 Mar 2018 10:22:51 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:33 GMT
+  recorded_at: Mon, 12 Mar 2018 10:22:56 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/azdmu0006_bfa11357-6a80-4de1-b395-67e870c14a91.vhd
@@ -2894,7 +2940,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:15:33 GMT
+      - Mon, 12 Mar 2018 10:22:56 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -2902,7 +2948,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:40C2xAlZxCNxVYwRgKquNBLV807Dhj9ThRxj6/oa0sQ=
+      - SharedKey miqazuretest14047:DBPlBdxZYvZ3O5x+ZYt1UxesvupcUhxl49HA3edIIRY=
   response:
     status:
       code: 200
@@ -2923,7 +2969,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 38f76888-001e-0006-3951-b6d107000000
+      - d37f5e6c-001e-00db-1dec-b982a9000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -2947,12 +2993,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:15:33 GMT
+      - Mon, 12 Mar 2018 10:22:52 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:33 GMT
+  recorded_at: Mon, 12 Mar 2018 10:22:57 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/billy1_20401b27-9da4-4276-a390-d59495aea954.vhd
@@ -2969,7 +3015,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:15:33 GMT
+      - Mon, 12 Mar 2018 10:22:57 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -2977,7 +3023,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:gTHCbDb2Muvgj9FdnR1rRqwGMksfE2JLgjJIlcYCmYc=
+      - SharedKey miqazuretest14047:Kg3lLT8D9J38d3x72gSHYk2H/AAZjFfVVspQ//F2RJU=
   response:
     status:
       code: 200
@@ -2998,7 +3044,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - af203fcf-001e-00e6-2f51-b6378f000000
+      - c9326fd1-001e-00cf-3eec-b941cd000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -3022,12 +3068,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:15:32 GMT
+      - Mon, 12 Mar 2018 10:22:52 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:34 GMT
+  recorded_at: Mon, 12 Mar 2018 10:22:58 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/billy2_2dfb8613-c1c1-4562-9307-db8c9b1b2426.vhd
@@ -3044,7 +3090,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:15:34 GMT
+      - Mon, 12 Mar 2018 10:22:58 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -3052,7 +3098,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:yNnPVXyqGguGfn50kmIhx8o0Ss3tXzAgsV63ySEpD3U=
+      - SharedKey miqazuretest14047:Ahi5k57GnwuF4tTib1ZViSpVeOut+Di6FUvNJwrBUtk=
   response:
     status:
       code: 200
@@ -3073,7 +3119,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - d5b20e65-001e-0062-7751-b661a7000000
+      - 6299bdb3-001e-010f-71ec-b98ddc000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -3097,12 +3143,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:15:34 GMT
+      - Mon, 12 Mar 2018 10:22:53 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:34 GMT
+  recorded_at: Mon, 12 Mar 2018 10:22:58 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/bronagh0316i_4cfc2b66-abbf-45da-8a9f-30746bd55d6d.vhd
@@ -3119,7 +3165,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:15:34 GMT
+      - Mon, 12 Mar 2018 10:22:58 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -3127,7 +3173,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:DiiPS+KgDGTt88LSi7vcw3G/dmLSDv9A0cxpPgHAKdA=
+      - SharedKey miqazuretest14047:VQvnkSb0iutCpx4PGlfdC/xAItCk7+BpAUEXa0aI+1w=
   response:
     status:
       code: 200
@@ -3148,7 +3194,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 16d3267b-001e-011a-2651-b64f45000000
+      - 1f246f02-001e-009b-31ec-b9ab47000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -3172,12 +3218,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:15:34 GMT
+      - Mon, 12 Mar 2018 10:22:54 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:35 GMT
+  recorded_at: Mon, 12 Mar 2018 10:22:59 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/bronagh316g_2137cec1-a36d-4bbd-a8d3-59d6862c2bb9.vhd
@@ -3194,7 +3240,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:15:35 GMT
+      - Mon, 12 Mar 2018 10:22:59 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -3202,7 +3248,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:vNCvBwihpq9Zrrsy73oWUyd2JM6AMvDOf4bk77XN7vo=
+      - SharedKey miqazuretest14047:hZ78NujWbvfM/ATsa316C+/ms4nVpM5v4sXVRxjX2tI=
   response:
     status:
       code: 200
@@ -3223,7 +3269,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 9198766d-001e-0135-0f51-b6ce7f000000
+      - 8db22da3-001e-013f-2eec-b9d7f6000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -3247,12 +3293,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:15:35 GMT
+      - Mon, 12 Mar 2018 10:22:55 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:35 GMT
+  recorded_at: Mon, 12 Mar 2018 10:23:00 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/bronagh427_95458494-4446-450d-9a4a-792d14d09717.vhd
@@ -3269,7 +3315,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:15:35 GMT
+      - Mon, 12 Mar 2018 10:23:00 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -3277,7 +3323,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:2RAhjypexjW48YtX29gVbmCvWshUbNRoxvSidg9JaoM=
+      - SharedKey miqazuretest14047:cuDd0RwxC3G3igVS4tq1Yzo+P6vxXipNkIsymF8Dg8o=
   response:
     status:
       code: 200
@@ -3298,7 +3344,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - c80c82f9-001e-0075-4f51-b6a1c4000000
+      - dd96ee14-001e-00df-77ec-b9772b000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -3322,12 +3368,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:15:35 GMT
+      - Mon, 12 Mar 2018 10:22:56 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:36 GMT
+  recorded_at: Mon, 12 Mar 2018 10:23:00 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/bronaghfip714a_4a63df99-9f73-4b8d-923f-dc06617d660d.vhd
@@ -3344,7 +3390,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:15:36 GMT
+      - Mon, 12 Mar 2018 10:23:00 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -3352,7 +3398,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:g/IVpfLyC+8iJJO+5fkGwDE7qut8c/t8JIN6/uYN2Gw=
+      - SharedKey miqazuretest14047:dKmy1XCmU9K9HsTd6sIBTDYcqltjNsb7AmdYcAhdyOY=
   response:
     status:
       code: 200
@@ -3373,7 +3419,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 244c5b73-001e-0065-0f51-b69722000000
+      - bcfdad47-001e-010b-2fec-b9785e000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -3397,12 +3443,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:15:36 GMT
+      - Mon, 12 Mar 2018 10:22:56 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:36 GMT
+  recorded_at: Mon, 12 Mar 2018 10:23:01 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/bronaghnoport_9943a499-b2ec-41e3-9a85-c14494f18cec.vhd
@@ -3419,7 +3465,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:15:36 GMT
+      - Mon, 12 Mar 2018 10:23:01 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -3427,7 +3473,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:TAF2AZ8k1et0roU57FhuC6SRxHL9uaEenRppa280usQ=
+      - SharedKey miqazuretest14047:2K8ce9/FAWKj24fa15S4upDzemTK61pnjR4q8RzG9rw=
   response:
     status:
       code: 200
@@ -3448,7 +3494,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 13fc2c5a-001e-00f5-7451-b6026e000000
+      - 21743f3a-001e-005b-0fec-b92103000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -3472,12 +3518,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:15:37 GMT
+      - Mon, 12 Mar 2018 10:22:56 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:37 GMT
+  recorded_at: Mon, 12 Mar 2018 10:23:02 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/bronaghreuseip_c33a6549-cc4d-4e3f-945d-28b6ca0880f0.vhd
@@ -3494,7 +3540,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:15:37 GMT
+      - Mon, 12 Mar 2018 10:23:02 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -3502,7 +3548,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:tM9QIBwYFI5bSi8p0dGUQ8iBfEAcyZ0ngB0FPXhpKIA=
+      - SharedKey miqazuretest14047:AplUwrmm54O9Rnp9oVo3PybJncZFa8quW1XfVpzJBO8=
   response:
     status:
       code: 200
@@ -3523,7 +3569,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - a3b80a24-001e-00bd-6951-b630f3000000
+      - b05e9521-001e-000f-42ec-b9cb89000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -3547,12 +3593,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:15:36 GMT
+      - Mon, 12 Mar 2018 10:22:57 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:38 GMT
+  recorded_at: Mon, 12 Mar 2018 10:23:02 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/bronaghrspec3_034c938b-eaa9-4399-8ed2-cb7216fabf0b.vhd
@@ -3569,7 +3615,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:15:38 GMT
+      - Mon, 12 Mar 2018 10:23:02 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -3577,7 +3623,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:WlqmssdC+acGL8fjXMVrdXHchcU4D56YLrSgfhUbIoM=
+      - SharedKey miqazuretest14047:bR6VoEtqqEwajl2Kt3jY2d1bvh0cgz9Ro4qgCgxoR2A=
   response:
     status:
       code: 200
@@ -3598,7 +3644,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 878475db-001e-0085-5651-b671aa000000
+      - 25c66bfc-001e-00c7-76ec-b95abe000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -3622,12 +3668,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:15:37 GMT
+      - Mon, 12 Mar 2018 10:22:58 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:38 GMT
+  recorded_at: Mon, 12 Mar 2018 10:23:03 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/bronaghtest23_e23609fb-9c7c-413c-9be6-9a0e1c9cdbd7.vhd
@@ -3644,7 +3690,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:15:38 GMT
+      - Mon, 12 Mar 2018 10:23:03 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -3652,7 +3698,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:aQWg5/Ej8sZAV3xa0XfRBmhGDXWdhUYB+9CYYiHUPsc=
+      - SharedKey miqazuretest14047:iA/zOVzFWdHcqkbpDLlYpRry7g7PK0Oq5pmW+vDCQlY=
   response:
     status:
       code: 200
@@ -3673,7 +3719,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 6da18733-001e-00dd-6d51-b675d1000000
+      - 55c1bb9e-001e-0067-41ec-b995d8000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -3697,12 +3743,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:15:39 GMT
+      - Mon, 12 Mar 2018 10:22:59 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:39 GMT
+  recorded_at: Mon, 12 Mar 2018 10:23:04 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/bronaghwiths_73b9a95a-dde1-43b5-8139-2bb0465d391a.vhd
@@ -3719,7 +3765,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:15:39 GMT
+      - Mon, 12 Mar 2018 10:23:04 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -3727,7 +3773,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:QsK20LrDjKjZN05mOIqABCXXJrCZ25uzt3kW/lTYN4c=
+      - SharedKey miqazuretest14047:coFFW+Xklx08TwtLz07V5jlBHQyd7GJAXWLcvc9n+Qs=
   response:
     status:
       code: 200
@@ -3748,7 +3794,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 97289b13-001e-006d-2251-b68c51000000
+      - 0c3793ae-001e-011f-2cec-b9bb3a000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -3772,12 +3818,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:15:39 GMT
+      - Mon, 12 Mar 2018 10:23:00 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:39 GMT
+  recorded_at: Mon, 12 Mar 2018 10:23:05 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/bsmetrics_20753af8-5ab8-45af-8545-4ec096985aa4.vhd
@@ -3794,7 +3840,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:15:39 GMT
+      - Mon, 12 Mar 2018 10:23:05 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -3802,7 +3848,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:7rNQlkD09KqUj5Qb/XRkH9H4y0tATU9QUToOZLBltBs=
+      - SharedKey miqazuretest14047:kUzvHHH56stA6Wk6iEP/31fi5UV1JtPDGQAKCPkHK8Q=
   response:
     status:
       code: 200
@@ -3823,7 +3869,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - a09838c3-001e-0021-0151-b64b4e000000
+      - de986031-001e-00d3-17ec-b999da000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -3847,12 +3893,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:15:39 GMT
+      - Mon, 12 Mar 2018 10:23:01 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:40 GMT
+  recorded_at: Mon, 12 Mar 2018 10:23:05 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/bweitest_0002_a156be9c-2fbe-41eb-9564-fbcb2553ee33.vhd
@@ -3869,7 +3915,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:15:40 GMT
+      - Mon, 12 Mar 2018 10:23:05 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -3877,7 +3923,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:3IhBIwKrPqPGCpA5WzAfmkQQHym1hUcT/a9FdhL6upw=
+      - SharedKey miqazuretest14047:BJryVw8gZ1ISM/SYn/0Dz1wTg/KGCRdDl3GxBMZNBzc=
   response:
     status:
       code: 200
@@ -3898,7 +3944,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 273c5bbf-001e-0061-2751-b662a0000000
+      - bb9bb478-001e-0073-1aec-b956bc000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -3922,12 +3968,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:15:40 GMT
+      - Mon, 12 Mar 2018 10:23:01 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:41 GMT
+  recorded_at: Mon, 12 Mar 2018 10:23:06 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/dberger-delete_a2a5d43f-aa05-4d61-8da8-95086a4d357e.vhd
@@ -3944,7 +3990,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:15:41 GMT
+      - Mon, 12 Mar 2018 10:23:06 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -3952,7 +3998,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:iTborXnwXQgNHI8fsAT07zxaH9zQsrFxwsUHoukvxag=
+      - SharedKey miqazuretest14047:6wT9BwkJ7qS3WlNCKuv6MDe6Jj99bB3z/BhhsHpc+uY=
   response:
     status:
       code: 200
@@ -3973,7 +4019,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - d313d4af-001e-00a4-3f51-b61c9b000000
+      - eaae5c9a-001e-00ef-2cec-b92d01000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -3997,12 +4043,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:15:40 GMT
+      - Mon, 12 Mar 2018 10:23:02 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:41 GMT
+  recorded_at: Mon, 12 Mar 2018 10:23:07 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/dberger-deleteme1_eefc1727-019b-4285-a5f8-0869efe8a037.vhd
@@ -4019,7 +4065,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:15:41 GMT
+      - Mon, 12 Mar 2018 10:23:07 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -4027,7 +4073,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:6YinSiQ/6jpSN8HtNQaTiwxm5iCs2Amx5hN4NCs3Ap0=
+      - SharedKey miqazuretest14047:0qAnIrUzTdxGry5DGvNJLWhB++3pSXq48W91BNyq/cQ=
   response:
     status:
       code: 200
@@ -4048,7 +4094,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 13188e68-001e-001c-0251-b6fe68000000
+      - 1c0d5a94-001e-0106-29ec-b99752000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -4072,12 +4118,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:15:41 GMT
+      - Mon, 12 Mar 2018 10:23:02 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:42 GMT
+  recorded_at: Mon, 12 Mar 2018 10:23:08 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/dbergerprov1_9a78aa4c-d5f6-4d58-b083-90691eda7b64.vhd
@@ -4094,7 +4140,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:15:42 GMT
+      - Mon, 12 Mar 2018 10:23:08 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -4102,7 +4148,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:givUjTx6FQFkrzs96aSQJ8BTqEt9Xb8cdtR7RYKBDSA=
+      - SharedKey miqazuretest14047:uUsWwyCKCdf4ROkEG2zAzzPCf+ovgeulBBA0LV1otJY=
   response:
     status:
       code: 200
@@ -4123,7 +4169,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - bb85d900-001e-0110-2751-b656cc000000
+      - 786aefa0-001e-0092-18ec-b9b1c9000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -4147,12 +4193,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:15:42 GMT
+      - Mon, 12 Mar 2018 10:23:03 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:42 GMT
+  recorded_at: Mon, 12 Mar 2018 10:23:08 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/dbergerprov2_a7be6d36-d0ca-4fad-8cd0-fc2f048e0446.vhd
@@ -4169,7 +4215,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:15:42 GMT
+      - Mon, 12 Mar 2018 10:23:08 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -4177,7 +4223,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:fRyNvbf3/17cHU7cFI4LwbKwe26XXyDRThHm8Ou6Y0o=
+      - SharedKey miqazuretest14047:GWc4gR4ZWV3e7TjTekj6AQpPzn1CCg5BciXZ3taOJtc=
   response:
     status:
       code: 200
@@ -4198,7 +4244,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 71532291-001e-0029-2b51-b6503d000000
+      - 3533cbdf-001e-0122-20ec-b90e1c000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -4222,12 +4268,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:15:42 GMT
+      - Mon, 12 Mar 2018 10:23:03 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:43 GMT
+  recorded_at: Mon, 12 Mar 2018 10:23:09 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/dbergerx_60873a6e-709e-409f-8048-9dcabc09d467.vhd
@@ -4244,7 +4290,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:15:43 GMT
+      - Mon, 12 Mar 2018 10:23:09 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -4252,7 +4298,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:YrltCJr0LrJOuT69jexwBEYoDtuE5hx+5K1SqEU1f6k=
+      - SharedKey miqazuretest14047:Oic+Qu2L06GkEYui1bTs8Roy4CcnmGv3MTJbv1RtrJU=
   response:
     status:
       code: 200
@@ -4273,7 +4319,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 0d22d823-001e-0008-4251-b63d0c000000
+      - 19da4e24-001e-0072-36ec-b95741000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -4297,12 +4343,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:15:42 GMT
+      - Mon, 12 Mar 2018 10:23:05 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:43 GMT
+  recorded_at: Mon, 12 Mar 2018 10:23:10 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/drew1_5c35f695-b2ae-4d86-937f-fcc6fcbb9fb0.vhd
@@ -4319,7 +4365,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:15:43 GMT
+      - Mon, 12 Mar 2018 10:23:10 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -4327,7 +4373,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:krazIH9DSeZZRbMngIJx7GeAjVQCIlpEZUikzy1/6g0=
+      - SharedKey miqazuretest14047:3Fy5KoRq4Vyb9fUJuPnXkYFmYP+9pFrXUVUKBuWxOxk=
   response:
     status:
       code: 200
@@ -4348,7 +4394,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 00fdfab6-001e-0020-1e51-b64ab3000000
+      - f6dbdf94-001e-0076-2aec-b9a2c3000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -4372,12 +4418,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:15:43 GMT
+      - Mon, 12 Mar 2018 10:23:06 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:44 GMT
+  recorded_at: Mon, 12 Mar 2018 10:23:11 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/jb_win_demo_vm_ad89c080-8b1d-47a2-8a73-ee6d7a53c6cc.vhd
@@ -4394,7 +4440,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:15:44 GMT
+      - Mon, 12 Mar 2018 10:23:11 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -4402,7 +4448,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:EjIceMx84wNGcZZW7wWKlasIhZ2YqGOKs054HKKFQ0U=
+      - SharedKey miqazuretest14047:g5sG3I4FXS8lH//nzqYm6PaKNxpcQeBtodllG5F00iY=
   response:
     status:
       code: 200
@@ -4423,7 +4469,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 4944e2f7-001e-0000-5551-b6267f000000
+      - 7fe4e3ec-001e-012e-2eec-b9e0ed000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -4447,12 +4493,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:15:44 GMT
+      - Mon, 12 Mar 2018 10:23:07 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:44 GMT
+  recorded_at: Mon, 12 Mar 2018 10:23:11 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/lucy_2_eef078a8-9bfe-469e-9340-e0342a4fe3bc.vhd
@@ -4469,7 +4515,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:15:44 GMT
+      - Mon, 12 Mar 2018 10:23:11 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -4477,7 +4523,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:cx1hnk7kKQKTClrLi+AXRnZEaBAuyqR7wTlj+2lxapI=
+      - SharedKey miqazuretest14047:maAwPLBvat2kW4w1Bb/FgrM4o0tdwx3eRNoSb8SCOVA=
   response:
     status:
       code: 200
@@ -4498,7 +4544,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 67331d63-001e-011c-2051-b6b83d000000
+      - aff501ba-001e-013a-0fec-b92389000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -4522,12 +4568,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:15:44 GMT
+      - Mon, 12 Mar 2018 10:23:07 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:45 GMT
+  recorded_at: Mon, 12 Mar 2018 10:23:12 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/lucy_3_d124b42c-7cf1-4184-9683-799c584a5919.vhd
@@ -4544,7 +4590,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:15:45 GMT
+      - Mon, 12 Mar 2018 10:23:12 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -4552,7 +4598,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:HZzuw7NTCoNIto9H9qyFMiW3sjI+6eeAcq50uyRA1YA=
+      - SharedKey miqazuretest14047:LrjQOrJ3U5RHBviAkhQKPz3MbhiymQL54Anf/+H3SV4=
   response:
     status:
       code: 200
@@ -4573,7 +4619,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 244264da-001e-0070-5f51-b655bb000000
+      - e056efb6-001e-0062-5aec-b961a7000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -4597,12 +4643,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:15:44 GMT
+      - Mon, 12 Mar 2018 10:23:08 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:46 GMT
+  recorded_at: Mon, 12 Mar 2018 10:23:13 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/lucy_4_261857b1-fb35-4ce0-b7b7-fd148c7e6ebd.vhd
@@ -4619,7 +4665,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:15:46 GMT
+      - Mon, 12 Mar 2018 10:23:13 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -4627,7 +4673,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:B2bPOmEKB9wBIA1yDcEUzqZMKqhIPI+M1U1TL2Zjjrk=
+      - SharedKey miqazuretest14047:YvIcMQ6uJkmL3OOp/d4NaN3ue18i0VMnFFxZ7AaRBW0=
   response:
     status:
       code: 200
@@ -4648,7 +4694,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - df7f6a1c-001e-0028-0b51-b651c0000000
+      - 2266090e-001e-011a-33ec-b94f45000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -4672,12 +4718,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:15:46 GMT
+      - Mon, 12 Mar 2018 10:23:09 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:46 GMT
+  recorded_at: Mon, 12 Mar 2018 10:23:14 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/sectest2_84ad7b2b-9100-40db-8997-a31912cf27c1.vhd
@@ -4694,7 +4740,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:15:46 GMT
+      - Mon, 12 Mar 2018 10:23:14 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -4702,7 +4748,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:v3TWhHg4/VJN4GZwl8l9Zt3MJkPtSxr228LSNEkmTno=
+      - SharedKey miqazuretest14047:BmTmAl2mr+t0p80pqAsNriCb1SgHrzTFMHxem/oIPy4=
   response:
     status:
       code: 200
@@ -4723,7 +4769,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - cf69e028-001e-0018-5c51-b60bea000000
+      - d36491eb-001e-0075-4aec-b9a1c4000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -4747,12 +4793,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:15:47 GMT
+      - Mon, 12 Mar 2018 10:23:09 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:47 GMT
+  recorded_at: Mon, 12 Mar 2018 10:23:14 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/test-billy-azure33_a676ca34-c43f-4f58-a96c-30cf0645f6ea.vhd
@@ -4769,7 +4815,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:15:47 GMT
+      - Mon, 12 Mar 2018 10:23:14 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -4777,7 +4823,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:zSKNX9aoirENxGxCGtgeRDQZZG8UgmZSdx3K0rsAuWE=
+      - SharedKey miqazuretest14047:RAdezrpaVCH6Xbm19xfbQNw0H3Apat4t7JrZjhUxN1s=
   response:
     status:
       code: 200
@@ -4798,7 +4844,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 0b11058d-001e-0034-0451-b689d7000000
+      - c4b3b681-001e-0065-4aec-b99722000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -4822,12 +4868,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:15:47 GMT
+      - Mon, 12 Mar 2018 10:23:09 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:48 GMT
+  recorded_at: Mon, 12 Mar 2018 10:23:15 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/test-billy-azure34_3c1cc2b6-174a-43bb-9d30-b3495444d9f6.vhd
@@ -4844,7 +4890,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:15:48 GMT
+      - Mon, 12 Mar 2018 10:23:15 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -4852,7 +4898,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:yPHGG3AUXwBLwOFTsPS3pZJct8z4JVjmGJ0iYK+Qmvg=
+      - SharedKey miqazuretest14047:3ieie3iSbYbN5Oj8hvqXcSd/zmQA9SOsLdTEsYvhgfI=
   response:
     status:
       code: 200
@@ -4873,7 +4919,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - fe048763-001e-0017-2951-b6e61c000000
+      - af0f6e1a-001e-00bd-17ec-b930f3000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -4897,12 +4943,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:15:47 GMT
+      - Mon, 12 Mar 2018 10:23:11 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:48 GMT
+  recorded_at: Mon, 12 Mar 2018 10:23:16 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/test-billy-azure35_caeaf4af-b486-4edc-9847-b658a0e197c2.vhd
@@ -4919,7 +4965,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:15:48 GMT
+      - Mon, 12 Mar 2018 10:23:16 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -4927,7 +4973,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:N0Q7c19AHcbYT5XbCz8lgqPXIfne8MDk4JJqjGvucVI=
+      - SharedKey miqazuretest14047:Ncqp4BULl7Xp+I2wiBedmatYzDb7N3jGsqR4kC5K7Hg=
   response:
     status:
       code: 200
@@ -4948,7 +4994,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 2654c07c-001e-00ab-3551-b6f16d000000
+      - 93a3c3b1-001e-0085-20ec-b971aa000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -4972,12 +5018,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:15:48 GMT
+      - Mon, 12 Mar 2018 10:23:11 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:49 GMT
+  recorded_at: Mon, 12 Mar 2018 10:23:16 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/test-billy-azure36_f88f59a7-cc6f-4464-88ba-61adca792ecc.vhd
@@ -4994,7 +5040,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:15:49 GMT
+      - Mon, 12 Mar 2018 10:23:16 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -5002,7 +5048,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:YVYMpYtZ7unq/WyXlPFnZ0Hp8DYgfe3sLiHbbve6OBE=
+      - SharedKey miqazuretest14047:Gfo245teNolmRJStefKR7Rp86IpIvXE8Zz1nUJRpe9w=
   response:
     status:
       code: 200
@@ -5023,7 +5069,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 9c3d6eef-001e-004b-5b51-b617e5000000
+      - 1aee6de0-001e-0115-3cec-b9a2b3000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -5047,12 +5093,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:15:49 GMT
+      - Mon, 12 Mar 2018 10:23:12 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:49 GMT
+  recorded_at: Mon, 12 Mar 2018 10:23:17 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/test-billy-azure38_e934e3f0-f3d8-4b5b-8015-55e5bd392cbc.vhd
@@ -5069,7 +5115,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:15:49 GMT
+      - Mon, 12 Mar 2018 10:23:17 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -5077,7 +5123,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:l1vb/Xz4QirM64KeMRj0I8BnZVn0X0cvY8usn/TkoNY=
+      - SharedKey miqazuretest14047:dcLGrS+K2bigk31tqiAyuSXY17CTh1hBoRDOrFAhdFw=
   response:
     status:
       code: 200
@@ -5098,7 +5144,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 88ef6b4b-001e-0063-6c51-b6605a000000
+      - 7f2f1ef7-001e-00dd-67ec-b975d1000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -5122,12 +5168,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:15:49 GMT
+      - Mon, 12 Mar 2018 10:23:13 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:50 GMT
+  recorded_at: Mon, 12 Mar 2018 10:23:18 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/test-billy-azure40_78c0ae1c-2b12-4aa8-bb3c-bf6270c11d1c.vhd
@@ -5144,7 +5190,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:15:50 GMT
+      - Mon, 12 Mar 2018 10:23:18 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -5152,7 +5198,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:OhIQPrc4ADKifPrMehdqBgaJ/l+9H9zBCexWwfd2jfw=
+      - SharedKey miqazuretest14047:421+T1qyVrKicjxqEX6jHHz0iDjSc9wUMnABT/b1DtM=
   response:
     status:
       code: 200
@@ -5173,7 +5219,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 1fac06c0-001e-001b-7b51-b608ed000000
+      - aeefe8d2-001e-0041-3cec-b90e6c000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -5197,12 +5243,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:15:49 GMT
+      - Mon, 12 Mar 2018 10:23:14 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:50 GMT
+  recorded_at: Mon, 12 Mar 2018 10:23:19 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/test-billy-azure51_d8d15880-191f-4221-99cc-cb102ba4dcf8.vhd
@@ -5219,7 +5265,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:15:50 GMT
+      - Mon, 12 Mar 2018 10:23:19 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -5227,7 +5273,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:ymJ9c6UKQ4Q6NFxk7yPWgk6zZVRn+f0fRlXFHrVYwts=
+      - SharedKey miqazuretest14047:uxIf8/i7p9eCsa00wPtJaSXIUOLzPIj+rSJDQyswwDk=
   response:
     status:
       code: 200
@@ -5248,7 +5294,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 259824b0-001e-00b3-5e51-b6dcf8000000
+      - 9ee91619-001e-006d-7eec-b98c51000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -5272,12 +5318,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:15:51 GMT
+      - Mon, 12 Mar 2018 10:23:14 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:51 GMT
+  recorded_at: Mon, 12 Mar 2018 10:23:20 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/test-billya37_f2f0e962-d3c7-4029-9b2d-14982e667016.vhd
@@ -5294,7 +5340,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:15:51 GMT
+      - Mon, 12 Mar 2018 10:23:20 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -5302,7 +5348,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:Kpy7ksKJDceVvzV5NttqP7/+HhfR2FN5mwSZWkVpqoA=
+      - SharedKey miqazuretest14047:SaJpJIhrtCHOcG5giAzH9l4mhtOln++dxCU9ZKRTYWA=
   response:
     status:
       code: 200
@@ -5323,7 +5369,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 3831194d-001e-007b-1151-b64dcf000000
+      - aabfdd52-001e-0021-3aec-b94b4e000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -5347,12 +5393,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:15:50 GMT
+      - Mon, 12 Mar 2018 10:23:15 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:52 GMT
+  recorded_at: Mon, 12 Mar 2018 10:23:21 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/testbillyaaa_953e913d-6625-471f-b6f0-4e9353723c39.vhd
@@ -5369,7 +5415,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:15:52 GMT
+      - Mon, 12 Mar 2018 10:23:21 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -5377,7 +5423,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:21c7tnRh8TdUXe7lDp09o/Vvbmqho2drkSXB5hfeUD0=
+      - SharedKey miqazuretest14047:qYwGu13V+gUMGCZt7XMDsTLBli2Y88Twpg/02VUFxtE=
   response:
     status:
       code: 200
@@ -5398,7 +5444,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 7e94054d-001e-00ce-6451-b64030000000
+      - 31888eff-001e-0061-41ec-b962a0000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -5422,12 +5468,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:15:52 GMT
+      - Mon, 12 Mar 2018 10:23:17 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:52 GMT
+  recorded_at: Mon, 12 Mar 2018 10:23:21 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/manageiq/testbillyzzzz_43cfa30e-2d72-49af-a72d-1e764dfbf756.vhd
@@ -5444,7 +5490,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:15:52 GMT
+      - Mon, 12 Mar 2018 10:23:21 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -5452,7 +5498,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:1xeVFT62Ol2SKK52U7sziIEUy9+rc67Nn4T4rAN+ZNg=
+      - SharedKey miqazuretest14047:sENwRQagD7crlG6VsT2wk/iH4Zb+WQQ5zetJul47mwY=
   response:
     status:
       code: 200
@@ -5473,7 +5519,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - f01a6b08-001e-005e-5451-b6d57c000000
+      - dc5d3e6f-001e-008c-2aec-b96b24000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -5497,12 +5543,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:15:52 GMT
+      - Mon, 12 Mar 2018 10:23:17 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:53 GMT
+  recorded_at: Mon, 12 Mar 2018 10:23:22 GMT
 - request:
     method: get
     uri: https://miqazuretest14047.blob.core.windows.net/system?comp=list&restype=container
@@ -5519,13 +5565,13 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:15:53 GMT
+      - Mon, 12 Mar 2018 10:23:22 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
       - 'true'
       Authorization:
-      - SharedKey miqazuretest14047:MOnMDPg7GYMUId2LPnGBfiHr4N0+oXyp69ZycZiv9Rc=
+      - SharedKey miqazuretest14047:3H8H/PBWagFgR/QIQoVTSVNZnvyhuVCCghwAdXepOac=
   response:
     status:
       code: 200
@@ -5538,17 +5584,17 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 206fe9cc-001e-00b6-7451-b62887000000
+      - de52d5d3-001e-00a4-6dec-b91c9b000000
       X-Ms-Version:
       - '2016-05-31'
       Date:
-      - Wed, 07 Mar 2018 20:15:52 GMT
+      - Mon, 12 Mar 2018 10:23:17 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9taXFhenVyZXRlc3QxNDA0Ny5ibG9iLmNvcmUud2luZG93cy5uZXQvIiBDb250YWluZXJOYW1lPSJzeXN0ZW0iPjxCbG9icz48QmxvYj48TmFtZT5NaWNyb3NvZnQuQ29tcHV0ZS9JbWFnZXMvbWlxLXRlc3QtY29udGFpbmVyL3Rlc3Qtd2luMmsxMi1pbWctb3NEaXNrLmUxN2E5NWIwLWY0ZmItNDE5Ni05M2M1LTBjOGJlN2Q1YzUzNi52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VHVlLCAyMiBNYXIgMjAxNiAxNzowODowMiBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDM1Mjc0ODc1QjRGOTE8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjE8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5NaWNyb3NvZnQuQ29tcHV0ZS9JbWFnZXMvbWlxLXRlc3QtY29udGFpbmVyL3Rlc3Qtd2luMmsxMi1pbWctdm1UZW1wbGF0ZS5lMTdhOTViMC1mNGZiLTQxOTYtOTNjNS0wYzhiZTdkNWM1MzYuanNvbjwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UdWUsIDIyIE1hciAyMDE2IDE3OjA4OjAzIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMzUyNzQ4Nzk3QTNCMDwvRXRhZz48Q29udGVudC1MZW5ndGg+MjAyNDwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9qc29uPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5zdURBYnR6RnBBVEpGYk55RDRLVWhBPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48QmxvYlR5cGU+QmxvY2tCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48L0Jsb2JzPjxOZXh0TWFya2VyIC8+PC9FbnVtZXJhdGlvblJlc3VsdHM+
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:53 GMT
+  recorded_at: Mon, 12 Mar 2018 10:23:23 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/system/Microsoft.Compute/Images/miq-test-container/test-win2k12-img-osDisk.e17a95b0-f4fb-4196-93c5-0c8be7d5c536.vhd
@@ -5565,7 +5611,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:15:53 GMT
+      - Mon, 12 Mar 2018 10:23:23 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -5573,7 +5619,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:5k1t3KWmo2uUrFc1WQ/y4BeLvRZxtx8gXbfI5CLOTbA=
+      - SharedKey miqazuretest14047:Vi/GfyBAOYg/+VXPaFt58uQhRjU64/GgvpScRrY7k84=
   response:
     status:
       code: 200
@@ -5594,7 +5640,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - cde8afa1-001e-0096-7c51-b6444b000000
+      - 1e528154-001e-001c-26ec-b9fe68000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Meta-Microsoftazurecompute-Capturedvmkey:
@@ -5626,12 +5672,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:15:53 GMT
+      - Mon, 12 Mar 2018 10:23:19 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:54 GMT
+  recorded_at: Mon, 12 Mar 2018 10:23:24 GMT
 - request:
     method: get
     uri: https://miqazuretest14047.blob.core.windows.net/vhds?comp=list&restype=container
@@ -5648,13 +5694,13 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:15:54 GMT
+      - Mon, 12 Mar 2018 10:23:24 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
       - 'true'
       Authorization:
-      - SharedKey miqazuretest14047:LyjBtfM6oszKWmXKBe1acI3UNtUxw9JFPO4HXt7MAgc=
+      - SharedKey miqazuretest14047:f5FfoLrIOy26TjvGeVQbtMtiiu9+dGMI0Mq0cSiGTVQ=
   response:
     status:
       code: 200
@@ -5667,17 +5713,17 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 82abc557-001e-004e-7451-b6e39a000000
+      - cdb0c2fd-001e-0110-35ec-b956cc000000
       X-Ms-Version:
       - '2016-05-31'
       Date:
-      - Wed, 07 Mar 2018 20:15:54 GMT
+      - Mon, 12 Mar 2018 10:23:20 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9taXFhenVyZXRlc3QxNDA0Ny5ibG9iLmNvcmUud2luZG93cy5uZXQvIiBDb250YWluZXJOYW1lPSJ2aGRzIj48QmxvYnM+PEJsb2I+PE5hbWU+bWlxLXRlc3Qtd2luMTIyMDE2MjE4MTEzMDE0LnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UaHUsIDE5IE9jdCAyMDE3IDAyOjAxOjM2IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhENTE2OTU1NDUyOTlERTwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MjkzPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+bGVhc2VkPC9MZWFzZVN0YXRlPjxMZWFzZUR1cmF0aW9uPmluZmluaXRlPC9MZWFzZUR1cmF0aW9uPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPm1pcS10ZXN0LXdpbmltZy5iOTdmZjQ4OC1lMTE0LTQwZWQtOGQ3YS1mNDUwMGQ3M2VlYzAuc3RhdHVzPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlR1ZSwgMjIgTWFyIDIwMTYgMTY6MzA6MjkgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzNTI2RjQ4MUUyQzQ3PC9FdGFnPjxDb250ZW50LUxlbmd0aD44ODQ8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT4xSytsTEp6c3U0SjVBbW5qcUJ1dVhBPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48QmxvYlR5cGU+QmxvY2tCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5taXEtdGVzdC13aW5pbWcuZTE3YTk1YjAtZjRmYi00MTk2LTkzYzUtMGM4YmU3ZDVjNTM2LnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UdWUsIDIyIE1hciAyMDE2IDE2OjU4OjQwIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMzUyNzMzN0VGQTA4MTwvRXRhZz48Q29udGVudC1MZW5ndGg+ODg0PC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+RFNCbitSZkhBZ0JGRFgrUzh6OVd1QT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+bWlxLXRlc3Qtd2luaW1nMjAxNjIyMjEwMTY0My52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VHVlLCAyMiBNYXIgMjAxNiAxNjozNzo0MiBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDM1MjcwNEEzQjFFQTY8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjEzNjM2NzMwOTMxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PlZiWWhXOS82Tk9YelFWSy92UWtkdmc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjE8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5taXEtdGVzdC13aW5pbWcyMDE2MjIyMTA0MDcudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlR1ZSwgMjIgTWFyIDIwMTYgMTY6NTk6MDAgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzNTI3MzQzQkEzMTUyPC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4xPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+bGVhc2VkPC9MZWFzZVN0YXRlPjxMZWFzZUR1cmF0aW9uPmluZmluaXRlPC9MZWFzZUR1cmF0aW9uPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPm1pcWF6dXJlLWNlbnRvczEuNzk2YzViY2MtMzM4YS00NDhkLWI2MWMtMTY1Mjc5YTdmYjNlLnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5GcmksIDIyIEFwciAyMDE2IDE5OjA1OjQ2IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEMzZBRTExQzQ3ODkxMDwvRXRhZz48Q29udGVudC1MZW5ndGg+NjgzPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+eExRZy9FbWJRNnVRR0VGaStiWG0zZz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+bWlxYXp1cmUtY2VudG9zMTIwMTYyMjExMDQ5NDYudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPkZyaSwgMjIgQXByIDIwMTYgMTk6MDU6NTggR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzNkFFMTIzOTU0QjM1PC9FdGFnPjxDb250ZW50LUxlbmd0aD4zMjIxMjI1NTIzMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PmJMSzdyZ1Q3SWdNTlgyWXhMOUJDeWc9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjE8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+bG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5sZWFzZWQ8L0xlYXNlU3RhdGU+PExlYXNlRHVyYXRpb24+aW5maW5pdGU8L0xlYXNlRHVyYXRpb24+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PC9CbG9icz48TmV4dE1hcmtlciAvPjwvRW51bWVyYXRpb25SZXN1bHRzPg==
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:55 GMT
+  recorded_at: Mon, 12 Mar 2018 10:23:25 GMT
 - request:
     method: head
     uri: https://miqazuretest14047.blob.core.windows.net/vhds/miq-test-winimg2016222101643.vhd
@@ -5694,7 +5740,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:15:55 GMT
+      - Mon, 12 Mar 2018 10:23:25 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -5702,7 +5748,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest14047:0YeQjhyqITxPHoylCG0CTK+jQI4nEFrSJkkw6L+P5QQ=
+      - SharedKey miqazuretest14047:Kl2MZgeGayBeOYziBPTTTdkcKLN1LalYXVjftt8yUkg=
   response:
     status:
       code: 200
@@ -5723,7 +5769,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 8638732a-001e-0056-2e51-b6ce0f000000
+      - d4d887c6-001e-00c4-1aec-b959b9000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -5747,12 +5793,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:15:55 GMT
+      - Mon, 12 Mar 2018 10:23:20 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:55 GMT
+  recorded_at: Mon, 12 Mar 2018 10:23:25 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/rspeclb/listKeys?api-version=2017-10-01
@@ -5769,7 +5815,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MjIsIm5iZiI6MTUyMDQ1MzQyMiwiZXhwIjoxNTIwNDU3MzIyLCJhaW8iOiJZMk5nWUxoellPWHF0WktxWGt5aTlYL21zTnhLQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMHlWaEh0SXBFRWlmUEJiYkdtQUFBQSIsInZlciI6IjEuMCJ9.QP6A55sbs1vcfUsm1cecTY5pxZmIqB-C8_KOg4kViYSlKjKM-gEfjTaWcsUxAn13OAXQwFsofoALvy8ljyBM9DY9WXXP834p1cYaV8b-hMCO6psMAmthDKtCr19YaqbwfxkC3e_yopKPRFEFMN8ZHdJDNfMFkBYh8vXgYyWx9HlojlH9p3Rf63zoO3gMsLvs5k5GksnAhRkxK4_kESH60F9wQdal_rvhmgSKqcQNSH0n19QWrKO4TPXldXXC0hLXPLpQlUFbe_3Z2Ld7C7Hw4od07vmK-IB9HudOOOWpF4a-nCptigsbLLNDsbly7kXaiZdDNv6FxEHO2ihXOS-E3A
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk4NTEsIm5iZiI6MTUyMDg0OTg1MSwiZXhwIjoxNTIwODUzNzUxLCJhaW8iOiJZMk5nWUdnMTdtbnB1TkxmdjhIZFd1M3MzNEFxQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoid0c3OGNmUVdWVU91d0VpUllMMGtBQSIsInZlciI6IjEuMCJ9.k3cg0W62L17a8oBj2LTqWNoP5vRlbfK38MP5Ri8Pd7XZzNvY5b_2C4aLzm2cnOci90jzEXKXLjhwJUF3OiPciavyrCme8MZtFHWMDRdOTfJS144MJfmk-fuNHf3UrJG6Bx0VDx8yI41oigsMKYrlXu9DJEyPNr9c9L0HSMT8F3sXGezL5mbwsDDBQdcq92mJpTb4E4r1o97h_kdv8WVJL8UdLKOc2c8QQB4c87lx9q-Ux11_XV-Cd5UCxtDDsStPEnALG_4_Q8cq65EcFKGRkMGMZ2LKary2pbnNZqRJrqKQpJgy79oCeFkSKvP6qeXxkOoeGYJd8G5j-mfE0tprYw
       Content-Length:
       - '0'
   response:
@@ -5790,26 +5836,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 350689ef-48c5-4a23-8184-67a5dc8257ab
+      - 5bb15de4-cdd2-4a49-a5d0-bf64033a645b
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1199'
+      - '1196'
       X-Ms-Correlation-Request-Id:
-      - 1f2be797-4f8a-45af-b1ab-01fb16e5669c
+      - 5400f28c-505f-4e89-8a74-f020fcff58e0
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201556Z:1f2be797-4f8a-45af-b1ab-01fb16e5669c
+      - WESTEUROPE:20180312T102322Z:5400f28c-505f-4e89-8a74-f020fcff58e0
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:15:56 GMT
+      - Mon, 12 Mar 2018 10:23:21 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keys":[{"keyName":"key1","value":"xMvZwiumnKCZnYVJjdtGLqaO1c2v6ERPx4XPDZO7TM1l7/jM1TxAAgtfCMkRn72aRPhqLqwWAn8n5a1iSGRHtA==","permissions":"Full"},{"keyName":"key2","value":"3nDvKhjGAIAvgnH2reuv7tzyeb/0dddgVeUT13VODYD5xO/jeAvQ7tkF3JqP2BAuFrmQqMB4GLkB4/cW4veYeA==","permissions":"Full"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:56 GMT
+  recorded_at: Mon, 12 Mar 2018 10:23:26 GMT
 - request:
     method: get
     uri: https://rspeclb.blob.core.windows.net/?comp=list
@@ -5826,13 +5872,13 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:15:56 GMT
+      - Mon, 12 Mar 2018 10:23:26 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
       - 'true'
       Authorization:
-      - SharedKey rspeclb:PU7EBluz8PV5vi4Qx9OoyJWt05m45uPR1U/k9FUypms=
+      - SharedKey rspeclb:yP+kPF6lW/5YZ3BuDlcosdeT/fesYEKDmZJRE+iRVj4=
   response:
     status:
       code: 200
@@ -5847,17 +5893,17 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - e8a8cc09-001c-005d-2451-b695c3000000
+      - e6e1ac33-f01c-0061-23ec-b92118000000
       X-Ms-Version:
       - '2016-05-31'
       Date:
-      - Wed, 07 Mar 2018 20:15:56 GMT
+      - Mon, 12 Mar 2018 10:23:22 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPEVudW1lcmF0aW9uUmVzdWx0cyBTZXJ2aWNlRW5kcG9pbnQ9Imh0dHBzOi8vcnNwZWNsYi5ibG9iLmNvcmUud2luZG93cy5uZXQvIj48Q29udGFpbmVycz48Q29udGFpbmVyPjxOYW1lPnZoZHM8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+RnJpLCAwMiBTZXAgMjAxNiAxNjoyOTo0MSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+JnF1b3Q7MHg4RDNEMzRFNTcwREZDMEEmcXVvdDs8L0V0YWc+PExlYXNlU3RhdHVzPmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+bGVhc2VkPC9MZWFzZVN0YXRlPjxMZWFzZUR1cmF0aW9uPmluZmluaXRlPC9MZWFzZUR1cmF0aW9uPjwvUHJvcGVydGllcz48L0NvbnRhaW5lcj48L0NvbnRhaW5lcnM+PE5leHRNYXJrZXIvPjwvRW51bWVyYXRpb25SZXN1bHRzPg==
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:57 GMT
+  recorded_at: Mon, 12 Mar 2018 10:23:27 GMT
 - request:
     method: get
     uri: https://rspeclb.blob.core.windows.net/vhds?comp=list&restype=container
@@ -5874,13 +5920,13 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:15:57 GMT
+      - Mon, 12 Mar 2018 10:23:27 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
       - 'true'
       Authorization:
-      - SharedKey rspeclb:bvaq9Tvx66BaIn+XdjWv1hxqKmGlVCCsdSqJtU+azSs=
+      - SharedKey rspeclb:bSR50ICpkqTFTPlW+GraTy2hKze4cGX0yzyGOYd0cV4=
   response:
     status:
       code: 200
@@ -5895,17 +5941,17 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - a711ffc2-b01c-000b-6951-b67db3000000
+      - 42236000-d01c-005f-0aec-b99739000000
       X-Ms-Version:
       - '2016-05-31'
       Date:
-      - Wed, 07 Mar 2018 20:15:57 GMT
+      - Mon, 12 Mar 2018 10:23:22 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPEVudW1lcmF0aW9uUmVzdWx0cyBTZXJ2aWNlRW5kcG9pbnQ9Imh0dHBzOi8vcnNwZWNsYi5ibG9iLmNvcmUud2luZG93cy5uZXQvIiBDb250YWluZXJOYW1lPSJ2aGRzIj48QmxvYnM+PEJsb2I+PE5hbWU+cnNwZWMtbGItYTIwMTY4MjEyMjgzOS52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+U2F0LCAwMyBTZXAgMjAxNiAxNDowMzoxNSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDNENDAzMENBMEFCRUY8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjMyMjEyMjU1MjMyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nLz48Q29udGVudC1MYW5ndWFnZS8+PENvbnRlbnQtTUQ1PjhCVzVocXJuT0xvUUlObFowNW9keEE9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wvPjxDb250ZW50LURpc3Bvc2l0aW9uLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4xPC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+bGVhc2VkPC9MZWFzZVN0YXRlPjxMZWFzZUR1cmF0aW9uPmluZmluaXRlPC9MZWFzZUR1cmF0aW9uPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjxCbG9iPjxOYW1lPnJzcGVjLWxiLWIyMDE2ODIxMjM2NTAudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlNhdCwgMDMgU2VwIDIwMTYgMTQ6MDU6NDAgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzRDQwMzYyRkUzODk4PC9FdGFnPjxDb250ZW50LUxlbmd0aD4zMjIxMjI1NTIzMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZy8+PENvbnRlbnQtTGFuZ3VhZ2UvPjxDb250ZW50LU1ENT44Qlc1aHFybk9Mb1FJTmxaMDVvZHhBPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sLz48Q29udGVudC1EaXNwb3NpdGlvbi8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MTwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJhdGlvbj5pbmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48L0Jsb2JzPjxOZXh0TWFya2VyLz48L0VudW1lcmF0aW9uUmVzdWx0cz4=
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:57 GMT
+  recorded_at: Mon, 12 Mar 2018 10:23:28 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/spec0deply1stor/listKeys?api-version=2017-10-01
@@ -5922,7 +5968,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MjIsIm5iZiI6MTUyMDQ1MzQyMiwiZXhwIjoxNTIwNDU3MzIyLCJhaW8iOiJZMk5nWUxoellPWHF0WktxWGt5aTlYL21zTnhLQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMHlWaEh0SXBFRWlmUEJiYkdtQUFBQSIsInZlciI6IjEuMCJ9.QP6A55sbs1vcfUsm1cecTY5pxZmIqB-C8_KOg4kViYSlKjKM-gEfjTaWcsUxAn13OAXQwFsofoALvy8ljyBM9DY9WXXP834p1cYaV8b-hMCO6psMAmthDKtCr19YaqbwfxkC3e_yopKPRFEFMN8ZHdJDNfMFkBYh8vXgYyWx9HlojlH9p3Rf63zoO3gMsLvs5k5GksnAhRkxK4_kESH60F9wQdal_rvhmgSKqcQNSH0n19QWrKO4TPXldXXC0hLXPLpQlUFbe_3Z2Ld7C7Hw4od07vmK-IB9HudOOOWpF4a-nCptigsbLLNDsbly7kXaiZdDNv6FxEHO2ihXOS-E3A
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk4NTEsIm5iZiI6MTUyMDg0OTg1MSwiZXhwIjoxNTIwODUzNzUxLCJhaW8iOiJZMk5nWUdnMTdtbnB1TkxmdjhIZFd1M3MzNEFxQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoid0c3OGNmUVdWVU91d0VpUllMMGtBQSIsInZlciI6IjEuMCJ9.k3cg0W62L17a8oBj2LTqWNoP5vRlbfK38MP5Ri8Pd7XZzNvY5b_2C4aLzm2cnOci90jzEXKXLjhwJUF3OiPciavyrCme8MZtFHWMDRdOTfJS144MJfmk-fuNHf3UrJG6Bx0VDx8yI41oigsMKYrlXu9DJEyPNr9c9L0HSMT8F3sXGezL5mbwsDDBQdcq92mJpTb4E4r1o97h_kdv8WVJL8UdLKOc2c8QQB4c87lx9q-Ux11_XV-Cd5UCxtDDsStPEnALG_4_Q8cq65EcFKGRkMGMZ2LKary2pbnNZqRJrqKQpJgy79oCeFkSKvP6qeXxkOoeGYJd8G5j-mfE0tprYw
       Content-Length:
       - '0'
   response:
@@ -5943,7 +5989,7 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 3e1a8f7b-f86f-42d0-8e3c-431f80b87da6
+      - bd4d9c2a-e777-49cb-b291-d52d30c0eb3f
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
@@ -5951,18 +5997,18 @@ http_interactions:
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
       - '1199'
       X-Ms-Correlation-Request-Id:
-      - 9e1b2fcd-4314-4c6f-b281-32f39dc27535
+      - 17d9b2ed-1beb-41ff-85d2-1a1bfdf36ebe
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201558Z:9e1b2fcd-4314-4c6f-b281-32f39dc27535
+      - WESTEUROPE:20180312T102324Z:17d9b2ed-1beb-41ff-85d2-1a1bfdf36ebe
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:15:58 GMT
+      - Mon, 12 Mar 2018 10:23:23 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keys":[{"keyName":"key1","value":"68JHlwL/JgyPmvNCqop65JbepxzK0RGKJ4uD6EKszcgv1nRUJKkxO6u4OoyW/6YPT+FMJxvzEBrCGD/bduFGJQ==","permissions":"Full"},{"keyName":"key2","value":"NCT/sPC/+mrVRzXq/V5IwjN2SPaWRF4kY2coPHzJ8f+IkWMUIyfUgYTAN//h4KnxeWuX9OkY1CPyssDhDs91fw==","permissions":"Full"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:58 GMT
+  recorded_at: Mon, 12 Mar 2018 10:23:29 GMT
 - request:
     method: get
     uri: https://spec0deply1stor.blob.core.windows.net/?comp=list
@@ -5979,13 +6025,13 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:15:58 GMT
+      - Mon, 12 Mar 2018 10:23:29 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
       - 'true'
       Authorization:
-      - SharedKey spec0deply1stor:yHRFPwYHYdXLMTnQr/bA+Y5aJpdCWG4xrSdK2kU62tU=
+      - SharedKey spec0deply1stor:rlhxYZmb2T237hICBIKhclXkEpRbWBXZ8PatVdYsn6w=
   response:
     status:
       code: 200
@@ -5998,17 +6044,17 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - f4bfd33c-001e-0079-4d51-b64f35000000
+      - efc3e7bc-001e-004c-36ec-b9e160000000
       X-Ms-Version:
       - '2016-05-31'
       Date:
-      - Wed, 07 Mar 2018 20:15:58 GMT
+      - Mon, 12 Mar 2018 10:23:24 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9zcGVjMGRlcGx5MXN0b3IuYmxvYi5jb3JlLndpbmRvd3MubmV0LyI+PENvbnRhaW5lcnM+PENvbnRhaW5lcj48TmFtZT5ib290ZGlhZ25vc3RpY3Mtc3BlYzBkZXBsLTRkMTUwMmQ1LTM1MWEtNDJmNC04NTY5LTIyMjg0ZjkwNmQ2ODwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5Nb24sIDA0IEFwciAyMDE2IDIzOjI0OjU2IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4iMHg4RDM1Q0UwNTU2MzlCQjMiPC9FdGFnPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0NvbnRhaW5lcj48Q29udGFpbmVyPjxOYW1lPmJvb3RkaWFnbm9zdGljcy1zcGVjMGRlcGwtZDcwMjIwMDgtZjZiMS00ZjRjLThiZTgtZTJkNjc3ZWYzMjYxPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPk1vbiwgMDQgQXByIDIwMTYgMjM6MjQ6NTYgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPiIweDhEMzVDRTA1NTg1QjcwQyI8L0V0YWc+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQ29udGFpbmVyPjxDb250YWluZXI+PE5hbWU+dmhkczwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5Nb24sIDA0IEFwciAyMDE2IDIzOjI0OjU3IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4iMHg4RDM1Q0UwNTVDRkEzN0IiPC9FdGFnPjxMZWFzZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJhdGlvbj5pbmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48L1Byb3BlcnRpZXM+PC9Db250YWluZXI+PC9Db250YWluZXJzPjxOZXh0TWFya2VyIC8+PC9FbnVtZXJhdGlvblJlc3VsdHM+
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:59 GMT
+  recorded_at: Mon, 12 Mar 2018 10:23:30 GMT
 - request:
     method: get
     uri: https://spec0deply1stor.blob.core.windows.net/vhds?comp=list&restype=container
@@ -6025,13 +6071,13 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:15:59 GMT
+      - Mon, 12 Mar 2018 10:23:30 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
       - 'true'
       Authorization:
-      - SharedKey spec0deply1stor:54AVFk+WyY9VksO4qEbIUVciBP8K5pywWJ2Sq3XvJgw=
+      - SharedKey spec0deply1stor:BQXq3vbk84cGwtUmtTy4IQszQGp82/l0MdhwZfN8JJM=
   response:
     status:
       code: 200
@@ -6044,17 +6090,17 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 370ac9d5-001e-0131-7251-b63bfd000000
+      - 1c6d7882-001e-0050-27ec-b93977000000
       X-Ms-Version:
       - '2016-05-31'
       Date:
-      - Wed, 07 Mar 2018 20:15:58 GMT
+      - Mon, 12 Mar 2018 10:23:26 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9zcGVjMGRlcGx5MXN0b3IuYmxvYi5jb3JlLndpbmRvd3MubmV0LyIgQ29udGFpbmVyTmFtZT0idmhkcyI+PEJsb2JzPjxCbG9iPjxOYW1lPm9zZGlzazAudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlNhdCwgMDMgU2VwIDIwMTYgMDI6MDQ6MzggR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzRDM5RUE4RjcxNzE1PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj40MzwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJhdGlvbj5pbmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5vc2Rpc2sxLnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5TYXQsIDAzIFNlcCAyMDE2IDAyOjA2OjM3IEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0QzOUVGMDJFMTZCNzwvRXRhZz48Q29udGVudC1MZW5ndGg+MTM2MzY3MzA5MzEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+VmJZaFc5LzZOT1h6UVZLL3ZRa2R2Zz09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+NTM8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+bG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5sZWFzZWQ8L0xlYXNlU3RhdGU+PExlYXNlRHVyYXRpb24+aW5maW5pdGU8L0xlYXNlRHVyYXRpb24+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+c3BlYzBkZXBseTF2bTAuZDcwMjIwMDgtZjZiMS00ZjRjLThiZTgtZTJkNjc3ZWYzMjYxLnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5TYXQsIDAzIFNlcCAyMDE2IDAyOjA0OjIxIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0QzOUU5RUU4ODdGQzwvRXRhZz48Q29udGVudC1MZW5ndGg+MjQyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+TjBqdys3eUJtbnA2c3hMTEkzbmNFQT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+c3BlYzBkZXBseTF2bTEuNGQxNTAyZDUtMzUxYS00MmY0LTg1NjktMjIyODRmOTA2ZDY4LnN0YXR1czwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5TYXQsIDAzIFNlcCAyMDE2IDAyOjA2OjMwIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhEM0QzOUVFQkNEMEUyMjwvRXRhZz48Q29udGVudC1MZW5ndGg+MjQyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+ZTNZVWlxWHBZcU81bGcvZnhabzRUQT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PC9CbG9icz48TmV4dE1hcmtlciAvPjwvRW51bWVyYXRpb25SZXN1bHRzPg==
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:15:59 GMT
+  recorded_at: Mon, 12 Mar 2018 10:23:30 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Storage/storageAccounts/miqazuretest26611/listKeys?api-version=2017-10-01
@@ -6071,7 +6117,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MjIsIm5iZiI6MTUyMDQ1MzQyMiwiZXhwIjoxNTIwNDU3MzIyLCJhaW8iOiJZMk5nWUxoellPWHF0WktxWGt5aTlYL21zTnhLQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMHlWaEh0SXBFRWlmUEJiYkdtQUFBQSIsInZlciI6IjEuMCJ9.QP6A55sbs1vcfUsm1cecTY5pxZmIqB-C8_KOg4kViYSlKjKM-gEfjTaWcsUxAn13OAXQwFsofoALvy8ljyBM9DY9WXXP834p1cYaV8b-hMCO6psMAmthDKtCr19YaqbwfxkC3e_yopKPRFEFMN8ZHdJDNfMFkBYh8vXgYyWx9HlojlH9p3Rf63zoO3gMsLvs5k5GksnAhRkxK4_kESH60F9wQdal_rvhmgSKqcQNSH0n19QWrKO4TPXldXXC0hLXPLpQlUFbe_3Z2Ld7C7Hw4od07vmK-IB9HudOOOWpF4a-nCptigsbLLNDsbly7kXaiZdDNv6FxEHO2ihXOS-E3A
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk4NTEsIm5iZiI6MTUyMDg0OTg1MSwiZXhwIjoxNTIwODUzNzUxLCJhaW8iOiJZMk5nWUdnMTdtbnB1TkxmdjhIZFd1M3MzNEFxQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoid0c3OGNmUVdWVU91d0VpUllMMGtBQSIsInZlciI6IjEuMCJ9.k3cg0W62L17a8oBj2LTqWNoP5vRlbfK38MP5Ri8Pd7XZzNvY5b_2C4aLzm2cnOci90jzEXKXLjhwJUF3OiPciavyrCme8MZtFHWMDRdOTfJS144MJfmk-fuNHf3UrJG6Bx0VDx8yI41oigsMKYrlXu9DJEyPNr9c9L0HSMT8F3sXGezL5mbwsDDBQdcq92mJpTb4E4r1o97h_kdv8WVJL8UdLKOc2c8QQB4c87lx9q-Ux11_XV-Cd5UCxtDDsStPEnALG_4_Q8cq65EcFKGRkMGMZ2LKary2pbnNZqRJrqKQpJgy79oCeFkSKvP6qeXxkOoeGYJd8G5j-mfE0tprYw
       Content-Length:
       - '0'
   response:
@@ -6092,7 +6138,7 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 9c71c3b0-f4b6-42ed-8112-fbdfeb186987
+      - 7397aa23-6c27-4208-94f4-03f5d3264e74
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
@@ -6100,18 +6146,18 @@ http_interactions:
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
       - '1198'
       X-Ms-Correlation-Request-Id:
-      - 7e6f73cc-f5ed-4925-9f6f-85f893710872
+      - d2f166fa-d653-4da9-979d-5d4cc669a066
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201600Z:7e6f73cc-f5ed-4925-9f6f-85f893710872
+      - WESTEUROPE:20180312T102327Z:d2f166fa-d653-4da9-979d-5d4cc669a066
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:16:00 GMT
+      - Mon, 12 Mar 2018 10:23:26 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keys":[{"keyName":"key1","value":"Hh1rIrLFYOsfGuufnXsDBIZhDPUM0RWfl1XnZojGXRDo2TRjpQFisw3U7OfrizJ0J7fcN1535PrBniNUt/sVcw==","permissions":"Full"},{"keyName":"key2","value":"EZOKcIq7u+qCjHAIWfhDG0VGJe6sez+D+lYt5cbevX1njlWq+Z2lkffcTOsR/Pe4cDZg4OBCO1SymcWm3A35RA==","permissions":"Full"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:00 GMT
+  recorded_at: Mon, 12 Mar 2018 10:23:32 GMT
 - request:
     method: get
     uri: https://miqazuretest26611.blob.core.windows.net/?comp=list
@@ -6128,13 +6174,13 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:16:00 GMT
+      - Mon, 12 Mar 2018 10:23:32 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
       - 'true'
       Authorization:
-      - SharedKey miqazuretest26611:CkyXdiJeWhHyi2WTY2bstJ04b5YwHBf0fRcjbd4QHTc=
+      - SharedKey miqazuretest26611:oxrAahm5fnCJqQgAuPps7EAjlGduH+41Zbc/RphnRy8=
   response:
     status:
       code: 200
@@ -6147,17 +6193,17 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - d3f17f29-101e-00e2-2f51-b62c3d000000
+      - 565e9578-701e-003e-70ec-b97e6e000000
       X-Ms-Version:
       - '2016-05-31'
       Date:
-      - Wed, 07 Mar 2018 20:16:00 GMT
+      - Mon, 12 Mar 2018 10:23:27 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9taXFhenVyZXRlc3QyNjYxMS5ibG9iLmNvcmUud2luZG93cy5uZXQvIj48Q29udGFpbmVycz48Q29udGFpbmVyPjxOYW1lPmJvb3RkaWFnbm9zdGljcy1qZm1ldHJpY3MtOTA0Y2M5ODEtZmE0ZC00ZGFmLWI4YjEtZGZjMGYwMTkzOGI1PC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPk1vbiwgMDIgTWF5IDIwMTYgMTg6MDI6MDEgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPiIweDhEMzcyQjNEQzk5NTRCRCI8L0V0YWc+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQ29udGFpbmVyPjxDb250YWluZXI+PE5hbWU+bWFuYWdlaXE8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VHVlLCAxNyBNYXkgMjAxNiAxODo0Mzo0NiBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+IjB4OEQzN0U4MzJFMjMwNEVEIjwvRXRhZz48TGVhc2VTdGF0dXM+bG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5sZWFzZWQ8L0xlYXNlU3RhdGU+PExlYXNlRHVyYXRpb24+aW5maW5pdGU8L0xlYXNlRHVyYXRpb24+PC9Qcm9wZXJ0aWVzPjwvQ29udGFpbmVyPjxDb250YWluZXI+PE5hbWU+dmhkczwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5Nb24sIDAyIE1heSAyMDE2IDE4OjAyOjAxIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4iMHg4RDM3MkIzRENCNjBCNTEiPC9FdGFnPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0NvbnRhaW5lcj48L0NvbnRhaW5lcnM+PE5leHRNYXJrZXIgLz48L0VudW1lcmF0aW9uUmVzdWx0cz4=
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:01 GMT
+  recorded_at: Mon, 12 Mar 2018 10:23:33 GMT
 - request:
     method: get
     uri: https://miqazuretest26611.blob.core.windows.net/manageiq?comp=list&restype=container
@@ -6174,13 +6220,13 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:16:01 GMT
+      - Mon, 12 Mar 2018 10:23:33 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
       - 'true'
       Authorization:
-      - SharedKey miqazuretest26611:rL0Y3svFlP2+ctOAN5zg5YzqZvDF+nquPK40clEDehs=
+      - SharedKey miqazuretest26611:k9TLj6Lr5LOum7RfatJk3WgOd/gMRN6DCEjAoPY4SgU=
   response:
     status:
       code: 200
@@ -6193,17 +6239,17 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - c832d98c-f01e-0085-0651-b69f9a000000
+      - 01c1e978-801e-0081-3dec-b96a18000000
       X-Ms-Version:
       - '2016-05-31'
       Date:
-      - Wed, 07 Mar 2018 20:16:00 GMT
+      - Mon, 12 Mar 2018 10:23:29 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9taXFhenVyZXRlc3QyNjYxMS5ibG9iLmNvcmUud2luZG93cy5uZXQvIiBDb250YWluZXJOYW1lPSJtYW5hZ2VpcSI+PEJsb2JzPjxCbG9iPjxOYW1lPm1pcW1pc21hdGNoMV81NzMwMmVlZS00NDJlLTRkYzUtOWIxMC04OTBlYjI5Njc0Y2QudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPlR1ZSwgMTcgTWF5IDIwMTYgMTk6MTU6NDQgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzN0U4N0E1NTY0N0E1PC9FdGFnPjxDb250ZW50LUxlbmd0aD4zMTQ1NzI4MDUxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PmhLZE9qa2F1cDdzQi9uemtXZXVoV0E9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjM8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+dW5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmF2YWlsYWJsZTwvTGVhc2VTdGF0ZT48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48QmxvYj48TmFtZT5taXFtaXNtYXRjaDFfODAyMTc0M2EtNTk1Ny00ZGMxLWE2NDUtY2EyMTBkNWQ3ZmM1LnZoZDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5UdWUsIDA2IE1hciAyMDE4IDIyOjI3OjUzIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4weDhENTgzQjE4MEMwMkEzODwvRXRhZz48Q29udGVudC1MZW5ndGg+MzE0NTcyODA1MTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5oS2RPamthdXA3c0IvbnprV2V1aFdBPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj4xNTU8L3gtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+PEJsb2JUeXBlPlBhZ2VCbG9iPC9CbG9iVHlwZT48TGVhc2VTdGF0dXM+bG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5sZWFzZWQ8L0xlYXNlU3RhdGU+PExlYXNlRHVyYXRpb24+aW5maW5pdGU8L0xlYXNlRHVyYXRpb24+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+bWlxbWlzbWF0Y2gxXzgxOGExZjI3LTAxYTYtNDdkYS1hNjU1LWQ5YjcyOTQ4MzRiNS52aGQ8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+VHVlLCAxNyBNYXkgMjAxNiAxOTo1Nzo1NSBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+MHg4RDM3RThEODk3RUZDOEE8L0V0YWc+PENvbnRlbnQtTGVuZ3RoPjMxNDU3MjgwNTEyPC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+aEtkT2prYXVwN3NCL256a1dldWhXQT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PHgtbXMtYmxvYi1zZXF1ZW5jZS1udW1iZXI+MTwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjxTZXJ2ZXJFbmNyeXB0ZWQ+ZmFsc2U8L1NlcnZlckVuY3J5cHRlZD48L1Byb3BlcnRpZXM+PC9CbG9iPjwvQmxvYnM+PE5leHRNYXJrZXIgLz48L0VudW1lcmF0aW9uUmVzdWx0cz4=
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:01 GMT
+  recorded_at: Mon, 12 Mar 2018 10:23:33 GMT
 - request:
     method: head
     uri: https://miqazuretest26611.blob.core.windows.net/manageiq/miqmismatch1_57302eee-442e-4dc5-9b10-890eb29674cd.vhd
@@ -6220,7 +6266,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:16:01 GMT
+      - Mon, 12 Mar 2018 10:23:33 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -6228,7 +6274,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest26611:bme93WV0FKCXKrDz6oCRkys2WmzYbkS2pcVvcignR5s=
+      - SharedKey miqazuretest26611:GC32W2D2m5tBwSMQI5AEiLMEGOACZYWeYMJVwgzIH0A=
   response:
     status:
       code: 200
@@ -6249,7 +6295,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 7e4293a7-201e-00c8-2d51-b65978000000
+      - d6997031-801e-004d-53ec-b90ead000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -6273,12 +6319,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:16:01 GMT
+      - Mon, 12 Mar 2018 10:23:29 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:02 GMT
+  recorded_at: Mon, 12 Mar 2018 10:23:34 GMT
 - request:
     method: head
     uri: https://miqazuretest26611.blob.core.windows.net/manageiq/miqmismatch1_818a1f27-01a6-47da-a655-d9b7294834b5.vhd
@@ -6295,7 +6341,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:16:02 GMT
+      - Mon, 12 Mar 2018 10:23:34 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -6303,7 +6349,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest26611:JR28N9U/FuSoA4dZutLHRiRte1k9W5Fn8Jt0KbiLWiI=
+      - SharedKey miqazuretest26611:Kb8JH2qLn43wESElD+nc6BBFxfJNMHNvHrR0e+nyJvk=
   response:
     status:
       code: 200
@@ -6324,7 +6370,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - b7d08a84-f01e-006b-2f51-b69519000000
+      - a7a038a4-201e-0040-2cec-b9e1a1000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -6348,12 +6394,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:16:01 GMT
+      - Mon, 12 Mar 2018 10:23:30 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:03 GMT
+  recorded_at: Mon, 12 Mar 2018 10:23:35 GMT
 - request:
     method: get
     uri: https://miqazuretest26611.blob.core.windows.net/vhds?comp=list&restype=container
@@ -6370,13 +6416,13 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:16:03 GMT
+      - Mon, 12 Mar 2018 10:23:35 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
       - 'true'
       Authorization:
-      - SharedKey miqazuretest26611:ZV0hkP3rc+dOpBntXc5IJwmcik8a2pMJmOHh97E1C7s=
+      - SharedKey miqazuretest26611:qJoLp6CLkp0SyGnzruc5hrWPvGoC82HEJAU2/GjHiho=
   response:
     status:
       code: 200
@@ -6389,17 +6435,17 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 51fe7134-201e-0087-7f51-b69d60000000
+      - 7f2a738e-d01e-0033-73ec-b99162000000
       X-Ms-Version:
       - '2016-05-31'
       Date:
-      - Wed, 07 Mar 2018 20:16:02 GMT
+      - Mon, 12 Mar 2018 10:23:30 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9taXFhenVyZXRlc3QyNjYxMS5ibG9iLmNvcmUud2luZG93cy5uZXQvIiBDb250YWluZXJOYW1lPSJ2aGRzIj48QmxvYnM+PEJsb2I+PE5hbWU+amYtbWV0cmljcy0xMjAxNjQyMTQxMjAudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPk1vbiwgMDIgTWF5IDIwMTYgMjA6MDE6NTUgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzNzJDNDlDQ0UzMUNGPC9FdGFnPjxDb250ZW50LUxlbmd0aD4xMzYzNjczMDkzMTI8L0NvbnRlbnQtTGVuZ3RoPjxDb250ZW50LVR5cGU+YXBwbGljYXRpb24vb2N0ZXQtc3RyZWFtPC9Db250ZW50LVR5cGU+PENvbnRlbnQtRW5jb2RpbmcgLz48Q29udGVudC1MYW5ndWFnZSAvPjxDb250ZW50LU1ENT5WYlloVzkvNk5PWHpRVksvdlFrZHZnPT08L0NvbnRlbnQtTUQ1PjxDYWNoZS1Db250cm9sIC8+PENvbnRlbnQtRGlzcG9zaXRpb24gLz48eC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj40PC94LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjxCbG9iVHlwZT5QYWdlQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PC9CbG9icz48TmV4dE1hcmtlciAvPjwvRW51bWVyYXRpb25SZXN1bHRzPg==
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:03 GMT
+  recorded_at: Mon, 12 Mar 2018 10:23:36 GMT
 - request:
     method: head
     uri: https://miqazuretest26611.blob.core.windows.net/vhds/jf-metrics-120164214120.vhd
@@ -6416,7 +6462,7 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:16:03 GMT
+      - Mon, 12 Mar 2018 10:23:36 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
@@ -6424,7 +6470,7 @@ http_interactions:
       Verb:
       - HEAD
       Authorization:
-      - SharedKey miqazuretest26611:NqhBEybG7woT7X7HilMLU2pg/XrssTPDKvwjkmYZOe8=
+      - SharedKey miqazuretest26611:lFHcuSBg9fERgSz/yQcpg1UojtfC6RGnqPEn5LIMJSw=
   response:
     status:
       code: 200
@@ -6445,7 +6491,7 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 695750e7-601e-002a-6d51-b6bd0a000000
+      - 268e9743-e01e-0116-6cec-b94f84000000
       X-Ms-Version:
       - '2016-05-31'
       X-Ms-Lease-Status:
@@ -6469,12 +6515,12 @@ http_interactions:
       X-Ms-Server-Encrypted:
       - 'false'
       Date:
-      - Wed, 07 Mar 2018 20:16:03 GMT
+      - Mon, 12 Mar 2018 10:23:32 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:04 GMT
+  recorded_at: Mon, 12 Mar 2018 10:23:36 GMT
 - request:
     method: post
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Storage/storageAccounts/miqazuretest16487/listKeys?api-version=2017-10-01
@@ -6491,7 +6537,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM0MjIsIm5iZiI6MTUyMDQ1MzQyMiwiZXhwIjoxNTIwNDU3MzIyLCJhaW8iOiJZMk5nWUxoellPWHF0WktxWGt5aTlYL21zTnhLQXdBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiMHlWaEh0SXBFRWlmUEJiYkdtQUFBQSIsInZlciI6IjEuMCJ9.QP6A55sbs1vcfUsm1cecTY5pxZmIqB-C8_KOg4kViYSlKjKM-gEfjTaWcsUxAn13OAXQwFsofoALvy8ljyBM9DY9WXXP834p1cYaV8b-hMCO6psMAmthDKtCr19YaqbwfxkC3e_yopKPRFEFMN8ZHdJDNfMFkBYh8vXgYyWx9HlojlH9p3Rf63zoO3gMsLvs5k5GksnAhRkxK4_kESH60F9wQdal_rvhmgSKqcQNSH0n19QWrKO4TPXldXXC0hLXPLpQlUFbe_3Z2Ld7C7Hw4od07vmK-IB9HudOOOWpF4a-nCptigsbLLNDsbly7kXaiZdDNv6FxEHO2ihXOS-E3A
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk4NTEsIm5iZiI6MTUyMDg0OTg1MSwiZXhwIjoxNTIwODUzNzUxLCJhaW8iOiJZMk5nWUdnMTdtbnB1TkxmdjhIZFd1M3MzNEFxQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoid0c3OGNmUVdWVU91d0VpUllMMGtBQSIsInZlciI6IjEuMCJ9.k3cg0W62L17a8oBj2LTqWNoP5vRlbfK38MP5Ri8Pd7XZzNvY5b_2C4aLzm2cnOci90jzEXKXLjhwJUF3OiPciavyrCme8MZtFHWMDRdOTfJS144MJfmk-fuNHf3UrJG6Bx0VDx8yI41oigsMKYrlXu9DJEyPNr9c9L0HSMT8F3sXGezL5mbwsDDBQdcq92mJpTb4E4r1o97h_kdv8WVJL8UdLKOc2c8QQB4c87lx9q-Ux11_XV-Cd5UCxtDDsStPEnALG_4_Q8cq65EcFKGRkMGMZ2LKary2pbnNZqRJrqKQpJgy79oCeFkSKvP6qeXxkOoeGYJd8G5j-mfE0tprYw
       Content-Length:
       - '0'
   response:
@@ -6512,26 +6558,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 0b2aa772-928c-45b3-b2e0-4ee9d6e32b52
+      - c42d7f50-15f2-41aa-89a7-60e847141264
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0 Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1197'
+      - '1195'
       X-Ms-Correlation-Request-Id:
-      - 3d517436-3ff2-4684-a9d8-115cdd2ae98b
+      - bccfb4cd-7af5-4aae-895e-c97127773c49
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T201604Z:3d517436-3ff2-4684-a9d8-115cdd2ae98b
+      - WESTEUROPE:20180312T102333Z:bccfb4cd-7af5-4aae-895e-c97127773c49
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:16:03 GMT
+      - Mon, 12 Mar 2018 10:23:32 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"keys":[{"keyName":"key1","value":"ELTQwCiFqVImh96hlGId6JwT3r2zczvyeG7cA2HURT1oTYsFnPeRQjgVTV/j4GSG+XCYe5YOthB26dPcd/8JXQ==","permissions":"Full"},{"keyName":"key2","value":"uNJn8gcE3/hHHewm5z+vzty/mieLySe+jKn3t0ZKcivOk95ggorfeXAxvsiehK2HiqQWMAvdhQKU+3Ero0YHyA==","permissions":"Full"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:04 GMT
+  recorded_at: Mon, 12 Mar 2018 10:23:37 GMT
 - request:
     method: get
     uri: https://miqazuretest16487.blob.core.windows.net/?comp=list
@@ -6548,13 +6594,13 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:16:04 GMT
+      - Mon, 12 Mar 2018 10:23:37 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
       - 'true'
       Authorization:
-      - SharedKey miqazuretest16487:4P9zM8yL3r9QV7Ru9dTb0KN3/3WkUhzdPTA/4w1tVx8=
+      - SharedKey miqazuretest16487:hWFuQJNb4NJUXFe2IMAYHYOE8EjvpOeqtsYzR94quEs=
   response:
     status:
       code: 200
@@ -6567,17 +6613,17 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - 3b5cf3a6-001e-000c-4951-b6c88e000000
+      - 1e523fca-001e-0023-2cec-b949b4000000
       X-Ms-Version:
       - '2016-05-31'
       Date:
-      - Wed, 07 Mar 2018 20:16:04 GMT
+      - Mon, 12 Mar 2018 10:23:33 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9taXFhenVyZXRlc3QxNjQ4Ny5ibG9iLmNvcmUud2luZG93cy5uZXQvIj48Q29udGFpbmVycz48Q29udGFpbmVyPjxOYW1lPmJvb3RkaWFnbm9zdGljcy1taXF0ZXN0dWItYzRkNTc3YWUtNGJlOC00MWMxLTg0ZjgtNjQyMzIwOTEwYTVlPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPkZyaSwgMTggTWFyIDIwMTYgMTc6Mjc6MzAgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPiIweDhEMzRGNTI5NUM2RTcwQyI8L0V0YWc+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PC9Qcm9wZXJ0aWVzPjwvQ29udGFpbmVyPjxDb250YWluZXI+PE5hbWU+Ym9vdGRpYWdub3N0aWNzLXJzcGVjbGJhLTIzYjBiZWFiLTE2ZDItNDEzNS1hMDFmLTJmZTcxMzIxN2ZkMDwvTmFtZT48UHJvcGVydGllcz48TGFzdC1Nb2RpZmllZD5GcmksIDAyIFNlcCAyMDE2IDE2OjI5OjQwIEdNVDwvTGFzdC1Nb2RpZmllZD48RXRhZz4iMHg4RDNEMzRFNTZFNEJCMkIiPC9FdGFnPjxMZWFzZVN0YXR1cz51bmxvY2tlZDwvTGVhc2VTdGF0dXM+PExlYXNlU3RhdGU+YXZhaWxhYmxlPC9MZWFzZVN0YXRlPjwvUHJvcGVydGllcz48L0NvbnRhaW5lcj48Q29udGFpbmVyPjxOYW1lPnZoZHM8L05hbWU+PFByb3BlcnRpZXM+PExhc3QtTW9kaWZpZWQ+RnJpLCAxOCBNYXIgMjAxNiAxNzoyNzozMCBHTVQ8L0xhc3QtTW9kaWZpZWQ+PEV0YWc+IjB4OEQzNEY1Mjk1REZDQzIyIjwvRXRhZz48TGVhc2VTdGF0dXM+bG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5sZWFzZWQ8L0xlYXNlU3RhdGU+PExlYXNlRHVyYXRpb24+aW5maW5pdGU8L0xlYXNlRHVyYXRpb24+PC9Qcm9wZXJ0aWVzPjwvQ29udGFpbmVyPjwvQ29udGFpbmVycz48TmV4dE1hcmtlciAvPjwvRW51bWVyYXRpb25SZXN1bHRzPg==
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:05 GMT
+  recorded_at: Mon, 12 Mar 2018 10:23:38 GMT
 - request:
     method: get
     uri: https://miqazuretest16487.blob.core.windows.net/vhds?comp=list&restype=container
@@ -6594,13 +6640,13 @@ http_interactions:
       Content-Type:
       - ''
       X-Ms-Date:
-      - Wed, 07 Mar 2018 20:16:05 GMT
+      - Mon, 12 Mar 2018 10:23:38 GMT
       X-Ms-Version:
       - '2016-05-31'
       Auth-String:
       - 'true'
       Authorization:
-      - SharedKey miqazuretest16487:sXbtjCL0cJQgcNRdtpASxsspKjDgs72Iag1R53vqR5c=
+      - SharedKey miqazuretest16487:+tzUxyO1fshRWHa6+ySK6B5eZG9l+b2bSgPmk6lTTtM=
   response:
     status:
       code: 200
@@ -6613,15 +6659,15 @@ http_interactions:
       Server:
       - Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
       X-Ms-Request-Id:
-      - cddf404e-001e-0060-7b51-b6635d000000
+      - 8032ee03-001e-00f7-7bec-b90094000000
       X-Ms-Version:
       - '2016-05-31'
       Date:
-      - Wed, 07 Mar 2018 20:16:05 GMT
+      - Mon, 12 Mar 2018 10:23:34 GMT
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         77u/PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48RW51bWVyYXRpb25SZXN1bHRzIFNlcnZpY2VFbmRwb2ludD0iaHR0cHM6Ly9taXFhenVyZXRlc3QxNjQ4Ny5ibG9iLmNvcmUud2luZG93cy5uZXQvIiBDb250YWluZXJOYW1lPSJ2aGRzIj48QmxvYnM+PEJsb2I+PE5hbWU+bWlxLXRlc3QtdWJ1bnR1MS5jNGQ1NzdhZS00YmU4LTQxYzEtODRmOC02NDIzMjA5MTBhNWUuc3RhdHVzPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPldlZCwgMjIgSnVuIDIwMTYgMjE6NTc6MDUgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzOUFFODI2NjgyQTA1PC9FdGFnPjxDb250ZW50LUxlbmd0aD4xNzY2PC9Db250ZW50LUxlbmd0aD48Q29udGVudC1UeXBlPmFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTwvQ29udGVudC1UeXBlPjxDb250ZW50LUVuY29kaW5nIC8+PENvbnRlbnQtTGFuZ3VhZ2UgLz48Q29udGVudC1NRDU+WlVyb1NISk1HTFRDZkRwOSt0dkNyUT09PC9Db250ZW50LU1ENT48Q2FjaGUtQ29udHJvbCAvPjxDb250ZW50LURpc3Bvc2l0aW9uIC8+PEJsb2JUeXBlPkJsb2NrQmxvYjwvQmxvYlR5cGU+PExlYXNlU3RhdHVzPnVubG9ja2VkPC9MZWFzZVN0YXR1cz48TGVhc2VTdGF0ZT5hdmFpbGFibGU8L0xlYXNlU3RhdGU+PFNlcnZlckVuY3J5cHRlZD5mYWxzZTwvU2VydmVyRW5jcnlwdGVkPjwvUHJvcGVydGllcz48L0Jsb2I+PEJsb2I+PE5hbWU+bWlxLXRlc3QtdWJ1bnR1MTIwMTYyMTgxMTI2NDcudmhkPC9OYW1lPjxQcm9wZXJ0aWVzPjxMYXN0LU1vZGlmaWVkPldlZCwgMjIgSnVuIDIwMTYgMjE6NTc6MzMgR01UPC9MYXN0LU1vZGlmaWVkPjxFdGFnPjB4OEQzOUFFODM3MEJGOTBDPC9FdGFnPjxDb250ZW50LUxlbmd0aD4zMTQ1NzI4MDUxMjwvQ29udGVudC1MZW5ndGg+PENvbnRlbnQtVHlwZT5hcHBsaWNhdGlvbi9vY3RldC1zdHJlYW08L0NvbnRlbnQtVHlwZT48Q29udGVudC1FbmNvZGluZyAvPjxDb250ZW50LUxhbmd1YWdlIC8+PENvbnRlbnQtTUQ1PmhLZE9qa2F1cDdzQi9uemtXZXVoV0E9PTwvQ29udGVudC1NRDU+PENhY2hlLUNvbnRyb2wgLz48Q29udGVudC1EaXNwb3NpdGlvbiAvPjx4LW1zLWJsb2Itc2VxdWVuY2UtbnVtYmVyPjI2NDwveC1tcy1ibG9iLXNlcXVlbmNlLW51bWJlcj48QmxvYlR5cGU+UGFnZUJsb2I8L0Jsb2JUeXBlPjxMZWFzZVN0YXR1cz5sb2NrZWQ8L0xlYXNlU3RhdHVzPjxMZWFzZVN0YXRlPmxlYXNlZDwvTGVhc2VTdGF0ZT48TGVhc2VEdXJhdGlvbj5pbmZpbml0ZTwvTGVhc2VEdXJhdGlvbj48U2VydmVyRW5jcnlwdGVkPmZhbHNlPC9TZXJ2ZXJFbmNyeXB0ZWQ+PC9Qcm9wZXJ0aWVzPjwvQmxvYj48L0Jsb2JzPjxOZXh0TWFya2VyIC8+PC9FbnVtZXJhdGlvblJlc3VsdHM+
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:16:05 GMT
+  recorded_at: Mon, 12 Mar 2018 10:23:39 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted_scope/vm_with_managed_disk_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/azure/cloud_manager/refresher_targeted_scope/vm_with_managed_disk_refresh.yml
@@ -37,25 +37,25 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Ms-Request-Id:
-      - 515c80e0-bfa7-4ff7-8f21-90181b630000
+      - e625c655-2e62-4756-9bf4-d3cc75512400
       P3p:
       - CP="DSP CUR OTPi IND OTRi ONL FIN"
       Set-Cookie:
-      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzOr8KBabi1wqmwKQBTVqtJ40_LAHfQt_CxjMg_zIm35eS5zqTzCdTAKGzi0hc3lkJotGDyUwL2Sk532rskOZHfyWhMzmnM8dzyrNxGzv8d_X32ZJancQI8MSxXDAIbHA0mZz5iTXIKngcMZcB59-9ZU9jPtwpeqMLK5A8cxa8bHggAA;
+      - esctx=AQABAAAAAABHh4kmS_aKT5XrjzxRAtHzFtdGQtNbtA1FbpDLYO_2A1IaoXgVTHlDASy7FWWfZJcSkrrggV5cTlHn2CzK_15ZvMiJ3S_KmErpVRXPQkdPC1PbtVvcmBUj3ZV2H6vkjCbH6-NvNxrsOUFJGctq4j_Mm-fW4mEqss0U5BdCrIasqLOpOc9zsfiew4Ts6TCp5gggAA;
         domain=.login.microsoftonline.com; path=/; secure; HttpOnly
       - stsservicecookie=ests; path=/; secure; HttpOnly
-      - x-ms-gateway-slice=007; path=/; secure; HttpOnly
+      - x-ms-gateway-slice=005; path=/; secure; HttpOnly
       X-Powered-By:
       - ASP.NET
       Date:
-      - Wed, 07 Mar 2018 20:22:52 GMT
+      - Mon, 12 Mar 2018 10:21:53 GMT
       Content-Length:
       - '1505'
     body:
       encoding: UTF-8
-      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1520457773","not_before":"1520453873","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM4NzMsIm5iZiI6MTUyMDQ1Mzg3MywiZXhwIjoxNTIwNDU3NzczLCJhaW8iOiJZMk5nWUxqajhVejNnMUc2a2JISUhyWmJZam8zQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNElCY1VhZV85MC1QSVpBWUcyTUFBQSIsInZlciI6IjEuMCJ9.XLexpehMA9dl4mhacnwxGG3S2lvMIb4BHDe32wESH_YOiib-yj8UACu_OqbiKf3bx02JnqjWQ_RReCVM6YwymWhCLEfsSOola2dcsAY9VcxPC6D7k8rfw_7AlYnRytwZnJFQUfqu0qMxYNpLiVfMuzsIixlfn1FtSi7y_KFyp__xKKbDXy9g012W5mz3Y1GDtlqiN4f5p241ZaRQY6iunMDmbtwk59iabFJiGywoRj83L8L_2jcJc2GRjOLitr-4xlxtO3S_d17cXfJp0kJlX6bZBZDoRoHLfnnyl5Y9aeNTbJjJIf2i_7nfLvk2Y49LJZR75l9veik-TovXh3Dkng"}'
+      string: '{"token_type":"Bearer","expires_in":"3599","ext_expires_in":"0","expires_on":"1520853713","not_before":"1520849813","resource":"https://management.azure.com/","access_token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk4MTMsIm5iZiI6MTUyMDg0OTgxMywiZXhwIjoxNTIwODUzNzEzLCJhaW8iOiJZMk5nWUpDZDhXSnQweXhCbDUvc0Y1YjhPKytVQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVmNZbDVtSXVWa2ViOU5QTWRWRWtBQSIsInZlciI6IjEuMCJ9.oGtUHBSLaX5r_VyBRrZpGWWcjlykefrjX4x1d247gSlwKCJ6Mk6vXcQoFg6Ud3klUVlb9J41q6bQ9-Ys2crNkckHouvL8qLEMgpAk-_HWQagM5hQ6rlvRVHRNxrVeB9Pvba-Ypj4ytHLkWzgSjkEVFRlD_Tsl1uEYssfUKckPh6dJEfHMzXWS-EmB62x5dW-04hbiyUFlAW22nx2V7asqBJ9i-UW3GKRVZTK9LC-aP8qiYe_8Ulg4afvZvGPoQMS5eAA1-neKC5VdBmEhXBQz-zZqCqppXXv_LjMAL9CYU_SsTPgoN5qqkHIFwKG0cJv07-FtzRHJstpI4hVYJVzxg"}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:22:53 GMT
+  recorded_at: Mon, 12 Mar 2018 10:21:58 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions?api-version=2016-06-01
@@ -72,7 +72,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM4NzMsIm5iZiI6MTUyMDQ1Mzg3MywiZXhwIjoxNTIwNDU3NzczLCJhaW8iOiJZMk5nWUxqajhVejNnMUc2a2JISUhyWmJZam8zQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNElCY1VhZV85MC1QSVpBWUcyTUFBQSIsInZlciI6IjEuMCJ9.XLexpehMA9dl4mhacnwxGG3S2lvMIb4BHDe32wESH_YOiib-yj8UACu_OqbiKf3bx02JnqjWQ_RReCVM6YwymWhCLEfsSOola2dcsAY9VcxPC6D7k8rfw_7AlYnRytwZnJFQUfqu0qMxYNpLiVfMuzsIixlfn1FtSi7y_KFyp__xKKbDXy9g012W5mz3Y1GDtlqiN4f5p241ZaRQY6iunMDmbtwk59iabFJiGywoRj83L8L_2jcJc2GRjOLitr-4xlxtO3S_d17cXfJp0kJlX6bZBZDoRoHLfnnyl5Y9aeNTbJjJIf2i_7nfLvk2Y49LJZR75l9veik-TovXh3Dkng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk4MTMsIm5iZiI6MTUyMDg0OTgxMywiZXhwIjoxNTIwODUzNzEzLCJhaW8iOiJZMk5nWUpDZDhXSnQweXhCbDUvc0Y1YjhPKytVQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVmNZbDVtSXVWa2ViOU5QTWRWRWtBQSIsInZlciI6IjEuMCJ9.oGtUHBSLaX5r_VyBRrZpGWWcjlykefrjX4x1d247gSlwKCJ6Mk6vXcQoFg6Ud3klUVlb9J41q6bQ9-Ys2crNkckHouvL8qLEMgpAk-_HWQagM5hQ6rlvRVHRNxrVeB9Pvba-Ypj4ytHLkWzgSjkEVFRlD_Tsl1uEYssfUKckPh6dJEfHMzXWS-EmB62x5dW-04hbiyUFlAW22nx2V7asqBJ9i-UW3GKRVZTK9LC-aP8qiYe_8Ulg4afvZvGPoQMS5eAA1-neKC5VdBmEhXBQz-zZqCqppXXv_LjMAL9CYU_SsTPgoN5qqkHIFwKG0cJv07-FtzRHJstpI4hVYJVzxg
   response:
     status:
       code: 200
@@ -91,26 +91,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Tenant-Reads:
-      - '14996'
+      - '14999'
       X-Ms-Request-Id:
-      - ad91cdd1-302d-48e9-a45a-a58d2789edb5
+      - cae9f913-ebf7-42c6-b115-9d3fd40ebc17
       X-Ms-Correlation-Request-Id:
-      - ad91cdd1-302d-48e9-a45a-a58d2789edb5
+      - cae9f913-ebf7-42c6-b115-9d3fd40ebc17
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202253Z:ad91cdd1-302d-48e9-a45a-a58d2789edb5
+      - WESTEUROPE:20180312T102153Z:cae9f913-ebf7-42c6-b115-9d3fd40ebc17
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:22:53 GMT
+      - Mon, 12 Mar 2018 10:21:53 GMT
     body:
       encoding: ASCII-8BIT
       string: '{"value":[{"id":"/subscriptions/7be814a0-2a8a-4798-ac8f-304eda9d56f3","subscriptionId":"7be814a0-2a8a-4798-ac8f-304eda9d56f3","displayName":"New
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"Sponsored_2016-01-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID","subscriptionId":"AZURE_SUBSCRIPTION_ID","displayName":"Microsoft
         Azure Sponsorship","state":"Enabled","subscriptionPolicies":{"locationPlacementId":"Public_2014-09-01","quotaId":"PayAsYouGo_2014-09-01","spendingLimit":"Off"},"authorizationSource":"RoleBased"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:22:53 GMT
+  recorded_at: Mon, 12 Mar 2018 10:21:58 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers?api-version=2015-01-01
@@ -127,7 +127,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM4NzMsIm5iZiI6MTUyMDQ1Mzg3MywiZXhwIjoxNTIwNDU3NzczLCJhaW8iOiJZMk5nWUxqajhVejNnMUc2a2JISUhyWmJZam8zQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNElCY1VhZV85MC1QSVpBWUcyTUFBQSIsInZlciI6IjEuMCJ9.XLexpehMA9dl4mhacnwxGG3S2lvMIb4BHDe32wESH_YOiib-yj8UACu_OqbiKf3bx02JnqjWQ_RReCVM6YwymWhCLEfsSOola2dcsAY9VcxPC6D7k8rfw_7AlYnRytwZnJFQUfqu0qMxYNpLiVfMuzsIixlfn1FtSi7y_KFyp__xKKbDXy9g012W5mz3Y1GDtlqiN4f5p241ZaRQY6iunMDmbtwk59iabFJiGywoRj83L8L_2jcJc2GRjOLitr-4xlxtO3S_d17cXfJp0kJlX6bZBZDoRoHLfnnyl5Y9aeNTbJjJIf2i_7nfLvk2Y49LJZR75l9veik-TovXh3Dkng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk4MTMsIm5iZiI6MTUyMDg0OTgxMywiZXhwIjoxNTIwODUzNzEzLCJhaW8iOiJZMk5nWUpDZDhXSnQweXhCbDUvc0Y1YjhPKytVQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVmNZbDVtSXVWa2ViOU5QTWRWRWtBQSIsInZlciI6IjEuMCJ9.oGtUHBSLaX5r_VyBRrZpGWWcjlykefrjX4x1d247gSlwKCJ6Mk6vXcQoFg6Ud3klUVlb9J41q6bQ9-Ys2crNkckHouvL8qLEMgpAk-_HWQagM5hQ6rlvRVHRNxrVeB9Pvba-Ypj4ytHLkWzgSjkEVFRlD_Tsl1uEYssfUKckPh6dJEfHMzXWS-EmB62x5dW-04hbiyUFlAW22nx2V7asqBJ9i-UW3GKRVZTK9LC-aP8qiYe_8Ulg4afvZvGPoQMS5eAA1-neKC5VdBmEhXBQz-zZqCqppXXv_LjMAL9CYU_SsTPgoN5qqkHIFwKG0cJv07-FtzRHJstpI4hVYJVzxg
   response:
     status:
       code: 200
@@ -144,39 +144,37 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14966'
+      - '14989'
       X-Ms-Request-Id:
-      - 91c85a58-a18c-4925-ae23-30b7beb1ebf7
+      - a678ef66-56e2-446f-b83c-d2bfdd9f8b13
       X-Ms-Correlation-Request-Id:
-      - 91c85a58-a18c-4925-ae23-30b7beb1ebf7
+      - a678ef66-56e2-446f-b83c-d2bfdd9f8b13
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202254Z:91c85a58-a18c-4925-ae23-30b7beb1ebf7
+      - WESTEUROPE:20180312T102155Z:a678ef66-56e2-446f-b83c-d2bfdd9f8b13
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:22:53 GMT
+      - Mon, 12 Mar 2018 10:21:55 GMT
       Content-Length:
-      - '310901'
+      - '320853'
     body:
       encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"},{"applicationId":"d87dcbc6-a371-462e-88e3-28ad15ec4e64","roleDefinitionId":"861776c5-e0df-4f95-be4f-ac1eec193323"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["West
+      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.AAD","namespace":"Microsoft.AAD","authorizations":[{"applicationId":"443155a6-77f3-45e3-882b-22b3a8d431fb","roleDefinitionId":"7389DE79-3180-4F07-B2BA-C5BA1F01B03A"},{"applicationId":"abba844e-bc0e-44b0-947a-dc74e5d09022","roleDefinitionId":"63BC473E-7767-42A5-A3BF-08EB71200E04"},{"applicationId":"d87dcbc6-a371-462e-88e3-28ad15ec4e64","roleDefinitionId":"861776c5-e0df-4f95-be4f-ac1eec193323"}],"resourceTypes":[{"resourceType":"DomainServices","locations":["East
+        Asia","Southeast Asia","Australia East","Australia Southeast","Japan East","Japan
+        West","Central India","South India","West India","West Europe","North Europe","Canada
+        Central","Canada East","Brazil South","West US","Central US","East US","South
+        Central US","East US 2","West Central US","North Central US","West US 2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
         US","Central US","East US","South Central US","West Europe","North Europe","East
         Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
         Central US","North Central US","Japan East","Japan West","Brazil South","Central
         India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["West
-        US","Central US","East US","South Central US","West Europe","North Europe","East
-        Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
-        Central US","North Central US","Japan East","Japan West","Brazil South","Central
-        India","South India","West India","Canada Central","Canada East","West US
-        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"operations","locations":["West
+        2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"locations/operationresults","locations":["East
+        Asia","Southeast Asia","Australia East","Australia Southeast","Japan East","Japan
+        West","Central India","South India","West India","West Europe","North Europe","Canada
+        Central","Canada East","Brazil South","West US","Central US","East US","South
+        Central US","East US 2","West Central US","North Central US","West US 2"],"apiVersions":["2017-06-01","2017-01-01"]},{"resourceType":"operations","locations":["West
         US","Central US","East US","South Central US","West Europe","North Europe","East
         Asia","Southeast Asia","East US 2","Australia East","Australia Southeast","West
         Central US","North Central US","Japan East","Japan West","Brazil South","Central
@@ -232,177 +230,177 @@ http_interactions:
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/internalLoadBalancers","locations":[],"apiVersions":["2017-11-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkDomainNameAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"domainNames/slots/roles/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"domainNames/slots/roles/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"domainNames/slots/roles/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"domainNames/capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"domainNames/serviceCertificates","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
         US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
         Central","Canada East","UK South","UK West","West US","Central US","South
         Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
-        East","Australia Southeast","West US 2","West Central US","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        East","Australia Southeast","West US 2","West Central US","France Central","South
+        India","Central India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
         US","East US 2","North Central US","North Europe","West Europe","Brazil South","Canada
         Central","Canada East","UK South","UK West","West US","Central US","South
         Central US","Japan East","Japan West","East Asia","Southeast Asia","Australia
-        East","Australia Southeast","West US 2","West Central US","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metrics","locations":["North
+        East","Australia Southeast","West US 2","West Central US","France Central","South
+        India","Central India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metrics","locations":["North
         Central US","South Central US","East US","East US 2","Canada Central","Canada
         East","West US","West US 2","West Central US","Central US","East Asia","Southeast
         Asia","North Europe","West Europe","UK South","UK West","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","South India","Central
-        India","West India","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"resourceTypes","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"moveSubscriptionResources","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"validateSubscriptionMoveAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operationStatuses","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operatingSystems","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"operatingSystemFamilies","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicNetwork","namespace":"Microsoft.ClassicNetwork","resourceTypes":[{"resourceType":"virtualNetworks","locations":["East
+        India","West India","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"resourceTypes","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"moveSubscriptionResources","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"validateSubscriptionMoveAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operationStatuses","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01"]},{"resourceType":"operatingSystems","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"operatingSystemFamilies","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicNetwork","namespace":"Microsoft.ClassicNetwork","resourceTypes":[{"resourceType":"virtualNetworks","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-11-15","2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"virtualNetworks/virtualNetworkPeerings","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"virtualNetworks/remoteVirtualNetworkPeeringProxies","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01"]},{"resourceType":"virtualNetworks/remoteVirtualNetworkPeeringProxies","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2016-11-01"]},{"resourceType":"reservedIps","locations":["East
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01"]},{"resourceType":"reservedIps","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"gatewaySupportedDevices","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"networkSecurityGroups","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"gatewaySupportedDevices","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]},{"resourceType":"networkSecurityGroups","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicStorage","namespace":"Microsoft.ClassicStorage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"expressRouteCrossConnections","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]},{"resourceType":"expressRouteCrossConnections/peerings","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-10-01","2015-06-01","2014-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ClassicStorage","namespace":"Microsoft.ClassicStorage","resourceTypes":[{"resourceType":"storageAccounts","locations":["East
         Asia","Southeast Asia","East US","East US 2","West US","West US 2","North
         Central US","South Central US","West Central US","Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia East","Australia
         Southeast","South India","Central India","West India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkStorageAccountAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"storageAccounts/services","locations":["West
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"quotas","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"checkStorageAccountAvailability","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-01-01"]},{"resourceType":"storageAccounts/services","locations":["West
         US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
         Asia","Australia East","Australia Southeast","South India","Central India","West
         India","West US 2","West Central US","East US","East US 2","North Central
         US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
-        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/diagnosticSettings","locations":["West
+        South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/diagnosticSettings","locations":["West
         US","Central US","South Central US","Japan East","Japan West","East Asia","Southeast
         Asia","Australia East","Australia Southeast","South India","Central India","West
         India","West US 2","West Central US","East US","East US 2","North Central
         US","North Europe","West Europe","Brazil South","Canada Central","Canada East","UK
-        South","UK West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"disks","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"images","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"vmImages","locations":[],"apiVersions":["2016-11-01"]},{"resourceType":"publicImages","locations":[],"apiVersions":["2016-11-01","2016-04-01"]},{"resourceType":"osImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"osPlatformImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute","namespace":"Microsoft.Compute","authorizations":[{"applicationId":"60e6cd67-9c8c-4951-9b3c-23c25a2169af","roleDefinitionId":"e4770acb-272e-4dc8-87f3-12f44a612224"},{"applicationId":"a303894e-f1d8-4a37-bf10-67aa654a0596","roleDefinitionId":"903ac751-8ad5-4e5a-bfc2-5e49f450a241"},{"applicationId":"a8b6bf88-1d1a-4626-b040-9a729ea93c65","roleDefinitionId":"45c8267c-80ba-4b96-9a43-115b8f49fccd"}],"resourceTypes":[{"resourceType":"availabilitySets","locations":["East
+        South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/services/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metricDefinitions","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"storageAccounts/metrics","locations":[],"apiVersions":["2014-04-01"]},{"resourceType":"capabilities","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"disks","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"images","locations":[],"apiVersions":["2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"vmImages","locations":[],"apiVersions":["2016-11-01"]},{"resourceType":"storageAccounts/vmImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01-beta","2014-04-01","2014-01-01"]},{"resourceType":"publicImages","locations":[],"apiVersions":["2016-11-01","2016-04-01"]},{"resourceType":"osImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"osPlatformImages","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2016-04-01","2015-12-01","2015-06-01","2014-06-01","2014-04-01","2014-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute","namespace":"Microsoft.Compute","authorizations":[{"applicationId":"60e6cd67-9c8c-4951-9b3c-23c25a2169af","roleDefinitionId":"e4770acb-272e-4dc8-87f3-12f44a612224"},{"applicationId":"a303894e-f1d8-4a37-bf10-67aa654a0596","roleDefinitionId":"903ac751-8ad5-4e5a-bfc2-5e49f450a241"},{"applicationId":"a8b6bf88-1d1a-4626-b040-9a729ea93c65","roleDefinitionId":"45c8267c-80ba-4b96-9a43-115b8f49fccd"}],"resourceTypes":[{"resourceType":"availabilitySets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachines/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/extensions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/virtualMachines/networkInterfaces","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"virtualMachineScaleSets/publicIPAddresses","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-10-30-preview","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/vmSizes","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/runCommands","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations/usages","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"locations/usages","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"locations/virtualMachines","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30"]},{"resourceType":"locations/publishers","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"operations","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-03-30","2015-06-15","2015-05-01-preview"]},{"resourceType":"restorePointCollections","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"restorePointCollections/restorePoints","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30"]},{"resourceType":"virtualMachines/diagnosticSettings","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"virtualMachines/metricDefinitions","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2014-04-01"]},{"resourceType":"sharedVMImages","locations":["West
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2014-04-01"]},{"resourceType":"sharedVMImages","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"sharedVMImages/versions","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"locations/capsoperations","locations":["West
         Central US"],"apiVersions":["2017-10-15-preview"]},{"resourceType":"disks","locations":["Southeast
@@ -410,27 +408,27 @@ http_interactions:
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"snapshots","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"snapshots","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"locations/diskoperations","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"locations/diskoperations","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-03-30","2016-04-30-preview"]},{"resourceType":"images","locations":["Southeast
+        Central","Korea South","West India","France Central"],"apiVersions":["2018-04-01","2017-03-30","2016-04-30-preview"]},{"resourceType":"images","locations":["Southeast
         Asia","East US 2","Central US","West Europe","East US","North Central US","South
         Central US","West US","North Europe","East Asia","Brazil South","West US 2","West
         Central US","UK West","UK South","Japan East","Japan West","Canada Central","Canada
         East","Central India","South India","Australia East","Australia Southeast","Korea
-        Central","Korea South","West India"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"]},{"resourceType":"locations/logAnalytics","locations":["East
+        Central","Korea South","West India","France Central"],"apiVersions":["2017-12-01","2017-03-30","2016-08-30","2016-04-30-preview"]},{"resourceType":"locations/logAnalytics","locations":["East
         US","East US 2","West US","Central US","North Central US","South Central US","North
         Europe","West Europe","East Asia","Southeast Asia","Japan East","Japan West","Australia
         East","Australia Southeast","Brazil South","South India","Central India","West
         India","Canada Central","Canada East","West US 2","West Central US","UK South","UK
-        West","Korea Central","Korea South"],"apiVersions":["2017-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
+        West","Korea Central","Korea South","France Central"],"apiVersions":["2017-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerRegistry","namespace":"Microsoft.ContainerRegistry","authorization":{"applicationId":"6a0ec4d3-30cb-4a83-91c0-ae56bc0e3d26","roleDefinitionId":"78e18383-93eb-418a-9887-bc9271046576"},"resourceTypes":[{"resourceType":"registries","locations":["West
         US","East US","South Central US","West Europe","North Europe","UK South","UK
         West","Australia East","Australia Southeast","Central India","East Asia","Japan
         East","Japan West","Southeast Asia","South India","Brazil South","Canada East","Canada
@@ -547,7 +545,12 @@ http_interactions:
         US","East Asia","East US","East US 2","Japan East","Japan West","North Central
         US","North Europe","South Central US","South India","Southeast Asia","West
         Central US","West Europe","West India","West US","West US 2","UK West","UK
-        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"},{"applicationId":"f5c26e74-f226-4ae8-85f0-b4af0080ac9e","roleDefinitionId":"529d7ae6-e892-4d43-809d-8547aeb90643"}],"resourceTypes":[{"resourceType":"components","locations":["East
+        South","Brazil South","Korea South","Korea Central"],"apiVersions":["2016-03-31","2016-03-19","2015-11-06","2015-04-08","2014-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        East","Australia Southeast","Central US","East US","East US 2","West US","West
+        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
+        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
+        India","South India","West India","Canada Central","Canada East","UK West","UK
+        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/consumergroups","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/disasterrecoveryconfigs","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/microsoft.insights","namespace":"microsoft.insights","authorizations":[{"applicationId":"11c174dc-1945-4a9a-a36b-c79a0f246b9b","roleDefinitionId":"dd9d4347-f397-45f2-b538-85f21c90037b"},{"applicationId":"035f9e1d-4f00-4419-bf50-bf2d87eb4878","roleDefinitionId":"323795fe-ba3d-4f5a-ad42-afb4e1ea9485"},{"applicationId":"f5c26e74-f226-4ae8-85f0-b4af0080ac9e","roleDefinitionId":"529d7ae6-e892-4d43-809d-8547aeb90643"}],"resourceTypes":[{"resourceType":"components","locations":["East
         US","South Central US","North Europe","West Europe","Southeast Asia","West
         US 2"],"apiVersions":["2015-05-01","2014-12-01-preview","2014-08-01","2014-04-01"]},{"resourceType":"webtests","locations":["East
         US","South Central US","North Europe","West Europe","Southeast Asia","West
@@ -614,32 +617,32 @@ http_interactions:
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"vaults/secrets","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"vaults/accessPolicies","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"vaults/accessPolicies","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-10-01","2015-06-01","2014-12-19-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2016-10-01","2015-06-01"]},{"resourceType":"deletedVaults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01","2014-12-19-preview"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01","2015-06-01"]},{"resourceType":"deletedVaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-10-01"]},{"resourceType":"locations/deletedVaults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations/deletedVaults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","East US","North Europe","West Europe","East Asia","Southeast
         Asia","East US 2","Central US","South Central US","West US","Japan East","Japan
         West","Australia East","Australia Southeast","Brazil South","Central India","South
         India","West India","Canada Central","Canada East","UK South","UK West","West
-        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
+        Central US","West US 2","Korea Central","Korea South","France Central"],"apiVersions":["2018-02-14-preview","2016-10-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.MachineLearning","namespace":"Microsoft.MachineLearning","authorization":{"applicationId":"0736f41a-0425-4b46-bdb5-1563eff02385","roleDefinitionId":"1cc297bc-1829-4524-941f-966373421033"},"resourceTypes":[{"resourceType":"Workspaces","locations":["South
         Central US","West Europe","Southeast Asia","Japan East","West Central US"],"apiVersions":["2016-04-01"]},{"resourceType":"webServices","locations":["South
         Central US","West Europe","Southeast Asia","Japan East","East US 2","West
         Central US"],"apiVersions":["2017-01-01","2016-05-01-preview"]},{"resourceType":"operations","locations":["South
@@ -665,97 +668,97 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"publicIPAddresses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkInterfaces","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"loadBalancers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationSecurityGroups","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"routeTables","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"networkWatchers","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30"]},{"resourceType":"networkWatchers/connectionMonitors","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"networkWatchers/lenses","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"networkWatchers/lenses","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01"]},{"resourceType":"virtualNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"localNetworkGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"connections","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGateways","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/operationResults","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/CheckDnsNameAvailability","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/usages","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"locations/virtualNetworkAvailableEndpointServices","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"dnszones","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnsOperationResults","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnsOperationStatuses","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01"]},{"resourceType":"dnszones/A","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/AAAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CNAME","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/PTR","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/MX","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/TXT","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SRV","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/SOA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/NS","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/CAA","locations":["global"],"apiVersions":["2017-10-01","2017-09-01"]},{"resourceType":"dnszones/recordsets","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"dnszones/all","locations":["global"],"apiVersions":["2017-10-01","2017-09-01","2016-04-01","2015-05-04-preview"]},{"resourceType":"trafficmanagerprofiles","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"checkTrafficManagerNameAvailability","locations":["global"],"apiVersions":["2017-05-01","2017-03-01","2015-11-01","2015-04-28-preview"]},{"resourceType":"trafficManagerUserMetricsKeys","locations":["global"],"apiVersions":["2017-09-01-preview"]},{"resourceType":"trafficManagerGeographicHierarchies","locations":["global"],"apiVersions":["2017-05-01","2017-03-01"]},{"resourceType":"expressRouteCircuits","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"expressRouteServiceProviders","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01","2016-11-01","2016-10-01","2016-09-01","2016-08-01","2016-07-01","2016-06-01","2016-03-30","2015-06-15","2015-05-01-preview","2014-12-01-preview"]},{"resourceType":"applicationGatewayAvailableWafRuleSets","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01"]},{"resourceType":"applicationGatewayAvailableSslOptions","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01"]},{"resourceType":"routeFilters","locations":["West
         US","East US","North Europe","West Europe","East Asia","Southeast Asia","North
         Central US","South Central US","Central US","East US 2","Japan East","Japan
         West","Brazil South","Australia East","Australia Southeast","Central India","South
         India","West India","Canada Central","Canada East","West Central US","West
-        US 2","UK West","UK South","Korea Central","Korea South"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
+        US 2","UK West","UK South","Korea Central","Korea South","France Central"],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]},{"resourceType":"bgpServiceCommunities","locations":[],"apiVersions":["2018-01-01","2017-11-01","2017-10-01","2017-09-01","2017-08-01","2017-06-01","2017-04-01","2017-03-01","2016-12-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.NotificationHubs","namespace":"Microsoft.NotificationHubs","resourceTypes":[{"resourceType":"namespaces","locations":["Australia
         East","Australia Southeast","Central US","East US","East US 2","West US","West
         US 2","North Central US","South Central US","West Central US","East Asia","Southeast
         Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
@@ -846,7 +849,7 @@ http_interactions:
         East","Australia Southeast","Central US","East US 2","Central India","South
         India","West Central US","Canada Central","Canada East","West US 2","UK South","UK
         West","Korea Central","Korea South"],"apiVersions":["2017-07-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ResourceHealth","namespace":"Microsoft.ResourceHealth","authorizations":[{"applicationId":"8bdebf23-c0fe-4187-a378-717ad86f6a53","roleDefinitionId":"cc026344-c8b1-4561-83ba-59eba84b27cc"}],"resourceTypes":[{"resourceType":"availabilityStatuses","locations":[],"apiVersions":["2017-07-01","2015-01-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]},{"resourceType":"notifications","locations":["Australia
-        Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Security","namespace":"Microsoft.Security","authorization":{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
+        Southeast"],"apiVersions":["2016-09-01","2016-06-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Security","namespace":"Microsoft.Security","authorizations":[{"applicationId":"8edd93e1-2103-40b4-bd70-6e34e586362d","roleDefinitionId":"855AF4C4-82F6-414C-B1A2-628025628B9A"},{"applicationId":"fc780465-2017-40d4-a0c5-307022471b92"}],"resourceTypes":[{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatuses","locations":["Central
         US","East US","West Europe","West Central US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/virtualMachines","locations":["Central
         US","East US"],"apiVersions":["2015-06-01-preview"]},{"resourceType":"securityStatus/endpoints","locations":["Central
@@ -898,565 +901,595 @@ http_interactions:
         Central US","South Central US","Central US","East US 2","Central India","South
         India"],"apiVersions":["2015-11-10","2015-08-15","2015-08-10","2015-06-10","2015-03-15"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Sql","namespace":"Microsoft.Sql","authorizations":[{"applicationId":"e4ab13ed-33cb-41b4-9140-6e264582cf85","roleDefinitionId":"ec3ddc95-44dc-47a2-9926-5e9f5ffd44ec"},{"applicationId":"0130cc9f-7ac5-4026-bd5f-80a08a54e6d9","roleDefinitionId":"45e8abf8-0ec4-44f3-9c37-cff4f7779302"},{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},{"applicationId":"76c7f279-7959-468f-8943-3954880e0d8c","roleDefinitionId":"7f7513a8-73f9-4c5f-97a2-c41f0ea783ef"}],"resourceTypes":[{"resourceType":"operations","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/capabilities","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/databaseAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/databaseOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverKeyOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/keys","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/encryptionProtector","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/usages","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01","2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/communicationLinks","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administrators","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administratorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/restorableDroppedDatabases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recoverableDatabases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/geoBackupPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/importExportOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/operationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/backupLongTermRetentionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/automaticTuning","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/automaticTuning","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/databases/transparentDataEncryption","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recommendedElasticPools","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/auditingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/connectionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/connectionPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies/rules","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/securityAlertPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/securityAlertPolicies","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/auditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/extendedAuditingSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/elasticpools","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-09-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/jobAgentOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/jobAgentAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/disasterRecoveryConfiguration","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/dnsAliases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/failoverGroups","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/virtualNetworkRules","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/virtualNetworkRulesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/virtualNetworkRulesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/databaseRestoreAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metricDefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/aggregatedDatabaseMetrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metricdefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries/queryText","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPools/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/advisors","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/extensions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPoolEstimates","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditRecords","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentScans","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/vulnerabilityAssessments","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentSettings","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessment","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/syncGroups","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups/syncMembers","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/syncAgents","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"managedInstances/administrators","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/databases","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metrics","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metricDefinitions","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/administratorAzureAsyncOperation","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/administratorOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncMemberOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncAgentOperationResults","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncDatabaseIds","locations":["Australia
-        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
-        India","Central US","East Asia","East US","East US 2","Japan East","Japan
-        West","Korea Central","Korea South","North Central US","North Europe","South
-        Central US","South India","Southeast Asia","UK South","UK West","West Central
-        US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorizations":[{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},{"applicationId":"e406a681-f3d4-42a8-90b6-c2b029497af1"}],"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/capabilities","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/databaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"locations/databaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"locations/serverKeyAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverKeyOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/keys","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/encryptionProtector","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/encryptionProtectorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/serverOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01","2014-04-01-preview"]},{"resourceType":"checkNameAvailability","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-01-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/serviceObjectives","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/communicationLinks","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/restorableDroppedDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recoverableDatabases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/geoBackupPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/backupLongTermRetentionVaults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/import","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/importExportOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/operationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/backupLongTermRetentionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databaseSecurityPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/automaticTuning","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/databases/transparentDataEncryption","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview","2014-04-01-preview","2014-04-01"]},{"resourceType":"servers/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/recommendedElasticPools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/auditingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/connectionPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/dataMaskingPolicies/rules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/securityAlertPolicies","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/auditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"servers/extendedAuditingSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/auditingSettingsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/extendedAuditingSettingsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/elasticPoolAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/elasticPoolOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/elasticpools","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview","2015-09-01-preview","2015-05-01-preview","2015-05-01","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"locations/jobAgentOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/jobAgentAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/disasterRecoveryConfiguration","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/dnsAliases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/dnsAliasOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/failoverGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/failoverGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/firewallRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnets","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"servers/virtualNetworkRules","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/virtualNetworkRulesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/virtualNetworkRulesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/deleteVirtualNetworkOrSubnetsAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2015-05-01"]},{"resourceType":"locations/databaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/deletedServerOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/usages","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/aggregatedDatabaseMetrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticpools/metricdefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/topQueries/queryText","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPools/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/advisors","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview","2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/databases/extensions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2014-04-01-preview","2014-04-01","2014-01-01"]},{"resourceType":"servers/elasticPoolEstimates","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/auditRecords","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentScans","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/vulnerabilityAssessments","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-10-01-preview","2017-03-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessmentSettings","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/VulnerabilityAssessment","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"servers/databases/syncGroups","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/databases/syncGroups/syncMembers","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"servers/syncAgents","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"managedInstances","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview","2015-05-01-preview"]},{"resourceType":"managedInstances/administrators","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/databases","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metrics","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"managedInstances/metricDefinitions","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedDatabaseRestoreOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/managedServerSecurityAlertPoliciesOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"virtualClusters","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/managedInstanceOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/administratorAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/administratorOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/syncGroupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncMemberOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncAgentOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/syncDatabaseIds","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2015-05-01-preview"]},{"resourceType":"locations/longTermRetentionPolicyOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionPolicyAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionBackupOperationResults","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]},{"resourceType":"locations/longTermRetentionBackupAzureAsyncOperation","locations":["Australia
+        East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
+        India","Central US","East Asia","East US","East US 2","France Central","Japan
+        East","Japan West","Korea Central","Korea South","North Central US","North
+        Europe","South Central US","South India","Southeast Asia","UK South","UK West","West
+        Central US","West Europe","West India","West US","West US 2"],"apiVersions":["2017-03-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Storage","namespace":"Microsoft.Storage","authorizations":[{"applicationId":"a6aa9161-5291-40bb-8c5c-923b567bee3b","roleDefinitionId":"070ab87f-0efc-4423-b18b-756f3bdb0236"},{"applicationId":"e406a681-f3d4-42a8-90b6-c2b029497af1"}],"resourceTypes":[{"resourceType":"storageAccounts","locations":["East
         US","East US 2","West US","West Europe","East Asia","Southeast Asia","Japan
         East","Japan West","North Central US","South Central US","Central US","North
         Europe","Brazil South","Australia East","Australia Southeast","South India","Central
@@ -1795,12 +1828,12 @@ http_interactions:
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","Canada Central","Canada East","UK South","UK West","West US 2","West
-        Central US","South India","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
+        Central US","South India","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"locations/operationResults","locations":["North
         Central US","South Central US","Central US","West Europe","North Europe","West
         US","East US","East US 2","Japan East","Japan West","Brazil South","Southeast
         Asia","East Asia","Australia East","Australia Southeast","Central India","West
         India","South India","Canada Central","Canada East","UK South","UK West","West
-        US 2","West Central US","Korea Central","Korea South"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Capacity","namespace":"Microsoft.Capacity","authorization":{"applicationId":"4d0ad6c7-f6c3-46d8-ab0d-1406d5e6c86b","roleDefinitionId":"FD9C0A9A-4DB9-4F41-8A61-98385DEB6E2D"},"resourceTypes":[{"resourceType":"resources","locations":["South
+        US 2","West Central US","Korea Central","Korea South","France Central"],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01","2014-04-01-preview","2014-04-01-alpha","2014-04-01"]},{"resourceType":"RedisConfigDefinition","locations":[],"apiVersions":["2017-10-01","2017-02-01","2016-04-01","2015-08-01","2015-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Capacity","namespace":"Microsoft.Capacity","authorization":{"applicationId":"4d0ad6c7-f6c3-46d8-ab0d-1406d5e6c86b","roleDefinitionId":"FD9C0A9A-4DB9-4F41-8A61-98385DEB6E2D"},"resourceTypes":[{"resourceType":"resources","locations":["South
         Central US"],"apiVersions":["2017-11-01"]},{"resourceType":"reservationOrders","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/reservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/reservations/revisions","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"catalogs","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"appliedReservations","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"checkOffers","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"checkScopes","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"calculatePrice","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/calculateRefund","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/return","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/split","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/merge","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"validateReservationOrder","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]},{"resourceType":"reservationOrders/availableScopes","locations":[],"apiVersions":["2017-11-01-beta","2017-11-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Cdn","namespace":"Microsoft.Cdn","resourceTypes":[{"resourceType":"profiles","locations":["Australia
         East","Australia Southeast","Brazil South","Canada Central","Canada East","Central
         India","Central US","East Asia","East US","East US 2","Japan East","Japan
@@ -1876,9 +1909,9 @@ http_interactions:
         2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/updateAccountsCreationSettings","locations":["West
         US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2017-04-18","2016-02-01-preview"]},{"resourceType":"locations/accountsCreationSettings","locations":["West
         US","Global","West Europe","Southeast Asia","West Central US","East US 2"],"apiVersions":["2016-02-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Commerce","namespace":"Microsoft.Commerce","resourceTypes":[{"resourceType":"UsageAggregates","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]},{"resourceType":"RateCard","locations":[],"apiVersions":["2016-08-31-preview","2015-06-01-preview","2015-05-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-01-preview","2015-03-31"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Consumption","namespace":"Microsoft.Consumption","resourceTypes":[{"resourceType":"ReservationSummaries","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationTransactions","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Balances","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Marketplaces","locations":[],"apiVersions":["2018-01-31"]},{"resourceType":"Pricesheets","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"ReservationDetails","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview"]},{"resourceType":"Budgets","locations":[],"apiVersions":["2018-01-31","2017-12-30-preview"]},{"resourceType":"Terms","locations":[],"apiVersions":["2018-01-31","2017-12-30-preview"]},{"resourceType":"UsageDetails","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview","2017-04-24-preview"]},{"resourceType":"Operations","locations":[],"apiVersions":["2018-01-31","2017-11-30","2017-06-30-preview","2017-04-24-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContainerInstance","namespace":"Microsoft.ContainerInstance","resourceTypes":[{"resourceType":"containerGroups","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/usages","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/operations","locations":["West
-        US","East US","West Europe","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/usages","locations":["West
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"locations/operations","locations":["West
+        US","East US","West Europe","West US 2","Southeast Asia"],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-01-preview","2017-12-01-preview","2017-10-01-preview","2017-08-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.ContentModerator","namespace":"Microsoft.ContentModerator","resourceTypes":[{"resourceType":"applications","locations":["Central
         US"],"apiVersions":["2016-04-08"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2016-04-08"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.CustomerInsights","namespace":"Microsoft.CustomerInsights","authorization":{"applicationId":"38c77d00-5fcb-4cce-9d93-af4738258e3c","roleDefinitionId":"E006F9C7-F333-477C-8AD6-1F3A9FE87F55"},"resourceTypes":[{"resourceType":"hubs","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/profiles","locations":["East
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"hubs/interactions","locations":["East
@@ -1895,7 +1928,9 @@ http_interactions:
         US 2","North Europe","Central US"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]},{"resourceType":"operations","locations":["East
         US 2"],"apiVersions":["2017-07-01","2017-01-01","2016-01-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Databricks","namespace":"Microsoft.Databricks","authorizations":[{"applicationId":"d9327919-6775-4843-9037-3fb0fb0473cb","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},{"applicationId":"2ff814a6-3304-4ab8-85cb-cd0e6f879c1d","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"}],"resourceTypes":[{"resourceType":"workspaces","locations":["West
         US","East US 2","West Europe","East US","North Europe","Southeast Asia","East
-        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]},{"resourceType":"locations","locations":["West
+        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2017-09-01-preview"]},{"resourceType":"workspaces/virtualNetworkPeerings","locations":["West
+        US","East US 2","West Europe","North Europe","East US","Southeast Asia","East
+        Asia","South Central US","North Central US"],"apiVersions":["2018-04-01"]},{"resourceType":"locations","locations":["West
         US","East US 2","West Europe","North Europe","East US","Southeast Asia"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["West
         US","East US 2","West Europe","East US","North Europe","Southeast Asia","East
         Asia","South Central US","North Central US"],"apiVersions":["2018-04-01","2018-03-15","2018-03-01","2017-09-01-preview","2017-08-01-preview","2016-09-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataCatalog","namespace":"Microsoft.DataCatalog","resourceTypes":[{"resourceType":"catalogs","locations":["East
@@ -1919,23 +1954,26 @@ http_interactions:
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/storageAccounts/containers/listSasTokens","locations":["East
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataLakeStore","namespace":"Microsoft.DataLakeStore","authorization":{"applicationId":"e9f49c6b-5ce5-44c8-925d-015017e9f7ad","roleDefinitionId":"17eb9cca-f08a-4499-b2d3-852d175f614f"},"resourceTypes":[{"resourceType":"accounts","locations":["East
         US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"accounts/firewallRules","locations":["East
-        US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataMigration","namespace":"Microsoft.DataMigration","authorization":{"applicationId":"a4bad4aa-bf02-4631-9f78-a64ffdba8150","roleDefinitionId":"b831a21d-db98-4760-89cb-bef871952df1","managedByRoleDefinitionId":"6256fb55-9e59-4018-a9e1-76b11c0a4c89"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services/projects","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationStatuses","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["Brazil
-        South","North Europe","South Central US","West Europe","West US","East US","Canada
-        Central","West India","Southeast Asia"],"apiVersions":["2017-11-15-preview","2017-04-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
+        US 2","North Europe","Central US","West Europe"],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/operationresults","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/checkNameAvailability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"locations/capability","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2016-11-01","2015-10-01-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DataMigration","namespace":"Microsoft.DataMigration","authorization":{"applicationId":"a4bad4aa-bf02-4631-9f78-a64ffdba8150","roleDefinitionId":"b831a21d-db98-4760-89cb-bef871952df1","managedByRoleDefinitionId":"6256fb55-9e59-4018-a9e1-76b11c0a4c89"},"resourceTypes":[{"resourceType":"locations","locations":[],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"services/projects","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationResults","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/operationStatuses","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["Brazil
+        South","West Europe","East US","Canada Central","West India","North Europe","South
+        Central US","Southeast Asia","West US"],"apiVersions":["2018-03-15-preview","2017-11-15-privatepreview","2017-11-15-preview","2017-04-15-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.DBforMySQL","namespace":"Microsoft.DBforMySQL","authorization":{"applicationId":"76cd24bf-a9fc-4344-b1dc-908275de6d6d","roleDefinitionId":"c13b7b9c-2ed1-4901-b8a8-16f35468da29"},"resourceTypes":[{"resourceType":"operations","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
-        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/recoverableServers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
@@ -1959,7 +1997,10 @@ http_interactions:
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
-        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"servers/recoverableServers","locations":["Brazil
+        South","Canada Central","Canada East","Central India","East Asia","East US
+        2","East US","Japan East","Japan West","North Central US","North Europe","South
+        Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview"]},{"resourceType":"servers/virtualNetworkRules","locations":["Brazil
         South","Canada Central","Canada East","Central India","East Asia","East US
         2","East US","Japan East","Japan West","North Central US","North Europe","South
         Central US","Southeast Asia","West Europe","West India","West US"],"apiVersions":["2017-12-01-preview","2017-04-30-preview","2016-02-01-privatepreview"]},{"resourceType":"checkNameAvailability","locations":["Brazil
@@ -2015,12 +2056,7 @@ http_interactions:
         US 2","East US","West US","Central US","East US 2","West Central US","West
         Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"extensionTopics","locations":["West
         US 2","East US","West US","Central US","East US 2","West Central US","West
-        Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.EventHub","namespace":"Microsoft.EventHub","authorization":{"applicationId":"80369ed6-5f11-4dd9-bef3-692475845e77","roleDefinitionId":"eb8e1991-5de0-42a6-a64b-29b059341b7b"},"resourceTypes":[{"resourceType":"namespaces","locations":["Australia
-        East","Australia Southeast","Central US","East US","East US 2","West US","West
-        US 2","North Central US","South Central US","West Central US","East Asia","Southeast
-        Asia","Brazil South","Japan East","Japan West","North Europe","West Europe","Central
-        India","South India","West India","Canada Central","Canada East","UK West","UK
-        South","Korea Central","Korea South"],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/authorizationrules","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/eventhubs/consumergroups","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"checkNamespaceAvailability","locations":[],"apiVersions":["2015-08-01","2014-09-01"]},{"resourceType":"checkNameAvailability","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"sku","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-04-01","2015-08-01","2014-09-01"]},{"resourceType":"namespaces/disasterrecoveryconfigs","locations":[],"apiVersions":["2017-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
+        Europe","North Europe","Southeast Asia","East Asia"],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationResults","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]},{"resourceType":"operationsStatus","locations":[],"apiVersions":["2018-01-01","2017-09-15-preview","2017-06-15-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Features","namespace":"Microsoft.Features","resourceTypes":[{"resourceType":"features","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"providers","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-12-01","2014-08-01-preview"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.HDInsight","namespace":"Microsoft.HDInsight","authorization":{"applicationId":"9191c4da-09fe-49d9-a5f1-d41cbe92ad95","roleDefinitionId":"d102a6f3-d9cb-4633-8950-1243b975886c","managedByRoleDefinitionId":"346da55d-e1db-4a5a-89db-33ab3cdb6fc6"},"resourceTypes":[{"resourceType":"clusters","locations":["East
         US 2","South Central US","Central US","Australia Southeast","Central India","West
         Central US","West US 2","Canada East","Canada Central","Brazil South","UK
         South","UK West","East Asia","Australia East","Japan East","Japan West","North
@@ -2131,7 +2167,7 @@ http_interactions:
         West","Japan East","East Asia","Southeast Asia","West Europe","North Europe","East
         US","West US","Australia East","Australia Southeast","Central US","Brazil
         South","Central India","West India","South India","South Central US","Canada
-        Central","Canada East","West Central US","West US 2"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
+        Central","Canada East","West Central US","West US 2"],"apiVersions":["2015-10-01","2015-04-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-02-05","2015-10-01","2015-04-01"]},{"resourceType":"checknameavailability","locations":[],"apiVersions":["2015-10-01","2015-04-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Migrate","namespace":"Microsoft.Migrate","resourceTypes":[{"resourceType":"projects","locations":["West
         Central US","East US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"operations","locations":["West
         Central US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations","locations":[],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]},{"resourceType":"locations/checkNameAvailability","locations":["West
         Central US","East US"],"apiVersions":["2018-02-02","2017-11-11-preview","2017-09-25-privatepreview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.PolicyInsights","namespace":"Microsoft.PolicyInsights","authorization":{"applicationId":"1d78a85d-813d-46f0-b496-dd72f50a3ec0","roleDefinitionId":"63d2b225-4c34-4641-8768-21a1f7c68ce8"},"resourceTypes":[{"resourceType":"policyEvents","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"policyStates","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-12-preview","2017-10-17-preview","2017-08-09-preview"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.PowerBI","namespace":"Microsoft.PowerBI","resourceTypes":[{"resourceType":"workspaceCollections","locations":["South
@@ -2163,12 +2199,12 @@ http_interactions:
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourceGroups","locations":["Central
         US","East Asia","Southeast Asia","East US","East US 2","West US","West US
         2","North Central US","South Central US","West Central US","North Europe","West
         Europe","Japan East","Japan West","Brazil South","Australia Southeast","Australia
         East","West India","South India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
+        East","UK South","UK West","Korea Central","Korea South","France Central"],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/resourcegroups/resources","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/locations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagnames","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"subscriptions/tagNames/tagValues","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"deployments/operations","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"links","locations":[],"apiVersions":["2017-08-01","2017-06-01","2017-05-10","2017-05-01","2017-03-01","2016-09-01","2016-07-01","2016-06-01","2016-02-01","2015-11-01","2015-01-01","2014-04-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-01-01"]}],"registrationState":"Registered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Scheduler","namespace":"Microsoft.Scheduler","resourceTypes":[{"resourceType":"jobcollections","locations":["North
         Central US","South Central US","North Europe","West Europe","East Asia","Southeast
         Asia","West US","East US","Japan West","Japan East","Brazil South","Central
         US","East US 2","Australia East","Australia Southeast","South India","Central
@@ -2208,40 +2244,50 @@ http_interactions:
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/clusterVersions","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"clusters/applications","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operations","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/clusterVersions","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/environments","locations":["West
         US","West US 2","West Central US","East US","East US 2","Central US","West
         Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
         Central US","East Asia","Southeast Asia","Japan West","Japan East","South
         India","West India","Central India","Brazil South","South Central US","Korea
-        Central","Korea South","Canada Central","Canada East"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operations","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"locations/operationResults","locations":["West
+        US","West US 2","West Central US","East US","East US 2","Central US","West
+        Europe","North Europe","UK West","UK South","Australia East","Australia Southeast","North
+        Central US","East Asia","Southeast Asia","Japan West","Japan East","South
+        India","West India","Central India","Brazil South","South Central US","Korea
+        Central","Korea South","Canada Central","Canada East","France Central"],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-07-01-preview","2016-09-01","2016-03-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Solutions","namespace":"Microsoft.Solutions","authorization":{"applicationId":"ba4bc2bd-843f-4d61-9d33-199178eae34e","roleDefinitionId":"6cb99a0b-29a8-49bc-b57b-057acc68cd9a","managedByRoleDefinitionId":"8e3af657-a8ff-443c-a75c-2fe8c4bcb635"},"resourceTypes":[{"resourceType":"appliances","locations":["West
         Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applianceDefinitions","locations":["West
         Central US"],"apiVersions":["2016-09-01-preview"]},{"resourceType":"applications","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]},{"resourceType":"applicationDefinitions","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
-        Central US"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]},{"resourceType":"locations","locations":["West
+        Central US"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"locations/operationstatuses","locations":["South
         Central US","North Central US","West Central US","West US","West US 2","East
         US","East US 2","Central US","West Europe","North Europe","East Asia","Southeast
         Asia","Brazil South","Japan West","Japan East","Australia East","Australia
         Southeast","South India","West India","Central India","Canada Central","Canada
-        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
+        East","UK South","UK West","Korea Central","Korea South"],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01","2016-09-01-preview"]},{"resourceType":"operations","locations":[],"apiVersions":["2018-03-01","2018-02-01","2017-12-01","2017-09-01"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.StorageSync","namespace":"Microsoft.StorageSync","authorizations":[{"applicationId":"9469b9f5-6722-4481-a2b2-14ed560b706f"}],"resourceTypes":[{"resourceType":"storageSyncServices","locations":["West
         US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
         US","Canada Central","Canada East","Central US","East US 2","UK South"],"apiVersions":["2017-06-05-preview"]},{"resourceType":"storageSyncServices/syncGroups","locations":["West
         US","West Europe","North Europe","Southeast Asia","East Asia","Australia East","East
@@ -2332,7 +2378,7 @@ http_interactions:
         US"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/providers/U2uconsult.TheIdentityHub","namespace":"U2uconsult.TheIdentityHub","resourceTypes":[{"resourceType":"services","locations":["West
         Europe"],"apiVersions":["2015-06-15"]},{"resourceType":"operations","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"listCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]},{"resourceType":"updateCommunicationPreference","locations":[],"apiVersions":["2015-06-15"]}],"registrationState":"NotRegistered"}]}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:22:54 GMT
+  recorded_at: Mon, 12 Mar 2018 10:22:00 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed?api-version=2017-12-01
@@ -2349,7 +2395,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM4NzMsIm5iZiI6MTUyMDQ1Mzg3MywiZXhwIjoxNTIwNDU3NzczLCJhaW8iOiJZMk5nWUxqajhVejNnMUc2a2JISUhyWmJZam8zQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNElCY1VhZV85MC1QSVpBWUcyTUFBQSIsInZlciI6IjEuMCJ9.XLexpehMA9dl4mhacnwxGG3S2lvMIb4BHDe32wESH_YOiib-yj8UACu_OqbiKf3bx02JnqjWQ_RReCVM6YwymWhCLEfsSOola2dcsAY9VcxPC6D7k8rfw_7AlYnRytwZnJFQUfqu0qMxYNpLiVfMuzsIixlfn1FtSi7y_KFyp__xKKbDXy9g012W5mz3Y1GDtlqiN4f5p241ZaRQY6iunMDmbtwk59iabFJiGywoRj83L8L_2jcJc2GRjOLitr-4xlxtO3S_d17cXfJp0kJlX6bZBZDoRoHLfnnyl5Y9aeNTbJjJIf2i_7nfLvk2Y49LJZR75l9veik-TovXh3Dkng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk4MTMsIm5iZiI6MTUyMDg0OTgxMywiZXhwIjoxNTIwODUzNzEzLCJhaW8iOiJZMk5nWUpDZDhXSnQweXhCbDUvc0Y1YjhPKytVQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVmNZbDVtSXVWa2ViOU5QTWRWRWtBQSIsInZlciI6IjEuMCJ9.oGtUHBSLaX5r_VyBRrZpGWWcjlykefrjX4x1d247gSlwKCJ6Mk6vXcQoFg6Ud3klUVlb9J41q6bQ9-Ys2crNkckHouvL8qLEMgpAk-_HWQagM5hQ6rlvRVHRNxrVeB9Pvba-Ypj4ytHLkWzgSjkEVFRlD_Tsl1uEYssfUKckPh6dJEfHMzXWS-EmB62x5dW-04hbiyUFlAW22nx2V7asqBJ9i-UW3GKRVZTK9LC-aP8qiYe_8Ulg4afvZvGPoQMS5eAA1-neKC5VdBmEhXBQz-zZqCqppXXv_LjMAL9CYU_SsTPgoN5qqkHIFwKG0cJv07-FtzRHJstpI4hVYJVzxg
   response:
     status:
       code: 200
@@ -2368,26 +2414,26 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/LowCostGet3Min;4689,Microsoft.Compute/LowCostGet30Min;37795
+      - Microsoft.Compute/LowCostGet3Min;4743,Microsoft.Compute/LowCostGet30Min;37795
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344652126238
       X-Ms-Request-Id:
-      - b018b794-1271-4d85-afb9-3e81f0c8a154
+      - bcc1c166-2385-46f4-995b-65d9e6215de4
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14972'
+      - '14983'
       X-Ms-Correlation-Request-Id:
-      - 1bd2e532-5d74-448a-89ab-363d3f6ec83a
+      - 36df6d15-6a19-44dc-a278-6fe152bec6b1
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202255Z:1bd2e532-5d74-448a-89ab-363d3f6ec83a
+      - WESTEUROPE:20180312T102158Z:36df6d15-6a19-44dc-a278-6fe152bec6b1
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:22:54 GMT
+      - Mon, 12 Mar 2018 10:21:57 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"61b7c052-1d09-4898-b995-cce5676aaab0\",\r\n
@@ -2411,7 +2457,7 @@ http_interactions:
         \ \"location\": \"eastus\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed\",\r\n
         \ \"name\": \"miqazure-linux-managed\"\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:22:55 GMT
+  recorded_at: Mon, 12 Mar 2018 10:22:02 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944?api-version=2018-01-01
@@ -2428,7 +2474,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM4NzMsIm5iZiI6MTUyMDQ1Mzg3MywiZXhwIjoxNTIwNDU3NzczLCJhaW8iOiJZMk5nWUxqajhVejNnMUc2a2JISUhyWmJZam8zQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNElCY1VhZV85MC1QSVpBWUcyTUFBQSIsInZlciI6IjEuMCJ9.XLexpehMA9dl4mhacnwxGG3S2lvMIb4BHDe32wESH_YOiib-yj8UACu_OqbiKf3bx02JnqjWQ_RReCVM6YwymWhCLEfsSOola2dcsAY9VcxPC6D7k8rfw_7AlYnRytwZnJFQUfqu0qMxYNpLiVfMuzsIixlfn1FtSi7y_KFyp__xKKbDXy9g012W5mz3Y1GDtlqiN4f5p241ZaRQY6iunMDmbtwk59iabFJiGywoRj83L8L_2jcJc2GRjOLitr-4xlxtO3S_d17cXfJp0kJlX6bZBZDoRoHLfnnyl5Y9aeNTbJjJIf2i_7nfLvk2Y49LJZR75l9veik-TovXh3Dkng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk4MTMsIm5iZiI6MTUyMDg0OTgxMywiZXhwIjoxNTIwODUzNzEzLCJhaW8iOiJZMk5nWUpDZDhXSnQweXhCbDUvc0Y1YjhPKytVQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVmNZbDVtSXVWa2ViOU5QTWRWRWtBQSIsInZlciI6IjEuMCJ9.oGtUHBSLaX5r_VyBRrZpGWWcjlykefrjX4x1d247gSlwKCJ6Mk6vXcQoFg6Ud3klUVlb9J41q6bQ9-Ys2crNkckHouvL8qLEMgpAk-_HWQagM5hQ6rlvRVHRNxrVeB9Pvba-Ypj4ytHLkWzgSjkEVFRlD_Tsl1uEYssfUKckPh6dJEfHMzXWS-EmB62x5dW-04hbiyUFlAW22nx2V7asqBJ9i-UW3GKRVZTK9LC-aP8qiYe_8Ulg4afvZvGPoQMS5eAA1-neKC5VdBmEhXBQz-zZqCqppXXv_LjMAL9CYU_SsTPgoN5qqkHIFwKG0cJv07-FtzRHJstpI4hVYJVzxg
   response:
     status:
       code: 200
@@ -2449,22 +2495,22 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 36f1102f-6e1c-44e2-8ad0-df2c90557377
+      - 45ca5703-2a91-4006-8e78-c4fabc4091ed
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14974'
+      - '14983'
       X-Ms-Correlation-Request-Id:
-      - c38a4061-39e3-4874-9709-a883dbeca3e2
+      - 902153f3-7410-461f-89e1-207d8b4beed7
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202256Z:c38a4061-39e3-4874-9709-a883dbeca3e2
+      - WESTEUROPE:20180312T102200Z:902153f3-7410-461f-89e1-207d8b4beed7
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:22:55 GMT
+      - Mon, 12 Mar 2018 10:21:59 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"miqazure-linux-manag944\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944\",\r\n
@@ -2487,10 +2533,10 @@ http_interactions:
         \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
         \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:22:56 GMT
+  recorded_at: Mon, 12 Mar 2018 10:22:05 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups/miq-azure-test4?api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed/instanceView?api-version=2017-12-01
     body:
       encoding: US-ASCII
       string: ''
@@ -2504,60 +2550,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM4NzMsIm5iZiI6MTUyMDQ1Mzg3MywiZXhwIjoxNTIwNDU3NzczLCJhaW8iOiJZMk5nWUxqajhVejNnMUc2a2JISUhyWmJZam8zQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNElCY1VhZV85MC1QSVpBWUcyTUFBQSIsInZlciI6IjEuMCJ9.XLexpehMA9dl4mhacnwxGG3S2lvMIb4BHDe32wESH_YOiib-yj8UACu_OqbiKf3bx02JnqjWQ_RReCVM6YwymWhCLEfsSOola2dcsAY9VcxPC6D7k8rfw_7AlYnRytwZnJFQUfqu0qMxYNpLiVfMuzsIixlfn1FtSi7y_KFyp__xKKbDXy9g012W5mz3Y1GDtlqiN4f5p241ZaRQY6iunMDmbtwk59iabFJiGywoRj83L8L_2jcJc2GRjOLitr-4xlxtO3S_d17cXfJp0kJlX6bZBZDoRoHLfnnyl5Y9aeNTbJjJIf2i_7nfLvk2Y49LJZR75l9veik-TovXh3Dkng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14963'
-      X-Ms-Request-Id:
-      - dcd8cb0a-5941-4e35-bbd7-69b1c636f16d
-      X-Ms-Correlation-Request-Id:
-      - dcd8cb0a-5941-4e35-bbd7-69b1c636f16d
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202256Z:dcd8cb0a-5941-4e35-bbd7-69b1c636f16d
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:22:56 GMT
-      Content-Length:
-      - '183'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4","name":"miq-azure-test4","location":"eastus","properties":{"provisioningState":"Succeeded"}}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:22:56 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute/locations/eastus/vmSizes?api-version=2017-12-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM4NzMsIm5iZiI6MTUyMDQ1Mzg3MywiZXhwIjoxNTIwNDU3NzczLCJhaW8iOiJZMk5nWUxqajhVejNnMUc2a2JISUhyWmJZam8zQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNElCY1VhZV85MC1QSVpBWUcyTUFBQSIsInZlciI6IjEuMCJ9.XLexpehMA9dl4mhacnwxGG3S2lvMIb4BHDe32wESH_YOiib-yj8UACu_OqbiKf3bx02JnqjWQ_RReCVM6YwymWhCLEfsSOola2dcsAY9VcxPC6D7k8rfw_7AlYnRytwZnJFQUfqu0qMxYNpLiVfMuzsIixlfn1FtSi7y_KFyp__xKKbDXy9g012W5mz3Y1GDtlqiN4f5p241ZaRQY6iunMDmbtwk59iabFJiGywoRj83L8L_2jcJc2GRjOLitr-4xlxtO3S_d17cXfJp0kJlX6bZBZDoRoHLfnnyl5Y9aeNTbJjJIf2i_7nfLvk2Y49LJZR75l9veik-TovXh3Dkng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk4MTMsIm5iZiI6MTUyMDg0OTgxMywiZXhwIjoxNTIwODUzNzEzLCJhaW8iOiJZMk5nWUpDZDhXSnQweXhCbDUvc0Y1YjhPKytVQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVmNZbDVtSXVWa2ViOU5QTWRWRWtBQSIsInZlciI6IjEuMCJ9.oGtUHBSLaX5r_VyBRrZpGWWcjlykefrjX4x1d247gSlwKCJ6Mk6vXcQoFg6Ud3klUVlb9J41q6bQ9-Ys2crNkckHouvL8qLEMgpAk-_HWQagM5hQ6rlvRVHRNxrVeB9Pvba-Ypj4ytHLkWzgSjkEVFRlD_Tsl1uEYssfUKckPh6dJEfHMzXWS-EmB62x5dW-04hbiyUFlAW22nx2V7asqBJ9i-UW3GKRVZTK9LC-aP8qiYe_8Ulg4afvZvGPoQMS5eAA1-neKC5VdBmEhXBQz-zZqCqppXXv_LjMAL9CYU_SsTPgoN5qqkHIFwKG0cJv07-FtzRHJstpI4hVYJVzxg
   response:
     status:
       code: 200
@@ -2576,26 +2569,151 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/LowCostGet3Min;4688,Microsoft.Compute/LowCostGet30Min;37794
+      - Microsoft.Compute/GetInstanceView3Min;4722,Microsoft.Compute/GetInstanceView30Min;23768
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344652126238
       X-Ms-Request-Id:
-      - 867f23fd-97d4-49ba-9f81-a929add73a77
+      - a9592923-2223-40de-8143-4b8a1b0460b8
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14967'
+      - '14987'
       X-Ms-Correlation-Request-Id:
-      - d95d6baa-7569-4a68-ae0e-0ea848739ee5
+      - ddcde08b-5c9f-472e-86fd-a7ae3ebe1036
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202257Z:d95d6baa-7569-4a68-ae0e-0ea848739ee5
+      - WESTEUROPE:20180312T102210Z:ddcde08b-5c9f-472e-86fd-a7ae3ebe1036
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:22:56 GMT
+      - Mon, 12 Mar 2018 10:22:09 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: "{\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"miqazure-linux-managed_OsDisk_1_7b2bdf790a7d4379ace2846d307730cd\",\r\n
+        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
+        succeeded\",\r\n          \"time\": \"2018-01-23T20:06:17.9818931+00:00\"\r\n
+        \       }\r\n      ]\r\n    },\r\n    {\r\n      \"name\": \"miqazure-linux-managed-data-disk\",\r\n
+        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
+        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
+        succeeded\",\r\n          \"time\": \"2018-01-23T20:06:17.9818931+00:00\"\r\n
+        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\":
+        \"ProvisioningState/succeeded\",\r\n      \"level\": \"Info\",\r\n      \"displayStatus\":
+        \"Provisioning succeeded\",\r\n      \"time\": \"2018-01-23T20:06:17.9975145+00:00\"\r\n
+        \   },\r\n    {\r\n      \"code\": \"PowerState/deallocated\",\r\n      \"level\":
+        \"Info\",\r\n      \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 10:22:14 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourcegroups/miq-azure-test4?api-version=2017-08-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk4MTMsIm5iZiI6MTUyMDg0OTgxMywiZXhwIjoxNTIwODUzNzEzLCJhaW8iOiJZMk5nWUpDZDhXSnQweXhCbDUvc0Y1YjhPKytVQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVmNZbDVtSXVWa2ViOU5QTWRWRWtBQSIsInZlciI6IjEuMCJ9.oGtUHBSLaX5r_VyBRrZpGWWcjlykefrjX4x1d247gSlwKCJ6Mk6vXcQoFg6Ud3klUVlb9J41q6bQ9-Ys2crNkckHouvL8qLEMgpAk-_HWQagM5hQ6rlvRVHRNxrVeB9Pvba-Ypj4ytHLkWzgSjkEVFRlD_Tsl1uEYssfUKckPh6dJEfHMzXWS-EmB62x5dW-04hbiyUFlAW22nx2V7asqBJ9i-UW3GKRVZTK9LC-aP8qiYe_8Ulg4afvZvGPoQMS5eAA1-neKC5VdBmEhXBQz-zZqCqppXXv_LjMAL9CYU_SsTPgoN5qqkHIFwKG0cJv07-FtzRHJstpI4hVYJVzxg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14984'
+      X-Ms-Request-Id:
+      - 790783ab-b898-40be-a70a-630652165fcd
+      X-Ms-Correlation-Request-Id:
+      - 790783ab-b898-40be-a70a-630652165fcd
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T102210Z:790783ab-b898-40be-a70a-630652165fcd
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 10:22:09 GMT
+      Content-Length:
+      - '183'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4","name":"miq-azure-test4","location":"eastus","properties":{"provisioningState":"Succeeded"}}'
+    http_version: 
+  recorded_at: Mon, 12 Mar 2018 10:22:14 GMT
+- request:
+    method: get
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute/locations/eastus/vmSizes?api-version=2017-12-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk4MTMsIm5iZiI6MTUyMDg0OTgxMywiZXhwIjoxNTIwODUzNzEzLCJhaW8iOiJZMk5nWUpDZDhXSnQweXhCbDUvc0Y1YjhPKytVQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVmNZbDVtSXVWa2ViOU5QTWRWRWtBQSIsInZlciI6IjEuMCJ9.oGtUHBSLaX5r_VyBRrZpGWWcjlykefrjX4x1d247gSlwKCJ6Mk6vXcQoFg6Ud3klUVlb9J41q6bQ9-Ys2crNkckHouvL8qLEMgpAk-_HWQagM5hQ6rlvRVHRNxrVeB9Pvba-Ypj4ytHLkWzgSjkEVFRlD_Tsl1uEYssfUKckPh6dJEfHMzXWS-EmB62x5dW-04hbiyUFlAW22nx2V7asqBJ9i-UW3GKRVZTK9LC-aP8qiYe_8Ulg4afvZvGPoQMS5eAA1-neKC5VdBmEhXBQz-zZqCqppXXv_LjMAL9CYU_SsTPgoN5qqkHIFwKG0cJv07-FtzRHJstpI4hVYJVzxg
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Vary:
+      - Accept-Encoding
+      X-Ms-Ratelimit-Remaining-Resource:
+      - Microsoft.Compute/LowCostGet3Min;4747,Microsoft.Compute/LowCostGet30Min;37791
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Ms-Served-By:
+      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344652126238
+      X-Ms-Request-Id:
+      - 1e218060-c561-4588-a709-53548db31e8c
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14986'
+      X-Ms-Correlation-Request-Id:
+      - f598c263-0199-4551-8ee8-f03951fa8c68
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T102211Z:f598c263-0199-4551-8ee8-f03951fa8c68
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 12 Mar 2018 10:22:10 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"Standard_B1ms\",\r\n
@@ -3072,6 +3190,12 @@ http_interactions:
         \   },\r\n    {\r\n      \"name\": \"Standard_F72s_v2\",\r\n      \"numberOfCores\":
         72,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
         589824,\r\n      \"memoryInMB\": 147456,\r\n      \"maxDataDiskCount\": 32\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_L8s_v2\",\r\n      \"numberOfCores\":
+        8,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        1811981,\r\n      \"memoryInMB\": 65536,\r\n      \"maxDataDiskCount\": 16\r\n
+        \   },\r\n    {\r\n      \"name\": \"Standard_L16s_v2\",\r\n      \"numberOfCores\":
+        16,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
+        3623962,\r\n      \"memoryInMB\": 131072,\r\n      \"maxDataDiskCount\": 32\r\n
         \   },\r\n    {\r\n      \"name\": \"Standard_ND6s\",\r\n      \"numberOfCores\":
         6,\r\n      \"osDiskSizeInMB\": 1047552,\r\n      \"resourceDiskSizeInMB\":
         344064,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 12\r\n
@@ -3098,7 +3222,7 @@ http_interactions:
         391168,\r\n      \"memoryInMB\": 114688,\r\n      \"maxDataDiskCount\": 64\r\n
         \   }\r\n  ]\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:22:57 GMT
+  recorded_at: Mon, 12 Mar 2018 10:22:15 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux73-20170504152123?api-version=2017-08-01
@@ -3115,7 +3239,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM4NzMsIm5iZiI6MTUyMDQ1Mzg3MywiZXhwIjoxNTIwNDU3NzczLCJhaW8iOiJZMk5nWUxqajhVejNnMUc2a2JISUhyWmJZam8zQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNElCY1VhZV85MC1QSVpBWUcyTUFBQSIsInZlciI6IjEuMCJ9.XLexpehMA9dl4mhacnwxGG3S2lvMIb4BHDe32wESH_YOiib-yj8UACu_OqbiKf3bx02JnqjWQ_RReCVM6YwymWhCLEfsSOola2dcsAY9VcxPC6D7k8rfw_7AlYnRytwZnJFQUfqu0qMxYNpLiVfMuzsIixlfn1FtSi7y_KFyp__xKKbDXy9g012W5mz3Y1GDtlqiN4f5p241ZaRQY6iunMDmbtwk59iabFJiGywoRj83L8L_2jcJc2GRjOLitr-4xlxtO3S_d17cXfJp0kJlX6bZBZDoRoHLfnnyl5Y9aeNTbJjJIf2i_7nfLvk2Y49LJZR75l9veik-TovXh3Dkng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk4MTMsIm5iZiI6MTUyMDg0OTgxMywiZXhwIjoxNTIwODUzNzEzLCJhaW8iOiJZMk5nWUpDZDhXSnQweXhCbDUvc0Y1YjhPKytVQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVmNZbDVtSXVWa2ViOU5QTWRWRWtBQSIsInZlciI6IjEuMCJ9.oGtUHBSLaX5r_VyBRrZpGWWcjlykefrjX4x1d247gSlwKCJ6Mk6vXcQoFg6Ud3klUVlb9J41q6bQ9-Ys2crNkckHouvL8qLEMgpAk-_HWQagM5hQ6rlvRVHRNxrVeB9Pvba-Ypj4ytHLkWzgSjkEVFRlD_Tsl1uEYssfUKckPh6dJEfHMzXWS-EmB62x5dW-04hbiyUFlAW22nx2V7asqBJ9i-UW3GKRVZTK9LC-aP8qiYe_8Ulg4afvZvGPoQMS5eAA1-neKC5VdBmEhXBQz-zZqCqppXXv_LjMAL9CYU_SsTPgoN5qqkHIFwKG0cJv07-FtzRHJstpI4hVYJVzxg
   response:
     status:
       code: 200
@@ -3132,19 +3256,19 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14976'
+      - '14986'
       X-Ms-Request-Id:
-      - f7173a38-95a3-48ed-bda3-9320335a5048
+      - f8326f53-9103-401e-9c0e-bea24b13fffd
       X-Ms-Correlation-Request-Id:
-      - f7173a38-95a3-48ed-bda3-9320335a5048
+      - f8326f53-9103-401e-9c0e-bea24b13fffd
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202257Z:f7173a38-95a3-48ed-bda3-9320335a5048
+      - WESTEUROPE:20180312T102212Z:f8326f53-9103-401e-9c0e-bea24b13fffd
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:22:57 GMT
+      - Mon, 12 Mar 2018 10:22:12 GMT
       Content-Length:
       - '3655'
     body:
@@ -3152,10 +3276,10 @@ http_interactions:
       string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux73-20170504152123","name":"RedHat.RedHatEnterpriseLinux73-20170504152123","properties":{"templateHash":"17557892638005511562","parameters":{"location":{"type":"String","value":"eastus"},"virtualMachineName":{"type":"String","value":"miqazure-linux-managed"},"virtualMachineSize":{"type":"String","value":"Basic_A0"},"adminUsername":{"type":"String","value":"dberger"},"virtualNetworkName":{"type":"String","value":"miq-azure-test2"},"networkInterfaceName":{"type":"String","value":"miqazure-linux-manag944"},"networkSecurityGroupName":{"type":"String","value":"miqazure-linux-managed-nsg"},"adminPassword":{"type":"SecureString"},"subnetName":{"type":"String","value":"default"},"publicIpAddressName":{"type":"String","value":"miqazure-linux-managed-ip"},"publicIpAddressType":{"type":"String","value":"Dynamic"}},"mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
         ResponseContent"},"provisioningState":"Succeeded","timestamp":"2017-05-04T21:24:59.0046283Z","duration":"PT3M31.8448945S","correlationId":"574cca40-c924-4c37-a5d7-8dba697b1afe","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkInterfaces","locations":["eastus"]},{"resourceType":"publicIpAddresses","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miqazure-linux-manag944"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miqazure-linux-managed"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIpAddresses/miqazure-linux-managed-ip","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miqazure-linux-managed-ip"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miqazure-linux-managed-nsg"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miqazure-linux-manag944"}],"outputs":{"adminUsername":{"type":"String","value":"dberger"}},"outputResources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIpAddresses/miqazure-linux-managed-ip"}]}}'
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:22:58 GMT
+  recorded_at: Mon, 12 Mar 2018 10:22:17 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux73-20170504152123/operations?api-version=2017-08-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqazure-linux-managed-ip?api-version=2018-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -3169,122 +3293,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM4NzMsIm5iZiI6MTUyMDQ1Mzg3MywiZXhwIjoxNTIwNDU3NzczLCJhaW8iOiJZMk5nWUxqajhVejNnMUc2a2JISUhyWmJZam8zQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNElCY1VhZV85MC1QSVpBWUcyTUFBQSIsInZlciI6IjEuMCJ9.XLexpehMA9dl4mhacnwxGG3S2lvMIb4BHDe32wESH_YOiib-yj8UACu_OqbiKf3bx02JnqjWQ_RReCVM6YwymWhCLEfsSOola2dcsAY9VcxPC6D7k8rfw_7AlYnRytwZnJFQUfqu0qMxYNpLiVfMuzsIixlfn1FtSi7y_KFyp__xKKbDXy9g012W5mz3Y1GDtlqiN4f5p241ZaRQY6iunMDmbtwk59iabFJiGywoRj83L8L_2jcJc2GRjOLitr-4xlxtO3S_d17cXfJp0kJlX6bZBZDoRoHLfnnyl5Y9aeNTbJjJIf2i_7nfLvk2Y49LJZR75l9veik-TovXh3Dkng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14978'
-      X-Ms-Request-Id:
-      - d1cc17e8-61a3-4435-9b8b-49e9149aa582
-      X-Ms-Correlation-Request-Id:
-      - d1cc17e8-61a3-4435-9b8b-49e9149aa582
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202259Z:d1cc17e8-61a3-4435-9b8b-49e9149aa582
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:22:58 GMT
-      Content-Length:
-      - '13388'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux73-20170504152123/operations/E17A626DABF7F701","operationId":"E17A626DABF7F701","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2017-05-04T21:24:58.5631352Z","duration":"PT3M15.5477395S","trackingId":"c65b5d1e-1bd3-4484-bf69-5b5537040dfb","serviceRequestId":"d5df9fa3-37f3-433f-ad85-92b3de0ab8e1","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miqazure-linux-managed"},"request":{"content":{"location":"eastus","properties":{"osProfile":{"computerName":"miqazure-linux-managed","adminUsername":"dberger","adminPassword":"Smartvm12345"},"hardwareProfile":{"vmSize":"Basic_A0"},"storageProfile":{"imageReference":{"publisher":"RedHat","offer":"RHEL","sku":"7.3","version":"latest"},"osDisk":{"createOption":"fromImage","managedDisk":{"storageAccountType":"Standard_LRS"}},"dataDisks":[]},"networkProfile":{"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944"}]}}}},"response":{"content":{"properties":{"vmId":"61b7c052-1d09-4898-b995-cce5676aaab0","hardwareProfile":{"vmSize":"Basic_A0"},"storageProfile":{"imageReference":{"publisher":"RedHat","offer":"RHEL","sku":"7.3","version":"latest"},"osDisk":{"osType":"Linux","name":"miqazure-linux-managed_OsDisk_1_7b2bdf790a7d4379ace2846d307730cd","createOption":"FromImage","caching":"ReadWrite","managedDisk":{"storageAccountType":"Standard_LRS","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/disks/miqazure-linux-managed_OsDisk_1_7b2bdf790a7d4379ace2846d307730cd"},"diskSizeGB":32},"dataDisks":[]},"osProfile":{"computerName":"miqazure-linux-managed","adminUsername":"dberger","linuxConfiguration":{"disablePasswordAuthentication":false},"secrets":[]},"networkProfile":{"networkInterfaces":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944"}]},"provisioningState":"Succeeded"},"type":"Microsoft.Compute/virtualMachines","location":"eastus","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed","name":"miqazure-linux-managed"}}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux73-20170504152123/operations/B438A12A9A8CB0AA","operationId":"B438A12A9A8CB0AA","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2017-05-04T21:21:42.9472179Z","duration":"PT1.1873533S","trackingId":"0dd7bbf0-df39-491b-a3d7-b89f277a0af6","serviceRequestId":"bb96530e-03cf-49b1-a7f4-32f08025c58a","statusCode":"Created","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miqazure-linux-manag944"},"request":{"content":{"location":"eastus","properties":{"ipConfigurations":[{"name":"ipconfig1","properties":{"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2/subnets/default"},"privateIPAllocationMethod":"Dynamic","publicIpAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIpAddresses/miqazure-linux-managed-ip"}}}],"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg"}}}},"response":{"content":{"name":"miqazure-linux-manag944","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944","etag":"W/\"9e1dcf5c-fa82-451d-b7cd-5b778fe457fb\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"c5e8b90e-5a78-49b0-b224-b70ed3fb45e5","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944/ipConfigurations/ipconfig1","etag":"W/\"9e1dcf5c-fa82-451d-b7cd-5b778fe457fb\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"172.25.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqazure-linux-managed-ip"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"z4rvb4m0otkutj51gosabmhjhe.bx.internal.cloudapp.net"},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg"}},"type":"Microsoft.Network/networkInterfaces"}}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux73-20170504152123/operations/D57E54B59A64B8F1","operationId":"D57E54B59A64B8F1","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2017-05-04T21:21:33.8029198Z","duration":"PT5.427532S","trackingId":"21e5f61f-f34c-45d7-8e43-9383a0d9fd11","serviceRequestId":"64aec950-3dbb-4746-a51e-e21a964c6312","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIpAddresses/miqazure-linux-managed-ip","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miqazure-linux-managed-ip"},"request":{"content":{"location":"eastus","properties":{"publicIpAllocationMethod":"Dynamic"}}},"response":{"content":{"name":"miqazure-linux-managed-ip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqazure-linux-managed-ip","etag":"W/\"58254756-c51e-40ac-a79e-33437e8dd6e8\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"6a2a9142-26e8-45cd-93bf-7318192f3528","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4},"type":"Microsoft.Network/publicIPAddresses"}}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux73-20170504152123/operations/55140E025C5A5F23","operationId":"55140E025C5A5F23","properties":{"provisioningOperation":"Create","provisioningState":"Succeeded","timestamp":"2017-05-04T21:21:41.4039897Z","duration":"PT13.0330257S","trackingId":"e934318c-da94-459f-b103-9870498df04b","serviceRequestId":"fa9c93e3-1fb9-4c3e-8e68-df06b99078a6","statusCode":"OK","targetResource":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miqazure-linux-managed-nsg"},"request":{"content":{"location":"eastus","properties":{"securityRules":[{"name":"default-allow-ssh","properties":{"priority":1000,"sourceAddressPrefix":"*","protocol":"TCP","destinationPortRange":"22","access":"Allow","direction":"Inbound","sourcePortRange":"*","destinationAddressPrefix":"*"}}]}}},"response":{"content":{"name":"miqazure-linux-managed-nsg","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg","etag":"W/\"a24683a1-cba4-4d6b-a6d8-a997f8baff1f\"","type":"Microsoft.Network/networkSecurityGroups","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"b4611f96-94a8-4486-94c5-16bb6c7a5c84","securityRules":[{"name":"default-allow-ssh","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/securityRules/default-allow-ssh","etag":"W/\"a24683a1-cba4-4d6b-a6d8-a997f8baff1f\"","properties":{"provisioningState":"Succeeded","protocol":"TCP","sourcePortRange":"*","destinationPortRange":"22","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Allow","priority":1000,"direction":"Inbound"}}],"defaultSecurityRules":[{"name":"AllowVnetInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/AllowVnetInBound","etag":"W/\"a24683a1-cba4-4d6b-a6d8-a997f8baff1f\"","properties":{"provisioningState":"Succeeded","description":"Allow
-        inbound traffic from all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Inbound"}},{"name":"AllowAzureLoadBalancerInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/AllowAzureLoadBalancerInBound","etag":"W/\"a24683a1-cba4-4d6b-a6d8-a997f8baff1f\"","properties":{"provisioningState":"Succeeded","description":"Allow
-        inbound traffic from azure load balancer","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"AzureLoadBalancer","destinationAddressPrefix":"*","access":"Allow","priority":65001,"direction":"Inbound"}},{"name":"DenyAllInBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/DenyAllInBound","etag":"W/\"a24683a1-cba4-4d6b-a6d8-a997f8baff1f\"","properties":{"provisioningState":"Succeeded","description":"Deny
-        all inbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Inbound"}},{"name":"AllowVnetOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/AllowVnetOutBound","etag":"W/\"a24683a1-cba4-4d6b-a6d8-a997f8baff1f\"","properties":{"provisioningState":"Succeeded","description":"Allow
-        outbound traffic from all VMs to all VMs in VNET","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"VirtualNetwork","destinationAddressPrefix":"VirtualNetwork","access":"Allow","priority":65000,"direction":"Outbound"}},{"name":"AllowInternetOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/AllowInternetOutBound","etag":"W/\"a24683a1-cba4-4d6b-a6d8-a997f8baff1f\"","properties":{"provisioningState":"Succeeded","description":"Allow
-        outbound traffic from all VMs to Internet","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"Internet","access":"Allow","priority":65001,"direction":"Outbound"}},{"name":"DenyAllOutBound","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg/defaultSecurityRules/DenyAllOutBound","etag":"W/\"a24683a1-cba4-4d6b-a6d8-a997f8baff1f\"","properties":{"provisioningState":"Succeeded","description":"Deny
-        all outbound traffic","protocol":"*","sourcePortRange":"*","destinationPortRange":"*","sourceAddressPrefix":"*","destinationAddressPrefix":"*","access":"Deny","priority":65500,"direction":"Outbound"}}]}}}}},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux73-20170504152123/operations/08587076739983179125","operationId":"08587076739983179125","properties":{"provisioningOperation":"EvaluateDeploymentOutput","provisioningState":"Succeeded","timestamp":"2017-05-04T21:24:58.8745974Z","duration":"PT0.1938804S","trackingId":"afd1ad5d-1efa-49ae-a469-e00c2f177cb1","statusCode":"OK","statusMessage":null}}]}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:22:59 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux73-20170504152123?api-version=2017-08-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM4NzMsIm5iZiI6MTUyMDQ1Mzg3MywiZXhwIjoxNTIwNDU3NzczLCJhaW8iOiJZMk5nWUxqajhVejNnMUc2a2JISUhyWmJZam8zQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNElCY1VhZV85MC1QSVpBWUcyTUFBQSIsInZlciI6IjEuMCJ9.XLexpehMA9dl4mhacnwxGG3S2lvMIb4BHDe32wESH_YOiib-yj8UACu_OqbiKf3bx02JnqjWQ_RReCVM6YwymWhCLEfsSOola2dcsAY9VcxPC6D7k8rfw_7AlYnRytwZnJFQUfqu0qMxYNpLiVfMuzsIixlfn1FtSi7y_KFyp__xKKbDXy9g012W5mz3Y1GDtlqiN4f5p241ZaRQY6iunMDmbtwk59iabFJiGywoRj83L8L_2jcJc2GRjOLitr-4xlxtO3S_d17cXfJp0kJlX6bZBZDoRoHLfnnyl5Y9aeNTbJjJIf2i_7nfLvk2Y49LJZR75l9veik-TovXh3Dkng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14964'
-      X-Ms-Request-Id:
-      - 7a0ec97b-8b86-4847-a655-53b1f2b94801
-      X-Ms-Correlation-Request-Id:
-      - 7a0ec97b-8b86-4847-a655-53b1f2b94801
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202259Z:7a0ec97b-8b86-4847-a655-53b1f2b94801
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:22:58 GMT
-      Content-Length:
-      - '3655'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux73-20170504152123","name":"RedHat.RedHatEnterpriseLinux73-20170504152123","properties":{"templateHash":"17557892638005511562","parameters":{"location":{"type":"String","value":"eastus"},"virtualMachineName":{"type":"String","value":"miqazure-linux-managed"},"virtualMachineSize":{"type":"String","value":"Basic_A0"},"adminUsername":{"type":"String","value":"dberger"},"virtualNetworkName":{"type":"String","value":"miq-azure-test2"},"networkInterfaceName":{"type":"String","value":"miqazure-linux-manag944"},"networkSecurityGroupName":{"type":"String","value":"miqazure-linux-managed-nsg"},"adminPassword":{"type":"SecureString"},"subnetName":{"type":"String","value":"default"},"publicIpAddressName":{"type":"String","value":"miqazure-linux-managed-ip"},"publicIpAddressType":{"type":"String","value":"Dynamic"}},"mode":"Incremental","debugSetting":{"detailLevel":"RequestContent,
-        ResponseContent"},"provisioningState":"Succeeded","timestamp":"2017-05-04T21:24:59.0046283Z","duration":"PT3M31.8448945S","correlationId":"574cca40-c924-4c37-a5d7-8dba697b1afe","providers":[{"namespace":"Microsoft.Compute","resourceTypes":[{"resourceType":"virtualMachines","locations":["eastus"]}]},{"namespace":"Microsoft.Network","resourceTypes":[{"resourceType":"networkInterfaces","locations":["eastus"]},{"resourceType":"publicIpAddresses","locations":["eastus"]},{"resourceType":"networkSecurityGroups","locations":["eastus"]}]}],"dependencies":[{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miqazure-linux-manag944"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed","resourceType":"Microsoft.Compute/virtualMachines","resourceName":"miqazure-linux-managed"},{"dependsOn":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIpAddresses/miqazure-linux-managed-ip","resourceType":"Microsoft.Network/publicIpAddresses","resourceName":"miqazure-linux-managed-ip"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg","resourceType":"Microsoft.Network/networkSecurityGroups","resourceName":"miqazure-linux-managed-nsg"}],"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944","resourceType":"Microsoft.Network/networkInterfaces","resourceName":"miqazure-linux-manag944"}],"outputs":{"adminUsername":{"type":"String","value":"dberger"}},"outputResources":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg"},{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIpAddresses/miqazure-linux-managed-ip"}]}}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:22:59 GMT
-- request:
-    method: post
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Resources/deployments/RedHat.RedHatEnterpriseLinux73-20170504152123/exportTemplate?api-version=2017-08-01
-    body:
-      encoding: ASCII-8BIT
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM4NzMsIm5iZiI6MTUyMDQ1Mzg3MywiZXhwIjoxNTIwNDU3NzczLCJhaW8iOiJZMk5nWUxqajhVejNnMUc2a2JISUhyWmJZam8zQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNElCY1VhZV85MC1QSVpBWUcyTUFBQSIsInZlciI6IjEuMCJ9.XLexpehMA9dl4mhacnwxGG3S2lvMIb4BHDe32wESH_YOiib-yj8UACu_OqbiKf3bx02JnqjWQ_RReCVM6YwymWhCLEfsSOola2dcsAY9VcxPC6D7k8rfw_7AlYnRytwZnJFQUfqu0qMxYNpLiVfMuzsIixlfn1FtSi7y_KFyp__xKKbDXy9g012W5mz3Y1GDtlqiN4f5p241ZaRQY6iunMDmbtwk59iabFJiGywoRj83L8L_2jcJc2GRjOLitr-4xlxtO3S_d17cXfJp0kJlX6bZBZDoRoHLfnnyl5Y9aeNTbJjJIf2i_7nfLvk2Y49LJZR75l9veik-TovXh3Dkng
-      Content-Length:
-      - '0'
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk4MTMsIm5iZiI6MTUyMDg0OTgxMywiZXhwIjoxNTIwODUzNzEzLCJhaW8iOiJZMk5nWUpDZDhXSnQweXhCbDUvc0Y1YjhPKytVQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVmNZbDVtSXVWa2ViOU5QTWRWRWtBQSIsInZlciI6IjEuMCJ9.oGtUHBSLaX5r_VyBRrZpGWWcjlykefrjX4x1d247gSlwKCJ6Mk6vXcQoFg6Ud3klUVlb9J41q6bQ9-Ys2crNkckHouvL8qLEMgpAk-_HWQagM5hQ6rlvRVHRNxrVeB9Pvba-Ypj4ytHLkWzgSjkEVFRlD_Tsl1uEYssfUKckPh6dJEfHMzXWS-EmB62x5dW-04hbiyUFlAW22nx2V7asqBJ9i-UW3GKRVZTK9LC-aP8qiYe_8Ulg4afvZvGPoQMS5eAA1-neKC5VdBmEhXBQz-zZqCqppXXv_LjMAL9CYU_SsTPgoN5qqkHIFwKG0cJv07-FtzRHJstpI4hVYJVzxg
   response:
     status:
       code: 200
@@ -3300,38 +3309,42 @@ http_interactions:
       - application/json; charset=utf-8
       Expires:
       - "-1"
+      Etag:
+      - W/"0efc9684-fb7d-4fb7-b9b9-f33dbac04a28"
       Vary:
       - Accept-Encoding
-      X-Ms-Ratelimit-Remaining-Subscription-Writes:
-      - '1199'
       X-Ms-Request-Id:
-      - a3bc4205-e2a3-4df6-88e9-4a4ed0b3ee14
-      X-Ms-Correlation-Request-Id:
-      - a3bc4205-e2a3-4df6-88e9-4a4ed0b3ee14
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202300Z:a3bc4205-e2a3-4df6-88e9-4a4ed0b3ee14
+      - e242f875-02e9-44d5-8b08-c32294a2fa76
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      - Microsoft-HTTPAPI/2.0
+      X-Ms-Ratelimit-Remaining-Subscription-Reads:
+      - '14986'
+      X-Ms-Correlation-Request-Id:
+      - 3f1e7171-3a10-4198-8e70-9976a7d11d44
+      X-Ms-Routing-Request-Id:
+      - WESTEUROPE:20180312T102215Z:3f1e7171-3a10-4198-8e70-9976a7d11d44
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:22:59 GMT
+      - Mon, 12 Mar 2018 10:22:15 GMT
     body:
       encoding: ASCII-8BIT
-      string: '{"template":{"$schema":"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#","contentVersion":"1.0.0.0","parameters":{"location":{"type":"String"},"virtualMachineName":{"type":"String"},"virtualMachineSize":{"type":"String"},"adminUsername":{"type":"String"},"virtualNetworkName":{"type":"String"},"networkInterfaceName":{"type":"String"},"networkSecurityGroupName":{"type":"String"},"adminPassword":{"type":"SecureString"},"subnetName":{"type":"String"},"publicIpAddressName":{"type":"String"},"publicIpAddressType":{"type":"String"}},"variables":{"vnetId":"[resourceId(''miq-azure-test2'',''Microsoft.Network/virtualNetworks'',
-        parameters(''virtualNetworkName''))]","subnetRef":"[concat(variables(''vnetId''),
-        ''/subnets/'', parameters(''subnetName''))]"},"resources":[{"type":"Microsoft.Compute/virtualMachines","name":"[parameters(''virtualMachineName'')]","apiVersion":"2016-04-30-preview","location":"[parameters(''location'')]","properties":{"osProfile":{"computerName":"[parameters(''virtualMachineName'')]","adminUsername":"[parameters(''adminUsername'')]","adminPassword":"[parameters(''adminPassword'')]"},"hardwareProfile":{"vmSize":"[parameters(''virtualMachineSize'')]"},"storageProfile":{"imageReference":{"publisher":"RedHat","offer":"RHEL","sku":"7.3","version":"latest"},"osDisk":{"createOption":"fromImage","managedDisk":{"storageAccountType":"Standard_LRS"}},"dataDisks":[]},"networkProfile":{"networkInterfaces":[{"id":"[resourceId(''Microsoft.Network/networkInterfaces'',
-        parameters(''networkInterfaceName''))]"}]}},"dependsOn":["[concat(''Microsoft.Network/networkInterfaces/'',
-        parameters(''networkInterfaceName''))]"]},{"type":"Microsoft.Network/networkInterfaces","name":"[parameters(''networkInterfaceName'')]","apiVersion":"2016-09-01","location":"[parameters(''location'')]","properties":{"ipConfigurations":[{"name":"ipconfig1","properties":{"subnet":{"id":"[variables(''subnetRef'')]"},"privateIPAllocationMethod":"Dynamic","publicIpAddress":{"id":"[resourceId(''miq-azure-test4'',''Microsoft.Network/publicIpAddresses'',
-        parameters(''publicIpAddressName''))]"}}}],"networkSecurityGroup":{"id":"[resourceId(''miq-azure-test4'',
-        ''Microsoft.Network/networkSecurityGroups'', parameters(''networkSecurityGroupName''))]"}},"dependsOn":["[concat(''Microsoft.Network/publicIpAddresses/'',
-        parameters(''publicIpAddressName''))]","[concat(''Microsoft.Network/networkSecurityGroups/'',
-        parameters(''networkSecurityGroupName''))]"]},{"type":"Microsoft.Network/publicIpAddresses","name":"[parameters(''publicIpAddressName'')]","apiVersion":"2016-09-01","location":"[parameters(''location'')]","properties":{"publicIpAllocationMethod":"[parameters(''publicIpAddressType'')]"}},{"type":"Microsoft.Network/networkSecurityGroups","name":"[parameters(''networkSecurityGroupName'')]","apiVersion":"2016-09-01","location":"[parameters(''location'')]","properties":{"securityRules":[{"name":"default-allow-ssh","properties":{"priority":1000,"sourceAddressPrefix":"*","protocol":"TCP","destinationPortRange":"22","access":"Allow","direction":"Inbound","sourcePortRange":"*","destinationAddressPrefix":"*"}}]}}],"outputs":{"adminUsername":{"type":"String","value":"[parameters(''adminUsername'')]"}}}}'
+      string: "{\r\n  \"name\": \"miqazure-linux-managed-ip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqazure-linux-managed-ip\",\r\n
+        \ \"etag\": \"W/\\\"0efc9684-fb7d-4fb7-b9b9-f33dbac04a28\\\"\",\r\n  \"location\":
+        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
+        \   \"resourceGuid\": \"6a2a9142-26e8-45cd-93bf-7318192f3528\",\r\n    \"publicIPAddressVersion\":
+        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
+        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944/ipConfigurations/ipconfig1\"\r\n
+        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
+        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:23:00 GMT
+  recorded_at: Mon, 12 Mar 2018 10:22:20 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/disks/miqazure-linux-managed-data-disk?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -3345,7 +3358,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM4NzMsIm5iZiI6MTUyMDQ1Mzg3MywiZXhwIjoxNTIwNDU3NzczLCJhaW8iOiJZMk5nWUxqajhVejNnMUc2a2JISUhyWmJZam8zQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNElCY1VhZV85MC1QSVpBWUcyTUFBQSIsInZlciI6IjEuMCJ9.XLexpehMA9dl4mhacnwxGG3S2lvMIb4BHDe32wESH_YOiib-yj8UACu_OqbiKf3bx02JnqjWQ_RReCVM6YwymWhCLEfsSOola2dcsAY9VcxPC6D7k8rfw_7AlYnRytwZnJFQUfqu0qMxYNpLiVfMuzsIixlfn1FtSi7y_KFyp__xKKbDXy9g012W5mz3Y1GDtlqiN4f5p241ZaRQY6iunMDmbtwk59iabFJiGywoRj83L8L_2jcJc2GRjOLitr-4xlxtO3S_d17cXfJp0kJlX6bZBZDoRoHLfnnyl5Y9aeNTbJjJIf2i_7nfLvk2Y49LJZR75l9veik-TovXh3Dkng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk4MTMsIm5iZiI6MTUyMDg0OTgxMywiZXhwIjoxNTIwODUzNzEzLCJhaW8iOiJZMk5nWUpDZDhXSnQweXhCbDUvc0Y1YjhPKytVQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVmNZbDVtSXVWa2ViOU5QTWRWRWtBQSIsInZlciI6IjEuMCJ9.oGtUHBSLaX5r_VyBRrZpGWWcjlykefrjX4x1d247gSlwKCJ6Mk6vXcQoFg6Ud3klUVlb9J41q6bQ9-Ys2crNkckHouvL8qLEMgpAk-_HWQagM5hQ6rlvRVHRNxrVeB9Pvba-Ypj4ytHLkWzgSjkEVFRlD_Tsl1uEYssfUKckPh6dJEfHMzXWS-EmB62x5dW-04hbiyUFlAW22nx2V7asqBJ9i-UW3GKRVZTK9LC-aP8qiYe_8Ulg4afvZvGPoQMS5eAA1-neKC5VdBmEhXBQz-zZqCqppXXv_LjMAL9CYU_SsTPgoN5qqkHIFwKG0cJv07-FtzRHJstpI4hVYJVzxg
   response:
     status:
       code: 200
@@ -3364,53 +3377,41 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/LowCostGet3Min;4706,Microsoft.Compute/LowCostGet30Min;37789
+      - Microsoft.Compute/LowCostGet3Min;4999,Microsoft.Compute/LowCostGet30Min;19999
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131626781321631045
       X-Ms-Request-Id:
-      - f7966ce5-d380-4a24-ba9b-bab7ffdd7b6b
+      - b1a39ea9-4018-4881-bd9e-3e4e7635ea5f
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14966'
+      - '14980'
       X-Ms-Correlation-Request-Id:
-      - dc37c465-b649-4185-906c-062df097e0d6
+      - 0b8a9014-3b19-4c4c-aafc-a1a9aa786b27
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202307Z:dc37c465-b649-4185-906c-062df097e0d6
+      - WESTEUROPE:20180312T102216Z:0b8a9014-3b19-4c4c-aafc-a1a9aa786b27
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:23:07 GMT
+      - Mon, 12 Mar 2018 10:22:16 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"properties\": {\r\n    \"vmId\": \"61b7c052-1d09-4898-b995-cce5676aaab0\",\r\n
-        \   \"hardwareProfile\": {\r\n      \"vmSize\": \"Basic_A0\"\r\n    },\r\n
-        \   \"storageProfile\": {\r\n      \"imageReference\": {\r\n        \"publisher\":
-        \"RedHat\",\r\n        \"offer\": \"RHEL\",\r\n        \"sku\": \"7.3\",\r\n
-        \       \"version\": \"latest\"\r\n      },\r\n      \"osDisk\": {\r\n        \"osType\":
-        \"Linux\",\r\n        \"name\": \"miqazure-linux-managed_OsDisk_1_7b2bdf790a7d4379ace2846d307730cd\",\r\n
-        \       \"createOption\": \"FromImage\",\r\n        \"caching\": \"ReadWrite\",\r\n
-        \       \"managedDisk\": {\r\n          \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/disks/miqazure-linux-managed_OsDisk_1_7b2bdf790a7d4379ace2846d307730cd\"\r\n
-        \       }\r\n      },\r\n      \"dataDisks\": [\r\n        {\r\n          \"lun\":
-        0,\r\n          \"name\": \"miqazure-linux-managed-data-disk\",\r\n          \"createOption\":
-        \"Attach\",\r\n          \"caching\": \"None\",\r\n          \"managedDisk\":
-        {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/disks/miqazure-linux-managed-data-disk\"\r\n
-        \         }\r\n        }\r\n      ]\r\n    },\r\n    \"osProfile\": {\r\n
-        \     \"computerName\": \"miqazure-linux-managed\",\r\n      \"adminUsername\":
-        \"dberger\",\r\n      \"linuxConfiguration\": {\r\n        \"disablePasswordAuthentication\":
-        false\r\n      },\r\n      \"secrets\": []\r\n    },\r\n    \"networkProfile\":
-        {\"networkInterfaces\":[{\"id\":\"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944\"}]},\r\n
-        \   \"provisioningState\": \"Succeeded\"\r\n  },\r\n  \"type\": \"Microsoft.Compute/virtualMachines\",\r\n
-        \ \"location\": \"eastus\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed\",\r\n
-        \ \"name\": \"miqazure-linux-managed\"\r\n}"
+      string: "{\r\n  \"managedBy\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed\",\r\n
+        \ \"sku\": {\r\n    \"name\": \"Standard_LRS\",\r\n    \"tier\": \"Standard\"\r\n
+        \ },\r\n  \"properties\": {\r\n    \"creationData\": {\r\n      \"createOption\":
+        \"Empty\"\r\n    },\r\n    \"diskSizeGB\": 1,\r\n    \"timeCreated\": \"2017-10-23T17:34:14.7022771+00:00\",\r\n
+        \   \"provisioningState\": \"Succeeded\",\r\n    \"diskState\": \"Reserved\"\r\n
+        \ },\r\n  \"type\": \"Microsoft.Compute/disks\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/disks/miqazure-linux-managed-data-disk\",\r\n
+        \ \"name\": \"miqazure-linux-managed-data-disk\"\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:23:07 GMT
+  recorded_at: Mon, 12 Mar 2018 10:22:21 GMT
 - request:
     method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed/instanceView?api-version=2017-12-01
+    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/disks/miqazure-linux-managed_OsDisk_1_7b2bdf790a7d4379ace2846d307730cd?api-version=2017-03-30
     body:
       encoding: US-ASCII
       string: ''
@@ -3424,7 +3425,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM4NzMsIm5iZiI6MTUyMDQ1Mzg3MywiZXhwIjoxNTIwNDU3NzczLCJhaW8iOiJZMk5nWUxqajhVejNnMUc2a2JISUhyWmJZam8zQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNElCY1VhZV85MC1QSVpBWUcyTUFBQSIsInZlciI6IjEuMCJ9.XLexpehMA9dl4mhacnwxGG3S2lvMIb4BHDe32wESH_YOiib-yj8UACu_OqbiKf3bx02JnqjWQ_RReCVM6YwymWhCLEfsSOola2dcsAY9VcxPC6D7k8rfw_7AlYnRytwZnJFQUfqu0qMxYNpLiVfMuzsIixlfn1FtSi7y_KFyp__xKKbDXy9g012W5mz3Y1GDtlqiN4f5p241ZaRQY6iunMDmbtwk59iabFJiGywoRj83L8L_2jcJc2GRjOLitr-4xlxtO3S_d17cXfJp0kJlX6bZBZDoRoHLfnnyl5Y9aeNTbJjJIf2i_7nfLvk2Y49LJZR75l9veik-TovXh3Dkng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk4MTMsIm5iZiI6MTUyMDg0OTgxMywiZXhwIjoxNTIwODUzNzEzLCJhaW8iOiJZMk5nWUpDZDhXSnQweXhCbDUvc0Y1YjhPKytVQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVmNZbDVtSXVWa2ViOU5QTWRWRWtBQSIsInZlciI6IjEuMCJ9.oGtUHBSLaX5r_VyBRrZpGWWcjlykefrjX4x1d247gSlwKCJ6Mk6vXcQoFg6Ud3klUVlb9J41q6bQ9-Ys2crNkckHouvL8qLEMgpAk-_HWQagM5hQ6rlvRVHRNxrVeB9Pvba-Ypj4ytHLkWzgSjkEVFRlD_Tsl1uEYssfUKckPh6dJEfHMzXWS-EmB62x5dW-04hbiyUFlAW22nx2V7asqBJ9i-UW3GKRVZTK9LC-aP8qiYe_8Ulg4afvZvGPoQMS5eAA1-neKC5VdBmEhXBQz-zZqCqppXXv_LjMAL9CYU_SsTPgoN5qqkHIFwKG0cJv07-FtzRHJstpI4hVYJVzxg
   response:
     status:
       code: 200
@@ -3443,196 +3444,40 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Ratelimit-Remaining-Resource:
-      - Microsoft.Compute/GetInstanceView3Min;4794,Microsoft.Compute/GetInstanceView30Min;23909
+      - Microsoft.Compute/LowCostGet3Min;4998,Microsoft.Compute/LowCostGet30Min;19998
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Ms-Served-By:
-      - 1a5498b5-371e-4a3a-8afd-84914b23eaad_131643344714001689
+      - 0c09dd6a-2d82-4972-90fb-776a852e0e14_131626781321631045
       X-Ms-Request-Id:
-      - a2ccc8af-3f2a-403f-a3a8-eb7784cc8094
+      - 1467839f-1a51-4e1c-ae2b-1a25d7fa3d34
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14762'
+      - '14986'
       X-Ms-Correlation-Request-Id:
-      - cd7b0a34-f2bd-48f9-b12a-e1dd1368ec5d
+      - c74b6eb3-8478-4418-bf7a-296c184c5cb4
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202319Z:cd7b0a34-f2bd-48f9-b12a-e1dd1368ec5d
+      - WESTEUROPE:20180312T102217Z:c74b6eb3-8478-4418-bf7a-296c184c5cb4
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:23:18 GMT
+      - Mon, 12 Mar 2018 10:22:16 GMT
     body:
       encoding: ASCII-8BIT
-      string: "{\r\n  \"disks\": [\r\n    {\r\n      \"name\": \"miqazure-linux-managed_OsDisk_1_7b2bdf790a7d4379ace2846d307730cd\",\r\n
-        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
-        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"time\": \"2018-01-23T20:06:17.9818931+00:00\"\r\n
-        \       }\r\n      ]\r\n    },\r\n    {\r\n      \"name\": \"miqazure-linux-managed-data-disk\",\r\n
-        \     \"statuses\": [\r\n        {\r\n          \"code\": \"ProvisioningState/succeeded\",\r\n
-        \         \"level\": \"Info\",\r\n          \"displayStatus\": \"Provisioning
-        succeeded\",\r\n          \"time\": \"2018-01-23T20:06:17.9818931+00:00\"\r\n
-        \       }\r\n      ]\r\n    }\r\n  ],\r\n  \"statuses\": [\r\n    {\r\n      \"code\":
-        \"ProvisioningState/succeeded\",\r\n      \"level\": \"Info\",\r\n      \"displayStatus\":
-        \"Provisioning succeeded\",\r\n      \"time\": \"2018-01-23T20:06:17.9975145+00:00\"\r\n
-        \   },\r\n    {\r\n      \"code\": \"PowerState/deallocated\",\r\n      \"level\":
-        \"Info\",\r\n      \"displayStatus\": \"VM deallocated\"\r\n    }\r\n  ]\r\n}"
+      string: "{\r\n  \"managedBy\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed\",\r\n
+        \ \"sku\": {\r\n    \"name\": \"Standard_LRS\",\r\n    \"tier\": \"Standard\"\r\n
+        \ },\r\n  \"properties\": {\r\n    \"osType\": \"Linux\",\r\n    \"creationData\":
+        {\r\n      \"createOption\": \"FromImage\",\r\n      \"imageReference\": {\r\n
+        \       \"id\": \"/Subscriptions/AZURE_SUBSCRIPTION_ID/Providers/Microsoft.Compute/Locations/eastus/Publishers/RedHat/ArtifactTypes/VMImage/Offers/RHEL/Skus/7.3/Versions/latest\"\r\n
+        \     }\r\n    },\r\n    \"diskSizeGB\": 32,\r\n    \"timeCreated\": \"2017-05-04T21:21:55.7801928+00:00\",\r\n
+        \   \"provisioningState\": \"Succeeded\",\r\n    \"diskState\": \"Reserved\"\r\n
+        \ },\r\n  \"type\": \"Microsoft.Compute/disks\",\r\n  \"location\": \"eastus\",\r\n
+        \ \"tags\": {\r\n    \"delete\": \"false\"\r\n  },\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/disks/miqazure-linux-managed_OsDisk_1_7b2bdf790a7d4379ace2846d307730cd\",\r\n
+        \ \"name\": \"miqazure-linux-managed_OsDisk_1_7b2bdf790a7d4379ace2846d307730cd\"\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:23:19 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Network/networkInterfaces?api-version=2017-11-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM4NzMsIm5iZiI6MTUyMDQ1Mzg3MywiZXhwIjoxNTIwNDU3NzczLCJhaW8iOiJZMk5nWUxqajhVejNnMUc2a2JISUhyWmJZam8zQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNElCY1VhZV85MC1QSVpBWUcyTUFBQSIsInZlciI6IjEuMCJ9.XLexpehMA9dl4mhacnwxGG3S2lvMIb4BHDe32wESH_YOiib-yj8UACu_OqbiKf3bx02JnqjWQ_RReCVM6YwymWhCLEfsSOola2dcsAY9VcxPC6D7k8rfw_7AlYnRytwZnJFQUfqu0qMxYNpLiVfMuzsIixlfn1FtSi7y_KFyp__xKKbDXy9g012W5mz3Y1GDtlqiN4f5p241ZaRQY6iunMDmbtwk59iabFJiGywoRj83L8L_2jcJc2GRjOLitr-4xlxtO3S_d17cXfJp0kJlX6bZBZDoRoHLfnnyl5Y9aeNTbJjJIf2i_7nfLvk2Y49LJZR75l9veik-TovXh3Dkng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 54428320-94af-48be-bb46-d685a9d6c77e
-      X-Ms-Correlation-Request-Id:
-      - 54428320-94af-48be-bb46-d685a9d6c77e
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202322Z:54428320-94af-48be-bb46-d685a9d6c77e
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:23:21 GMT
-      Content-Length:
-      - '31614'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[{"name":"miqazure-coreos1235","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235","etag":"W/\"4a6546ab-a4c0-4d27-bccd-f6ebf3c405a2\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"fb0a5e60-a6c2-4bb8-a2f5-0c16216a49b0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235/ipConfigurations/ipconfig1","etag":"W/\"4a6546ab-a4c0-4d27-bccd-f6ebf3c405a2\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.20.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/publicIPAddresses/miqazure-coreos1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/virtualNetworks/miq-azure-test3/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"rliadcyr3l1elbnsw4rabxqg1f.dx.internal.cloudapp.net"},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkSecurityGroups/miqazure-coreos1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Compute/virtualMachines/miqazure-coreos1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"dbergerprov1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/dbergerprov1","etag":"W/\"074dd836-918c-4e40-a118-94f0d366e175\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"ecdcd2f0-91bb-4c40-91cd-a3d76fc5e455","ipConfigurations":[{"name":"dbergerprov1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/dbergerprov1/ipConfigurations/dbergerprov1","etag":"W/\"074dd836-918c-4e40-a118-94f0d366e175\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.9","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/dbergerprov1-publicIp"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/virtualMachines/dbergerprov1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-rhel1390","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390","etag":"W/\"f006e6f9-0292-42cd-99fc-f72f194553c1\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"98853f48-2806-4065-be57-cf9159550440","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1","etag":"W/\"f006e6f9-0292-42cd-99fc-f72f194553c1\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"macAddress":"00-0D-3A-10-EB-AB","enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-rhel1"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-rhel1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-ubuntu1989","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989","etag":"W/\"64e07488-15a2-4cec-b84a-6fd5ef04323c\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"134a6669-ac4a-4d08-a0db-387bc4c49537","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989/ipConfigurations/ipconfig1","etag":"W/\"64e07488-15a2-4cec-b84a-6fd5ef04323c\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.17.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-ubuntu1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest18687/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-ubuntu1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-ubuntu1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-win12610","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610","etag":"W/\"dd925ef5-33d1-402c-a0f4-18c78c2641f4\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"5c2eef2c-0b36-4277-a940-957ed4d13be0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610/ipConfigurations/ipconfig1","etag":"W/\"dd925ef5-33d1-402c-a0f4-18c78c2641f4\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.18.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-win12"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miqazuretest19881/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miq-test-win12"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-win12"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miq-test-winimg241","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241","etag":"W/\"4a17a745-16a9-42d9-88c9-17a518959525\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"8ed2f3b0-4a4b-49ae-9f1d-ff7890dbd396","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241/ipConfigurations/ipconfig1","etag":"W/\"4a17a745-16a9-42d9-88c9-17a518959525\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.7","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqtestwinimg6202"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqtestwinimg3696"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miq-test-winimg"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-centos1611","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611","etag":"W/\"26031ef6-bb55-4019-8185-2dd1edcb207c\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"f1760e49-9853-4fdc-acfc-4ea232b9ed76","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1","etag":"W/\"26031ef6-bb55-4019-8185-2dd1edcb207c\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.5","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/miqazure-centos1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Compute/virtualMachines/miqazure-centos1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqmismatch1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1","etag":"W/\"3a72d0c3-bfda-4da5-a61b-e8c33e43de79\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"23d804a8-b623-49e7-9c8d-1d64245bef1e","ipConfigurations":[{"name":"miqmismatch1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1/ipConfigurations/miqmismatch1","etag":"W/\"3a72d0c3-bfda-4da5-a61b-e8c33e43de79\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.8","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqmismatch1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqmismatch1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"rspec-lb-a670","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670","etag":"W/\"cf3a0b0d-d596-4f33-bc31-749f92ba4f00\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"46cb8216-786e-408e-9d86-c0855b357349","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1","etag":"W/\"cf3a0b0d-d596-4f33-bc31-749f92ba4f00\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.6","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-a-ip"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/inboundNatRules/rspec-lb1-NAT"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[],"internalDomainNameSuffix":"l2pezv5ekcfezj54pdvn1rvzcf.bx.internal.cloudapp.net"},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-a-nsg"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/rspec-lb-a"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"rspec-lb-b843","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843","etag":"W/\"76aabe0c-8678-43f0-81a5-2f15784a4b99\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"3ef6fa01-ac34-43a1-8fd7-67c706b4d8ef","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1","etag":"W/\"76aabe0c-8678-43f0-81a5-2f15784a4b99\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.16.0.11","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-b-ip"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/miq-azure-test1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/backendAddressPools/rspec-lb-pool"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkSecurityGroups/rspec-lb-b-nsg"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/rspec-lb-b"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"spec0deply1nic0","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0","etag":"W/\"b817491c-aab8-4aab-b41d-b07bfffa5639\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"80ad9866-071d-4e3f-91d0-d47954eccee0","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic0/ipConfigurations/ipconfig1","etag":"W/\"b817491c-aab8-4aab-b41d-b07bfffa5639\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.4","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM0"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm0"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"spec0deply1nic1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1","etag":"W/\"2ec58a0b-4c03-4d0a-b788-9daffd54e7b2\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"57bbf7aa-d6c4-4f56-8f6a-089d15334221","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/spec0deply1nic1/ipConfigurations/ipconfig1","etag":"W/\"2ec58a0b-4c03-4d0a-b788-9daffd54e7b2\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.0.0.5","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/virtualNetworks/spec0deply1vnet/subnets/Subnet-1"},"primary":true,"privateIPAddressVersion":"IPv4","loadBalancerBackendAddressPools":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/backendAddressPools/BackendPool1"}],"loadBalancerInboundNatRules":[{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/inboundNatRules/RDP-VM1"}]}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST1/providers/Microsoft.Compute/virtualMachines/spec0deply1vm1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqmismatch2656","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqmismatch2656","etag":"W/\"fef6a836-2802-4897-90c3-b3d71f133384\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"969dde6c-73c0-4340-877d-2b5fe2060026","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqmismatch2656/ipConfigurations/ipconfig1","etag":"W/\"fef6a836-2802-4897-90c3-b3d71f133384\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"172.23.0.4","privateIPAllocationMethod":"Dynamic","subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/virtualNetworks/miqazuretest33606/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkSecurityGroups/miqmismatch2-nsg"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Compute/virtualMachines/miqmismatch2"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-linux-manag944","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944","etag":"W/\"b6339880-8ead-4c9e-b5c0-f38c4f8612d5\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"c5e8b90e-5a78-49b0-b224-b70ed3fb45e5","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944/ipConfigurations/ipconfig1","etag":"W/\"b6339880-8ead-4c9e-b5c0-f38c4f8612d5\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"172.25.0.4","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqazure-linux-managed-ip"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg"},"primary":true,"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"jf-metrics-2751","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751","etag":"W/\"c5f6f02a-b17c-4f34-882b-11c7adef0b44\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"207a58d3-f18d-4dab-8168-919877297a52","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751/ipConfigurations/ipconfig1","etag":"W/\"c5f6f02a-b17c-4f34-882b-11c7adef0b44\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.7","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-2"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-2"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/jf-metrics-2"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"jf-metrics-3421","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421","etag":"W/\"0b6f160b-ad10-48f8-9d0c-657193bb823f\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"b8b345e8-a353-4700-992e-be48a717b4e2","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421/ipConfigurations/ipconfig1","etag":"W/\"0b6f160b-ad10-48f8-9d0c-657193bb823f\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.8","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-3"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/jf-metrics-3"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/jf-metrics-3"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-oraclelinux310","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310","etag":"W/\"54cd4fe1-3ed5-4a8c-bc8d-527679c7a631\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"6a3fc1d7-4532-4ca0-b5c2-546cc8f7f313","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310/ipConfigurations/ipconfig1","etag":"W/\"54cd4fe1-3ed5-4a8c-bc8d-527679c7a631\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.5","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux1"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux1"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"},{"name":"miqazure-oraclelinux993","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993","etag":"W/\"a9432274-7b40-4eb3-a64f-a04267a423ff\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"75d8ed14-e0ae-4d84-99f6-e3f43d073e76","ipConfigurations":[{"name":"ipconfig1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993/ipConfigurations/ipconfig1","etag":"W/\"a9432274-7b40-4eb3-a64f-a04267a423ff\"","properties":{"provisioningState":"Succeeded","privateIPAddress":"10.19.0.6","privateIPAllocationMethod":"Dynamic","publicIPAddress":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux2"},"subnet":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miqazure-sharedvn1/subnets/default"},"primary":true,"privateIPAddressVersion":"IPv4"}}],"dnsSettings":{"dnsServers":[],"appliedDnsServers":[]},"enableAcceleratedNetworking":false,"enableIPForwarding":false,"networkSecurityGroup":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkSecurityGroups/miqazure-sharednsg1"},"virtualMachine":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Compute/virtualMachines/miqazure-oraclelinux2"},"virtualNetworkTapProvisioningState":"NotProvisioned"},"type":"Microsoft.Network/networkInterfaces"}]}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:23:22 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Network/publicIPAddresses?api-version=2017-11-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM4NzMsIm5iZiI6MTUyMDQ1Mzg3MywiZXhwIjoxNTIwNDU3NzczLCJhaW8iOiJZMk5nWUxqajhVejNnMUc2a2JISUhyWmJZam8zQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNElCY1VhZV85MC1QSVpBWUcyTUFBQSIsInZlciI6IjEuMCJ9.XLexpehMA9dl4mhacnwxGG3S2lvMIb4BHDe32wESH_YOiib-yj8UACu_OqbiKf3bx02JnqjWQ_RReCVM6YwymWhCLEfsSOola2dcsAY9VcxPC6D7k8rfw_7AlYnRytwZnJFQUfqu0qMxYNpLiVfMuzsIixlfn1FtSi7y_KFyp__xKKbDXy9g012W5mz3Y1GDtlqiN4f5p241ZaRQY6iunMDmbtwk59iabFJiGywoRj83L8L_2jcJc2GRjOLitr-4xlxtO3S_d17cXfJp0kJlX6bZBZDoRoHLfnnyl5Y9aeNTbJjJIf2i_7nfLvk2Y49LJZR75l9veik-TovXh3Dkng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 3a777f63-0076-49b7-b465-2842ed6d74a2
-      X-Ms-Correlation-Request-Id:
-      - 3a777f63-0076-49b7-b465-2842ed6d74a2
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202324Z:3a777f63-0076-49b7-b465-2842ed6d74a2
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:23:24 GMT
-      Content-Length:
-      - '13978'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[{"name":"miqazure-coreos1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/publicIPAddresses/miqazure-coreos1","etag":"W/\"da64b64b-a755-4389-a2f3-5cba32f18c06\"","location":"westus","properties":{"provisioningState":"Succeeded","resourceGuid":"28617ed1-0270-4b39-873a-c3b48b3deef1","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Network/networkInterfaces/miqazure-coreos1235/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"dbergerprov1-publicIp","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/dbergerprov1-publicIp","etag":"W/\"3d984c69-3f35-41ce-bdfc-8d207053a6a9\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"eb0e8804-e169-44ac-bb47-0929370977d2","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/dbergerprov1/ipConfigurations/dbergerprov1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"ladas_test","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/ladas_test","etag":"W/\"32e21623-9a1b-4c40-80f4-6a350aa237a7\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"3daa5f66-5a01-4242-b95b-c4e0ee8f0c36","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[]},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miq-test-rhel1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-rhel1","etag":"W/\"054052bb-11ff-4f6e-ac1a-3427c2fd17aa\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"f6cfc635-411e-48ce-a627-39a2fc0d3168","ipAddress":"52.224.165.15","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-rhel1390/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miq-test-ubuntu1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-ubuntu1","etag":"W/\"bcae50c5-146f-4fcb-a461-7c1030ba7b74\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"e272bd74-f661-484f-b223-88dd128a4049","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-ubuntu1989/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miq-test-win12","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miq-test-win12","etag":"W/\"56ce00f4-50d7-4682-9ee8-6836bf5c0ea6\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"b9200977-8147-40a5-83c2-d5892d5ddedc","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-win12610/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miqazure-centos1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqazure-centos1","etag":"W/\"734a3944-a880-444c-8c92-cace6e28e303\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"475a66f0-9e89-4226-a9f0-9baaaf31d619","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqazure-centos1611/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miqtestwinimg6202","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/miqtestwinimg6202","etag":"W/\"b656279a-26ff-4021-94bb-263420cf494e\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"fb942169-855b-44f8-b12f-fd63e961b140","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miq-test-winimg241/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"rspec-lb-a-ip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-a-ip","etag":"W/\"3ba30997-7d2f-470c-96f6-301158e93b7c\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"3c605f75-23c0-46ab-ba2b-6fd4430140fd","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-a670/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"rspec-lb-b-ip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb-b-ip","etag":"W/\"cf6012c7-3d47-438f-84d7-332ad1ef4500\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"5d1a2425-a351-4c0f-bc87-37e6500bff22","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/rspec-lb-b843/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"rspec-lb1-LoadBalancerFrontEnd","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb1-LoadBalancerFrontEnd","etag":"W/\"a38434c8-7b23-4092-b7c6-402238eac0dc\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"f28e0f25-b372-4edf-97d9-13a9e3b4ba2d","ipAddress":"40.71.82.83","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Static","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb1/frontendIPConfigurations/LoadBalancerFrontEnd"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"rspec-lb2-publicip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/rspec-lb2-publicip","etag":"W/\"cddd97d1-6111-4477-8a00-3dc885237a1d\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"83e7257d-ab94-4229-8eb5-4798f37ef28d","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/rspec-lb2/frontendIPConfigurations/LoadBalancerFrontEnd"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"spec0deply1ip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/publicIPAddresses/spec0deply1ip","etag":"W/\"2080997a-38a6-420d-ba86-e9582e1331c7\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"a08b891e-e45a-4970-aefc-f6c996989490","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"spec0deply1dns","fqdn":"spec0deply1dns.eastus.cloudapp.azure.com"},"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/loadBalancers/spec0deply1lb/frontendIPConfigurations/LoadBalancerFrontEnd"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miqazure-linux-managed-ip","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqazure-linux-managed-ip","etag":"W/\"0efc9684-fb7d-4fb7-b9b9-f33dbac04a28\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"6a2a9142-26e8-45cd-93bf-7318192f3528","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miqmismatch1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqmismatch1","etag":"W/\"9b8b1729-21c4-4c53-94f2-15715315ad73\"","location":"eastus","properties":{"provisioningState":"Succeeded","resourceGuid":"a97c71d0-6b78-4ffe-8e5c-0be1ee653f8c","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"dnsSettings":{"domainNameLabel":"miqmismatch1","fqdn":"miqmismatch1.eastus.cloudapp.azure.com"},"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test1/providers/Microsoft.Network/networkInterfaces/miqmismatch1/ipConfigurations/miqmismatch1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"jf-metrics-2","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-2","etag":"W/\"b43ebe01-574c-4454-87eb-3401fbcf36f2\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"e446f3e4-9410-4d7f-bb04-2652096359de","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-2751/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"jf-metrics-3","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/jf-metrics-3","etag":"W/\"a6ee7100-6202-4ae2-a2db-f828abec8af9\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"de5995a4-15c1-40ba-ad78-67e70a92654b","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/jf-metrics-3421/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miqazure-oraclelinux1","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux1","etag":"W/\"98bee7b4-2fcc-471d-b5ce-92850e6c3d6b\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"f2ac7c18-520b-4b42-94e7-da264a842f41","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux310/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}},{"name":"miqazure-oraclelinux2","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/publicIPAddresses/miqazure-oraclelinux2","etag":"W/\"0865cebc-95b9-49d2-9f10-21dbafb23cac\"","location":"centralus","properties":{"provisioningState":"Succeeded","resourceGuid":"2f4e1091-46f0-474c-a697-8dbcea6ba2a6","publicIPAddressVersion":"IPv4","publicIPAllocationMethod":"Dynamic","idleTimeoutInMinutes":4,"ipTags":[],"ipConfiguration":{"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/networkInterfaces/miqazure-oraclelinux993/ipConfigurations/ipconfig1"}},"type":"Microsoft.Network/publicIPAddresses","sku":{"name":"Basic"}}]}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:23:24 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/providers/Microsoft.Compute/disks?api-version=2017-03-30
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM4NzMsIm5iZiI6MTUyMDQ1Mzg3MywiZXhwIjoxNTIwNDU3NzczLCJhaW8iOiJZMk5nWUxqajhVejNnMUc2a2JISUhyWmJZam8zQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNElCY1VhZV85MC1QSVpBWUcyTUFBQSIsInZlciI6IjEuMCJ9.XLexpehMA9dl4mhacnwxGG3S2lvMIb4BHDe32wESH_YOiib-yj8UACu_OqbiKf3bx02JnqjWQ_RReCVM6YwymWhCLEfsSOola2dcsAY9VcxPC6D7k8rfw_7AlYnRytwZnJFQUfqu0qMxYNpLiVfMuzsIixlfn1FtSi7y_KFyp__xKKbDXy9g012W5mz3Y1GDtlqiN4f5p241ZaRQY6iunMDmbtwk59iabFJiGywoRj83L8L_2jcJc2GRjOLitr-4xlxtO3S_d17cXfJp0kJlX6bZBZDoRoHLfnnyl5Y9aeNTbJjJIf2i_7nfLvk2Y49LJZR75l9veik-TovXh3Dkng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 2766c0f3-358e-43cd-9c1a-f2f8b3688877
-      X-Ms-Correlation-Request-Id:
-      - 2766c0f3-358e-43cd-9c1a-f2f8b3688877
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202325Z:2766c0f3-358e-43cd-9c1a-f2f8b3688877
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:23:25 GMT
-      Content-Length:
-      - '2517'
-    body:
-      encoding: ASCII-8BIT
-      string: '{"value":[{"managedBy":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test3/providers/Microsoft.Compute/virtualMachines/miqmismatch2","sku":{"name":"Standard_LRS","tier":"Standard"},"properties":{"osType":"Linux","creationData":{"createOption":"FromImage","imageReference":{"id":"/Subscriptions/AZURE_SUBSCRIPTION_ID/Providers/Microsoft.Compute/Locations/eastus/Publishers/redhat/ArtifactTypes/VMImage/Offers/rhel-byol-preview/Skus/rhel74/Versions/7.4.0"}},"diskSizeGB":64,"timeCreated":"2017-10-20T18:43:28.8491982+00:00","provisioningState":"Succeeded","diskState":"Reserved"},"type":"Microsoft.Compute/disks","location":"eastus","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST3/providers/Microsoft.Compute/disks/miqmismatch2_OsDisk_1_a7515d62695740d88c0f6656166bad2e","name":"miqmismatch2_OsDisk_1_a7515d62695740d88c0f6656166bad2e"},{"managedBy":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed","sku":{"name":"Standard_LRS","tier":"Standard"},"properties":{"creationData":{"createOption":"Empty"},"diskSizeGB":1,"timeCreated":"2017-10-23T17:34:14.7022771+00:00","provisioningState":"Succeeded","diskState":"Reserved"},"type":"Microsoft.Compute/disks","location":"eastus","id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/disks/miqazure-linux-managed-data-disk","name":"miqazure-linux-managed-data-disk"},{"managedBy":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed","sku":{"name":"Standard_LRS","tier":"Standard"},"properties":{"osType":"Linux","creationData":{"createOption":"FromImage","imageReference":{"id":"/Subscriptions/AZURE_SUBSCRIPTION_ID/Providers/Microsoft.Compute/Locations/eastus/Publishers/RedHat/ArtifactTypes/VMImage/Offers/RHEL/Skus/7.3/Versions/latest"}},"diskSizeGB":32,"timeCreated":"2017-05-04T21:21:55.7801928+00:00","provisioningState":"Succeeded","diskState":"Reserved"},"type":"Microsoft.Compute/disks","location":"eastus","tags":{"delete":"false"},"id":"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/MIQ-AZURE-TEST4/providers/Microsoft.Compute/disks/miqazure-linux-managed_OsDisk_1_7b2bdf790a7d4379ace2846d307730cd","name":"miqazure-linux-managed_OsDisk_1_7b2bdf790a7d4379ace2846d307730cd"}]}'
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:23:26 GMT
+  recorded_at: Mon, 12 Mar 2018 10:22:21 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg?api-version=2018-01-01
@@ -3649,7 +3494,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM4NzMsIm5iZiI6MTUyMDQ1Mzg3MywiZXhwIjoxNTIwNDU3NzczLCJhaW8iOiJZMk5nWUxqajhVejNnMUc2a2JISUhyWmJZam8zQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNElCY1VhZV85MC1QSVpBWUcyTUFBQSIsInZlciI6IjEuMCJ9.XLexpehMA9dl4mhacnwxGG3S2lvMIb4BHDe32wESH_YOiib-yj8UACu_OqbiKf3bx02JnqjWQ_RReCVM6YwymWhCLEfsSOola2dcsAY9VcxPC6D7k8rfw_7AlYnRytwZnJFQUfqu0qMxYNpLiVfMuzsIixlfn1FtSi7y_KFyp__xKKbDXy9g012W5mz3Y1GDtlqiN4f5p241ZaRQY6iunMDmbtwk59iabFJiGywoRj83L8L_2jcJc2GRjOLitr-4xlxtO3S_d17cXfJp0kJlX6bZBZDoRoHLfnnyl5Y9aeNTbJjJIf2i_7nfLvk2Y49LJZR75l9veik-TovXh3Dkng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk4MTMsIm5iZiI6MTUyMDg0OTgxMywiZXhwIjoxNTIwODUzNzEzLCJhaW8iOiJZMk5nWUpDZDhXSnQweXhCbDUvc0Y1YjhPKytVQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVmNZbDVtSXVWa2ViOU5QTWRWRWtBQSIsInZlciI6IjEuMCJ9.oGtUHBSLaX5r_VyBRrZpGWWcjlykefrjX4x1d247gSlwKCJ6Mk6vXcQoFg6Ud3klUVlb9J41q6bQ9-Ys2crNkckHouvL8qLEMgpAk-_HWQagM5hQ6rlvRVHRNxrVeB9Pvba-Ypj4ytHLkWzgSjkEVFRlD_Tsl1uEYssfUKckPh6dJEfHMzXWS-EmB62x5dW-04hbiyUFlAW22nx2V7asqBJ9i-UW3GKRVZTK9LC-aP8qiYe_8Ulg4afvZvGPoQMS5eAA1-neKC5VdBmEhXBQz-zZqCqppXXv_LjMAL9CYU_SsTPgoN5qqkHIFwKG0cJv07-FtzRHJstpI4hVYJVzxg
   response:
     status:
       code: 200
@@ -3670,22 +3515,22 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 90630667-6860-411e-9952-e817d7309126
+      - 03e2ba30-16b8-4868-81c6-c4f6e4049481
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14974'
+      - '14985'
       X-Ms-Correlation-Request-Id:
-      - 7f858690-e3b8-4c1b-bc6c-68ab8507f6ad
+      - eebe20fb-fa29-41ef-8c92-be636018ebc4
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202326Z:7f858690-e3b8-4c1b-bc6c-68ab8507f6ad
+      - WESTEUROPE:20180312T102218Z:eebe20fb-fa29-41ef-8c92-be636018ebc4
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:23:26 GMT
+      - Mon, 12 Mar 2018 10:22:17 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"miqazure-linux-managed-nsg\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg\",\r\n
@@ -3770,7 +3615,7 @@ http_interactions:
         \   ],\r\n    \"networkInterfaces\": [\r\n      {\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944\"\r\n
         \     }\r\n    ]\r\n  }\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:23:26 GMT
+  recorded_at: Mon, 12 Mar 2018 10:22:22 GMT
 - request:
     method: get
     uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2?api-version=2018-01-01
@@ -3787,7 +3632,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM4NzMsIm5iZiI6MTUyMDQ1Mzg3MywiZXhwIjoxNTIwNDU3NzczLCJhaW8iOiJZMk5nWUxqajhVejNnMUc2a2JISUhyWmJZam8zQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNElCY1VhZV85MC1QSVpBWUcyTUFBQSIsInZlciI6IjEuMCJ9.XLexpehMA9dl4mhacnwxGG3S2lvMIb4BHDe32wESH_YOiib-yj8UACu_OqbiKf3bx02JnqjWQ_RReCVM6YwymWhCLEfsSOola2dcsAY9VcxPC6D7k8rfw_7AlYnRytwZnJFQUfqu0qMxYNpLiVfMuzsIixlfn1FtSi7y_KFyp__xKKbDXy9g012W5mz3Y1GDtlqiN4f5p241ZaRQY6iunMDmbtwk59iabFJiGywoRj83L8L_2jcJc2GRjOLitr-4xlxtO3S_d17cXfJp0kJlX6bZBZDoRoHLfnnyl5Y9aeNTbJjJIf2i_7nfLvk2Y49LJZR75l9veik-TovXh3Dkng
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA4NDk4MTMsIm5iZiI6MTUyMDg0OTgxMywiZXhwIjoxNTIwODUzNzEzLCJhaW8iOiJZMk5nWUpDZDhXSnQweXhCbDUvc0Y1YjhPKytVQUFBPSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiVmNZbDVtSXVWa2ViOU5QTWRWRWtBQSIsInZlciI6IjEuMCJ9.oGtUHBSLaX5r_VyBRrZpGWWcjlykefrjX4x1d247gSlwKCJ6Mk6vXcQoFg6Ud3klUVlb9J41q6bQ9-Ys2crNkckHouvL8qLEMgpAk-_HWQagM5hQ6rlvRVHRNxrVeB9Pvba-Ypj4ytHLkWzgSjkEVFRlD_Tsl1uEYssfUKckPh6dJEfHMzXWS-EmB62x5dW-04hbiyUFlAW22nx2V7asqBJ9i-UW3GKRVZTK9LC-aP8qiYe_8Ulg4afvZvGPoQMS5eAA1-neKC5VdBmEhXBQz-zZqCqppXXv_LjMAL9CYU_SsTPgoN5qqkHIFwKG0cJv07-FtzRHJstpI4hVYJVzxg
   response:
     status:
       code: 200
@@ -3808,22 +3653,22 @@ http_interactions:
       Vary:
       - Accept-Encoding
       X-Ms-Request-Id:
-      - 5c3b5eb9-d8db-4b04-810d-ba8461b4b1df
+      - cbb779a8-790e-4345-badb-c01e5a13f616
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       Server:
       - Microsoft-HTTPAPI/2.0
       - Microsoft-HTTPAPI/2.0
       X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14968'
+      - '14987'
       X-Ms-Correlation-Request-Id:
-      - a1db7476-3229-4e4e-9fd6-8a4bcae1c548
+      - 0bfef059-06be-4412-b6f0-b9e63790dbd7
       X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202326Z:a1db7476-3229-4e4e-9fd6-8a4bcae1c548
+      - WESTEUROPE:20180312T102220Z:0bfef059-06be-4412-b6f0-b9e63790dbd7
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Mar 2018 20:23:26 GMT
+      - Mon, 12 Mar 2018 10:22:19 GMT
     body:
       encoding: ASCII-8BIT
       string: "{\r\n  \"name\": \"miq-azure-test2\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2\",\r\n
@@ -3841,146 +3686,5 @@ http_interactions:
         [],\r\n    \"enableDdosProtection\": false,\r\n    \"enableVmProtection\":
         false\r\n  }\r\n}"
     http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:23:27 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM4NzMsIm5iZiI6MTUyMDQ1Mzg3MywiZXhwIjoxNTIwNDU3NzczLCJhaW8iOiJZMk5nWUxqajhVejNnMUc2a2JISUhyWmJZam8zQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNElCY1VhZV85MC1QSVpBWUcyTUFBQSIsInZlciI6IjEuMCJ9.XLexpehMA9dl4mhacnwxGG3S2lvMIb4BHDe32wESH_YOiib-yj8UACu_OqbiKf3bx02JnqjWQ_RReCVM6YwymWhCLEfsSOola2dcsAY9VcxPC6D7k8rfw_7AlYnRytwZnJFQUfqu0qMxYNpLiVfMuzsIixlfn1FtSi7y_KFyp__xKKbDXy9g012W5mz3Y1GDtlqiN4f5p241ZaRQY6iunMDmbtwk59iabFJiGywoRj83L8L_2jcJc2GRjOLitr-4xlxtO3S_d17cXfJp0kJlX6bZBZDoRoHLfnnyl5Y9aeNTbJjJIf2i_7nfLvk2Y49LJZR75l9veik-TovXh3Dkng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"b6339880-8ead-4c9e-b5c0-f38c4f8612d5"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 2fd8d8e0-9393-477c-a7c8-7c894e9dd8be
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14974'
-      X-Ms-Correlation-Request-Id:
-      - 9423314a-0ea9-4dc1-a5ec-b61449c62395
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202327Z:9423314a-0ea9-4dc1-a5ec-b61449c62395
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:23:27 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"miqazure-linux-manag944\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944\",\r\n
-        \ \"etag\": \"W/\\\"b6339880-8ead-4c9e-b5c0-f38c4f8612d5\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"c5e8b90e-5a78-49b0-b224-b70ed3fb45e5\",\r\n    \"ipConfigurations\":
-        [\r\n      {\r\n        \"name\": \"ipconfig1\",\r\n        \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944/ipConfigurations/ipconfig1\",\r\n
-        \       \"etag\": \"W/\\\"b6339880-8ead-4c9e-b5c0-f38c4f8612d5\\\"\",\r\n
-        \       \"properties\": {\r\n          \"provisioningState\": \"Succeeded\",\r\n
-        \         \"privateIPAddress\": \"172.25.0.4\",\r\n          \"privateIPAllocationMethod\":
-        \"Dynamic\",\r\n          \"publicIPAddress\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqazure-linux-managed-ip\"\r\n
-        \         },\r\n          \"subnet\": {\r\n            \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test2/providers/Microsoft.Network/virtualNetworks/miq-azure-test2/subnets/default\"\r\n
-        \         },\r\n          \"primary\": true,\r\n          \"privateIPAddressVersion\":
-        \"IPv4\"\r\n        }\r\n      }\r\n    ],\r\n    \"dnsSettings\": {\r\n      \"dnsServers\":
-        [],\r\n      \"appliedDnsServers\": []\r\n    },\r\n    \"enableAcceleratedNetworking\":
-        false,\r\n    \"enableIPForwarding\": false,\r\n    \"networkSecurityGroup\":
-        {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkSecurityGroups/miqazure-linux-managed-nsg\"\r\n
-        \   },\r\n    \"primary\": true,\r\n    \"virtualMachine\": {\r\n      \"id\":
-        \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Compute/virtualMachines/miqazure-linux-managed\"\r\n
-        \   },\r\n    \"virtualNetworkTapProvisioningState\": \"NotProvisioned\"\r\n
-        \ },\r\n  \"type\": \"Microsoft.Network/networkInterfaces\"\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:23:27 GMT
-- request:
-    method: get
-    uri: https://management.azure.com/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqazure-linux-managed-ip?api-version=2018-01-01
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.4.2p198
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCIsImtpZCI6IlNTUWRoSTFjS3ZoUUVEU0p4RTJnR1lzNDBRMCJ9.eyJhdWQiOiJodHRwczovL21hbmFnZW1lbnQuYXp1cmUuY29tLyIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0Lzc3ZWNlZmI2LWNmZjAtNGU4ZC1hNDQ2LTc1N2E2OWNiOTQ4NS8iLCJpYXQiOjE1MjA0NTM4NzMsIm5iZiI6MTUyMDQ1Mzg3MywiZXhwIjoxNTIwNDU3NzczLCJhaW8iOiJZMk5nWUxqajhVejNnMUc2a2JISUhyWmJZam8zQUE9PSIsImFwcGlkIjoiZmMxYzIyMjUtMDY1Zi00YmE4LTgzZDktZDg2NjYyZjU3OGFmIiwiYXBwaWRhY3IiOiIxIiwiZ3JvdXBzIjpbIjQwNzM4OTg2LTNjODItNGNmMS05OWZjLTEzNDU3ZTMzMzJmYyIsIjBkMDE0M2VhLTMzOWUtNDJlMC1hMjRlLWI1YThmYzY5ZmYxNCIsImQ2NWYyZTVkLWZiZmItNDE1My04NmIyLTU5NzliNGU2YjU5MiJdLCJpZHAiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83N2VjZWZiNi1jZmYwLTRlOGQtYTQ0Ni03NTdhNjljYjk0ODUvIiwib2lkIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwic3ViIjoiMzA2ZWI0MmEtMzU4NS00YTM3LTk1YjctMzhiYzBlOTgyOGQyIiwidGlkIjoiNzdlY2VmYjYtY2ZmMC00ZThkLWE0NDYtNzU3YTY5Y2I5NDg1IiwidXRpIjoiNElCY1VhZV85MC1QSVpBWUcyTUFBQSIsInZlciI6IjEuMCJ9.XLexpehMA9dl4mhacnwxGG3S2lvMIb4BHDe32wESH_YOiib-yj8UACu_OqbiKf3bx02JnqjWQ_RReCVM6YwymWhCLEfsSOola2dcsAY9VcxPC6D7k8rfw_7AlYnRytwZnJFQUfqu0qMxYNpLiVfMuzsIixlfn1FtSi7y_KFyp__xKKbDXy9g012W5mz3Y1GDtlqiN4f5p241ZaRQY6iunMDmbtwk59iabFJiGywoRj83L8L_2jcJc2GRjOLitr-4xlxtO3S_d17cXfJp0kJlX6bZBZDoRoHLfnnyl5Y9aeNTbJjJIf2i_7nfLvk2Y49LJZR75l9veik-TovXh3Dkng
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Etag:
-      - W/"0efc9684-fb7d-4fb7-b9b9-f33dbac04a28"
-      Vary:
-      - Accept-Encoding
-      X-Ms-Request-Id:
-      - 5d703dfc-e8ad-4e8a-b3f0-5166e36dc855
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains
-      Server:
-      - Microsoft-HTTPAPI/2.0
-      - Microsoft-HTTPAPI/2.0
-      X-Ms-Ratelimit-Remaining-Subscription-Reads:
-      - '14980'
-      X-Ms-Correlation-Request-Id:
-      - f0827b68-9b93-4a96-87c2-5b9229834f73
-      X-Ms-Routing-Request-Id:
-      - WESTEUROPE:20180307T202327Z:f0827b68-9b93-4a96-87c2-5b9229834f73
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 07 Mar 2018 20:23:27 GMT
-    body:
-      encoding: ASCII-8BIT
-      string: "{\r\n  \"name\": \"miqazure-linux-managed-ip\",\r\n  \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/publicIPAddresses/miqazure-linux-managed-ip\",\r\n
-        \ \"etag\": \"W/\\\"0efc9684-fb7d-4fb7-b9b9-f33dbac04a28\\\"\",\r\n  \"location\":
-        \"eastus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n
-        \   \"resourceGuid\": \"6a2a9142-26e8-45cd-93bf-7318192f3528\",\r\n    \"publicIPAddressVersion\":
-        \"IPv4\",\r\n    \"publicIPAllocationMethod\": \"Dynamic\",\r\n    \"idleTimeoutInMinutes\":
-        4,\r\n    \"ipTags\": [],\r\n    \"ipConfiguration\": {\r\n      \"id\": \"/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/miq-azure-test4/providers/Microsoft.Network/networkInterfaces/miqazure-linux-manag944/ipConfigurations/ipconfig1\"\r\n
-        \   }\r\n  },\r\n  \"type\": \"Microsoft.Network/publicIPAddresses\",\r\n
-        \ \"sku\": {\r\n    \"name\": \"Basic\"\r\n  }\r\n}"
-    http_version: 
-  recorded_at: Wed, 07 Mar 2018 20:23:28 GMT
+  recorded_at: Mon, 12 Mar 2018 10:22:25 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
Optimize fetching of stack templates and resources. We will fetch templates and resources only if stack's timestamp has changed. Then add optimizations of storage entities and network entities API collection optimizations.

Partially fixes https://bugzilla.redhat.com/show_bug.cgi?id=1487602
Depends on:
- [x] https://github.com/ManageIQ/manageiq-providers-azure/pull/219


Numbers:
the speed improvement for full refresh is 2200s vs 120s now (with private images included)
the targeted refresh of one Vm takes 15-20s, before it was around 40s

refresh of all Vms at once (targeted refresh) ```EmsRefresh.refresh(Vm.all.to_a)``` takes 81s for 82 VMs, it does a lot of n+1 requests, but we have it configurable threshold to fetch all instead of by 1